### PR TITLE
Translations for i18n/po/ja_JP/server_installation/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/master.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/master.ja_JP.po
@@ -1,19 +1,22 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__master.ja_JP.po\n"
 
 #. type: Title =
+#: source/server_installation/master.adoc:9
 #, no-wrap
 msgid "{installguide_name}"
-msgstr ""
+msgstr "{installguide_name}"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__master/ja_JP/index.html
