### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__network__https.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/network/https.adoc:2
 #, no-wrap
 msgid "Setting up HTTPS/SSL"
-msgstr ""
+msgstr "HTTPS/SSLの設定"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:6
@@ -28,113 +29,122 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーの代わりにリバースプロキシ上、このいずれかでSSLを有効にすることを強くおすすめします。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:9
 msgid ""
 "This default behavior is defined by the SSL/HTTPS mode of each "
-"{project_name} realm.  This is discussed in more detail in the link:"
-"{adminguide_link}[{adminguide_name}], but let's give some context and a "
-"brief overview of these modes."
+"{project_name} realm.  This is discussed in more detail in the "
+"link:{adminguide_link}[{adminguide_name}], but let's give some context and a"
+" brief overview of these modes."
 msgstr ""
+"このデフォルトの動作は、各{project_name}レルムのSSL/HTTPSモードによって定義されています。これについて詳しくはlink:{adminguide_link}[{adminguide_name}]でご"
+" 説明しますが、これらのモードの関連事項と簡単な概要についてはここに示します。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:10
 #: source/server_admin/topics/realms/ssl.adoc:19
 #, no-wrap
 msgid "external requests"
-msgstr ""
+msgstr "external requests"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:13
 msgid ""
 "{project_name} can run out of the box without SSL so long as you stick to "
-"private IP addresses like `localhost`, `127.0.0.1`, `10.0.x.x`, `192.168.x."
-"x`, and `172..16.x.x`.  If you don’t have SSL/HTTPS configured on the server "
-"or you try to access {project_name} over HTTP from a non-private IP adress "
-"you will get an error."
+"private IP addresses like `localhost`, `127.0.0.1`, `10.0.x.x`, "
+"`192.168.x.x`, and `172..16.x.x`.  If you don’t have SSL/HTTPS configured on"
+" the server or you try to access {project_name} over HTTP from a non-private"
+" IP adress you will get an error."
 msgstr ""
+"SSLが無効でも、 `localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 "
+"`172..16.x.x` "
+"のようなプライベートIPアドレス以外であれば、{project_name}をそのまま実行することは可能です。サーバにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスする場合はエラーになります。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:14
 #: source/server_admin/topics/realms/ssl.adoc:23
 #, no-wrap
 msgid "none"
-msgstr ""
+msgstr "none"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:16
 msgid ""
 "{project_name} does not require SSL.  This should really only be used in "
 "development when you are playing around with things."
-msgstr ""
+msgstr "{project_name}はSSLが必要なわけではありません。開発段階でいろいろといじっている時にのみ使用されるものです。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:17
 #: source/server_admin/topics/realms/ssl.adoc:27
 #, no-wrap
 msgid "all requests"
-msgstr ""
+msgstr "all requests"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:19
 #: source/server_admin/topics/realms/ssl.adoc:28
 msgid "{project_name} requires SSL for all IP addresses."
-msgstr ""
+msgstr "{project_name}では、すべてのIPアドレス用のSSLが必要です。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:21
 msgid ""
 "The SSL mode for each realm can be configured in the {project_name} admin "
 "console."
-msgstr ""
+msgstr "各レルム用のSSLモードは、{project_name}管理コンソール内で設定できます。"
 
 #. type: Title ====
 #: source/server_installation/topics/network/https.adoc:22
 #, no-wrap
 msgid "Enabling SSL/HTTPS for the {project_name} Server"
-msgstr ""
+msgstr "{project_name}サーバー用SSL/HTTPSの有効化"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:26
 msgid ""
 "If you are not using a reverse proxy or load balancer to handle HTTPS "
-"traffic for you, you'll need to enable HTTPS for the {project_name} server.  "
-"This involves"
+"traffic for you, you'll need to enable HTTPS for the {project_name} server."
+"  This involves"
 msgstr ""
+"HTTPSトラフィックを処理するためにリバースプロキシまたはロードバランサーを使用していない場合、{project_name}サーバ用にHTTPSを有効にする必要があります。これには下記が含まれます。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:28
 msgid ""
 "Obtaining or generating a keystore that contains the private key and "
 "certificate for SSL/HTTP traffic"
-msgstr ""
+msgstr "SSL/HTTPトラフィック用の秘密鍵と証明書を含むキーストアの取得または生成"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:29
 msgid ""
 "Configuring the {project_name} server to use this keypair and certificate."
-msgstr ""
+msgstr "このキーペアと証明書を使用するための{project_name}サーバー設定"
 
 #. type: Title =====
 #: source/server_installation/topics/network/https.adoc:30
 #, no-wrap
 msgid "Creating the Certificate and Java Keystore"
-msgstr ""
+msgstr "証明書とJavaキーストアの作成"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:33
 msgid ""
 "In order to allow HTTPS connections, you need to obtain a self signed or "
-"third-party signed certificate and import it into a Java keystore before you "
-"can enable HTTPS in the web container you are deploying the {project_name} "
+"third-party signed certificate and import it into a Java keystore before you"
+" can enable HTTPS in the web container you are deploying the {project_name} "
 "Server to."
 msgstr ""
+"HTTPS接続が許可されるには、{project_name}サーバーがデプロイされているwebコンテナ内でHTTPSを有効にする前に、自己署名証明書または第三者署名証明書を取得してJavaキーストアにインポートする必要があります。"
 
-#. type: Plain text
-#: source/server_installation/topics/network/https.adoc:35
-msgid "====== Self Signed Certificate"
-msgstr ""
+#. type: Title ======
+#: source/server_installation/topics/network/https.adoc:34
+#, no-wrap
+msgid "Self Signed Certificate"
+msgstr "Self Signed Certificate"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:38
@@ -143,6 +153,8 @@ msgid ""
 "available to test a {project_name} deployment so you'll need to generate a "
 "self-signed one using the `keytool` utility that comes with the Java JDK."
 msgstr ""
+"開発段階で、{project_name}の構成をテストするための第三者署名証明書を用意していない場合、JavaJDKに付属する `keytool` "
+"ユーティリティーを使用して自己署名証明書を生成する必要があります。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:60
@@ -166,42 +178,68 @@ msgid ""
 "    Is CN=localhost, OU=Keycloak, O=Test, L=Westford, ST=MA, C=US correct?\n"
 "    [no]:  yes\n"
 msgstr ""
+"$ keytool -genkey -alias localhost -keyalg RSA -keystore keycloak.jks -validity 10950\n"
+" Enter keystore password: secret\n"
+" Re-enter new password: secret\n"
+" What is your first and last name?\n"
+" [Unknown]: localhost\n"
+" What is the name of your organizational unit?\n"
+" [Unknown]: Keycloak\n"
+" What is the name of your organization?\n"
+" [Unknown]: Red Hat\n"
+" What is the name of your City or Locality?\n"
+" [Unknown]: Westford\n"
+" What is the name of your State or Province?\n"
+" [Unknown]: MA\n"
+" What is the two-letter country code for this unit?\n"
+" [Unknown]: US\n"
+" Is CN=localhost, OU=Keycloak, O=Test, L=Westford, ST=MA, C=US correct?\n"
+" [no]: yes\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:65
 msgid ""
-"You should answer `What is your first and last name ?` question with the DNS "
-"name of the machine you're installing the server on.  For testing purposes, "
-"`localhost` should be used.  After executing this command, the `keycloak."
-"jks` file will be generated in the same directory as you executed the "
-"`keytool` command in."
+"You should answer `What is your first and last name ?` question with the DNS"
+" name of the machine you're installing the server on.  For testing purposes,"
+" `localhost` should be used.  After executing this command, the "
+"`keycloak.jks` file will be generated in the same directory as you executed "
+"the `keytool` command in."
 msgstr ""
+"サーバーをインストールしたマシンのDNS名で、 `What is your first and last name ?` "
+"という質問に答える必要があります。 テストが目的なので、 `localhost` を使用する必要があります。このコマンドを実行すると、 "
+"`keytool` コマンドが実行されたのと同じディレクトリ内で `keycloak.jks` ファイルが生成されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:68
 msgid ""
 "If you want a third-party signed certificate, but don't have one, you can "
-"obtain one for free at http://www.cacert.org[cacert.org].  You'll have to do "
-"a little set up first before doing this though."
+"obtain one for free at http://www.cacert.org[cacert.org].  You'll have to do"
+" a little set up first before doing this though."
 msgstr ""
+"第三者署名証明書が必要だが用意していない場合、http://www.cacert.org[cacert.org]で無料で取得することができます。しかしこの方法で取得する前に、少し設定が必要になります。"
+" "
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:70
 msgid "The first thing to do is generate a Certificate Request:"
-msgstr ""
+msgstr "まず、証明書リクエストを生成します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:75
 #, no-wrap
-msgid "$ keytool -certreq -alias yourdomain -keystore keycloak.jks > keycloak.careq\n"
+msgid ""
+"$ keytool -certreq -alias yourdomain -keystore keycloak.jks > "
+"keycloak.careq\n"
 msgstr ""
+"$ keytool -certreq -alias yourdomain -keystore keycloak.jks > "
+"keycloak.careq\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:79
 msgid ""
 "Where `yourdomain` is a DNS name for which this certificate is generated "
 "for.  Keytool generates the request:"
-msgstr ""
+msgstr "`yourdomain` はこの証明書が生成されるDNS名になります。Keytoolによってリクエストが生成されます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:98
@@ -223,57 +261,81 @@ msgid ""
 "vqIFQeuLL3BaHwpl3t7j2lMWcK1p80laAxEASib/fAwrRHpLHBXRcq6uALUOZl4Alt8=\n"
 "-----END NEW CERTIFICATE REQUEST-----\n"
 msgstr ""
+"-----BEGIN NEW CERTIFICATE REQUEST-----\n"
+"MIIC2jCCAcICAQAwZTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAk1BMREwDwYDVQQHEwhXZXN0Zm9y\n"
+"ZDEQMA4GA1UEChMHUmVkIEhhdDEQMA4GA1UECxMHUmVkIEhhdDESMBAGA1UEAxMJbG9jYWxob3N0\n"
+"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr7kck2TaavlEOGbcpi9c0rncY4HhdzmY\n"
+"Ax2nZfq1eZEaIPqI5aTxwQZzzLDK9qbeAd8Ji79HzSqnRDxNYaZu7mAYhFKHgixsolE3o5Yfzbw1\n"
+"29RvyeUVe+WZxv5oo9wolVVpdSINIMEL2LaFhtX/c1dqiqYVpfnvFshZQaIg2nL8juzZcBjj4as\n"
+"H98gIS7khql/dkZKsw9NLvyxgJvp7PaXurX29fNf3ihG+oFrL22oFyV54BWWxXCKU/GPn61EGZGw\n"
+"Ft2qSIGLdctpMD1aJR2bcnlhEjZKDksjQZoQ5YMXaAGkcYkG6QkgrocDE2YXDbi7GIdf9MegVJ35\n"
+"2DQMpwIDAQABoDAwLgYJKoZIhvcNAQkOMSEwHzAdBgNVHQ4EFgQUQwlZJBA+fjiDdiVzaO9vrE/i\n"
+"n2swDQYJKoZIhvcNAQELBQADggEBAC5FRvMkhal3q86tHPBYWBuTtmcSjs4qUm6V6f63frhveWHf\n"
+"PzRrI1xH272XUIeBk0gtzWo0nNZnf0mMCtUBbHhhDcG82xolikfqibZijoQZCiGiedVjHJFtniDQ\n"
+"9bMDUOXEMQ7gHZg5q6mJfNG9MbMpQaUVEEFvfGEQQxbiFK7hRWU8S23/d80e8nExgQxdJWJ6vd0X\n"
+"MzzFK6j4Dj55bJVuM7GFmfdNC52pNOD5vYe47Aqh8oajHX9XTycVtPXl45rrWAH33ftbrS8SrZ2S\n"
+"vqIFQeuLL3BaHwpl3t7j2lMWcK1p80laAxEASib/fAwrRHpLHBXRcq6uALUOZl4Alt8=\n"
+"-----END NEW CERTIFICATE REQUEST-----\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:104
 msgid ""
-"Send this ca request to your CA.  The CA will issue you a signed certificate "
-"and send it to you.  Before you import your new cert, you must obtain and "
+"Send this ca request to your CA.  The CA will issue you a signed certificate"
+" and send it to you.  Before you import your new cert, you must obtain and "
 "import the root certificate of the CA.  You can download the cert from CA "
 "(ie.: root.crt) and import as follows:"
 msgstr ""
+"このcaリクエストをCAに送信します。CAは署名された証明書を発行し、送信します。ただし、新しい証明書をインポートする前に、まずCAのルート証明書を取得してインポートする必要があります。CAからルート証明書と署名証明書をダウンロードし、以下の通りインポートします。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:109
 #, no-wrap
 msgid "$ keytool -import -keystore keycloak.jks -file root.crt -alias root\n"
-msgstr ""
+msgstr "$ keytool -import -keystore keycloak.jks -file root.crt -alias root\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:112
 msgid ""
 "Last step is to import your new CA generated certificate to your keystore:"
-msgstr ""
+msgstr "最後に、新しいCA生成証明書をキーストアにインポートします。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:117
 #, no-wrap
-msgid "$ keytool -import -alias yourdomain -keystore keycloak.jks -file your-certificate.cer\n"
+msgid ""
+"$ keytool -import -alias yourdomain -keystore keycloak.jks -file your-"
+"certificate.cer\n"
 msgstr ""
+"$ keytool -import -alias yourdomain -keystore keycloak.jks -file your-"
+"certificate.cer\n"
 
 #. type: Title =====
 #: source/server_installation/topics/network/https.adoc:119
 #, no-wrap
 msgid "Configure {project_name} to Use the Keystore"
-msgstr ""
+msgstr "キーストアを使用できるように{project_name}を設定します。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:124
 msgid ""
 "Now that you have a Java keystore with the appropriate certificates, you "
-"need to configure your {project_name} installation to use it.  First step is "
-"to move the keystore file to the _configuration/_ directory of your "
-"deployment and to edit the _standalone.xml_, _standalone-ha.xml_ or _domain."
-"xml_ file to use the keystore and enable HTTPS.  (See <<_operating-mode, "
-"operating mode>>)."
+"need to configure your {project_name} installation to use it.  First step is"
+" to move the keystore file to the _configuration/_ directory of your "
+"deployment and to edit the _standalone.xml_, _standalone-ha.xml_ or "
+"_domain.xml_ file to use the keystore and enable HTTPS.  (See <<_operating-"
+"mode, operating mode>>)."
 msgstr ""
+"適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}インストールを設定する必要があります。まず、キーストアファイルを"
+" _configuration/_ ディレクトリ構成に移動し、 _standalone.xml_ 、 _standalone-ha.xml_ または "
+"_domain.xml_ ファイルを編集し、キーストアを使用してHTTPSを有効にします。<<_operating-mode, operating "
+"mode>>をご参照ください。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:126
 msgid ""
 "In the standalone or domain configuration file, search for the `security-"
 "realms` element and add:"
-msgstr ""
+msgstr "スタンドアロンまたはドメイン設定ファイル内で、 `security-realms` 要素を検索して以下を追加します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:137
@@ -287,6 +349,13 @@ msgid ""
 "    </server-identities>\n"
 "</security-realm>\n"
 msgstr ""
+"<security-realm name=\"UndertowRealm\">\n"
+" <server-identities>\n"
+" <ssl>\n"
+" <keystore path=\"keycloak.jks\" relative-to=\"jboss.server.config.dir\" keystore-password=\"secret\" />\n"
+" </ssl>\n"
+" </server-identities>\n"
+"</security-realm>\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:140
@@ -294,6 +363,8 @@ msgid ""
 "Find the element `server name=\"default-server\"` (it's a child element of "
 "`subsystem xmlns=\"{subsystem_undertow_xml_urn}\"`) and add:"
 msgstr ""
+"`server name=\"default-server\"` 要素、 `subsystem "
+"xmlns=\"{subsystem_undertow_xml_urn}\"` の子要素のことですが、を検索して以下を追加します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:149
@@ -306,3 +377,9 @@ msgid ""
 "   ...\n"
 "</subsystem>\n"
 msgstr ""
+"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
+" <buffer-cache name=\"default\"/>\n"
+" <server name=\"default-server\">\n"
+" <https-listener name=\"https\" socket-binding=\"https\" security-realm=\"UndertowRealm\"/>\n"
+" ...\n"
+"</subsystem>\n"

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーの代わりにリバースプロキシ上、このいずれかでSSLを有効にすることを強くおすすめします。\n"
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くおすすめします。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:9
@@ -39,8 +39,7 @@ msgid ""
 "link:{adminguide_link}[{adminguide_name}], but let's give some context and a"
 " brief overview of these modes."
 msgstr ""
-"このデフォルトの動作は、各{project_name}レルムのSSL/HTTPSモードによって定義されています。これについて詳しくはlink:{adminguide_link}[{adminguide_name}]でご"
-" 説明しますが、これらのモードの関連事項と簡単な概要についてはここに示します。"
+"このデフォルトの動作は、各{project_name}レルムのSSL/HTTPSモードによって定義されています。これについて詳しくはlink:{adminguide_link}[{adminguide_name}]でご説明しますが、これらのモードの関連事項と簡単な概要についてはここで示します。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:10
@@ -74,7 +73,7 @@ msgstr "none"
 msgid ""
 "{project_name} does not require SSL.  This should really only be used in "
 "development when you are playing around with things."
-msgstr "{project_name}はSSLが必要なわけではありません。開発段階でいろいろといじっている時にのみ使用されるものです。"
+msgstr "{project_name}はSSLを要求しません。この設定は、開発段階でいろいろといじっている時にのみ使用すべきです。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:17
@@ -87,7 +86,7 @@ msgstr "all requests"
 #: source/server_installation/topics/network/https.adoc:19
 #: source/server_admin/topics/realms/ssl.adoc:28
 msgid "{project_name} requires SSL for all IP addresses."
-msgstr "{project_name}では、すべてのIPアドレス用のSSLが必要です。"
+msgstr "{project_name}はすべてのIPアドレスに対してSSLを要求します。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:21
@@ -109,7 +108,7 @@ msgid ""
 "traffic for you, you'll need to enable HTTPS for the {project_name} server."
 "  This involves"
 msgstr ""
-"HTTPSトラフィックを処理するためにリバースプロキシまたはロードバランサーを使用していない場合、{project_name}サーバ用にHTTPSを有効にする必要があります。これには下記が含まれます。"
+"HTTPSトラフィックを処理するためにリバースプロキシまたはロードバランサーを使用していない場合、{project_name}サーバー用にHTTPSを有効にする必要があります。これには下記が含まれます。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:28
@@ -144,7 +143,7 @@ msgstr ""
 #: source/server_installation/topics/network/https.adoc:34
 #, no-wrap
 msgid "Self Signed Certificate"
-msgstr "Self Signed Certificate"
+msgstr "自己署名証明書"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:38
@@ -153,7 +152,7 @@ msgid ""
 "available to test a {project_name} deployment so you'll need to generate a "
 "self-signed one using the `keytool` utility that comes with the Java JDK."
 msgstr ""
-"開発段階で、{project_name}の構成をテストするための第三者署名証明書を用意していない場合、JavaJDKに付属する `keytool` "
+"開発段階で、{project_name}の構成をテストするための第三者署名証明書を用意していない場合、Java JDKに付属する `keytool` "
 "ユーティリティーを使用して自己署名証明書を生成する必要があります。"
 
 #. type: delimited block -
@@ -179,22 +178,22 @@ msgid ""
 "    [no]:  yes\n"
 msgstr ""
 "$ keytool -genkey -alias localhost -keyalg RSA -keystore keycloak.jks -validity 10950\n"
-" Enter keystore password: secret\n"
-" Re-enter new password: secret\n"
-" What is your first and last name?\n"
-" [Unknown]: localhost\n"
-" What is the name of your organizational unit?\n"
-" [Unknown]: Keycloak\n"
-" What is the name of your organization?\n"
-" [Unknown]: Red Hat\n"
-" What is the name of your City or Locality?\n"
-" [Unknown]: Westford\n"
-" What is the name of your State or Province?\n"
-" [Unknown]: MA\n"
-" What is the two-letter country code for this unit?\n"
-" [Unknown]: US\n"
-" Is CN=localhost, OU=Keycloak, O=Test, L=Westford, ST=MA, C=US correct?\n"
-" [no]: yes\n"
+"    Enter keystore password: secret\n"
+"    Re-enter new password: secret\n"
+"    What is your first and last name?\n"
+"    [Unknown]:  localhost\n"
+"    What is the name of your organizational unit?\n"
+"    [Unknown]:  Keycloak\n"
+"    What is the name of your organization?\n"
+"    [Unknown]:  Red Hat\n"
+"    What is the name of your City or Locality?\n"
+"    [Unknown]:  Westford\n"
+"    What is the name of your State or Province?\n"
+"    [Unknown]:  MA\n"
+"    What is the two-letter country code for this unit?\n"
+"    [Unknown]:  US\n"
+"    Is CN=localhost, OU=Keycloak, O=Test, L=Westford, ST=MA, C=US correct?\n"
+"    [no]:  yes\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:65
@@ -205,9 +204,9 @@ msgid ""
 "`keycloak.jks` file will be generated in the same directory as you executed "
 "the `keytool` command in."
 msgstr ""
-"サーバーをインストールしたマシンのDNS名で、 `What is your first and last name ?` "
-"という質問に答える必要があります。 テストが目的なので、 `localhost` を使用する必要があります。このコマンドを実行すると、 "
-"`keytool` コマンドが実行されたのと同じディレクトリ内で `keycloak.jks` ファイルが生成されます。"
+"`What is your first and last name ?` という質問にはサーバーをインストールしたマシンのDNS名を答えてください。 "
+"テスト目的なので、 `localhost` を使用します。このコマンドを実行すると、 `keytool` コマンドが実行されたのと同じディレクトリ内で "
+"`keycloak.jks` ファイルが生成されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:68
@@ -222,7 +221,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:70
 msgid "The first thing to do is generate a Certificate Request:"
-msgstr "まず、証明書リクエストを生成します。"
+msgstr "まず、証明書署名要求を生成します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:75
@@ -239,7 +238,7 @@ msgstr ""
 msgid ""
 "Where `yourdomain` is a DNS name for which this certificate is generated "
 "for.  Keytool generates the request:"
-msgstr "`yourdomain` はこの証明書が生成されるDNS名になります。Keytoolによってリクエストが生成されます。"
+msgstr "`yourdomain` はこの証明書が生成されるDNS名になります。Keytoolにより以下のように生成されます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:98
@@ -285,7 +284,7 @@ msgid ""
 "import the root certificate of the CA.  You can download the cert from CA "
 "(ie.: root.crt) and import as follows:"
 msgstr ""
-"このcaリクエストをCAに送信します。CAは署名された証明書を発行し、送信します。ただし、新しい証明書をインポートする前に、まずCAのルート証明書を取得してインポートする必要があります。CAからルート証明書と署名証明書をダウンロードし、以下の通りインポートします。"
+"この証明書署名要求を認証局に送信します。認証局は署名された証明書を発行し、送り返します。ただし、新しい証明書をインポートする前に、まず認証局のルート証明書を取得してインポートする必要があります。認証局からルート証明書（例：root.crt）をダウンロードし、以下のとおりインポートします。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:109
@@ -297,7 +296,7 @@ msgstr "$ keytool -import -keystore keycloak.jks -file root.crt -alias root\n"
 #: source/server_installation/topics/network/https.adoc:112
 msgid ""
 "Last step is to import your new CA generated certificate to your keystore:"
-msgstr "最後に、新しいCA生成証明書をキーストアにインポートします。"
+msgstr "最後に、以下のように新しい認証局の生成した証明書をキーストアにインポートします。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:117
@@ -313,7 +312,7 @@ msgstr ""
 #: source/server_installation/topics/network/https.adoc:119
 #, no-wrap
 msgid "Configure {project_name} to Use the Keystore"
-msgstr "キーストアを使用できるように{project_name}を設定します。"
+msgstr "キーストアを使用するための{project_name}設定"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:124
@@ -325,10 +324,10 @@ msgid ""
 "_domain.xml_ file to use the keystore and enable HTTPS.  (See <<_operating-"
 "mode, operating mode>>)."
 msgstr ""
-"適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}インストールを設定する必要があります。まず、キーストアファイルを"
-" _configuration/_ ディレクトリ構成に移動し、 _standalone.xml_ 、 _standalone-ha.xml_ または "
-"_domain.xml_ ファイルを編集し、キーストアを使用してHTTPSを有効にします。<<_operating-mode, operating "
-"mode>>をご参照ください。"
+"適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}を設定する必要があります。まず、キーストアファイルを"
+" _configuration/_ ディレクトリ構成に移動し、キーストアを使用するように _standalone.xml_ 、 _standalone-"
+"ha.xml_ または _domain.xml_ ファイルを編集し、HTTPSを有効にします（<<_operating-mode, "
+"動作モード>>をご参照ください）。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:126
@@ -350,11 +349,11 @@ msgid ""
 "</security-realm>\n"
 msgstr ""
 "<security-realm name=\"UndertowRealm\">\n"
-" <server-identities>\n"
-" <ssl>\n"
-" <keystore path=\"keycloak.jks\" relative-to=\"jboss.server.config.dir\" keystore-password=\"secret\" />\n"
-" </ssl>\n"
-" </server-identities>\n"
+"    <server-identities>\n"
+"        <ssl>\n"
+"            <keystore path=\"keycloak.jks\" relative-to=\"jboss.server.config.dir\" keystore-password=\"secret\" />\n"
+"        </ssl>\n"
+"    </server-identities>\n"
 "</security-realm>\n"
 
 #. type: Plain text
@@ -363,8 +362,8 @@ msgid ""
 "Find the element `server name=\"default-server\"` (it's a child element of "
 "`subsystem xmlns=\"{subsystem_undertow_xml_urn}\"`) and add:"
 msgstr ""
-"`server name=\"default-server\"` 要素、 `subsystem "
-"xmlns=\"{subsystem_undertow_xml_urn}\"` の子要素のことですが、を検索して以下を追加します。"
+"`server name=\"default-server\"` 要素（ `subsystem "
+"xmlns=\"{subsystem_undertow_xml_urn}\"` の子要素）を検索して以下を追加します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/network/https.adoc:149
@@ -378,8 +377,8 @@ msgid ""
 "</subsystem>\n"
 msgstr ""
 "<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
-" <buffer-cache name=\"default\"/>\n"
-" <server name=\"default-server\">\n"
-" <https-listener name=\"https\" socket-binding=\"https\" security-realm=\"UndertowRealm\"/>\n"
-" ...\n"
+"   <buffer-cache name=\"default\"/>\n"
+"   <server name=\"default-server\">\n"
+"      <https-listener name=\"https\" socket-binding=\"https\" security-realm=\"UndertowRealm\"/>\n"
+"   ...\n"
 "</subsystem>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__network__https/ja_JP/index.html
