### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__operating-mode.ja_JP.po\n"
 
 #. type: Title ==
 #: source/server_installation/topics/operating-mode.adoc:4
@@ -29,11 +30,7 @@ msgid ""
 "your server configurations? Your choice of operating mode effects how you "
 "configure databases, configure caching and even how you boot the server."
 msgstr ""
-"プロダクション環境で{project_name}をデプロイする前に、どのタイプの動作モード"
-"を使用するか決定する必要があります。クラスター内で{project_name}を実行します"
-"か？サーバー設定を一元管理しますか？どの動作モードを選択するかによって、デー"
-"タベースやキャッシュをどのように設定するか、さらにはサーバーをどのように起動"
-"するかさえ変わってきます。"
+"プロダクション環境で{project_name}をデプロイする前に、どのタイプの動作モードを使用するか決定する必要があります。クラスター内で{project_name}を実行しますか？サーバー設定を一元管理しますか？どの動作モードを選択するかによって、データベースやキャッシュをどのように設定するか、さらにはサーバーをどのように起動するかさえ変わってきます。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode.adoc:12
@@ -42,4 +39,5 @@ msgid ""
 "The {project_name} is built on top of the {appserver_name} Application Server.  This guide will only\n"
 "     go over the basics for deployment within a specific mode.  If you want specific information on this, a better place\n"
 "     to go would be the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_].\n"
-msgstr "{project_name}は{appserver_name}アプリケーション・サーバー上に構築されています。このガイドは、基本的な特定のモードでのデプロイについてご説明します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
+msgstr ""
+"{project_name}は{appserver_name}アプリケーション・サーバー上に構築されています。このガイドでは、基本的な特定のモードでのデプロイメントについてご説明します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__operating-mode/ja_JP/index.html
