### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/boot.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/boot.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/boot.ja_JP.po
@@ -23,7 +23,6 @@ msgstr "サーバーの起動"
 
 #. type: Plain text
 #: source/getting_started/topics/first-boot/boot.adoc:5
-#, no-wrap
 msgid ""
 "To boot the {project_name} server, go to the _bin/_ directory of the server "
 "distribution."
@@ -40,7 +39,6 @@ msgstr "スタンンドアロン起動スクリプト"
 #: source/getting_started/topics/first-boot/boot.adoc:8
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:34
 #: source/server_installation/topics/operating-mode/standalone.adoc:17
-#, no-wrap
 msgid "image:{project_images}/standalone-boot-files.png[]"
 msgstr "image:{project_images}/standalone-boot-files.png[]"
 
@@ -49,7 +47,6 @@ msgstr "image:{project_images}/standalone-boot-files.png[]"
 #: source/server_installation/topics/operating-mode/domain.adoc:186
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:36
 #: source/server_installation/topics/operating-mode/standalone.adoc:19
-#, no-wrap
 msgid "To boot the server:"
 msgstr "サーバーを起動するには下記を実行します"
 

--- a/i18n/po/ja_JP/getting_started/topics/first-boot/boot.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/boot.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -24,12 +23,11 @@ msgstr "サーバーの起動"
 
 #. type: Plain text
 #: source/getting_started/topics/first-boot/boot.adoc:5
+#, no-wrap
 msgid ""
 "To boot the {project_name} server, go to the _bin/_ directory of the server "
 "distribution."
-msgstr ""
-"{project_name}サーバーを起動するには、サーバー配布物の _bin/_ ディレクトリに"
-"移動します。"
+msgstr "{project_name}サーバーを起動するには、サーバー配布物の _bin/_ ディレクトリに移動します。"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:6
@@ -42,6 +40,7 @@ msgstr "スタンンドアロン起動スクリプト"
 #: source/getting_started/topics/first-boot/boot.adoc:8
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:34
 #: source/server_installation/topics/operating-mode/standalone.adoc:17
+#, no-wrap
 msgid "image:{project_images}/standalone-boot-files.png[]"
 msgstr "image:{project_images}/standalone-boot-files.png[]"
 
@@ -50,17 +49,9 @@ msgstr "image:{project_images}/standalone-boot-files.png[]"
 #: source/server_installation/topics/operating-mode/domain.adoc:186
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:36
 #: source/server_installation/topics/operating-mode/standalone.adoc:19
-#, fuzzy
+#, no-wrap
 msgid "To boot the server:"
-msgstr ""
-"#-#-#-#-#  standalone-ha.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  domain.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  standalone.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  boot.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します"
+msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:11


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/boot.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__boot
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__first-boot__boot/ja_JP/index.html
