### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/overview.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/overview.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__overview."
-"ja_JP.po\n"
 
 #. type: Title ==
 #: source/server_installation/topics/overview.adoc:2
@@ -31,7 +32,8 @@ msgid ""
 " at runtime (standalone or domain mode), configure a shared database for {project_name} storage, set up encryption and HTTPS,\n"
 " and finally set up {project_name} to run in a cluster.  This guide walks through each and every aspect of any pre-boot\n"
 " decisions and setup you must do prior to deploying the server.\n"
-msgstr "このガイドは、{project_name}サーバーの初回起動の前に完了する必要があるいくつかの手順についてご説明するためのものです。{project_name}をテストしたいだけの場合は、組み込みのローカル専用のデータベースでそのまま実行する方がよいでしょう。実際にプロダクション環境にデプロイしたい場合は、まずどのようにランタイム（スタンドアロンまたはドメインモード）でサーバー設定を管理するか定義して、{project_name}の共有データベースを設定し、暗号化およびHTTPS設定を行い、最後に{project_name}をセットアップしてクラスター内で実行する必要があります。このガイドは、当サーバーをデプロイする前に、起動に先んじて定義および設定が必要なすべての手順を、ひとつひとつご説明していきます。\n"
+msgstr ""
+"このガイドは、{project_name}サーバーの初回起動の前に完了する必要があるいくつかの手順についてご説明するためのものです。{project_name}をテストしたいだけの場合は、組み込みのローカル専用のデータベースでそのまま実行する方がよいでしょう。実際にプロダクション環境にデプロイしたい場合は、まずどのようにランタイム（スタンドアロンまたはドメインモード）でサーバー設定を管理するか定義して、{project_name}の共有データベースを設定し、暗号化およびHTTPS設定を行い、最後に{project_name}をセットアップしてクラスター内で実行する必要があります。このガイドは、当サーバーをデプロイする前に、起動に先んじて定義および設定が必要なすべての手順を、ひとつひとつご説明していきます。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/overview.adoc:15
@@ -42,7 +44,4 @@ msgid ""
 "Often this guide will direct you to documentation outside of the manual if "
 "you want to dive into more detail."
 msgstr ""
-"ただし、{project_name}は{appserver_name}アプリケーション・サーバーに基づいて"
-"いて、{project_name}の設定は{appserver_name}の設定項目と密接に関わっていま"
-"す。そのためこのガイドでは、詳細の説明について、このチュートリアルとは別の外"
-"部ドキュメントをご紹介することがあります。その点はご留意ください。"
+"ただし、{project_name}は{appserver_name}アプリケーション・サーバーに基づいていて、{project_name}の設定は{appserver_name}の設定項目と密接に関わっています。そのためこのガイドでは、詳細の説明について、このチュートリアルとは別の外部ドキュメントをご紹介することがあります。その点はご留意ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__overview/ja_JP/index.html
