### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,18 +27,18 @@ msgid ""
 "This section covers configuring {project_name} to run in a cluster.  There's"
 " a number of things you have to do when setting up a cluster, specifically:"
 msgstr ""
-"このセクションでは、クラスターを実行するように{project_name}を設定する方法についてご説明します。 "
+"このセクションでは、{project_name}をクラスター内で実行するように設定する方法についてご説明します。 "
 "クラスターを設定する場合、多くの設定が必要になります。具体的には以下のとおりです。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:9
 msgid "<<_operating-mode,Pick an operation mode>>"
-msgstr "<<_operating-mode,Pick an operation mode>>"
+msgstr "<<_operating-mode,動作モードの選択>>"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:10
 msgid "<<_database,Configure a shared external database>>"
-msgstr "<<_database,Configure a shared external database>>"
+msgstr "<<_database,外部共有データベースの設定>>"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:11
@@ -58,7 +58,7 @@ msgid ""
 " load balancer and supplying a private network.  We'll also discuss some "
 "issues that you need to be aware of when booting up a host in the cluster."
 msgstr ""
-"操作モードの選択と共有データベースの設定については、このガイドの前半でご説明しました。この章では、ロードバランサーの設定とプライベートネットワークの提供についてご説明します。また、クラスタ内でホストを起動する場合の注意点についてもご説明します。"
+"動作モードの選択と共有データベースの設定については、このガイドの前半でご説明しました。この章では、ロードバランサーの設定とプライベート・ネットワークの提供についてご説明します。また、クラスター内でホストを起動する場合の注意点についてもご説明します。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:17
@@ -68,5 +68,5 @@ msgid ""
 "link:{appserver_jgroups_link}[JGroups] chapter of the "
 "_{appserver_jgroups_name}_."
 msgstr ""
-"IPマルチキャストなしでも{project_name}をクラスタリングすることは可能ですが、このトピックについてはこのガイドの範囲を超えています。詳しくは、"
+"IPマルチキャストなしでも{project_name}をクラスターを構成することは可能ですが、このトピックについてはこのガイドの範囲を超えています。詳しくは、"
 " _{appserver_jgroups_name}_ のlink:{appserver_jgroups_link}[JGroups]をご覧ください。"

--- a/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
@@ -1,65 +1,72 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__clustering.ja_JP.po\n"
 
 #. type: Title ==
 #: source/server_installation/topics/clustering.adoc:3
 #, no-wrap
 msgid "Clustering"
-msgstr ""
+msgstr "クラスタリング"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:7
 msgid ""
-"This section covers configuring {project_name} to run in a cluster.  There's "
-"a number of things you have to do when setting up a cluster, specifically:"
+"This section covers configuring {project_name} to run in a cluster.  There's"
+" a number of things you have to do when setting up a cluster, specifically:"
 msgstr ""
+"このセクションでは、クラスターを実行するように{project_name}を設定する方法についてご説明します。 "
+"クラスターを設定する場合、多くの設定が必要になります。具体的には以下のとおりです。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:9
 msgid "<<_operating-mode,Pick an operation mode>>"
-msgstr ""
+msgstr "<<_operating-mode,Pick an operation mode>>"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:10
 msgid "<<_database,Configure a shared external database>>"
-msgstr ""
+msgstr "<<_database,Configure a shared external database>>"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:11
 msgid "Set up a load balancer"
-msgstr ""
+msgstr "ロードバランサーの設定"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:12
 msgid "Supplying a private network that supports IP multicast"
-msgstr ""
+msgstr "IPマルチキャストをサポートするプライベート・ネットワークの提供"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:16
 msgid ""
 "Picking an operation mode and configuring a shared database have been "
-"discussed earlier in this guide.  In this chapter we'll discuss setting up a "
-"load balancer and supplying a private network.  We'll also discuss some "
+"discussed earlier in this guide.  In this chapter we'll discuss setting up a"
+" load balancer and supplying a private network.  We'll also discuss some "
 "issues that you need to be aware of when booting up a host in the cluster."
 msgstr ""
+"操作モードの選択と共有データベースの設定については、このガイドの前半でご説明しました。この章では、ロードバランサーの設定とプライベートネットワークの提供についてご説明します。また、クラスタ内でホストを起動する場合の注意点についてもご説明します。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering.adoc:17
 msgid ""
 "It is possible to cluster {project_name} without IP Multicast, but this "
-"topic is beyond the scope of this guide.  For more information, see link:"
-"{appserver_jgroups_link}[JGroups] chapter of the _{appserver_jgroups_name}_."
+"topic is beyond the scope of this guide.  For more information, see "
+"link:{appserver_jgroups_link}[JGroups] chapter of the "
+"_{appserver_jgroups_name}_."
 msgstr ""
+"IPマルチキャストなしでも{project_name}をクラスタリングすることは可能ですが、このトピックについてはこのガイドの範囲を超えています。詳しくは、"
+" _{appserver_jgroups_name}_ のlink:{appserver_jgroups_link}[JGroups]をご覧ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__clustering/ja_JP/index.html
