### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -62,8 +62,8 @@ msgid ""
 "CLI allows you to configure servers locally or remotely.  And it is "
 "especially useful when combined with scripting."
 msgstr ""
-"設定の変更は、手作業だけでなく、 _jboss-cli_ "
-"toolツールを使用しコマンドを発行しても行うことできます。CLIを使用すると、サーバーをローカルまたはリモートで設定することもできます。スクリプティングと組み合わせると特に便利です。"
+"設定変更は、手作業で編集するだけでなく、 _jboss-cli_ "
+"toolツールを使用しコマンドを発行して行うこともできます。CLIを使用すると、サーバーをローカルまたはリモートで設定することもできます。スクリプティングと組み合わせると特に便利です。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:10
@@ -88,11 +88,12 @@ msgstr "> ...\\bin\\jboss-cli.bat\n"
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:24
 #: source/server_installation/topics/manage.adoc:28
 msgid "This will bring you to a prompt like this:"
-msgstr "これを実行すると、以下の通りプロンプトに移動します。"
+msgstr "これを実行すると、以下のようなプロンプトが表示されます。"
 
-#. type: Block title
+#. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:25
 #: source/server_installation/topics/manage.adoc:29
+#: source/server_admin/topics/identity-broker/oidc.adoc:50
 #, no-wrap
 msgid "Prompt"
 msgstr "プロンプト"
@@ -160,7 +161,7 @@ msgid ""
 "requests.  To do this, first execute the `embed` command with the config "
 "file you wish to change."
 msgstr ""
-"サーバーがアクティブではない間にスタンドアロンサーバと同じマシン上にコマンドが発行された場合は、サーバーをCLIに組み込み、着信要求を許可しない特殊モードに変更することができます。これを行うには、まず、変更したい設定ファイルで"
+"サーバーがアクティブではない間にスタンドアロン・サーバーと同じマシン上にコマンドが発行された場合は、サーバーをCLIに組み込み、受信要求を許可しない特殊モードに変更することができます。これを行うには、まず、変更したい設定ファイルで"
 " `embed` コマンドを実行します。"
 
 #. type: Block title

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__config-"
-"subsystem__start-cli.ja_JP.po\n"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:11
@@ -61,15 +62,13 @@ msgid ""
 "CLI allows you to configure servers locally or remotely.  And it is "
 "especially useful when combined with scripting."
 msgstr ""
-"設定の変更は、手作業だけでなく、 _jboss-cli_ toolツールを使用しコマンドを発行"
-"しても行うことできます。CLIを使用すると、サーバーをローカルまたはリモートで設"
-"定することもできます。スクリプティングと組み合わせると特に便利です。"
+"設定の変更は、手作業だけでなく、 _jboss-cli_ "
+"toolツールを使用しコマンドを発行しても行うことできます。CLIを使用すると、サーバーをローカルまたはリモートで設定することもできます。スクリプティングと組み合わせると特に便利です。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:10
 msgid "To start the {appserver_name} CLI, you need to run `jboss-cli`."
-msgstr ""
-"{appserver_name}CLIを起動するには、 `jboss-cli` を実行する必要があります。"
+msgstr "{appserver_name}CLIを起動するには、 `jboss-cli` を実行する必要があります。"
 
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:15
@@ -88,13 +87,8 @@ msgstr "> ...\\bin\\jboss-cli.bat\n"
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:24
 #: source/server_installation/topics/manage.adoc:28
-#, fuzzy
 msgid "This will bring you to a prompt like this:"
-msgstr ""
-"#-#-#-#-#  manage.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"これにより、以下のようなプロンプトが表示されます。\n"
-"#-#-#-#-#  start-cli.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"これにより、以下のようなプロンプトが表示されます。"
+msgstr "これを実行すると、以下の通りプロンプトに移動します。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:25
@@ -115,9 +109,7 @@ msgstr "[disconnected /]\n"
 msgid ""
 "If you wish to execute commands on a running server, you will first execute "
 "the `connect` command."
-msgstr ""
-"実行中のサーバーでコマンドを実行する場合、まず `connect` コマンドを実行しま"
-"す。"
+msgstr "実行中のサーバーでコマンドを実行する場合、まず `connect` コマンドを実行します。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:34
@@ -141,30 +133,17 @@ msgstr ""
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:46
 #: source/server_installation/topics/manage.adoc:49
-#, fuzzy
 msgid ""
 "You may be thinking to yourself, \"I didn't enter in any username or "
 "password!\".  If you run `jboss-cli` on the same machine as your running "
-"standalone server or domain controller and your account has appropriate file "
-"permissions, you do not have to setup or enter in a admin username and "
-"password.  See the link:{appserver_admindoc_link}[_{appserver_admindoc_name}"
-"_] for more details on how to make things more secure if you are "
-"uncomfortable with that setup."
+"standalone server or domain controller and your account has appropriate file"
+" permissions, you do not have to setup or enter in a admin username and "
+"password.  See the "
+"link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more details"
+" on how to make things more secure if you are uncomfortable with that setup."
 msgstr ""
-"#-#-#-#-#  manage.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"ユーザー名もパスワードも入力していない！と思っているかもしれませんが、 "
-"`jboss-cli` を実行中のスタンドアロン・サーバーまたはドメイン・コントローラー"
-"と同じマシンで実行し、アカウントに適切なファイルの許可がある場合は、管理者の"
-"ユーザー名とパスワードを設定または入力する必要はありません。この設定では心配"
-"でよりセキュアにしたい場合、詳しくはlink:{appserver_admindoc_link}"
-"[_{appserver_admindoc_name}_]をご覧ください。\n"
-"#-#-#-#-#  start-cli.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"ユーザー名もパスワードも入力していない！と思っているかもしれませんが、 "
-"`jboss-cli` を実行中のスタンドアロン・サーバーまたはドメイン・コントローラー"
-"と同じマシンで実行し、アカウントに適切なファイルの許可がある場合は、管理者の"
-"ユーザー名とパスワードを設定または入力する必要はありません。この設定では心配"
-"でよりセキュアにしたい場合、詳しくはlink:{appserver_admindoc_link}"
-"[_{appserver_admindoc_name}_]をご覧ください。"
+"ユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
+"を実行中のスタンドアロン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイルの許可がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
 
 #. type: Title ===
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:47
@@ -175,16 +154,14 @@ msgstr "CLI組み込みモード"
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:53
 msgid ""
-"If you do happen to be on the same machine as your standalone server and you "
-"want to issue commands while the server is not active, you can embed the "
+"If you do happen to be on the same machine as your standalone server and you"
+" want to issue commands while the server is not active, you can embed the "
 "server into CLI and make changes in a special mode that disallows incoming "
 "requests.  To do this, first execute the `embed` command with the config "
 "file you wish to change."
 msgstr ""
-"サーバーがアクティブではない間にスタンドアロンサーバと同じマシン上にコマンド"
-"が発行された場合は、サーバーをCLIに組み込み、着信要求を許可しない特殊モードに"
-"変更することができます。これを行うには、まず、変更したい設定ファイルで "
-"`embed` コマンドを実行します。"
+"サーバーがアクティブではない間にスタンドアロンサーバと同じマシン上にコマンドが発行された場合は、サーバーをCLIに組み込み、着信要求を許可しない特殊モードに変更することができます。これを行うには、まず、変更したい設定ファイルで"
+" `embed` コマンドを実行します。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:54
@@ -217,11 +194,7 @@ msgid ""
 "formatting your CLI commands and learning about the options available.  The "
 "GUI can also retrieve server logs from a local or remote server."
 msgstr ""
-"CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全"
-"体をグラフィカルに表示および編集できるSwingアプリケーションを起動します。GUI"
-"モードは、CLIコマンドの書式を設定したりオプションを調べる際のヘルプとして特に"
-"便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得すること"
-"もできます。"
+"CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションを起動します。GUIモードは、CLIコマンドの書式を設定したりオプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:69
@@ -241,21 +214,19 @@ msgid ""
 "_Note: to connect to a remote server, you pass the `--connect` option as "
 "well.  Use the --help option for more details._"
 msgstr ""
-"_Note: リモートサーバーに接続するには `--connect` オプションも渡します。詳し"
-"くは、 --helpオプションをご覧ください。_"
+"_Note: リモートサーバーに接続するには `--connect` オプションも渡します。詳しくは、 --helpオプションをご覧ください。_"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:81
 msgid ""
 "After launching GUI mode, you will probably want to scroll down to find the "
-"node, `subsystem=keycloak-server`.  If you right-click on the node and click "
-"`Explore subsystem=keycloak-server`, you will get a new tab that shows only "
-"the keycloak-server subsystem."
+"node, `subsystem=keycloak-server`.  If you right-click on the node and click"
+" `Explore subsystem=keycloak-server`, you will get a new tab that shows only"
+" the keycloak-server subsystem."
 msgstr ""
-"GUIモードを起動したら、スクロールダウンすると `subsystem=keycloak-server` "
-"ノードが見つかります。ノードを右クリックして `Explore subsystem=keycloak-"
-"server` をクリックすると、keycloak-serverサブシステムのみを表示する新しいタブ"
-"が表示されます。"
+"GUIモードを起動したら、スクロールダウンすると `subsystem=keycloak-server` ノードが見つかります。ノードを右クリックして "
+"`Explore subsystem=keycloak-server` をクリックすると、keycloak-"
+"serverサブシステムのみを表示する新しいタブが表示されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:83
@@ -275,9 +246,7 @@ msgid ""
 "with CLI commands in it.  Consider a simple script that turns off theme and "
 "template caching."
 msgstr ""
-"CLIには、さまざまなスクリプト機能があります。スクリプトはCLIコマンドを含む単"
-"なるテキストファイルです。テーマとテンプレートのキャッシュをオフにする簡単な"
-"スクリプトをみていきましょう。"
+"CLIには、さまざまなスクリプト機能があります。スクリプトはCLIコマンドを含む単なるテキストファイルです。テーマとテンプレートのキャッシュをオフにする簡単なスクリプトをみていきましょう。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:90
@@ -301,8 +270,7 @@ msgid ""
 "To execute the script, I can follow the `Scripts` menu in CLI GUI, or "
 "execute the script from the command line as follows:"
 msgstr ""
-"スクリプトを実行するには、CLI GUI の `Scripts` メニューに従う、または以下のよ"
-"うにコマンドラインからスクリプトを実行します。"
+"スクリプトを実行するには、CLI GUI の `Scripts` メニューに従う、または以下のようにコマンドラインからスクリプトを実行します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:101


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__config-subsystem__start-cli/ja_JP/index.html
