### PR TITLE
Translations for i18n/po/ja_JP/upgrading/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/master.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/master.ja_JP.po
@@ -2,7 +2,7 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -12,6 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-upgrading__master/ja_JP/index.html
