### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -15,6 +15,14 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Title ===
+#: source/securing_apps/topics/oidc/oidc-generic.adoc:134
+#: source/securing_apps/topics/client-registration.adoc:126
+#: source/server_development/topics/admin-rest-api.adoc:13
+#, no-wrap
+msgid "Example using CURL"
+msgstr "CURLを使用した例"
+
 #. type: Title ==
 #: source/securing_apps/topics/client-registration.adoc:2
 #, no-wrap
@@ -29,9 +37,7 @@ msgid ""
 " console (or admin REST endpoints), but clients can also register themselves"
 " through the {project_name} client registration service."
 msgstr ""
-"{project_name}をアプリケーションまたはサービスで使用するには、{project_name}にクライアントを登録する必要があります。管理者は管理コンソール（または"
-" "
-"管理RESTエンドポイント）にて登録できますが、クライアント自身でも{project_name}クライアント登録サービスにおいて登録することはできます。"
+"{project_name}をアプリケーションまたはサービスで使用するには、{project_name}にクライアントを登録する必要があります。管理者は管理コンソール（または管理RESTエンドポイント）にて登録できますが、クライアント自身でも{project_name}クライアント登録サービスにおいて登録することはできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:10
@@ -54,7 +60,7 @@ msgstr "サポートされている組み込みの `providers` は以下のと�
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:14
 msgid "default - {project_name} Client Representation (JSON)"
-msgstr "default - {project_name}クライアント形式（JSON）"
+msgstr "default - {project_name} Client Representation（JSON）"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:15
@@ -132,17 +138,17 @@ msgid ""
 "token from a Service Account with only the `create-client` role (see "
 "link:{adminguide_link}[{adminguide_name}] for more details)."
 msgstr ""
-"クライアントを作成するためにベアラー・トークンを使用する場合、`create-"
-"client`ロールのみを持つサービス・アカウントのトークンを使用することをおすすめします（詳細については、link:{adminguide_link}[{adminguide_name}]を参照して下さい）。"
+"クライアントを作成するためにベアラー・トークンを使用する場合、 `create-client` "
+"ロールのみを持つサービス・アカウントのトークンを使用することをおすすめします（詳細については、link:{adminguide_link}[{adminguide_name}]を参照して下さい）。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:35
+#: source/securing_apps/topics/client-registration.adoc:36
 #, no-wrap
 msgid "Initial Access Token"
 msgstr "初期アクセス・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:39
+#: source/securing_apps/topics/client-registration.adoc:40
 msgid ""
 "The recommended approach to registering new clients is by using initial "
 "access tokens.  An initial access token can only be used to create clients "
@@ -152,7 +158,7 @@ msgstr ""
 "新しいクライアントを登録するための推奨される方法は、初期アクセス・トークンを使用することです。初期アクセス・トークンは、クライアントを作成する場合にのみ使用でき、有効期限が設定できるだけでなく、クライアントを作成可能な回数の上限も設定できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:43
+#: source/securing_apps/topics/client-registration.adoc:44
 msgid ""
 "An initial access token can be created through the admin console.  To create"
 " a new initial access token first select the realm in the admin console, "
@@ -160,12 +166,12 @@ msgid ""
 "Registration` in the tabs displayed in the page. Then finally click on "
 "`Initial Access Tokens` sub-tab."
 msgstr ""
-"初期アクセス・トークンは、管理コンソールで作成できます。新たに初期アクセス・トークンを作成するには、まず管理者コンソールでレルムを選択し、左側のメニューの"
+"初期アクセス・トークンは、管理コンソールで作成できます。新たに初期アクセス・トークンを作成するには、まず管理コンソールでレルムを選択し、左側のメニューの"
 " `Realm Settings` 、続いてページに表示されるタブの `Client Registration` をクリックします。そして、最後に "
 "`Initial Access Tokens` のサブ・タブをクリックします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:47
+#: source/securing_apps/topics/client-registration.adoc:48
 msgid ""
 "You will now be able to see any existing initial access tokens. If you have "
 "access you can delete tokens that are no longer required. You can only "
@@ -174,13 +180,13 @@ msgid ""
 "should be valid, also how many clients can be created using the token. After"
 " you click on `Save` the token value is displayed."
 msgstr ""
-"既存の初期アクセス・トークンを参照できるようになります。アクセスできる場合は、不要になったトークンを削除できます。トークンを作成するときは、トークンの値だけを取得できます。"
+"これにより既存の初期アクセス・トークンを参照できるようになります。アクセスできる場合は、不要になったトークンを削除できます。トークン作成時のみその値を取得できます。"
 " `Create` "
 "をクリックして新しいトークンを作成します。必要に応じてトークンの有効期間や、トークンを使用して作成することができるクライアント数を追加できます。 "
 "`Save` をクリックすると、トークンの値が表示されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:49
+#: source/securing_apps/topics/client-registration.adoc:50
 msgid ""
 "It is important that you copy/paste this token now as you won't be able to "
 "retrieve it later. If you forget to copy/paste it, then delete the token and"
@@ -189,7 +195,7 @@ msgstr ""
 "後でトークンを取得することはできないので、このトークンをコピー/ペーストすることが重要です。コピー/ペーストすることを忘れた場合は、そのトークンを削除し、別のトークンを1つを作成して下さい。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:52
+#: source/securing_apps/topics/client-registration.adoc:53
 msgid ""
 "The token value is used as a standard bearer token when invoking the Client "
 "Registration Services, by adding it to the Authorization header in the "
@@ -199,19 +205,19 @@ msgstr ""
 " 例えば:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:56
+#: source/securing_apps/topics/client-registration.adoc:57
 #, no-wrap
 msgid "Authorization: bearer eyJhbGciOiJSUz...\n"
 msgstr "Authorization: bearer eyJhbGciOiJSUz...\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:58
+#: source/securing_apps/topics/client-registration.adoc:59
 #, no-wrap
 msgid "Registration Access Token"
 msgstr "登録アクセス・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:64
+#: source/securing_apps/topics/client-registration.adoc:65
 msgid ""
 "When you create a client through the Client Registration Service the "
 "response will include a registration access token.  The registration access "
@@ -224,7 +230,7 @@ msgstr ""
 "クライアント登録サービスを介してクライアントを作成するとき、レスポンスには登録アクセス・トークンが含まれます。登録アクセス・トークンは、クライアント設定を取得するだけでなく、更新や削除のために、クライアントへのアクセスを提供します。登録アクセス・トークンは、ベアラー・トークンや初期のアクセス・トークンと同じ方法でリクエストに含まれます。登録アクセス・トークンは、新しいトークンを含むレスポンスを使用する場合に一度だけ有効です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:68
+#: source/securing_apps/topics/client-registration.adoc:69
 msgid ""
 "If a client was created outside of the Client Registration Service it won't "
 "have a registration access token associated with it.  You can create one "
@@ -237,13 +243,13 @@ msgstr ""
 " `Credentials` をクリックします。そして、 `Generate registration access token` をクリックします。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:69
+#: source/securing_apps/topics/client-registration.adoc:70
 #, no-wrap
 msgid "{project_name} Representations"
 msgstr "{project_name} Representations"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:74
+#: source/securing_apps/topics/client-registration.adoc:75
 msgid ""
 "The `default` client registration provider can be used to create, retrieve, "
 "update and delete a client.  It uses {project_name} Client Representation "
@@ -255,16 +261,16 @@ msgstr ""
 "クライアント登録プロバイダーは、クライアントを作成、取得、更新、削除するために使用できます。管理コンソールでの設定と同等なクライアント設定機能のサポートを提供する{project_name}クライアント表現形式を使用します（例えば、プロトコル・マッパーの設定などを含む）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:76
+#: source/securing_apps/topics/client-registration.adoc:77
 msgid ""
-"To create a client create a Client Representation (JSON) then do a HTTP POST"
-" to `/realms/<realm>/clients-registrations/default`."
+"To create a client create a Client Representation (JSON) then perform an "
+"HTTP POST request to `/realms/<realm>/clients-registrations/default`."
 msgstr ""
-"クライアントを作成するには、クライアント表現（JSON）を作成し、 `/realms/<realm>/clients-"
-"registrations/default` に、HTTP POSTリクエストを送信します。"
+"クライアントを作成するには、クライアント表現(JSON)を作成し、HTTP POSTリクエストを `/realms/<realm>/clients-"
+"registrations/default` に送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:79
+#: source/securing_apps/topics/client-registration.adoc:80
 msgid ""
 "It will return a Client Representation that also includes the registration "
 "access token.  You should save the registration access token somewhere if "
@@ -273,47 +279,47 @@ msgstr ""
 "登録アクセス・トークンを含むクライアント表現が返されます。設定を取得したり、クライアントを後で更新、削除したい場合は、登録アクセス・トークンをどこかに保存する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:81
+#: source/securing_apps/topics/client-registration.adoc:82
 msgid ""
-"To retrieve the Client Representation then do a HTTP GET to `/realms/<realm"
-">/clients-registrations/default/<client id>`."
+"To retrieve the Client Representation perform an HTTP GET request to "
+"`/realms/<realm>/clients-registrations/default/<client id>`."
 msgstr ""
-"クライアント表現を取得するには、 `/realms/<realm>/clients-registrations/default/<client id>`"
-" にHTTP GETします。"
+"クライアント表現を取得するには、HTTP GETリクエストを `/realms/<realm>/clients-"
+"registrations/default/<client id>` に送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:83
-#: source/securing_apps/topics/client-registration.adoc:88
+#: source/securing_apps/topics/client-registration.adoc:84
+#: source/securing_apps/topics/client-registration.adoc:89
 msgid "It will also return a new registration access token."
 msgstr "新しい登録アクセス・トークンも返します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:86
+#: source/securing_apps/topics/client-registration.adoc:87
 msgid ""
-"To update the Client Representation then do a HTTP PUT to with the updated "
-"Client Representation to: `/realms/<realm>/clients-"
+"To update the Client Representation perform an HTTP PUT request with the "
+"updated Client Representation to: `/realms/<realm>/clients-"
 "registrations/default/<client id>`."
 msgstr ""
-"クライアント表現を更新するには、更新したクライアント表現を次のURLにHTTP PUTします:  `/realms/<realm>/clients-"
-"registrations/default/<client id>` 。"
+"Client Representationを更新するには、更新したClient Representationを次のURLにHTTP PUTします：  "
+"`/realms/<realm>/clients-registrations/default/<client id>` 。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:91
+#: source/securing_apps/topics/client-registration.adoc:92
 msgid ""
-"To delete the Client Representation then do a HTTP DELETE to: "
+"To delete the Client Representation perform an HTTP DELETE request to: "
 "`/realms/<realm>/clients-registrations/default/<client id>`"
 msgstr ""
-"クライアント表現を削除するには、 `/realms/<realm>/clients-registrations/default/<client id>`"
-" にHTTP DELETEします。"
+"クライアント表現を削除するには、HTTP DELETEリクエストを次のURLに送信します: `/realms/<realm>/clients-"
+"registrations/default/<client id>`"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:92
+#: source/securing_apps/topics/client-registration.adoc:93
 #, no-wrap
 msgid "{project_name} Adapter Configuration"
 msgstr "{project_name}アダプター設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:97
+#: source/securing_apps/topics/client-registration.adoc:98
 msgid ""
 "The `installation` client registration provider can be used to retrieve the "
 "adapter configuration for a client.  In addition to token authentication you"
@@ -325,22 +331,22 @@ msgstr ""
 " これを行うには、リクエストに次のヘッダーを含めます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:101
+#: source/securing_apps/topics/client-registration.adoc:102
 #, no-wrap
 msgid "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
 msgstr "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:104
+#: source/securing_apps/topics/client-registration.adoc:105
 msgid ""
-"To retrieve the Adapter Configuration then do a HTTP GET to `/realms/<realm"
-">/clients-registrations/install/<client id>`."
+"To retrieve the Adapter Configuration then perfrom an HTTP GET request to "
+"`/realms/<realm>/clients-registrations/install/<client id>`."
 msgstr ""
-"アダプター設定を取得するには、 `/realms/<realm>/clients-registrations/install/<client id>` "
-"にHTTP GETします。"
+"アダプタ設定を取得するには、HTTP GETリクエストを次のURLに送信します:  `/realms/<realm>/clients-"
+"registrations/install/<client id>`。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:107
+#: source/securing_apps/topics/client-registration.adoc:108
 msgid ""
 "No authentication is required for public clients.  This means that for the "
 "JavaScript adapter you can load the client configuration directly from "
@@ -349,13 +355,13 @@ msgstr ""
 "パブリック・クライアントは認証が要求されません。これは、JavaScriptアダプターは、上記URLを使用して、直接{project_name}からクライアント設定を読み込めることを意味します。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:108
+#: source/securing_apps/topics/client-registration.adoc:109
 #, no-wrap
 msgid "OpenID Connect Dynamic Client Registration"
 msgstr "OpenID Connect動的クライアント登録"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:111
+#: source/securing_apps/topics/client-registration.adoc:112
 msgid ""
 "{project_name} implements https://openid.net/specs/openid-connect-"
 "registration-1_0.html[OpenID Connect Dynamic Client Registration], which "
@@ -365,12 +371,12 @@ msgid ""
 msgstr ""
 "{project_name}は、 https://tools.ietf.org/html/rfc7591[OAuth 2.0 Dynamic "
 "Client Registration Protocol] と https://tools.ietf.org/html/rfc7592[OAuth "
-"2.0 Dynamic Client Registration Management Protocol] を継承した "
+"2.0 Dynamic Client Registration Management Protocol] を拡張した "
 "https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect"
-" Dynamic Client Registration] を実装します。"
+" Dynamic Client Registration] を実装しています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:113
+#: source/securing_apps/topics/client-registration.adoc:114
 msgid ""
 "The endpoint to use these specifications to register clients in "
 "{project_name} is `/realms/<realm>/clients-registrations/openid-"
@@ -380,7 +386,7 @@ msgstr ""
 "registrations/openid-connect[/<client id>]` です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:115
+#: source/securing_apps/topics/client-registration.adoc:116
 msgid ""
 "This endpoints can also be found in the OpenID Connect Discovery endpoint "
 "for the realm, `/realms/<realm>/.well-known/openid-configuration`."
@@ -389,14 +395,14 @@ msgstr ""
 "known/openid-configuration` ）にも見つかります。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:116
+#: source/securing_apps/topics/client-registration.adoc:117
 #: source/server_admin/topics/clients/saml/entity-descriptors.adoc:2
 #, no-wrap
 msgid "SAML Entity Descriptors"
 msgstr "SAMLエンティティ記述子"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:122
+#: source/securing_apps/topics/client-registration.adoc:123
 msgid ""
 "The SAML Entity Descriptor endpoint only supports using SAML v2 Entity "
 "Descriptors to create clients.  It doesn't support retrieving, updating or "
@@ -409,24 +415,17 @@ msgstr ""
 "v2エンティティ記述子を使用することだけをサポートします。クライアントの取得、更新、削除はサポートしていません。これらの操作に対して、{project_name}形式のエンドポイントを使用してください。クライアントを作成すると、作成されたクライアントの詳細とともに、{project_name}クライアント表現が返されます（登録アクセス・トークンを含みます）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:124
-msgid ""
-"To create a client do a HTTP POST with the SAML Entity Descriptor to "
-"`/realms/<realm>/clients-registrations/saml2-entity-descriptor`."
-msgstr ""
-"クライアントを作成するには、 `/realms/<realm>/clients-registrations/saml2-entity-"
-"descriptor` にSAMLエンティティ記述子を含むHTTP POSTリクエストを送信します。"
-
-#. type: Title ===
 #: source/securing_apps/topics/client-registration.adoc:125
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:134
-#: source/server_development/topics/admin-rest-api.adoc:13
-#, no-wrap
-msgid "Example using CURL"
-msgstr "CURLを使用した例"
+msgid ""
+"To create a client perform an HTTP POST request with the SAML Entity "
+"Descriptor to `/realms/<realm>/clients-registrations/saml2-entity-"
+"descriptor`."
+msgstr ""
+"クライアントを作成するには、SAMLエンティティ記述子を使用して `/realms/<realm>/clients-"
+"registrations/saml2-entity-descriptor` にHTTP POSTリクエストを送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:129
+#: source/securing_apps/topics/client-registration.adoc:130
 msgid ""
 "The following example creates a client with the clientId `myclient` using "
 "CURL. You need to replace `eyJhbGciOiJSUz...` with a proper initial access "
@@ -437,7 +436,7 @@ msgstr ""
 "を置き換える必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:137
+#: source/securing_apps/topics/client-registration.adoc:138
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -453,13 +452,13 @@ msgstr ""
 "    http://localhost:8080/auth/realms/master/clients-registrations/default\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:139
+#: source/securing_apps/topics/client-registration.adoc:140
 #, no-wrap
 msgid "Example using Java Client Registration API"
 msgstr "Javaクライアント登録APIを使用した例"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:143
+#: source/securing_apps/topics/client-registration.adoc:144
 msgid ""
 "The Client Registration Java API makes it easy to use the Client "
 "Registration Service using Java.  To use include the dependency "
@@ -469,7 +468,7 @@ msgstr ""
 "`org.keycloak:keycloak-client-registration-api:>VERSION<` の依存関係を含めて下さい。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:146
+#: source/securing_apps/topics/client-registration.adoc:147
 msgid ""
 "For full instructions on using the Client Registration refer to the "
 "JavaDocs.  Below is an example of creating a client. You need to replace "
@@ -479,13 +478,13 @@ msgstr ""
 "`eyJhbGciOiJSUz...` を適切な初期アクセス・トークンまたはベアラー・トークンに置き換える必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:150
+#: source/securing_apps/topics/client-registration.adoc:151
 #, no-wrap
 msgid "String token = \"eyJhbGciOiJSUz...\";\n"
 msgstr "String token = \"eyJhbGciOiJSUz...\";\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:153
+#: source/securing_apps/topics/client-registration.adoc:154
 #, no-wrap
 msgid ""
 "ClientRepresentation client = new ClientRepresentation();\n"
@@ -495,7 +494,7 @@ msgstr ""
 "client.setClientId(CLIENT_ID);\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:157
+#: source/securing_apps/topics/client-registration.adoc:158
 #, no-wrap
 msgid ""
 "ClientRegistration reg = ClientRegistration.create()\n"
@@ -507,38 +506,38 @@ msgstr ""
 "    .build();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:159
+#: source/securing_apps/topics/client-registration.adoc:160
 #, no-wrap
 msgid "reg.auth(Auth.token(token));\n"
 msgstr "reg.auth(Auth.token(token));\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:161
+#: source/securing_apps/topics/client-registration.adoc:162
 #, no-wrap
 msgid "client = reg.create(client);\n"
 msgstr "client = reg.create(client);\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:163
+#: source/securing_apps/topics/client-registration.adoc:164
 #, no-wrap
 msgid "String registrationAccessToken = client.getRegistrationAccessToken();\n"
 msgstr "String registrationAccessToken = client.getRegistrationAccessToken();\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:165
+#: source/securing_apps/topics/client-registration.adoc:166
 #, no-wrap
 msgid "Client Registration Policies"
 msgstr "クライアント登録ポリシー"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:168
+#: source/securing_apps/topics/client-registration.adoc:169
 msgid ""
 "{project_name} currently supports 2 ways how can be new clients registered "
 "through Client Registration Service."
 msgstr "{project_name}は現在、クライアント登録サービスを介して新しいクライアントを登録できる2つの方法をサポートしています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:170
+#: source/securing_apps/topics/client-registration.adoc:171
 msgid ""
 "Authenticated requests - Request to register new client must contain either "
 "`Initial Access Token` or `Bearer Token` as mentioned above."
@@ -547,14 +546,14 @@ msgstr ""
 "のいずれかを含める必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:172
+#: source/securing_apps/topics/client-registration.adoc:173
 msgid ""
 "Anonymous requests - Request to register new client doesn't need to contain "
 "any token at all"
 msgstr "匿名リクエスト - 新しいクライアントを登録するためのリクエストは、すべての任意のトークンを含める必要はありません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:175
+#: source/securing_apps/topics/client-registration.adoc:176
 msgid ""
 "Anonymous client registration requests are very interesting and powerful "
 "feature, however you usually don't want that anyone is able to register new "
@@ -566,7 +565,7 @@ msgstr ""
 " `Client Registration Policy SPI` があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:178
+#: source/securing_apps/topics/client-registration.adoc:179
 msgid ""
 "In {project_name} admin console, you can click to `Client Registration` tab "
 "and then `Client Registration Policies` sub-tab. Here you will see what "
@@ -578,7 +577,7 @@ msgstr ""
 "サブタブをクリックします。ここでは、匿名リクエストに対してデフォルトでどのようなポリシーが設定されるか、認証リクエストに対してどのようなポリシーを設定されるかが表示されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:184
+#: source/securing_apps/topics/client-registration.adoc:185
 msgid ""
 "The anonymous requests (requests without any token) are allowed just for "
 "creating (registration) of new clients. So when you register new client "
@@ -597,12 +596,12 @@ msgstr ""
 "`Consent Required` ポリシーが存在する場合などに、 `Consent Required` を無効にすることはできません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:186
+#: source/securing_apps/topics/client-registration.adoc:187
 msgid "Currently we have these policy implementations:"
-msgstr "現在、これらのポリシーの実装があります。"
+msgstr "現在、以下のポリシーの実装があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:190
+#: source/securing_apps/topics/client-registration.adoc:191
 msgid ""
 "Trusted Hosts Policy - You can configure list of trusted hosts and trusted "
 "domains. Request to Client Registration Service can be sent just from those "
@@ -618,7 +617,7 @@ msgstr ""
 "を設定することは許可されません。デフォルトでは、ホワイトリストに登録されているホストが無いため、匿名クライアント登録は事実上無効になっています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:194
+#: source/securing_apps/topics/client-registration.adoc:195
 msgid ""
 "Consent Required Policy - Newly registered clients will have `Consent "
 "Allowed` switch enabled. So after successful authentication, user will "
@@ -630,7 +629,7 @@ msgstr ""
 "スイッチが有効になります。したがって、認証成功後、個人情報とアクセス権(プロトコルマッパーとロール)を承認する必要がある場合、常に同意画面が表示されます。つまり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権にアクセスすることができません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:198
+#: source/securing_apps/topics/client-registration.adoc:199
 msgid ""
 "Protocol Mappers Policy - Allows to configure list of whitelisted protocol "
 "mapper implementations. New client can't be registered or updated if it "
@@ -642,7 +641,7 @@ msgstr ""
 "プロトコル・マッパーの実装のホワイト・リストを設定できます。ホワイト・リストに無いプロトコル・マッパーが含まれている場合は、新たなクライアントを登録または更新できません。このポリシーは認証済みのリクエストにも使用されるため、認証済みのリクエストに対してもプロトコルマッパーを使用できるいくつかの制限があることに注意して下さい。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:201
+#: source/securing_apps/topics/client-registration.adoc:202
 msgid ""
 "Client Template Policy - Allow to whitelist `Client Templates`, which can be"
 " used with newly registered or updated clients.  There are no whitelisted "
@@ -652,7 +651,7 @@ msgstr ""
 "のホワイト・リスト化を許可します。デフォルトでは、ホワイト・リスト化されたテンプレートはありません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:204
+#: source/securing_apps/topics/client-registration.adoc:205
 msgid ""
 "Full Scope Policy - Newly registered clients will have `Full Scope Allowed` "
 "switch disabled. This means they won't have any scoped realm roles or client"
@@ -662,7 +661,7 @@ msgstr ""
 "スイッチが無効に切り替わります。これは、スコープが設定されたレルム・ロールや他のクライアントのクライアント・ロールが無いことを意味します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:206
+#: source/securing_apps/topics/client-registration.adoc:207
 msgid ""
 "Max Clients Policy - Rejects registration if current number of clients in "
 "the realm is same or bigger than specified limit. It's 200 by default for "
@@ -671,7 +670,7 @@ msgstr ""
 "Max Clients Policy - レルム内の現在のクライアント数が指定された制限以上の場合、登録を拒否します。匿名登録のデフォルトは200です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:209
+#: source/securing_apps/topics/client-registration.adoc:210
 msgid ""
 "Client Disabled Policy - Newly registered client will be disabled. This "
 "means that admin needs to manually approve and enable all newly registered "

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -114,7 +114,7 @@ msgid ""
 " following permissions are required to invoke the endpoints (see "
 "link:{adminguide_link}[{adminguide_name}] for more details):"
 msgstr ""
-"ベアラー・トークンは、ユーザーやサービス・アカウントに代わって発行されます。エンドポイントを呼び出すには、次の権限が必要です（詳細についてはlink:{adminguide_link}[{adminguide_name}]を参照して下さい）。"
+"ベアラー・トークンは、ユーザーやサービス・アカウントに代わって発行されます。エンドポイントを呼び出すには、次の権限が必要です（詳細についてはlink:{adminguide_link}[{adminguide_name}]を参照してください）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:30
@@ -139,7 +139,7 @@ msgid ""
 "link:{adminguide_link}[{adminguide_name}] for more details)."
 msgstr ""
 "クライアントを作成するためにベアラー・トークンを使用する場合、 `create-client` "
-"ロールのみを持つサービス・アカウントのトークンを使用することをおすすめします（詳細については、link:{adminguide_link}[{adminguide_name}]を参照して下さい）。"
+"ロールのみを持つサービス・アカウントのトークンを使用することをおすすめします（詳細については、link:{adminguide_link}[{adminguide_name}]を参照してください）。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration.adoc:36
@@ -192,7 +192,7 @@ msgid ""
 "retrieve it later. If you forget to copy/paste it, then delete the token and"
 " create another one."
 msgstr ""
-"後でトークンを取得することはできないので、このトークンをコピー/ペーストすることが重要です。コピー/ペーストすることを忘れた場合は、そのトークンを削除し、別のトークンを1つを作成して下さい。"
+"後でトークンを取得することはできないので、このトークンをコピー/ペーストすることが重要です。コピー/ペーストすることを忘れた場合は、そのトークンを削除し、別のトークンを作成してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:53
@@ -201,8 +201,7 @@ msgid ""
 "Registration Services, by adding it to the Authorization header in the "
 "request.  For example:"
 msgstr ""
-"リクエストのAuthorizationヘッダーを追加することにより、トークンの値はクライアント登録サービスを呼び出す際の標準ベアラー・トークンとして使用されます。"
-" 例えば:"
+"リクエストにAuthorizationヘッダーを追加することにより、トークンの値はクライアント登録サービスを呼び出す際の標準ベアラー・トークンとして使用されます。以下に例を示します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration.adoc:57
@@ -227,7 +226,7 @@ msgid ""
 "  Registration access tokens are only valid once when it's used the response"
 " will include a new token."
 msgstr ""
-"クライアント登録サービスを介してクライアントを作成するとき、レスポンスには登録アクセス・トークンが含まれます。登録アクセス・トークンは、クライアント設定を取得するだけでなく、更新や削除のために、クライアントへのアクセスを提供します。登録アクセス・トークンは、ベアラー・トークンや初期のアクセス・トークンと同じ方法でリクエストに含まれます。登録アクセス・トークンは、新しいトークンを含むレスポンスを使用する場合に一度だけ有効です。"
+"クライアント登録サービスを介してクライアントを作成する際には、レスポンスには登録アクセス・トークンが含まれます。登録アクセス・トークンは、クライアント設定を取得するだけでなく、クライアントの更新や削除のためのアクセス権を提供します。登録アクセス・トークンは、ベアラー・トークンや初期アクセス・トークンと同じ方法でリクエストに含まれます。登録アクセス・トークンの使用は一度だけ有効であり、新しいトークンがレスポンスに含まれます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:69
@@ -258,7 +257,8 @@ msgid ""
 "protocol mappers."
 msgstr ""
 "`default` "
-"クライアント登録プロバイダーは、クライアントを作成、取得、更新、削除するために使用できます。管理コンソールでの設定と同等なクライアント設定機能のサポートを提供する{project_name}クライアント表現形式を使用します（例えば、プロトコル・マッパーの設定などを含む）。"
+"クライアント登録プロバイダーは、クライアントを作成、取得、更新、削除するために使用できます。管理コンソールでの設定と同等なクライアント設定のサポートを提供する、{project_name}"
+" Client Representation形式を使用します。また、プロトコル・マッパーの設定例が含まれています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:77
@@ -266,8 +266,8 @@ msgid ""
 "To create a client create a Client Representation (JSON) then perform an "
 "HTTP POST request to `/realms/<realm>/clients-registrations/default`."
 msgstr ""
-"クライアントを作成するには、クライアント表現(JSON)を作成し、HTTP POSTリクエストを `/realms/<realm>/clients-"
-"registrations/default` に送信します。"
+"クライアントを作成するには、Client Representation（JSON）を作成し、次にHTTP POSTリクエストを "
+"`/realms/<realm>/clients-registrations/default` に送信します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:80
@@ -276,7 +276,8 @@ msgid ""
 "access token.  You should save the registration access token somewhere if "
 "you want to retrieve the config, update or delete the client later."
 msgstr ""
-"登録アクセス・トークンを含むクライアント表現が返されます。設定を取得したり、クライアントを後で更新、削除したい場合は、登録アクセス・トークンをどこかに保存する必要があります。"
+"登録アクセス・トークンを含むClient "
+"Representationが返されます。設定を取得したり、クライアントを後で更新、削除したい場合は、登録アクセス・トークンをどこかに保存する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:82
@@ -284,7 +285,7 @@ msgid ""
 "To retrieve the Client Representation perform an HTTP GET request to "
 "`/realms/<realm>/clients-registrations/default/<client id>`."
 msgstr ""
-"クライアント表現を取得するには、HTTP GETリクエストを `/realms/<realm>/clients-"
+"Client Representationを取得するには、HTTP GETリクエストを `/realms/<realm>/clients-"
 "registrations/default/<client id>` に送信します。"
 
 #. type: Plain text
@@ -309,8 +310,8 @@ msgid ""
 "To delete the Client Representation perform an HTTP DELETE request to: "
 "`/realms/<realm>/clients-registrations/default/<client id>`"
 msgstr ""
-"クライアント表現を削除するには、HTTP DELETEリクエストを次のURLに送信します: `/realms/<realm>/clients-"
-"registrations/default/<client id>`"
+"Client Representationを削除するには、HTTP DELETEリクエストを `/realms/<realm>/clients-"
+"registrations/default/<client id>` に送信します。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration.adoc:93
@@ -326,9 +327,8 @@ msgid ""
 " can also authenticate with client credentials using HTTP basic "
 "authentication.  To do this include the following header in the request:"
 msgstr ""
-"`installation` "
-"クライアント登録プロバイダーは、クライアントのアダプター設定を取得するために使用できます。トークン認証に加えて、HTTP基本認証を使用してクライアントクレデンシャルで認証することもできます。"
-" これを行うには、リクエストに次のヘッダーを含めます。"
+"`installation` クライアント登録プロバイダーは、クライアントのアダプター設定を取得するために使用できます。トークン認証に加えて、HTTP "
+"BASIC認証を使用してクライアント・クレデンシャルで認証することもできます。 これを行うには、リクエストに次のヘッダーを含めます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration.adoc:102
@@ -342,8 +342,8 @@ msgid ""
 "To retrieve the Adapter Configuration then perfrom an HTTP GET request to "
 "`/realms/<realm>/clients-registrations/install/<client id>`."
 msgstr ""
-"アダプタ設定を取得するには、HTTP GETリクエストを次のURLに送信します:  `/realms/<realm>/clients-"
-"registrations/install/<client id>`。"
+"アダプター設定を取得するには、HTTP GETリクエストを   `/realms/<realm>/clients-"
+"registrations/install/<client id>` に送信します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:108
@@ -382,7 +382,7 @@ msgid ""
 "{project_name} is `/realms/<realm>/clients-registrations/openid-"
 "connect[/<client id>]`."
 msgstr ""
-"これらの仕様を使用して、{project_name}にクライアントを登録するエンドポイントは、 `/realms/<realm>/clients-"
+"これらの仕様を使用した、{project_name}にクライアントを登録するエンドポイントは、 `/realms/<realm>/clients-"
 "registrations/openid-connect[/<client id>]` です。"
 
 #. type: Plain text
@@ -392,7 +392,7 @@ msgid ""
 "for the realm, `/realms/<realm>/.well-known/openid-configuration`."
 msgstr ""
 "このエンドポイントは、そのレルムのOpenID Connect Discoveryエンドポイント（ `/realms/<realm>/.well-"
-"known/openid-configuration` ）にも見つかります。"
+"known/openid-configuration` ）でも見つかります。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration.adoc:117
@@ -412,7 +412,10 @@ msgid ""
 "a registration access token."
 msgstr ""
 "SAMLエンティティ記述子エンドポイントは、クライアントを作成するために、SAML "
-"v2エンティティ記述子を使用することだけをサポートします。クライアントの取得、更新、削除はサポートしていません。これらの操作に対して、{project_name}形式のエンドポイントを使用してください。クライアントを作成すると、作成されたクライアントの詳細とともに、{project_name}クライアント表現が返されます（登録アクセス・トークンを含みます）。"
+"v2エンティティ記述子を使用することだけをサポートします。クライアントの取得、更新、削除はサポートしていません。これらの操作に対しては、{project_name}"
+" "
+"represendationのエンドポイントを使用してください。クライアントを作成すると、作成されたクライアントの詳細とともに、{project_name}"
+" Client Representationが返されます（登録アクセス・トークンを含みます）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:125
@@ -432,7 +435,7 @@ msgid ""
 "token or bearer token."
 msgstr ""
 "CURLを使用して、クライアントID `myclient` "
-"でクライアントを作成する例を次にします。適切な初期アクセス・トークンまたはベアラー・トークンで `eyJhbGciOiJSUz...` "
+"でクライアントを作成する例を次に示します。適切な初期アクセス・トークンまたはベアラー・トークンで `eyJhbGciOiJSUz...` "
 "を置き換える必要があります。"
 
 #. type: delimited block -
@@ -464,8 +467,8 @@ msgid ""
 "Registration Service using Java.  To use include the dependency "
 "`org.keycloak:keycloak-client-registration-api:>VERSION<` from Maven."
 msgstr ""
-"クライアント登録Java APIは、 Javaを使用してクライアント登録サービスを使いやすくします。使用するには、Mavenに "
-"`org.keycloak:keycloak-client-registration-api:>VERSION<` の依存関係を含めて下さい。"
+"クライアント登録Java APIは、Javaを使用してクライアント登録サービスを使いやすくします。使用するには、Mavenに `org.keycloak"
+":keycloak-client-registration-api:>VERSION<` の依存関係を含めてください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:147
@@ -474,7 +477,7 @@ msgid ""
 "JavaDocs.  Below is an example of creating a client. You need to replace "
 "`eyJhbGciOiJSUz...` with a proper initial access token or bearer token."
 msgstr ""
-"クライアント登録の使用方法の完全な説明は、JavaDocsを参照して下さい。 以下は、クライアントを作成する例です。 "
+"クライアント登録の使用方法の完全な説明は、JavaDocsを参照してください。以下は、クライアントを作成する例です。 "
 "`eyJhbGciOiJSUz...` を適切な初期アクセス・トークンまたはベアラー・トークンに置き換える必要があります。"
 
 #. type: delimited block -
@@ -561,7 +564,7 @@ msgid ""
 "SPI`, which provide a way to limit who can register new clients and under "
 "which conditions."
 msgstr ""
-"匿名クライアント登録リクエストは、非常に面白く、強力な機能ですが、誰でも制限なく新しいクライアントを登録できることを通常は望みません。したがって、そのような条件下で、新しいクライアントを登録できるユーザーを、制限する方法を提供する"
+"匿名クライアント登録リクエストは、非常に面白く、強力な機能ですが、誰でも制限なく新しいクライアントを登録できることを通常は望みません。したがって、そのような条件下で、新しいクライアントを登録できるユーザーを制限する方法を提供する、"
 " `Client Registration Policy SPI` があります。"
 
 #. type: Plain text
@@ -590,10 +593,10 @@ msgid ""
 "disable `Consent Required` when updating client and when `Consent Required` "
 "policy is present etc."
 msgstr ""
-"匿名リクエスト(トークンの無いリクエスト)は、新しいクライアントを作成(登録)することだけが許可されています。したがって、匿名リクエストを使用して新しいクライアントを登録すると、レスポンスにはそのクライアントの読み取り、更新、削除リクエストに使用する登録アクセス・トークンが含まれます。ただし、匿名登録レスポンスから取得した登録アクセス・トークンを使用すると、匿名ポリシーの対象にもなります！これは、例えば、"
+"匿名リクエスト（トークンの無いリクエスト）は、新しいクライアントを作成（登録）することだけが許可されています。したがって、匿名リクエストを使用して新しいクライアントを登録すると、レスポンスにはそのクライアントの読み取り、更新、削除リクエストに使用する登録アクセス・トークンが含まれます。ただし、匿名登録レスポンスから取得した登録アクセス・トークンを使用すると、匿名ポリシーの対象にもなります！これは、例えば、"
 " `Trusted Hosts` "
-"ポリシーを持っているならば、クライアント更新リクエストも信頼されたホストから来る必要があることを意味します。また、例えば、クライアントの更新時や "
-"`Consent Required` ポリシーが存在する場合などに、 `Consent Required` を無効にすることはできません。"
+"ポリシーがあるならば、クライアント更新リクエストも信頼されたホストから来る必要があることを意味します。また、例えば、クライアントの更新時に "
+"`Consent Required` ポリシーが存在する場合に、 `Consent Required` を無効にするなどはできません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:187
@@ -626,7 +629,7 @@ msgid ""
 "access to any personal info or permission of user unless user approves it."
 msgstr ""
 "Consent Required Policy - 新たに登録されたクライアントは、 `Consent Allowed` "
-"スイッチが有効になります。したがって、認証成功後、個人情報とアクセス権(プロトコルマッパーとロール)を承認する必要がある場合、常に同意画面が表示されます。つまり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権にアクセスすることができません。"
+"スイッチが有効になります。したがって、認証成功後、個人情報とアクセス権（プロトコルマッパーとロール）を承認する必要がある場合、常に同意画面が表示されます。つまり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権にアクセスすることができません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:199
@@ -638,7 +641,7 @@ msgid ""
 " are some limitations which protocol mappers can be used."
 msgstr ""
 "Protocol Mappers Policy - "
-"プロトコル・マッパーの実装のホワイト・リストを設定できます。ホワイト・リストに無いプロトコル・マッパーが含まれている場合は、新たなクライアントを登録または更新できません。このポリシーは認証済みのリクエストにも使用されるため、認証済みのリクエストに対してもプロトコルマッパーを使用できるいくつかの制限があることに注意して下さい。"
+"プロトコル・マッパー実装のホワイトリストを設定できます。ホワイトリストに無いプロトコル・マッパーが含まれている場合は、新たなクライアントを登録または更新できません。このポリシーは認証済みのリクエストにも使用されるため、認証済みのリクエストに対しても、どのプロトコル・マッパーを使用できるかの制限があることに注意してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:202
@@ -647,8 +650,8 @@ msgid ""
 " used with newly registered or updated clients.  There are no whitelisted "
 "templates by default."
 msgstr ""
-"Client Template Policy - 新たに登録/更新したクライアントと使うことができる `Client Templates` "
-"のホワイト・リスト化を許可します。デフォルトでは、ホワイト・リスト化されたテンプレートはありません。"
+"Client Template Policy - 新たに登録または更新したクライアントで使うことができる `Client Templates` "
+"のホワイトリスト化を許可します。デフォルトでは、ホワイトリスト化されたテンプレートはありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:205
@@ -678,5 +681,4 @@ msgid ""
 "registration."
 msgstr ""
 "Client Disabled Policy - "
-"新たに登録されたクライアントは無効になります。これは、管理者が新しく登録された全てのクライアントを手動で承認し、有効にする必要があることを意味します。 "
-"匿名登録に対しても、デフォルトではこのポリシーは使用されません。"
+"新たに登録されたクライアントは無効になります。これは、管理者が新しく登録された全てのクライアントを手動で承認し、有効にする必要があることを意味します。このポリシーは、匿名登録でもデフォルトでは使用されません。"

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
@@ -26,27 +25,26 @@ msgstr "クライアントの登録"
 #: source/securing_apps/topics/client-registration.adoc:7
 msgid ""
 "In order for an application or service to utilize {project_name} it has to "
-"register a client in {project_name}.  An admin can do this through the admin "
-"console (or admin REST endpoints), but clients can also register themselves "
-"through the {project_name} client registration service."
+"register a client in {project_name}.  An admin can do this through the admin"
+" console (or admin REST endpoints), but clients can also register themselves"
+" through the {project_name} client registration service."
 msgstr ""
-"{project_name}をアプリケーションまたはサービスで使用するには、{project_name}"
-"にクライアントを登録する必要があります。管理者は管理コンソール（または 管理"
-"RESTエンドポイント）にて登録できますが、クライアント自身でも{project_name}ク"
-"ライアント登録サービスにおいて登録することはできます。"
+"{project_name}をアプリケーションまたはサービスで使用するには、{project_name}にクライアントを登録する必要があります。管理者は管理コンソール（または"
+" "
+"管理RESTエンドポイント）にて登録できますが、クライアント自身でも{project_name}クライアント登録サービスにおいて登録することはできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:10
 msgid ""
-"The Client Registration Service provides built-in support for {project_name} "
-"Client Representations, OpenID Connect Client Meta Data and SAML Entity "
-"Descriptors.  The Client Registration Service endpoint is `/realms/<realm>/"
-"clients-registrations/<provider>`."
+"The Client Registration Service provides built-in support for {project_name}"
+" Client Representations, OpenID Connect Client Meta Data and SAML Entity "
+"Descriptors.  The Client Registration Service endpoint is `/realms/<realm"
+">/clients-registrations/<provider>`."
 msgstr ""
-"クライアント登録サービスには、{project_name} Client Representations、OpenID "
-"Connect Client Meta DataおよびSAML Entity Descriptorsのビルトインサポートをご"
-"用意しております。クライアント登録サービスのエンドポイントは `/realms/"
-"<realm>/clients-registrations/<provider>` です。"
+"クライアント登録サービスには、{project_name} Client Representations、OpenID Connect Client "
+"Meta DataおよびSAML Entity "
+"Descriptorsのビルトインサポートをご用意しております。クライアント登録サービスのエンドポイントは `/realms/<realm"
+">/clients-registrations/<provider>` です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:12
@@ -66,9 +64,7 @@ msgstr "install - {project_name}アダプター設定 （JSON）"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:16
 msgid "openid-connect - OpenID Connect Client Metadata Description (JSON)"
-msgstr ""
-"openid-connect - OpenID Connectクライアント・メタデータ・ディスクリプション"
-"（JSON）"
+msgstr "openid-connect - OpenID Connectクライアント・メタデータ・ディスクリプション（JSON）"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:17
@@ -97,10 +93,7 @@ msgid ""
 "token as well, but then you need to configure Client Registration Policies "
 "(see below)."
 msgstr ""
-"クライアント登録サービスを呼び出すには、通常トークンが必要です。トークンは、"
-"ベアラー・トークン、初期アクセス・トークン、登録アクセス・トークンのいずれか"
-"です。いずれのトークンも含まず、同様に新規クライアントを登録する方法がありま"
-"すが、クライアント登録ポリシー（下記参照）を設定する必要があります。"
+"クライアント登録サービスを呼び出すには、通常トークンが必要です。トークンは、ベアラー・トークン、初期アクセス・トークン、登録アクセス・トークンのいずれかです。いずれのトークンも含まず、同様に新規クライアントを登録する方法がありますが、クライアント登録ポリシー（下記参照）を設定する必要があります。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration.adoc:25
@@ -111,13 +104,11 @@ msgstr "ベアラー・トークン"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:28
 msgid ""
-"The bearer token can be issued on behalf of a user or a Service Account. The "
-"following permissions are required to invoke the endpoints (see link:"
-"{adminguide_link}[{adminguide_name}] for more details):"
+"The bearer token can be issued on behalf of a user or a Service Account. The"
+" following permissions are required to invoke the endpoints (see "
+"link:{adminguide_link}[{adminguide_name}] for more details):"
 msgstr ""
-"ベアラー・トークンは、ユーザーやサービス・アカウントに代わって発行されます。"
-"エンドポイントを呼び出すには、次の権限が必要です（詳細についてはlink:"
-"{adminguide_link}[{adminguide_name}]を参照して下さい）。"
+"ベアラー・トークンは、ユーザーやサービス・アカウントに代わって発行されます。エンドポイントを呼び出すには、次の権限が必要です（詳細についてはlink:{adminguide_link}[{adminguide_name}]を参照して下さい）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:30
@@ -138,13 +129,11 @@ msgstr "manage-client - クライアントの更新または削除権限"
 #: source/securing_apps/topics/client-registration.adoc:34
 msgid ""
 "If you are using a bearer token to create clients it's recommend to use a "
-"token from a Service Account with only the `create-client` role (see link:"
-"{adminguide_link}[{adminguide_name}] for more details)."
+"token from a Service Account with only the `create-client` role (see "
+"link:{adminguide_link}[{adminguide_name}] for more details)."
 msgstr ""
-"クライアントを作成するためにベアラー・トークンを使用する場合、`create-client`"
-"ロールのみを持つサービス・アカウントのトークンを使用することをおすすめします"
-"（詳細については、link:{adminguide_link}[{adminguide_name}]を参照して下さ"
-"い）。"
+"クライアントを作成するためにベアラー・トークンを使用する場合、`create-"
+"client`ロールのみを持つサービス・アカウントのトークンを使用することをおすすめします（詳細については、link:{adminguide_link}[{adminguide_name}]を参照して下さい）。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration.adoc:35
@@ -160,25 +149,20 @@ msgid ""
 "and has a configurable expiration as well as a configurable limit on how "
 "many clients can be created."
 msgstr ""
-"新しいクライアントを登録するための推奨される方法は、初期アクセス・トークンを"
-"使用することです。初期アクセス・トークンは、クライアントを作成する場合にのみ"
-"使用でき、有効期限が設定できるだけでなく、クライアントを作成可能な回数の上限"
-"も設定できます。"
+"新しいクライアントを登録するための推奨される方法は、初期アクセス・トークンを使用することです。初期アクセス・トークンは、クライアントを作成する場合にのみ使用でき、有効期限が設定できるだけでなく、クライアントを作成可能な回数の上限も設定できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:43
 msgid ""
-"An initial access token can be created through the admin console.  To create "
-"a new initial access token first select the realm in the admin console, then "
-"click on `Realm Settings` in the menu on the left, followed by `Client "
+"An initial access token can be created through the admin console.  To create"
+" a new initial access token first select the realm in the admin console, "
+"then click on `Realm Settings` in the menu on the left, followed by `Client "
 "Registration` in the tabs displayed in the page. Then finally click on "
 "`Initial Access Tokens` sub-tab."
 msgstr ""
-"初期アクセス・トークンは、管理コンソールで作成できます。新たに初期アクセス・"
-"トークンを作成するには、まず管理者コンソールでレルムを選択し、左側のメニュー"
-"の `Realm Settings` 、続いてページに表示されるタブの `Client Registration` を"
-"クリックします。そして、最後に `Initial Access Tokens` のサブ・タブをクリック"
-"します。"
+"初期アクセス・トークンは、管理コンソールで作成できます。新たに初期アクセス・トークンを作成するには、まず管理者コンソールでレルムを選択し、左側のメニューの"
+" `Realm Settings` 、続いてページに表示されるタブの `Client Registration` をクリックします。そして、最後に "
+"`Initial Access Tokens` のサブ・タブをクリックします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:47
@@ -187,26 +171,22 @@ msgid ""
 "access you can delete tokens that are no longer required. You can only "
 "retrieve the value of the token when you are creating it. To create a new "
 "token click on `Create`. You can now optionally add how long the token "
-"should be valid, also how many clients can be created using the token. After "
-"you click on `Save` the token value is displayed."
+"should be valid, also how many clients can be created using the token. After"
+" you click on `Save` the token value is displayed."
 msgstr ""
-"既存の初期アクセス・トークンを参照できるようになります。アクセスできる場合"
-"は、不要になったトークンを削除できます。トークンを作成するときは、トークンの"
-"値だけを取得できます。 `Create` をクリックして新しいトークンを作成します。必"
-"要に応じてトークンの有効期間や、トークンを使用して作成することができるクライ"
-"アント数を追加できます。 `Save` をクリックすると、トークンの値が表示されま"
-"す。"
+"既存の初期アクセス・トークンを参照できるようになります。アクセスできる場合は、不要になったトークンを削除できます。トークンを作成するときは、トークンの値だけを取得できます。"
+" `Create` "
+"をクリックして新しいトークンを作成します。必要に応じてトークンの有効期間や、トークンを使用して作成することができるクライアント数を追加できます。 "
+"`Save` をクリックすると、トークンの値が表示されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:49
 msgid ""
 "It is important that you copy/paste this token now as you won't be able to "
-"retrieve it later. If you forget to copy/paste it, then delete the token and "
-"create another one."
+"retrieve it later. If you forget to copy/paste it, then delete the token and"
+" create another one."
 msgstr ""
-"後でトークンを取得することはできないので、このトークンをコピー/ペーストするこ"
-"とが重要です。コピー/ペーストすることを忘れた場合は、そのトークンを削除し、別"
-"のトークンを1つを作成して下さい。"
+"後でトークンを取得することはできないので、このトークンをコピー/ペーストすることが重要です。コピー/ペーストすることを忘れた場合は、そのトークンを削除し、別のトークンを1つを作成して下さい。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:52
@@ -215,19 +195,14 @@ msgid ""
 "Registration Services, by adding it to the Authorization header in the "
 "request.  For example:"
 msgstr ""
-"リクエストのAuthorizationヘッダーを追加することにより、トークンの値はクライア"
-"ント登録サービスを呼び出す際の標準ベアラー・トークンとして使用されます。 例え"
-"ば:"
+"リクエストのAuthorizationヘッダーを追加することにより、トークンの値はクライアント登録サービスを呼び出す際の標準ベアラー・トークンとして使用されます。"
+" 例えば:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:57
+#: source/securing_apps/topics/client-registration.adoc:56
 #, no-wrap
-msgid ""
-"Authorization: bearer eyJhbGciOiJSUz...\n"
-"----            \n"
-msgstr ""
-"Authorization: bearer eyJhbGciOiJSUz...\n"
-"----            \n"
+msgid "Authorization: bearer eyJhbGciOiJSUz...\n"
+msgstr "Authorization: bearer eyJhbGciOiJSUz...\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration.adoc:58
@@ -235,40 +210,31 @@ msgstr ""
 msgid "Registration Access Token"
 msgstr "登録アクセス・トークン"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:64
 msgid ""
 "When you create a client through the Client Registration Service the "
 "response will include a registration access token.  The registration access "
 "token provides access to retrieve the client configuration later, but also "
 "to update or delete the client.  The registration access token is included "
-"with the request in the same way as a bearer token or initial access token.  "
-"Registration access tokens are only valid once when it's used the response "
-"will include a new token."
+"with the request in the same way as a bearer token or initial access token."
+"  Registration access tokens are only valid once when it's used the response"
+" will include a new token."
 msgstr ""
-"クライアント登録サービスを介してクライアントを作成するとき、レスポンスには登"
-"録アクセス・トークンが含まれます。登録アクセス・トークンは、クライアント設定"
-"を取得するだけでなく、更新や削除のために、クライアントへのアクセスを提供しま"
-"す。登録アクセス・トークンは、ベアラー・トークンや初期のアクセス・トークンと"
-"同じ方法でリクエストに含まれます。登録アクセス・トークンは、新しいトークンを"
-"含むレスポンスを使用する場合に一度だけ有効です。"
+"クライアント登録サービスを介してクライアントを作成するとき、レスポンスには登録アクセス・トークンが含まれます。登録アクセス・トークンは、クライアント設定を取得するだけでなく、更新や削除のために、クライアントへのアクセスを提供します。登録アクセス・トークンは、ベアラー・トークンや初期のアクセス・トークンと同じ方法でリクエストに含まれます。登録アクセス・トークンは、新しいトークンを含むレスポンスを使用する場合に一度だけ有効です。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:68
 msgid ""
 "If a client was created outside of the Client Registration Service it won't "
 "have a registration access token associated with it.  You can create one "
 "through the admin console. This can also be useful if you loose the token "
-"for a particular client.  To create a new token find the client in the admin "
-"console and click on `Credentials`. Then click on `Generate registration "
+"for a particular client.  To create a new token find the client in the admin"
+" console and click on `Credentials`. Then click on `Generate registration "
 "access token`."
 msgstr ""
-"クライアント登録サービス以外でクライアントが作成された場合、それに関連付けら"
-"れた登録アクセス・トークンはありません。管理コンソールを介して、登録アクセ"
-"ス・トークンを作成できます。これは、特定のクライアントのトークンを紛失した場"
-"合に役立ちます。新しいトークンを作成するには、管理コンソールでクライアントを"
-"検索し、 `Credentials` をクリックします。そして、 `Generate registration "
-"access token` をクリックします。"
+"クライアント登録サービス以外でクライアントが作成された場合、それに関連付けられた登録アクセス・トークンはありません。管理コンソールを介して、登録アクセス・トークンを作成できます。これは、特定のクライアントのトークンを紛失した場合に役立ちます。新しいトークンを作成するには、管理コンソールでクライアントを検索し、"
+" `Credentials` をクリックします。そして、 `Generate registration access token` をクリックします。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration.adoc:69
@@ -276,73 +242,69 @@ msgstr ""
 msgid "{project_name} Representations"
 msgstr "{project_name} Representations"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:74
 msgid ""
 "The `default` client registration provider can be used to create, retrieve, "
 "update and delete a client.  It uses {project_name} Client Representation "
-"format which provides support for configuring clients exactly as they can be "
-"configured through the admin console, including for example configuring "
+"format which provides support for configuring clients exactly as they can be"
+" configured through the admin console, including for example configuring "
 "protocol mappers."
 msgstr ""
-"`default` クライアント登録プロバイダーは、クライアントを作成、取得、更新、削"
-"除するために使用できます。管理コンソールでの設定と同等なクライアント設定機能"
-"のサポートを提供する{project_name}クライアント表現形式を使用します（例えば、"
-"プロトコル・マッパーの設定などを含む）。"
+"`default` "
+"クライアント登録プロバイダーは、クライアントを作成、取得、更新、削除するために使用できます。管理コンソールでの設定と同等なクライアント設定機能のサポートを提供する{project_name}クライアント表現形式を使用します（例えば、プロトコル・マッパーの設定などを含む）。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:76
 msgid ""
-"To create a client create a Client Representation (JSON) then do a HTTP POST "
-"to `/realms/<realm>/clients-registrations/default`."
+"To create a client create a Client Representation (JSON) then do a HTTP POST"
+" to `/realms/<realm>/clients-registrations/default`."
 msgstr ""
-"クライアントを作成するには、クライアント表現（JSON）を作成し、 `/realms/"
-"<realm>/clients-registrations/default` に、HTTP POSTリクエストを送信します。"
+"クライアントを作成するには、クライアント表現（JSON）を作成し、 `/realms/<realm>/clients-"
+"registrations/default` に、HTTP POSTリクエストを送信します。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:79
 msgid ""
 "It will return a Client Representation that also includes the registration "
 "access token.  You should save the registration access token somewhere if "
 "you want to retrieve the config, update or delete the client later."
 msgstr ""
-"登録アクセス・トークンを含むクライアント表現が返されます。設定を取得したり、"
-"クライアントを後で更新、削除したい場合は、登録アクセス・トークンをどこかに保"
-"存する必要があります。"
+"登録アクセス・トークンを含むクライアント表現が返されます。設定を取得したり、クライアントを後で更新、削除したい場合は、登録アクセス・トークンをどこかに保存する必要があります。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:81
 msgid ""
-"To retrieve the Client Representation then do a HTTP GET to `/realms/<realm>/"
-"clients-registrations/default/<client id>`."
+"To retrieve the Client Representation then do a HTTP GET to `/realms/<realm"
+">/clients-registrations/default/<client id>`."
 msgstr ""
-"クライアント表現を取得するには、 `/realms/<realm>/clients-registrations/"
-"default/<client id>` にHTTP GETします。"
+"クライアント表現を取得するには、 `/realms/<realm>/clients-registrations/default/<client id>`"
+" にHTTP GETします。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:83
 #: source/securing_apps/topics/client-registration.adoc:88
 msgid "It will also return a new registration access token."
 msgstr "新しい登録アクセス・トークンも返します。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:86
 msgid ""
 "To update the Client Representation then do a HTTP PUT to with the updated "
-"Client Representation to: `/realms/<realm>/clients-registrations/default/"
-"<client id>`."
+"Client Representation to: `/realms/<realm>/clients-"
+"registrations/default/<client id>`."
 msgstr ""
-"クライアント表現を更新するには、更新したクライアント表現を次のURLにHTTP PUTし"
-"ます:  `/realms/<realm>/clients-registrations/default/<client id>` 。"
+"クライアント表現を更新するには、更新したクライアント表現を次のURLにHTTP PUTします:  `/realms/<realm>/clients-"
+"registrations/default/<client id>` 。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:91
 msgid ""
-"To delete the Client Representation then do a HTTP DELETE to: `/realms/"
-"<realm>/clients-registrations/default/<client id>`"
+"To delete the Client Representation then do a HTTP DELETE to: "
+"`/realms/<realm>/clients-registrations/default/<client id>`"
 msgstr ""
-"クライアント表現を削除するには、 `/realms/<realm>/clients-registrations/"
-"default/<client id>` にHTTP DELETEします。"
+"クライアント表現を削除するには、 `/realms/<realm>/clients-registrations/default/<client id>`"
+" にHTTP DELETEします。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration.adoc:92
@@ -350,45 +312,32 @@ msgstr ""
 msgid "{project_name} Adapter Configuration"
 msgstr "{project_name}アダプター設定"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:97
 msgid ""
 "The `installation` client registration provider can be used to retrieve the "
-"adapter configuration for a client.  In addition to token authentication you "
-"can also authenticate with client credentials using HTTP basic "
+"adapter configuration for a client.  In addition to token authentication you"
+" can also authenticate with client credentials using HTTP basic "
 "authentication.  To do this include the following header in the request:"
 msgstr ""
-"`installation` クライアント登録プロバイダーは、クライアントのアダプター設定を"
-"取得するために使用できます。トークン認証に加えて、HTTP基本認証を使用してクラ"
-"イアントクレデンシャルで認証することもできます。 これを行うには、リクエストに"
-"次のヘッダーを含めます。"
+"`installation` "
+"クライアント登録プロバイダーは、クライアントのアダプター設定を取得するために使用できます。トークン認証に加えて、HTTP基本認証を使用してクライアントクレデンシャルで認証することもできます。"
+" これを行うには、リクエストに次のヘッダーを含めます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:99
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:109
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:39
-#: source/server_development/topics/providers.adoc:202
-msgid "[source]"
-msgstr "[source]"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:102
+#: source/securing_apps/topics/client-registration.adoc:101
 #, no-wrap
-msgid ""
-"Authorization: basic BASE64(client-id + ':' + client-secret)\n"
-"----        \n"
-msgstr ""
-"Authorization: basic BASE64(client-id + ':' + client-secret)\n"
-"----        \n"
+msgid "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
+msgstr "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:104
 msgid ""
-"To retrieve the Adapter Configuration then do a HTTP GET to `/realms/<realm>/"
-"clients-registrations/install/<client id>`."
+"To retrieve the Adapter Configuration then do a HTTP GET to `/realms/<realm"
+">/clients-registrations/install/<client id>`."
 msgstr ""
-"アダプター設定を取得するには、 `/realms/<realm>/clients-registrations/"
-"install/<client id>` にHTTP GETします。"
+"アダプター設定を取得するには、 `/realms/<realm>/clients-registrations/install/<client id>` "
+"にHTTP GETします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:107
@@ -397,9 +346,7 @@ msgid ""
 "JavaScript adapter you can load the client configuration directly from "
 "{project_name} using the above URL."
 msgstr ""
-"パブリック・クライアントは認証が要求されません。これは、JavaScriptアダプター"
-"は、上記URLを使用して、直接{project_name}からクライアント設定を読み込めること"
-"を意味します。"
+"パブリック・クライアントは認証が要求されません。これは、JavaScriptアダプターは、上記URLを使用して、直接{project_name}からクライアント設定を読み込めることを意味します。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration.adoc:108
@@ -418,20 +365,19 @@ msgid ""
 msgstr ""
 "{project_name}は、 https://tools.ietf.org/html/rfc7591[OAuth 2.0 Dynamic "
 "Client Registration Protocol] と https://tools.ietf.org/html/rfc7592[OAuth "
-"2.0 Dynamic Client Registration Management Protocol] を継承した https://"
-"openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect Dynamic "
-"Client Registration] を実装します。"
+"2.0 Dynamic Client Registration Management Protocol] を継承した "
+"https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect"
+" Dynamic Client Registration] を実装します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:113
 msgid ""
 "The endpoint to use these specifications to register clients in "
-"{project_name} is `/realms/<realm>/clients-registrations/openid-connect[/"
-"<client id>]`."
+"{project_name} is `/realms/<realm>/clients-registrations/openid-"
+"connect[/<client id>]`."
 msgstr ""
-"これらの仕様を使用して、{project_name}にクライアントを登録するエンドポイント"
-"は、 `/realms/<realm>/clients-registrations/openid-connect[/<client id>]` で"
-"す。"
+"これらの仕様を使用して、{project_name}にクライアントを登録するエンドポイントは、 `/realms/<realm>/clients-"
+"registrations/openid-connect[/<client id>]` です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:115
@@ -439,8 +385,8 @@ msgid ""
 "This endpoints can also be found in the OpenID Connect Discovery endpoint "
 "for the realm, `/realms/<realm>/.well-known/openid-configuration`."
 msgstr ""
-"このエンドポイントは、そのレルムのOpenID Connect Discoveryエンドポイント（ `/"
-"realms/<realm>/.well-known/openid-configuration` ）にも見つかります。"
+"このエンドポイントは、そのレルムのOpenID Connect Discoveryエンドポイント（ `/realms/<realm>/.well-"
+"known/openid-configuration` ）にも見つかります。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration.adoc:116
@@ -459,25 +405,21 @@ msgid ""
 "Representation is returned with details about the created client, including "
 "a registration access token."
 msgstr ""
-"SAMLエンティティ記述子エンドポイントは、クライアントを作成するために、SAML v2"
-"エンティティ記述子を使用することだけをサポートします。クライアントの取得、更"
-"新、削除はサポートしていません。これらの操作に対して、{project_name}形式のエ"
-"ンドポイントを使用してください。クライアントを作成すると、作成されたクライア"
-"ントの詳細とともに、{project_name}クライアント表現が返されます（登録アクセ"
-"ス・トークンを含みます）。"
+"SAMLエンティティ記述子エンドポイントは、クライアントを作成するために、SAML "
+"v2エンティティ記述子を使用することだけをサポートします。クライアントの取得、更新、削除はサポートしていません。これらの操作に対して、{project_name}形式のエンドポイントを使用してください。クライアントを作成すると、作成されたクライアントの詳細とともに、{project_name}クライアント表現が返されます（登録アクセス・トークンを含みます）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:124
 msgid ""
-"To create a client do a HTTP POST with the SAML Entity Descriptor to `/"
-"realms/<realm>/clients-registrations/saml2-entity-descriptor`."
+"To create a client do a HTTP POST with the SAML Entity Descriptor to "
+"`/realms/<realm>/clients-registrations/saml2-entity-descriptor`."
 msgstr ""
-"クライアントを作成するには、 `/realms/<realm>/clients-registrations/saml2-"
-"entity-descriptor` にSAMLエンティティ記述子を含むHTTP POSTリクエストを送信し"
-"ます。"
+"クライアントを作成するには、 `/realms/<realm>/clients-registrations/saml2-entity-"
+"descriptor` にSAMLエンティティ記述子を含むHTTP POSTリクエストを送信します。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration.adoc:125
+#: source/securing_apps/topics/oidc/oidc-generic.adoc:134
 #: source/server_development/topics/admin-rest-api.adoc:13
 #, no-wrap
 msgid "Example using CURL"
@@ -490,9 +432,9 @@ msgid ""
 "CURL. You need to replace `eyJhbGciOiJSUz...` with a proper initial access "
 "token or bearer token."
 msgstr ""
-"CURLを使用して、クライアントID `myclient` でクライアントを作成する例を次にし"
-"ます。適切な初期アクセス・トークンまたはベアラー・トークンで "
-"`eyJhbGciOiJSUz...` を置き換える必要があります。"
+"CURLを使用して、クライアントID `myclient` "
+"でクライアントを作成する例を次にします。適切な初期アクセス・トークンまたはベアラー・トークンで `eyJhbGciOiJSUz...` "
+"を置き換える必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration.adoc:137
@@ -520,12 +462,11 @@ msgstr "Javaクライアント登録APIを使用した例"
 #: source/securing_apps/topics/client-registration.adoc:143
 msgid ""
 "The Client Registration Java API makes it easy to use the Client "
-"Registration Service using Java.  To use include the dependency `org."
-"keycloak:keycloak-client-registration-api:>VERSION<` from Maven."
+"Registration Service using Java.  To use include the dependency "
+"`org.keycloak:keycloak-client-registration-api:>VERSION<` from Maven."
 msgstr ""
-"クライアント登録Java APIは、 Javaを使用してクライアント登録サービスを使いやす"
-"くします。使用するには、Mavenに `org.keycloak:keycloak-client-registration-"
-"api:>VERSION<` の依存関係を含めて下さい。"
+"クライアント登録Java APIは、 Javaを使用してクライアント登録サービスを使いやすくします。使用するには、Mavenに "
+"`org.keycloak:keycloak-client-registration-api:>VERSION<` の依存関係を含めて下さい。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:146
@@ -534,9 +475,8 @@ msgid ""
 "JavaDocs.  Below is an example of creating a client. You need to replace "
 "`eyJhbGciOiJSUz...` with a proper initial access token or bearer token."
 msgstr ""
-"クライアント登録の使用方法の完全な説明は、JavaDocsを参照して下さい。 以下は、"
-"クライアントを作成する例です。 `eyJhbGciOiJSUz...` を適切な初期アクセス・トー"
-"クンまたはベアラー・トークンに置き換える必要があります。"
+"クライアント登録の使用方法の完全な説明は、JavaDocsを参照して下さい。 以下は、クライアントを作成する例です。 "
+"`eyJhbGciOiJSUz...` を適切な初期アクセス・トークンまたはベアラー・トークンに置き換える必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration.adoc:150
@@ -595,9 +535,7 @@ msgstr "クライアント登録ポリシー"
 msgid ""
 "{project_name} currently supports 2 ways how can be new clients registered "
 "through Client Registration Service."
-msgstr ""
-"{project_name}は現在、クライアント登録サービスを介して新しいクライアントを登"
-"録できる2つの方法をサポートしています。"
+msgstr "{project_name}は現在、クライアント登録サービスを介して新しいクライアントを登録できる2つの方法をサポートしています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:170
@@ -605,18 +543,15 @@ msgid ""
 "Authenticated requests - Request to register new client must contain either "
 "`Initial Access Token` or `Bearer Token` as mentioned above."
 msgstr ""
-"認証済みリクエスト - 新しいクライアントを登録するためのリクエストは、前述の `"
-"初期アクセス・トークン` または `ベアラー・トークン` のいずれかを含める必要が"
-"あります。"
+"認証済みリクエスト - 新しいクライアントを登録するためのリクエストは、前述の `初期アクセス・トークン` または `ベアラー・トークン` "
+"のいずれかを含める必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:172
 msgid ""
 "Anonymous requests - Request to register new client doesn't need to contain "
 "any token at all"
-msgstr ""
-"匿名リクエスト - 新しいクライアントを登録するためのリクエストは、すべての任意"
-"のトークンを含める必要はありません。"
+msgstr "匿名リクエスト - 新しいクライアントを登録するためのリクエストは、すべての任意のトークンを含める必要はありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:175
@@ -627,10 +562,8 @@ msgid ""
 "SPI`, which provide a way to limit who can register new clients and under "
 "which conditions."
 msgstr ""
-"匿名クライアント登録リクエストは、非常に面白く、強力な機能ですが、誰でも制限"
-"なく新しいクライアントを登録できることを通常は望みません。したがって、そのよ"
-"うな条件下で、新しいクライアントを登録できるユーザーを、制限する方法を提供す"
-"る `Client Registration Policy SPI` があります。"
+"匿名クライアント登録リクエストは、非常に面白く、強力な機能ですが、誰でも制限なく新しいクライアントを登録できることを通常は望みません。したがって、そのような条件下で、新しいクライアントを登録できるユーザーを、制限する方法を提供する"
+" `Client Registration Policy SPI` があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:178
@@ -640,10 +573,9 @@ msgid ""
 "policies are configured by default for anonymous requests and what policies "
 "are configured for authenticated requests."
 msgstr ""
-"{project_name}管理コンソールで、 `Client Registration` タブ、 `Client "
-"Registration Policies` サブタブをクリックします。ここでは、匿名リクエストに対"
-"してデフォルトでどのようなポリシーが設定されるか、認証リクエストに対してどの"
-"ようなポリシーを設定されるかが表示されます。"
+"{project_name}管理コンソールで、 `Client Registration` タブ、 `Client Registration "
+"Policies` "
+"サブタブをクリックします。ここでは、匿名リクエストに対してデフォルトでどのようなポリシーが設定されるか、認証リクエストに対してどのようなポリシーを設定されるかが表示されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:184
@@ -659,15 +591,10 @@ msgid ""
 "disable `Consent Required` when updating client and when `Consent Required` "
 "policy is present etc."
 msgstr ""
-"匿名リクエスト(トークンの無いリクエスト)は、新しいクライアントを作成(登録)す"
-"ることだけが許可されています。したがって、匿名リクエストを使用して新しいクラ"
-"イアントを登録すると、レスポンスにはそのクライアントの読み取り、更新、削除リ"
-"クエストに使用する登録アクセス・トークンが含まれます。ただし、匿名登録レスポ"
-"ンスから取得した登録アクセス・トークンを使用すると、匿名ポリシーの対象にもな"
-"ります！これは、例えば、 `Trusted Hosts` ポリシーを持っているならば、クライア"
-"ント更新リクエストも信頼されたホストから来る必要があることを意味します。ま"
-"た、例えば、クライアントの更新時や `Consent Required` ポリシーが存在する場合"
-"などに、 `Consent Required` を無効にすることはできません。"
+"匿名リクエスト(トークンの無いリクエスト)は、新しいクライアントを作成(登録)することだけが許可されています。したがって、匿名リクエストを使用して新しいクライアントを登録すると、レスポンスにはそのクライアントの読み取り、更新、削除リクエストに使用する登録アクセス・トークンが含まれます。ただし、匿名登録レスポンスから取得した登録アクセス・トークンを使用すると、匿名ポリシーの対象にもなります！これは、例えば、"
+" `Trusted Hosts` "
+"ポリシーを持っているならば、クライアント更新リクエストも信頼されたホストから来る必要があることを意味します。また、例えば、クライアントの更新時や "
+"`Consent Required` ポリシーが存在する場合などに、 `Consent Required` を無効にすることはできません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:186
@@ -685,14 +612,10 @@ msgid ""
 "pointing to some untrusted host. By default, there is not any whitelisted "
 "host, so anonymous client registration is de-facto disabled by default."
 msgstr ""
-"Trusted Hosts Policy - 信頼されたホストと信頼されているドメインの一覧を設定で"
-"きます。それらのホストやドメインだけからクライアント登録サービスへのリクエス"
-"トを送信できます。信頼されていないIPから送信されたリクエストは拒否されます。"
-"また、新たに登録されたクライアントのURLは、信頼されたホストやドメインだけを使"
-"わなければなりません。例えば、信頼できないホストを指すクライアントの "
-"`Redirect URI` を設定することは許可されません。デフォルトでは、ホワイトリスト"
-"に登録されているホストが無いため、匿名クライアント登録は事実上無効になってい"
-"ます。"
+"Trusted Hosts Policy - "
+"信頼されたホストと信頼されているドメインの一覧を設定できます。それらのホストやドメインだけからクライアント登録サービスへのリクエストを送信できます。信頼されていないIPから送信されたリクエストは拒否されます。また、新たに登録されたクライアントのURLは、信頼されたホストやドメインだけを使わなければなりません。例えば、信頼できないホストを指すクライアントの"
+" `Redirect URI` "
+"を設定することは許可されません。デフォルトでは、ホワイトリストに登録されているホストが無いため、匿名クライアント登録は事実上無効になっています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:194
@@ -704,47 +627,39 @@ msgid ""
 "access to any personal info or permission of user unless user approves it."
 msgstr ""
 "Consent Required Policy - 新たに登録されたクライアントは、 `Consent Allowed` "
-"スイッチが有効になります。したがって、認証成功後、個人情報とアクセス権(プロト"
-"コルマッパーとロール)を承認する必要がある場合、常に同意画面が表示されます。つ"
-"まり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権"
-"にアクセスすることができません。"
+"スイッチが有効になります。したがって、認証成功後、個人情報とアクセス権(プロトコルマッパーとロール)を承認する必要がある場合、常に同意画面が表示されます。つまり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権にアクセスすることができません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:198
 msgid ""
 "Protocol Mappers Policy - Allows to configure list of whitelisted protocol "
 "mapper implementations. New client can't be registered or updated if it "
-"contains some non-whitelisted protocol mapper. Note that this policy is used "
-"for authenticated requests as well, so even for authenticated request there "
-"are some limitations which protocol mappers can be used."
+"contains some non-whitelisted protocol mapper. Note that this policy is used"
+" for authenticated requests as well, so even for authenticated request there"
+" are some limitations which protocol mappers can be used."
 msgstr ""
-"Protocol Mappers Policy - プロトコル・マッパーの実装のホワイト・リストを設定"
-"できます。ホワイト・リストに無いプロトコル・マッパーが含まれている場合は、新"
-"たなクライアントを登録または更新できません。このポリシーは認証済みのリクエス"
-"トにも使用されるため、認証済みのリクエストに対してもプロトコルマッパーを使用"
-"できるいくつかの制限があることに注意して下さい。"
+"Protocol Mappers Policy - "
+"プロトコル・マッパーの実装のホワイト・リストを設定できます。ホワイト・リストに無いプロトコル・マッパーが含まれている場合は、新たなクライアントを登録または更新できません。このポリシーは認証済みのリクエストにも使用されるため、認証済みのリクエストに対してもプロトコルマッパーを使用できるいくつかの制限があることに注意して下さい。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:201
 msgid ""
-"Client Template Policy - Allow to whitelist `Client Templates`, which can be "
-"used with newly registered or updated clients.  There are no whitelisted "
+"Client Template Policy - Allow to whitelist `Client Templates`, which can be"
+" used with newly registered or updated clients.  There are no whitelisted "
 "templates by default."
 msgstr ""
-"Client Template Policy - 新たに登録/更新したクライアントと使うことができる "
-"`Client Templates` のホワイト・リスト化を許可します。デフォルトでは、ホワイ"
-"ト・リスト化されたテンプレートはありません。"
+"Client Template Policy - 新たに登録/更新したクライアントと使うことができる `Client Templates` "
+"のホワイト・リスト化を許可します。デフォルトでは、ホワイト・リスト化されたテンプレートはありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:204
 msgid ""
 "Full Scope Policy - Newly registered clients will have `Full Scope Allowed` "
-"switch disabled. This means they won't have any scoped realm roles or client "
-"roles of other clients."
+"switch disabled. This means they won't have any scoped realm roles or client"
+" roles of other clients."
 msgstr ""
-"Full Scope Policy - 新たに登録されたクライアントは `Full Scope Allowed` ス"
-"イッチが無効に切り替わります。これは、スコープが設定されたレルム・ロールや他"
-"のクライアントのクライアント・ロールが無いことを意味します。"
+"Full Scope Policy - 新たに登録されたクライアントは `Full Scope Allowed` "
+"スイッチが無効に切り替わります。これは、スコープが設定されたレルム・ロールや他のクライアントのクライアント・ロールが無いことを意味します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:206
@@ -753,17 +668,16 @@ msgid ""
 "the realm is same or bigger than specified limit. It's 200 by default for "
 "anonymous registrations."
 msgstr ""
-"Max Clients Policy - レルム内の現在のクライアント数が指定された制限以上の場"
-"合、登録を拒否します。匿名登録のデフォルトは200です。"
+"Max Clients Policy - レルム内の現在のクライアント数が指定された制限以上の場合、登録を拒否します。匿名登録のデフォルトは200です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration.adoc:209
 msgid ""
 "Client Disabled Policy - Newly registered client will be disabled. This "
 "means that admin needs to manually approve and enable all newly registered "
-"clients.  This policy is not used by default even for anonymous registration."
+"clients.  This policy is not used by default even for anonymous "
+"registration."
 msgstr ""
-"Client Disabled Policy - 新たに登録されたクライアントは無効になります。これ"
-"は、管理者が新しく登録された全てのクライアントを手動で承認し、有効にする必要"
-"があることを意味します。 匿名登録に対しても、デフォルトではこのポリシーは使用"
-"されません。"
+"Client Disabled Policy - "
+"新たに登録されたクライアントは無効になります。これは、管理者が新しく登録された全てのクライアントを手動で承認し、有効にする必要があることを意味します。 "
+"匿名登録に対しても、デフォルトではこのポリシーは使用されません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__client-registration/ja_JP/index.html
