### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -15,24 +15,17 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ###
-#: source/server_installation/topics/clustering/troubleshooting.adoc:2
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:391
-#: source/securing_apps/topics/saml/java/debugging.adoc:2
-#: source/server_admin/topics/authentication/kerberos.adoc:191
-#: source/server_admin/topics/authentication/x509.adoc:201
+#. type: Attribute :installguide_troubleshooting_name:
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
 #. type: Title ==
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:2
 #, no-wrap
 msgid "Client Registration CLI"
 msgstr "クライアント登録CLI"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:6
 msgid ""
 "`Client Registration CLI` is a command line interface tool for application "
 "developers to configure new clients in self-service manner when integrating "
@@ -44,7 +37,6 @@ msgstr ""
 " これは、{project_name}クライアント登録RESTエンドポイントと対話するように特別に設計されています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:10
 msgid ""
 "In order for any application to be able to use {project_name} it is "
 "necessary to create or obtain a client configuration. Usually a new client "
@@ -57,7 +49,6 @@ msgstr ""
 " `client_id` で識別する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:12
 msgid ""
 "`Client Registration CLI` allows you to configure application clients from a"
 " command line, and can be used in shell scripts as well."
@@ -65,7 +56,6 @@ msgstr ""
 "`クライアント登録CLI` では、コマンドラインからアプリケーション・クライアントを設定することができます。シェルスクリプトでも使用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:15
 #, no-wrap
 msgid ""
 "To allow a particular user to use `Client Registration CLI` the {project_name} administrator will typically use `Admin Console` to configure\n"
@@ -76,13 +66,11 @@ msgstr ""
 "へのアクセス権を与えるように新しいクライアントとクライアント・シークレットを設定します 。\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:18
 #, no-wrap
 msgid "Configuring a new regular user for use with Client Registration CLI"
 msgstr "クライアント登録CLIで使用するための新しい正規ユーザーの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:27
 msgid ""
 "Login as `admin` into `Admin Console` (e.g. "
 "`http://localhost:8080/auth/admin`). Select a realm you want to administer."
@@ -107,7 +95,6 @@ msgstr ""
 "を選択できます。これらの権限により、ユーザーは<<_initial_access_token,初期アクセス・トークン>>または<<_registration_access_token,登録アクセス・トークン>>を使用せずに操作を実行できるようになります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:31
 msgid ""
 "It's possible to not assign users any of `realm-management` roles. In that "
 "case user can still login with `Registration Client CLI` but will not be "
@@ -120,7 +107,6 @@ msgstr ""
 "を所有していなければ使用することはできません。それなしで何らかの操作を実行しようとすると `403 Forbidden` エラーが発生します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:33
 msgid ""
 "Administrator can issue `Initial Access Tokens` from `Admin Console` by "
 "selecting `Client Registration` tab under `Realm Settings`, then `Initial "
@@ -130,13 +116,11 @@ msgstr ""
 "Token` サブ・タブを選択することによって、管理コンソールから `初期アクセストークン` を発行することができます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:35
 #, no-wrap
 msgid "Configuring a client for use with Client Registration CLI"
 msgstr "クライアント登録CLIで使用するためのクライアント設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:41
 msgid ""
 "By default the `Client Registration CLI` identifies to the server as `admin-"
 "cli` client which is automatically configured for every new realm.  No "
@@ -153,7 +137,6 @@ msgstr ""
 "オプションを使用してシークレットを提供する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:44
 msgid ""
 "If you want to use a separate client configuration for `Registration Client "
 "CLI` then you can create a new client - you can call it `reg-cli` for "
@@ -165,7 +148,6 @@ msgstr ""
 "`clientId` を使用するかを指定する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:48
 msgid ""
 "If you want to use a service account associated with the client, you first "
 "need to enable service accounts. In `Admin Console` go to `Clients` section,"
@@ -179,14 +161,12 @@ msgstr ""
 "することを忘れないでください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:50
 msgid ""
 "Under `Credentials` tab you can choose to configure either `Client Id and "
 "Secret`, or `Signed JWT`."
 msgstr "`Credentials` タブで、`Client Id and Secret` か `Signed JWT` のどちらかを設定できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:52
 msgid ""
 "Having done that you can then omit specifying user during `kcreg config "
 "credentials`, and only provide client secret or keystore info."
@@ -195,13 +175,11 @@ msgstr ""
 "の実行中にユーザーを指定することを省略し、クライアント・シークレットやキーストア情報のみを提供することができます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:54
 #, no-wrap
 msgid "Installing Client Registration CLI"
 msgstr "クライアント登録CLIのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:57
 msgid ""
 "Client Registration CLI is packaged inside Keycloak Server distribution. You"
 " can find execution scripts inside `bin` directory."
@@ -210,14 +188,12 @@ msgstr ""
 "ディレクトリ内に実行スクリプトがあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:59
 msgid ""
 "The Linux script is called `kcreg.sh`, and the one for Windows is called "
 "`kcreg.bat`."
 msgstr "Linuxのスクリプトは `kcreg.sh` 、Windowsのスクリプトは `kcreg.bat` という名前です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:61
 msgid ""
 "In order to setup the client for use from any location on the filesystem you"
 " may want to add Keycloak server directory to your PATH."
@@ -225,19 +201,10 @@ msgstr ""
 "ファイルシステム上の任意の場所からクライアントを使用できるように設定するには、PATHにKeycloakサーバーのディレクトリを追加します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:63
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:244
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:304
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:341
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:359
-#: source/server_admin/topics/admin-cli.adoc:17
-#: source/server_admin/topics/admin-cli.adoc:381
-#: source/server_admin/topics/admin-cli.adoc:392
 msgid "On Linux:"
 msgstr "Linuxの場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:67
 #, no-wrap
 msgid ""
 "$ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
@@ -247,21 +214,10 @@ msgstr ""
 "$ kcreg.sh\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:70
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:206
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:250
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:275
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:290
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:312
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:329
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:347
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:365
-#: source/server_admin/topics/admin-cli.adoc:22
 msgid "On Windows:"
 msgstr "Windowsの場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:74
 #, no-wrap
 msgid ""
 "c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
@@ -271,20 +227,17 @@ msgstr ""
 "c:\\> kcreg\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:77
 msgid ""
 "Where KEYCLOAK_HOME refers to a directory where Keycloak Server distribution"
 " was unpacked."
 msgstr "KEYCLOAK_HOMEは、Keycloakサーバーの配布物が解凍されたディレクトリを示します。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:80
 #, no-wrap
 msgid "Using Client Registration CLI"
 msgstr "クライアント登録CLIの使用"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:83
 msgid ""
 "First you need to start an authenticated session (i.e. logging in) by "
 "providing credentials. Then you perform operations on Client Registration "
@@ -293,19 +246,10 @@ msgstr ""
 "まず、クレデンシャルを提供して認証されたセッション（つまりログイン）を開始する必要があります。次に、クライアント登録RESTエンドポイントで操作を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:85
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:108
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:144
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:191
-#: source/server_admin/topics/admin-cli.adoc:42
-#: source/server_admin/topics/admin-cli.adoc:62
-#: source/server_admin/topics/admin-cli.adoc:221
-#: source/server_admin/topics/admin-cli.adoc:301
 msgid "For example on Linux:"
 msgstr "例えば、Linux の場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:91
 #, no-wrap
 msgid ""
 "$ kcreg.sh config credentials --server http://localhost:8080/auth --realm demo --user user --client reg-cli\n"
@@ -317,24 +261,10 @@ msgstr ""
 "$ kcreg.sh get my_client\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:94
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:114
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:151
-#: source/server_admin/topics/admin-cli.adoc:50
-#: source/server_admin/topics/admin-cli.adoc:66
-#: source/server_admin/topics/admin-cli.adoc:227
-#: source/server_admin/topics/admin-cli.adoc:305
-#: source/server_admin/topics/admin-cli.adoc:322
-#: source/server_admin/topics/admin-cli.adoc:343
-#: source/server_admin/topics/admin-cli.adoc:385
-#: source/server_admin/topics/admin-cli.adoc:396
-#: source/server_admin/topics/admin-cli.adoc:708
-#: source/server_admin/topics/admin-cli.adoc:760
 msgid "Or on Windows:"
-msgstr "またはWindowsの場合："
+msgstr "または、Windowsの場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:100
 #, no-wrap
 msgid ""
 "c:\\> kcreg config credentials --server http://localhost:8080/auth --realm demo --user user --client reg-cli\n"
@@ -346,7 +276,6 @@ msgstr ""
 "c:\\> kcreg get my_client\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:106
 msgid ""
 "In a production environment Keycloak has to be accessed with `https:` to "
 "avoid exposing tokens to network sniffers. If server's certificate is not "
@@ -359,7 +288,6 @@ msgstr ""
 " `truststore.jks` ファイルを準備し、それを使用するように、 `クライアント登録CLI` に指示する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:111
 #, no-wrap
 msgid ""
 "$ kcreg.sh config truststore --trustpass $PASSWORD "
@@ -369,7 +297,6 @@ msgstr ""
 "~/.keycloak/truststore.jks\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:118
 #, no-wrap
 msgid ""
 "c:\\> kcreg config truststore --trustpass %PASSWORD% "
@@ -379,13 +306,11 @@ msgstr ""
 "%HOMEPATH%\\.keycloak\\truststore.jks\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:122
 #, no-wrap
 msgid "Logging In"
 msgstr "ログイン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:128
 msgid ""
 "When logging in with `Client Registration CLI` you specify a server endpoint"
 " url, and a realm. Then you specify a username or, alternatively, a client "
@@ -399,7 +324,6 @@ msgstr ""
 " `署名済みJWT` のみが使用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:133
 msgid ""
 "Regardless of the method, the account that logs in needs proper permissions "
 "to be able to perform client registration operations. Keep in mind that any "
@@ -413,7 +337,6 @@ msgstr ""
 " `master` レルムで1人のユーザーを作成して、異なるレルムのクライアントを管理するロールを追加します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:136
 msgid ""
 "`Client Registration CLI` by itself does not support configuring users, for "
 "that you would need to use `Admin Console` web interface or Admin Client CLI"
@@ -425,7 +348,6 @@ msgstr ""
 " [{adminguide_name}]）を使う必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:139
 msgid ""
 "When `kcreg` successfully logs in it receives authorization tokens and saves"
 " them into private config file so they can be used for subsequent "
@@ -437,39 +359,32 @@ msgstr ""
 " 次の章>>を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:141
 msgid ""
 "See built-in help for more information on using `Client Registration CLI`."
 msgstr "`クライアント登録CLI` の使用方法の詳細については、組み込みのヘルプを参照してください。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:147
 #, no-wrap
 msgid "$ kcreg.sh help\n"
 msgstr "$ kcreg.sh help\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:154
 #, no-wrap
 msgid "c:\\> kcreg help\n"
 msgstr "c:\\> kcreg help\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:157
 msgid ""
 "See `kcreg config credentials --help` for more information about starting an"
 " authenticated session."
 msgstr "認証されたセッションの開始についての詳細は、 `kcreg config credentials --help` を参照してください。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:161
-#: source/server_admin/topics/admin-cli.adoc:110
 #, no-wrap
 msgid "Working with alternative configurations"
 msgstr "代替設定の使用"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:165
 msgid ""
 "By default, `Client Registration CLI` automatically maintains a "
 "configuration file at a default location - `./.keycloak/kcreg.config` under "
@@ -479,7 +394,6 @@ msgstr ""
 "`./.keycloak/kcreg.config` ）に設定ファイルを自動的に保持します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:168
 msgid ""
 "You can always use `--config` option to point to a different file / "
 "location. This way you can mantain multiple authenticated sessions in "
@@ -490,7 +404,6 @@ msgstr ""
 "オプションを使うと、いつでも別のファイル/場所を指すことができます。これにより、複数の認証済みセッションを並行して処理できます。1つのスレッドから1つの設定ファイルに結び付けられた操作を実行するのが最も安全です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:170
 msgid ""
 "Make sure to not make the config file visible to other users on the system "
 "as it contains access tokens, and secrets that should be kept private."
@@ -498,7 +411,6 @@ msgstr ""
 "アクセス・トークンとプライベートにしておかなければならないシークレットが含まれているため、設定ファイルをシステム上の他のユーザーには参照できないようにしてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:174
 msgid ""
 "You may want to avoid storing any secrets at all inside a config file for "
 "the price of less convenience and having to do more token requests.  In that"
@@ -509,13 +421,11 @@ msgstr ""
 " `--no-config` オプションを使用できます。 `kcreg` の呼び出しごとに、すべての認証情報を指定する必要があります。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:178
 #, no-wrap
 msgid "Initial Access and Registration Access Tokens"
 msgstr "初期アクセス・トークンと登録アクセス・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:185
 msgid ""
 "`Client Registration CLI` can be used by developers who don't have an "
 "account configured at Keycloak server they want to use.  That's possible "
@@ -531,7 +441,6 @@ msgstr ""
 "を発行することにより、開発者は使用することができます。トークンを発行して配布する方法を決定するのは、レルム管理者次第です。管理者は、初期アクセス・トークンの最大有効期間と作成できるクライアントの総数を制限できます。レルム管理者は、たくさんの初期アクセス・トークンを作成することができますが、それをアプリケーション開発者に配布するのはレルム管理者次第となります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:189
 msgid ""
 "Once a developer is in possession of Initial Access Token they can use it to"
 " create new clients without authenticating with `kcreg config credentials`. "
@@ -543,7 +452,6 @@ msgstr ""
 "コマンドの一部として指定することもできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:195
 #, no-wrap
 msgid ""
 "$ kcreg.sh config initial-token $TOKEN\n"
@@ -553,19 +461,15 @@ msgstr ""
 "$ kcreg.sh create -s clientId=myclient\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:198
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:213
 msgid "or"
 msgstr "または"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:202
 #, no-wrap
 msgid "$ kcreg.sh create -s clientId=myclient -t $TOKEN\n"
 msgstr "$ kcreg.sh create -s clientId=myclient -t $TOKEN\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:210
 #, no-wrap
 msgid ""
 "c:\\> kcreg config initial-token %TOKEN%\n"
@@ -575,13 +479,11 @@ msgstr ""
 "c:\\> kcreg create -s clientId=myclient\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:217
 #, no-wrap
 msgid "c:\\> kcreg create -s clientId=myclient -t %TOKEN%\n"
 msgstr "c:\\> kcreg create -s clientId=myclient -t %TOKEN%\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:222
 msgid ""
 "When Initial Access Token is used, the server response will include a newly "
 "issued Registration Access Token.  Any subsequent operation for that client "
@@ -591,7 +493,6 @@ msgstr ""
 "初期アクセス・トークンが使用されると、サーバー・レスポンスに新たに発行された登録アクセス・トークンを含まれます。そのクライアントの後続の操作は、そのクライアントに対してのみ有効な登録アクセス・トークンで認証し、実行する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:226
 msgid ""
 "`Client Registration CLI` automatically uses its private configuration file "
 "to save, and use this token with its associated client.  As long as the same"
@@ -603,7 +504,6 @@ msgstr ""
 "は、自動的にプライベート設定ファイルを使用して保存し、このトークンを関連するクライアントと共に使用します。同じ設定ファイルがすべてのクライアント操作に使用されている限り、このように作成されたクライアントの読み取り、更新、削除を行うために、開発者は認証する必要はありません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:229
 msgid ""
 "You can read more about Initial Access and Registration Access Tokens in "
 "<<_client_registration,Client Registration chapter>>."
@@ -611,7 +511,6 @@ msgstr ""
 "初期アクセス・トークンと登録アクセス・トークンの詳細については、<<_client_registration,クライアント登録の章>>をご覧ください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:231
 msgid ""
 "See `kcreg config initial-token --help` and `kcreg config registration-token"
 " --help` for more information on how to configure them with `Client "
@@ -621,20 +520,17 @@ msgstr ""
 "--help` と `kcreg config registration-token --help` を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:235
 #, no-wrap
 msgid "Creating client configuration"
 msgstr "クライアント設定の作成"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:238
 msgid ""
 "After authenticating with credentials or configuring Initial Access Token, "
 "the first operation will usually be to create a new client."
 msgstr "クレデンシャルで認証したり、初期アクセス・トークンを設定した後に、通常は最初の操作で新しいクライアントを作成します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:242
 msgid ""
 "We've seen the simplest create command already. Often we may want to use a "
 "prepared JSON file as a template and set / override some of the attributes. "
@@ -646,7 +542,6 @@ msgstr ""
 " `clientId` をオーバーライドし、他の属性も設定し、正常に作成した後に設定を標準出力に出力する方法があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:247
 #, no-wrap
 msgid ""
 "$ kcreg.sh create -f client-template.json -s clientId=myclient -s "
@@ -656,7 +551,6 @@ msgstr ""
 "baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:253
 #, no-wrap
 msgid ""
 "C:\\> kcreg create -f client-template.json -s clientId=myclient -s "
@@ -666,12 +560,10 @@ msgstr ""
 "baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:257
 msgid "See `kcreg create --help` for more information about `kcreg create`."
 msgstr "`kcreg create` の詳細については、 `kcreg create --help` を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:262
 msgid ""
 "You can use `kcreg attrs` to list available attributes. Keep in mind that "
 "many configuration attributes are not checked for validity or consistency. "
@@ -684,79 +576,64 @@ msgstr ""
 " `id` フィールドを持たせず、 `kcreg create` の引数としても指定しないように注意してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:264
 #, no-wrap
 msgid "Retrieving client configuration"
 msgstr "クライアント設定の取得"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:267
 msgid "You can retrieve an existing client by using `kcreg get`."
 msgstr "既に存在するクライアントについては、 `kcreg get` を使用することで取得できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:269
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:284
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:323
 msgid "For example, on Linux:"
 msgstr "例えば、Linux の場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:272
 #, no-wrap
 msgid "$ kcreg.sh get myclient\n"
 msgstr "$ kcreg.sh get myclient\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:278
 #, no-wrap
 msgid "C:\\> kcreg get myclient\n"
 msgstr "C:\\> kcreg get myclient\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:282
 msgid ""
 "You can also get client configuration as adapter configuration file which "
 "you can package with your web application."
 msgstr "また、Webアプリケーションとパッケージ化できるアダプター設定ファイルとして、クライアント設定を取得することもできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:287
 #, no-wrap
 msgid "$ kcreg.sh get myclient -e install > keycloak.json\n"
 msgstr "$ kcreg.sh get myclient -e install > keycloak.json\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:293
 #, no-wrap
 msgid "C:\\> kcreg get myclient -e install > keycloak.json\n"
 msgstr "C:\\> kcreg get myclient -e install > keycloak.json\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:296
 msgid "See `kcreg get --help` for more information about `kcreg get`."
 msgstr "`kcreg get` の詳細については、 `kcreg get --help` を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:297
 #, no-wrap
 msgid "Modifying client configuration"
 msgstr "クライアント設定の更新"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:300
 msgid "There are two modes of updating client configuration."
 msgstr "クライアント設定の更新には2つのモードがあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:302
 msgid ""
 "One is to submit a complete new state to the server after getting current "
 "configuration, saving it into a file, editing it, and posting it back."
 msgstr "1つは、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信する方法です。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:309
 #, no-wrap
 msgid ""
 "$ kcreg.sh get myclient > myclient.json\n"
@@ -768,7 +645,6 @@ msgstr ""
 "$ kcreg.sh update myclient -f myclient.json\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:317
 #, no-wrap
 msgid ""
 "C:\\> kcreg get myclient > myclient.json\n"
@@ -780,26 +656,22 @@ msgstr ""
 "C:\\> kcreg update myclient -f myclient.json\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:321
 msgid ""
 "Another way is to fetch current client, set or delete fields on it, and post"
 " it back all in one single step."
 msgstr "別の方法は、現在のクライアントをフェッチし、そのフィールドを設定または削除し、POST送信するという全てを1つのステップで行う方法です。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:326
 #, no-wrap
 msgid "$ kcreg.sh update myclient -s enabled=false -d redirectUris\n"
 msgstr "$ kcreg.sh update myclient -s enabled=false -d redirectUris\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:332
 #, no-wrap
 msgid "C:\\> kcreg update myclient -s enabled=false -d redirectUris\n"
 msgstr "C:\\> kcreg update myclient -s enabled=false -d redirectUris\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:338
 msgid ""
 "You can even use a file that only contains changes to be applied so you "
 "don't have to specify too many values as arguments.  In this case specify "
@@ -812,58 +684,48 @@ msgstr ""
 "に指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:344
 #, no-wrap
 msgid "$ kcreg.sh update myclient --merge -d redirectUris -f mychanges.json\n"
 msgstr "$ kcreg.sh update myclient --merge -d redirectUris -f mychanges.json\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:350
 #, no-wrap
 msgid "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 msgstr "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:353
 msgid "See `kcreg update --help` for more information about `kcreg update`."
 msgstr "`kcreg update` の詳細については、 `kcreg update --help` を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:354
 #, no-wrap
 msgid "Deleting client configuration"
 msgstr "クライアント設定の削除"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:357
 msgid "You may sometimes also need to delete a client."
 msgstr "クライアントを削除する必要がある場合もあります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:362
 #, no-wrap
 msgid "$ kcreg.sh delete myclient\n"
 msgstr "$ kcreg.sh delete myclient\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:368
 #, no-wrap
 msgid "C:\\> kcreg delete myclient\n"
 msgstr "C:\\> kcreg delete myclient\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:371
 msgid "See `kcreg delete --help` for more information about `kcreg delete`."
 msgstr "`kcreg delete` の詳細については、 `kcreg delete --help` を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:375
 #, no-wrap
 msgid "Refreshing Invalid Registration Access Tokens"
 msgstr "無効な登録アクセス・トークンのリフレッシュ"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:380
 msgid ""
 "When performing a CRUD operation using `--no-config` mode, `Client "
 "Registration CLI` can no longer handle Registration Access Tokens for you.  "
@@ -877,7 +739,6 @@ msgstr ""
 "、'manage-clients'権限を持つアカウントで認証なしでは、そのクライアントでそれ以上のCRUD操作を実行することは不可能になります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:385
 msgid ""
 "If you have permissions, you can issue a new Registration Access Token for "
 "the client, and have it printed to stdout or saved to a config file of your "
@@ -893,14 +754,12 @@ msgstr ""
 " コマンドを使って新しいトークンを設定ファイルに保存し、 `クライアント登録CLI` が自動的にそれを処理するようにすることもできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:387
 msgid ""
 "See `kcreg update-token --help` for more information about `kcreg update-"
 "token`."
 msgstr "`kcreg update-token` の詳細については、 `kcreg update-token --help` を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:394
 msgid ""
 "Q: When logging in I get an error: `Parameter client_assertion_type is "
 "missing [invalid_client]`"
@@ -909,7 +768,6 @@ msgstr ""
 "[invalid_client]`"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:395
 msgid ""
 "A: Your client is configured with `Signed JWT` token credentials which means"
 " you have to use `--keystore` parameter when logging in."

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -39,7 +39,7 @@ msgid ""
 "with {project_name}. It is specifically designed to interact with "
 "{project_name} Client Registration REST endpoints."
 msgstr ""
-"`Client Registration CLI` "
+"`クライアント登録CLI` "
 "は、アプリケーション開発者が{project_name}と統合する際にセルフ・サービスで新しいクライアントを設定するためのコマンドライン・インターフェイス・ツールです。"
 " これは、{project_name}クライアント登録RESTエンドポイントと対話するように特別に設計されています。"
 
@@ -62,8 +62,7 @@ msgid ""
 "`Client Registration CLI` allows you to configure application clients from a"
 " command line, and can be used in shell scripts as well."
 msgstr ""
-"`Client Registration CLI` "
-"では、コマンドラインからアプリケーション・クライアントを設定することができます。シェルスクリプトでも使用できます。"
+"`クライアント登録CLI` では、コマンドラインからアプリケーション・クライアントを設定することができます。シェルスクリプトでも使用できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:15
@@ -72,8 +71,8 @@ msgid ""
 "To allow a particular user to use `Client Registration CLI` the {project_name} administrator will typically use `Admin Console` to configure\n"
 " a new user with proper roles, or configure a new client and client secret to grant access to `Client Registration REST API`.\n"
 msgstr ""
-"特定のユーザーが `Client Registration CLI` を使用できるようにするため、通常、{project_name}管理者は "
-"`管理コンソール` を使って新しいユーザーを適切なロールで設定するか、`Client Registration REST API` "
+"特定のユーザーが `クライアント登録CLI` を使用できるようにするため、通常、{project_name}管理者は `管理コンソール` "
+"を使って新しいユーザーを適切なロールで設定するか、`クライアント登録REST API` "
 "へのアクセス権を与えるように新しいクライアントとクライアント・シークレットを設定します 。\n"
 
 #. type: Title ===
@@ -441,7 +440,7 @@ msgstr ""
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:141
 msgid ""
 "See built-in help for more information on using `Client Registration CLI`."
-msgstr "`Client Registration CLI` の使用方法の詳細については、組み込みのヘルプを参照してください。"
+msgstr "`クライアント登録CLI` の使用方法の詳細については、組み込みのヘルプを参照してください。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:147

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -113,7 +113,7 @@ msgid ""
 "Access Token` sub-tab."
 msgstr ""
 "管理者は、 `Realm Settings` の下の `Client Registration` タブを選択し、 `Initial Access "
-"Token` サブ・タブを選択することによって、管理コンソールから `初期アクセストークン` を発行することができます。"
+"Token` サブ・タブを選択することによって、管理コンソールから `初期アクセス・トークン` を発行することができます。"
 
 #. type: Title ===
 #, no-wrap
@@ -155,7 +155,7 @@ msgid ""
 "Type` to `Confidential`, and toggle `Service Accounts Enabled` setting to "
 "`On`. Make sure to `Save` the configuration."
 msgstr ""
-"クライアントに関連付けられたサービス・アカウントを使用する場合は、まずサービス・アカウントを有効にする必要があります。 `管理者コンソール` で "
+"クライアントに関連付けられたサービス・アカウントを使用する場合は、まずサービス・アカウントを有効にする必要があります。 `管理コンソール` で "
 "`Clients` のセクションに行き、編集するクライアントを選択します。 次に、`Settings` の下で、 `Access Type` を "
 "`Confidential` に変更し、 `Service Accounts Enabled` を `On` に切り替えます。設定を `Save` "
 "することを忘れないでください。"
@@ -247,7 +247,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "For example on Linux:"
-msgstr "例えば、Linux の場合："
+msgstr "たとえば、Linux の場合："
 
 #. type: delimited block -
 #, no-wrap
@@ -343,9 +343,8 @@ msgid ""
 " command line tool (see link:{adminguide_link}[{adminguide_name}] for more "
 "details)."
 msgstr ""
-"インターフェイス`クライアント登録CLI` "
-"自体はユーザーの設定をサポートしていません。そのためには、管理者コンソールのWebインターフェイスまたは管理者クライアントCLIコマンドライン・ツール（詳細はlink:{adminguide_link}"
-" [{adminguide_name}]）を使う必要があります。"
+"`クライアント登録CLI` "
+"自体はユーザーの設定をサポートしていません。そのためには、管理コンソールのWebインターフェイスまたは管理クライアントCLIコマンドライン・ツール（詳細はlink:{adminguide_link}[{adminguide_name}]）を使う必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -437,7 +436,7 @@ msgid ""
 "application developers."
 msgstr ""
 "`クライアント登録CLI` は、使用したいKeycloakサーバーで設定されたアカウントを持っていない開発者が使用できます。レルム管理者が開発者に "
-"`初期アクセストークン` "
+"`初期アクセス・トークン` "
 "を発行することにより、開発者は使用することができます。トークンを発行して配布する方法を決定するのは、レルム管理者次第です。管理者は、初期アクセス・トークンの最大有効期間と作成できるクライアントの総数を制限できます。レルム管理者は、たくさんの初期アクセス・トークンを作成することができますが、それをアプリケーション開発者に配布するのはレルム管理者次第となります。"
 
 #. type: Plain text
@@ -516,8 +515,8 @@ msgid ""
 " --help` for more information on how to configure them with `Client "
 "Registration CLI`."
 msgstr ""
-"`Client Registration CLI` で設定する方法の詳細については、 `kcreg config initial-token "
-"--help` と `kcreg config registration-token --help` を参照してください。"
+"`クライアント登録CLI` で設定する方法の詳細については、 `kcreg config initial-token --help` と `kcreg "
+"config registration-token --help` を参照してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -538,7 +537,7 @@ msgid ""
 "may contain, set any other attributes as well, and after successful creation"
 " print the configuration to standard output."
 msgstr ""
-"最もシンプルなcreateコマンドをすでに見てきました。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定/上書きすることはよくあります。たとえば、JSONファイルを読み込み、含まれている"
+"最もシンプルなcreateコマンドをすでに見てきました。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定/オーバーライドすることはよくあります。たとえば、JSONファイルを読み込み、含まれている"
 " `clientId` をオーバーライドし、他の属性も設定し、正常に作成した後に設定を標準出力に出力する方法があります。"
 
 #. type: delimited block -
@@ -586,7 +585,7 @@ msgstr "既に存在するクライアントについては、 `kcreg get` を�
 
 #. type: Plain text
 msgid "For example, on Linux:"
-msgstr "例えば、Linux の場合："
+msgstr "たとえば、Linux の場合："
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -2,25 +2,25 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title ###
 #: source/server_installation/topics/clustering/troubleshooting.adoc:2
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:386
 #: source/securing_apps/topics/saml/java/debugging.adoc:2
 #: source/server_admin/topics/authentication/kerberos.adoc:191
+#: source/server_admin/topics/authentication/x509.adoc:201
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
@@ -36,9 +36,7 @@ msgstr "クライアント登録CLI"
 msgid ""
 "Client Registration CLI is a Technology Preview feature and is not fully "
 "supported."
-msgstr ""
-"クライアント登録CLIはテクニカル・プレビュー機能であり、完全にはサポートされて"
-"いません。"
+msgstr "クライアント登録CLIはテクニカル・プレビュー機能であり、完全にはサポートされていません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:10
@@ -48,10 +46,8 @@ msgid ""
 "{project_name}. It is specifically designed to interact with {project_name} "
 "Client Registration REST endpoints."
 msgstr ""
-"`Client Registration CLI` は、{project_name}と統合する新しいクライアントを設"
-"定するために、アプリケーション開発者が使用できるコマンドライン・インターフェ"
-"イス・ツールです。{project_name}クライアント登録RESTエンドポイントと対話する"
-"ためだけに設計されています。"
+"`Client Registration CLI` "
+"は、{project_name}と統合する新しいクライアントを設定するために、アプリケーション開発者が使用できるコマンドライン・インターフェイス・ツールです。{project_name}クライアント登録RESTエンドポイントと対話するためだけに設計されています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:13
@@ -61,18 +57,16 @@ msgid ""
 "interact with the application (and vice-versa) and perform its function of "
 "providing a login page, SSO session management etc."
 msgstr ""
-"{project_name}がアプリケーションと相互に対話したり、ログイン・ページやSSOセッ"
-"ション管理などを提供する機能を実行できるようにするには、一意なホスト名でホス"
-"トされるアプリケーション毎にクライアントの設定を作成する必要があります。"
+"{project_name}がアプリケーションと相互に対話したり、ログイン・ページやSSOセッション管理などを提供する機能を実行できるようにするには、一意なホスト名でホストされるアプリケーション毎にクライアントの設定を作成する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:15
 msgid ""
-"`Client Registration CLI` allows you to configure application clients from a "
-"command line, and can be used in shell scripts as well."
+"`Client Registration CLI` allows you to configure application clients from a"
+" command line, and can be used in shell scripts as well."
 msgstr ""
-"`Client Registration CLI` では、コマンドラインからアプリケーション・クライア"
-"ントを設定することができます。シェルスクリプトでも使用できます。"
+"`Client Registration CLI` "
+"では、コマンドラインからアプリケーション・クライアントを設定することができます。シェルスクリプトでも使用できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:18
@@ -81,26 +75,36 @@ msgid ""
 "To allow a particular user to use `Client Registration CLI` a {project_name} administrator will typically use `Admin Console` to configure\n"
 " a new user, or configure a new client, and a client secret, to protect access to `Client Registration REST API`.\n"
 msgstr ""
+"特定のユーザーが `Client Registration CLI` を使用できるようにするため、通常、{project_name}管理者は "
+"`Admin Console` を使って、 `Client Registration REST API` "
+"へのアクセスを保護するために、新しいユーザー(またはクライアント)とクライアントシークレットを設定します。\n"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:21
 #, no-wrap
 msgid "Configuring a new regular user for use with Client Registration CLI"
-msgstr ""
+msgstr "クライアント登録CLIで使用するための新しい正規ユーザーの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:29
 msgid ""
-"Login as `admin` into `Admin Console` (e.g. `http://localhost:8080/auth/"
-"admin`). Select a realm you want to administer.  If you want to use existing "
-"user, select it for edit, otherwise create a new user. Go to `Role Mappings` "
-"tab. Under `Client Roles` select `realm-management`. Under `Available Roles` "
-"select `manage-client` for full set of client management permissions. "
-"Alternatively you can choose `view-clients` for read-only or `create-client` "
-"for ability to create new clients.  These permissions grant user the "
-"capability to perform operations without the use of `Initial Access Token` "
-"or `Registration Access Token`."
+"Login as `admin` into `Admin Console` (e.g. "
+"`http://localhost:8080/auth/admin`). Select a realm you want to administer."
+"  If you want to use existing user, select it for edit, otherwise create a "
+"new user. Go to `Role Mappings` tab. Under `Client Roles` select `realm-"
+"management`. Under `Available Roles` select `manage-client` for full set of "
+"client management permissions. Alternatively you can choose `view-clients` "
+"for read-only or `create-client` for ability to create new clients.  These "
+"permissions grant user the capability to perform operations without the use "
+"of `Initial Access Token` or `Registration Access Token`."
 msgstr ""
+"`Admin Console` にログインしてください(例: "
+"`http://localhost:8080/auth/admin`)。管理するレルムを選択します。既存のユーザーを使用する場合は編集を選択し、そうでない場合は新規ユーザーを作成します。`Role"
+" Mappings` タブをクリックします。 `Client Roles`  以下の `realm-management` "
+"を選択します。`Available Roles`  以下のクライアント管理権限のフルセットの `manage-client` "
+"を選択します。あるいは、読み取り専用の場合は `view-clients` を、新しいクライアントを作成する場合は `create-client` "
+"を選択できます。これらのアクセス権は、 `Initial Access Token` または `Registration Access Token` "
+"を使用せずに、ユーザーに操作を実行する機能を付与します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:33
@@ -111,6 +115,10 @@ msgid ""
 "Trying to perform any operations without it will result in `403 Forbidden` "
 "error."
 msgstr ""
+"ユーザーに `realm-management` ロールを割り当てないことも可能です。その場合、ユーザーは `Initial Access Token`"
+" を所有していなくても、 `Registration Client CLI` "
+"でログインすることはできますが、それを使用することはできません。所有せずに何らかの操作を実行しようとすると、 `403 Forbidden`  "
+"エラーが発生します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:35
@@ -118,24 +126,31 @@ msgid ""
 "Administrator can issue `Initial Access Tokens` from `Admin Console` by "
 "selecting `Initial Access Token` tab under `Realm Settings`."
 msgstr ""
+"管理者は `Realm Settings` 以下の `Initial Access Tokens` タブを選択することで、 `Admin "
+"Console` から `Initial Access Tokens` を発行することができます。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:37
 #, no-wrap
 msgid "Configuring a client for use with Client Registration CLI"
-msgstr ""
+msgstr "クライアント登録CLIで使用するためのクライアントの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:43
 msgid ""
 "By default the `Client Registration CLI` identifies as `admin-cli` client "
-"which is automatically configured for every new realm.  No additional client "
-"configuration is required when using login with a username. You may wish to "
-"strengthen security by configuring the client `Access Type` as "
+"which is automatically configured for every new realm.  No additional client"
+" configuration is required when using login with a username. You may wish to"
+" strengthen security by configuring the client `Access Type` as "
 "`Confidential`, and under `Credentials` tab select `ClientId and Secret`. "
 "When running `kcreg config credentials` you would then also have to provide "
 "a secret e.g. by using `--secret`."
 msgstr ""
+"デフォルトでは、 `Client Registration CLI` は `admin-cli` "
+"クライアントとして識別されます。これは新しいレルムごとに自動的に設定されます。ユーザー名でのログインを使用する場合、追加のクライアント設定は必要ありません。クライアントの"
+" `Access Type` を `Confidential` に設定することでセキュリティを強化したい場合は、 `Credentials` タブで "
+"`ClientId and Secret` を選択できます。 `kcreg config credentials` "
+"を実行する際に、シークレット(例えば、 `--secret` を使用)を提供する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:46
@@ -145,6 +160,9 @@ msgid ""
 "cli`. When running `kcreg config credentials` you then need to specify a "
 "`clientId` to use e.g. `--client reg-cli`."
 msgstr ""
+"`Registration Client CLI` とは別のクライアント設定を使いたい場合は、新しいクライアントを作成できます。例えば `reg-"
+"cli` を呼ぶことができます。 `kcreg config credentials` を実行中に、 `clientId` "
+"を指定する必要があります(例えば、 `--client reg-cli` を使用)。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:50
@@ -155,13 +173,17 @@ msgid ""
 "`Access Type` to `Confidential`.  Then toggle `Service Accounts Enabled` "
 "setting to `On`, and `Save` the configuration."
 msgstr ""
+"クライアントに関連付けられたサービス・アカウントを使用したい場合は、サービス・アカウントを有効にする必要があります。 `Admin Client` で "
+"`Clients` セクションに遷移し、編集するクライアントを選択します。次に、`Settings` の下の `Access Type` を "
+"`Confidential` に変更します。 次に、 `Service Accounts Enabled` "
+"設定を「オン」に切り替え、設定を「保存」します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:52
 msgid ""
 "Under `Credentials` tab you can choose to configure either `Client Id and "
 "Secret`, or `Signed JWT`."
-msgstr ""
+msgstr "`Credentials` タブで、`Client Id and Secret` か `Signed JWT` のどちらかを設定できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:54
@@ -169,28 +191,30 @@ msgid ""
 "You can now avoid specifying user when using `kcreg config credentials` and "
 "only provide a client secret or keystore info."
 msgstr ""
+" `kcreg config credentials` "
+"を使用すると、ユーザーを指定せずに、クライアントシークレットまたはキーストア情報のみを提供できるようになりました。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:56
 #, no-wrap
 msgid "Installing Client Registration CLI"
-msgstr ""
+msgstr "クライアント登録CLIのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:59
 msgid ""
-"Client Registration CLI is packaged inside Keycloak Server distribution. You "
-"can find execution scripts inside `bin` directory."
+"Client Registration CLI is packaged inside Keycloak Server distribution. You"
+" can find execution scripts inside `bin` directory."
 msgstr ""
-"クライアント登録CLIは、{project_name}サーバーのディストリビューションの中に"
-"パッケージされています。 `bin` ディレクトリ内に実行スクリプトがあります。"
+"クライアント登録CLIは、{project_name}サーバーのディストリビューションの中にパッケージされています。 `bin` "
+"ディレクトリ内に実行スクリプトがあります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:61
 msgid ""
 "The Linux script is called `kcreg.sh`, and the one for Windows is called "
 "`kcreg.bat`."
-msgstr ""
+msgstr "Linuxのスクリプトは `kcreg.sh` と呼ばれ、Windowsのスクリプトは `kcreg.bat` と呼ばれます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:63
@@ -198,9 +222,7 @@ msgid ""
 "In order to setup the client to be used from any location on the filesystem "
 "you may want to add Keycloak server directory to your PATH."
 msgstr ""
-"ファイルシステム上の任意の場所から使用できるようにクライアントをセットアップ"
-"するために、{project_name}サーバーのディレクトリをPATHに追加した方がいいで"
-"す。"
+"ファイルシステム上の任意の場所から使用できるようにクライアントをセットアップするために、{project_name}サーバーのディレクトリをPATHに追加した方がいいです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:65
@@ -255,7 +277,7 @@ msgstr ""
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:79
 #, no-wrap
 msgid "Using Client Registration CLI"
-msgstr ""
+msgstr "クライアント登録CLIの使用"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:82
@@ -263,7 +285,7 @@ msgstr ""
 msgid ""
 "Usually a user will first start an authenticated session by providing "
 "credentials, then perform some CRUD operations."
-msgstr ""
+msgstr "通常、ユーザーはまずクレデンシャルを提供して認証されたセッションを開始し、次にいくつかのCRUD操作を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:84
@@ -324,43 +346,52 @@ msgid ""
 "In a production environment Keycloak has to be accessed with `https:` to "
 "avoid exposing tokens to network sniffers. If server's certificate is not "
 "issued by one of the trusted CAs that are included in Java's default "
-"certificate truststore, then you will need to prepare a truststore.jks file, "
-"and instruct `Client Registration CLI` to use it."
+"certificate truststore, then you will need to prepare a truststore.jks file,"
+" and instruct `Client Registration CLI` to use it."
 msgstr ""
-"本番環境では、ネットワーク・スニッファでトークンを解読されることを避けるため"
-"に、{project_name}には `https:` でアクセスできなければなりません。サーバーの"
-"証明書がJavaのデフォルト証明書のトラスト・ストアに含まれる信頼できるCAによっ"
-"て発行されていない場合、truststore.jksファイルを用意し、それを使用するように "
-"`Client Registration CLI` に指示する必要があります。"
+"本番環境では、ネットワーク・スニッファでトークンを解読されることを避けるために、{project_name}には `https:` "
+"でアクセスできなければなりません。サーバーの証明書がJavaのデフォルト証明書のトラスト・ストアに含まれる信頼できるCAによって発行されていない場合、truststore.jksファイルを用意し、それを使用するように"
+" `Client Registration CLI` に指示する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:110
 #, no-wrap
-msgid "$ kcreg.sh config truststore --trustpass $PASSWORD ~/.keycloak/truststore.jks\n"
-msgstr "$ kcreg.sh config truststore --trustpass $PASSWORD ~/.keycloak/truststore.jks\n"
+msgid ""
+"$ kcreg.sh config truststore --trustpass $PASSWORD "
+"~/.keycloak/truststore.jks\n"
+msgstr ""
+"$ kcreg.sh config truststore --trustpass $PASSWORD "
+"~/.keycloak/truststore.jks\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:117
 #, no-wrap
-msgid "c:\\> kcreg config truststore --trustpass %PASSWORD% %HOMEPATH%\\.keycloak\\truststore.jks\n"
-msgstr "c:\\> kcreg config truststore --trustpass %PASSWORD% %HOMEPATH%\\.keycloak\\truststore.jks\n"
+msgid ""
+"c:\\> kcreg config truststore --trustpass %PASSWORD% "
+"%HOMEPATH%\\.keycloak\\truststore.jks\n"
+msgstr ""
+"c:\\> kcreg config truststore --trustpass %PASSWORD% "
+"%HOMEPATH%\\.keycloak\\truststore.jks\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:121
 #, no-wrap
 msgid "Logging In"
-msgstr ""
+msgstr "ログイン"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:127
 msgid ""
-"When logging in with `Client Registration CLI` you specify a server endpoint "
-"url, and a realm. Then you specify a username, or alternatively you can only "
-"specify a client id, which will result in special service account being "
-"used. In the first case, a password for the specified user has to be used at "
-"login. In the latter case there is no user password - only client secret or "
-"a `Signed JWT` is used."
+"When logging in with `Client Registration CLI` you specify a server endpoint"
+" url, and a realm. Then you specify a username, or alternatively you can "
+"only specify a client id, which will result in special service account being"
+" used. In the first case, a password for the specified user has to be used "
+"at login. In the latter case there is no user password - only client secret "
+"or a `Signed JWT` is used."
 msgstr ""
+"`Client Registration CLI` "
+"でログインする際に、サーバー・エンドポイントURLとレルムを指定します。その後、ユーザー名を指定するか、またはクライアントIDのみを指定することができます。これにより、特別なサービスアカウントが使用されます。前者の場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。後者の場合、ユーザーパスワードはありません。クライアント・シークレットのみか"
+" `Signed JWT` が使用されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:131
@@ -371,6 +402,7 @@ msgid ""
 "within the same realm.  If you need to manage different realms, you need to "
 "configure users in different realms with permissions to manage clients."
 msgstr ""
+"方法にかかわらず、ログインするアカウントは、クライアント登録操作を実行できるようにするために適切な権限を持っている必要があります。すべてのアカウントは、同じレルム内のクライアントを管理するための権限しか持たないことに注意してください。異なるレルムを管理する必要がある場合は、クライアントを管理する権限を持つ異なるレルムにユーザーを設定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:134
@@ -379,21 +411,26 @@ msgid ""
 "for that you would need to use `Admin Console` web interface or `Admin "
 "Client CLI` once it's available."
 msgstr ""
+"`Client Registration CLI` 自体はユーザーの設定をサポートしていません。利用できるようにするには、 `Admin "
+"Console` ウェブ・インタフェースや `Admin Client CLI` を使う必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:137
 msgid ""
-"When `kcreg` successfully logs in it receives authorization tokens and saves "
-"them into a private config file so they can be used for subsequent "
+"When `kcreg` successfully logs in it receives authorization tokens and saves"
+" them into a private config file so they can be used for subsequent "
 "invocations. See <<_working_with_alternative_configurations, next chapter>> "
 "for more info on configuration file."
 msgstr ""
+"`kcreg` "
+"が正常にログインすると、認証トークンを受け取り、それを後の呼び出しに使用できるようにプライベート設定ファイルに保存します。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
+" next chapter>>を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:139
 msgid ""
 "See built-in help for more information on using `Client Registration CLI`."
-msgstr ""
+msgstr "`Client Registration CLI` の使用方法の詳細については、組み込みのヘルプを参照してください。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:145
@@ -410,16 +447,16 @@ msgstr "c:\\> kcreg help\n"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:155
 msgid ""
-"See `kcreg config credentials --help` for more information about starting an "
-"authenticated session."
-msgstr ""
+"See `kcreg config credentials --help` for more information about starting an"
+" authenticated session."
+msgstr "認証されたセッションの開始についての詳細は、 `kcreg config credentials --help` を参照してください。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:159
 #: source/server_admin/topics/admin-cli.adoc:113
 #, no-wrap
 msgid "Working with alternative configurations"
-msgstr ""
+msgstr "代替設定の使用"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:163
@@ -428,9 +465,9 @@ msgid ""
 "configuration file at a default location - `.keycloak/kcreg.config` under "
 "user's home directory."
 msgstr ""
-"`Client Registration CLI` は、デフォルトの場所に設定ファイルを自動的に保持し"
-"ます（デフォルトでは、ユーザーのホーム・ディレクトリの下の `.keycloak/kcreg."
-"config` ）。"
+"`Client Registration CLI` "
+"は、デフォルトの場所に設定ファイルを自動的に保持します（デフォルトでは、ユーザーのホーム・ディレクトリの下の "
+"`.keycloak/kcreg.config` ）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:166
@@ -440,6 +477,8 @@ msgid ""
 "parallel. It is safest to perform operations tied to a single config file "
 "from a single thread."
 msgstr ""
+" `--config` オプションを使うと、いつでも別のファイル/場所を指すことができます。 "
+"これにより、複数の認証済みセッションを並行して処理できます。 1つのスレッドから1つの設定ファイルに結び付けられた操作を実行することが最も安全です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:168
@@ -448,21 +487,24 @@ msgid ""
 "Make sure to not make a config file visible to other users on the system as "
 "it contains access tokens, and secrets that should be kept private."
 msgstr ""
+"アクセストークンとプライベートにしておくべきシークレットを含んでいるため、システム上の他のユーザーに設定ファイルを表示しないようにしてください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:172
 msgid ""
 "You may want to avoid storing any secrets at all inside a config file for "
-"the price of less convenience and having to do more token requests.  In that "
-"case you can use `--no-config` option with all your commands. You will have "
-"to specify all authentication info with each `kcreg` invocation."
+"the price of less convenience and having to do more token requests.  In that"
+" case you can use `--no-config` option with all your commands. You will have"
+" to specify all authentication info with each `kcreg` invocation."
 msgstr ""
+"利便性が低く、さらにトークン要求をしなければならないために、設定ファイルの中にシークレットを保存することは避けたいかもしれません。その場合、すべてのコマンドで"
+" `--no-config` オプションを使用できます。 `kcreg` の呼び出しごとに、すべての認証情報を指定する必要があります。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:176
 #, no-wrap
 msgid "Initial Access and Registration Access Tokens"
-msgstr ""
+msgstr "初期アクセス・トークンと登録アクセス・トークン"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:182
@@ -475,21 +517,23 @@ msgid ""
 "number of clients that can be created with it. Many Initial Access Tokens "
 "can be created, and it's up to realm administrator to distribute them."
 msgstr ""
-"`Client Registration CLI`は、使用したい{project_name}サーバーで設定されたアカ"
-"ウントを持っていない開発者が使用できます。レルム管理者が開発者に `Initial "
-"Access Token` を発行するときに可能です。 これらのトークンを発行して配布する方"
-"法を決定するのは、レルム管理者次第です。 管理者は、初期アクセストークンを最大"
-"経過時間と作成できるクライアントの総数で制限できます。 多くの初期アクセストー"
-"クンを作成することができ、また、それらを配布するのはレルム管理者の責任です。"
+"`Client Registration "
+"CLI`は、使用したい{project_name}サーバーで設定されたアカウントを持っていない開発者が使用できます。レルム管理者が開発者に "
+"`Initial Access Token` を発行するときに可能です。 これらのトークンを発行して配布する方法を決定するのは、レルム管理者次第です。 "
+"管理者は、初期アクセストークンを最大経過時間と作成できるクライアントの総数で制限できます。 "
+"多くの初期アクセストークンを作成することができ、また、それらを配布するのはレルム管理者の責任です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:186
 msgid ""
-"Once a developer is in possession of Initial Access Token they can use it to "
-"create new clients without authenticating with `kcreg config credentials`. "
-"Rather, Initial Access Token can be stored in configuration, or specified as "
-"part of `kcreg create` command."
+"Once a developer is in possession of Initial Access Token they can use it to"
+" create new clients without authenticating with `kcreg config credentials`. "
+"Rather, Initial Access Token can be stored in configuration, or specified as"
+" part of `kcreg create` command."
 msgstr ""
+"開発者が初期アクセストークンを所有すると、 `kcreg config credentials` "
+"で認証せずに新しいクライアントを作成できます。むしろ、初期アクセストークンは設定に保存することも、  `kcreg create` "
+"コマンドの一部として指定することもできます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:192
@@ -511,7 +555,7 @@ msgstr "または"
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:199
 #, no-wrap
 msgid "$ kcreg.sh create -s clientId=myclient -t $TOKEN\n"
-msgstr ""
+msgstr "$ kcreg.sh create -s clientId=myclient -t $TOKEN\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:207
@@ -534,9 +578,10 @@ msgstr "c:\\> kcreg create -s clientId=myclient -t %TOKEN%\n"
 msgid ""
 "When Initial Access Token is used, the server response will include a newly "
 "issued Registration Access Token for client that was just created. Any "
-"subsequent operation for that client needs to be performed by authenticating "
-"with that token."
+"subsequent operation for that client needs to be performed by authenticating"
+" with that token."
 msgstr ""
+"初期アクセストークンが使用される場合、サーバーのレスポンスには、作成されたクライアントに対して新たに発行された登録アクセストークンが含まれます。その後のクライアントに対する操作は、登録アクセストークンで認証してから実行する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:223
@@ -547,6 +592,9 @@ msgid ""
 "will not need to authenticate in order to read, update, or delete a client "
 "they created."
 msgstr ""
+"`Client Registration CLI` "
+"は、自動的にプライベート設定ファイルを使用して保存し、作成されたクライアントごとにこのトークンを使用します。 "
+"すべてのクライアント操作で同じ設定ファイルが使用されている限り、開発者は作成したクライアントの読み取り、更新、または削除を行うために認証する必要はありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:226
@@ -554,55 +602,70 @@ msgid ""
 "You can read more about Initial Access and Registration Access Tokens in "
 "<<_client_registration,Client Registration chapter>>."
 msgstr ""
+"<<_client_registration,Client Registration "
+"chapter>>の初期アクセス・トークンと登録アクセス・トークンの詳細については、こちらをご覧ください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:228
 msgid ""
-"See `kcreg config initial-token --help` and `kcreg config registration-token "
-"--help` for more information on how to configure them with `Client "
+"See `kcreg config initial-token --help` and `kcreg config registration-token"
+" --help` for more information on how to configure them with `Client "
 "Registration CLI`."
 msgstr ""
+"`Client Registration CLI` でそれらを設定する方法の詳細については、 `kcreg config initial-token "
+"--help` と `kcreg config registration-token --help` を参照してください。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:232
 #, no-wrap
 msgid "Performing CRUD operations"
-msgstr ""
+msgstr "CRUD操作の実行"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:236
 msgid ""
 "After authenticating with credentials or configuring Initial Access Token, "
 "the first operation will usually be to create a new client."
-msgstr ""
+msgstr "クレデンシャルで認証したり、初期アクセストークンを設定すると、通常は最初の操作で新しいクライアントが作成されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:241
 msgid ""
-"We've seen the simplest command to create a new client already. Often we may "
-"want to use a prepared JSON file as a template, and set / override some of "
+"We've seen the simplest command to create a new client already. Often we may"
+" want to use a prepared JSON file as a template, and set / override some of "
 "the attributes. For example, this is how you read a JSON file in default "
-"client configuration format, override any clientId it may contain with a new "
-"one, override / set any other attributes as well, and after successful "
+"client configuration format, override any clientId it may contain with a new"
+" one, override / set any other attributes as well, and after successful "
 "creation print the new client configuration to standard output."
 msgstr ""
+"すでに新しいクライアントを作成するための最も簡単なコマンドを見てきました。テンプレートとして準備されたJSONファイルを使用し、いくつかの属性を設定/上書きしたいことはよくあります。"
+" "
+"たとえば、これはデフォルトのクライアント設定形式でJSONファイルを読み込み、新しいクライアントIDを含むクライアントIDを上書きし、他の属性もオーバーライド/設定し、作成後に新しいクライアントの設定を標準出力に出力する方法です。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:246
 #, no-wrap
-msgid "$ kcreg.sh create -s clientId=myclient -f client-template.json -s baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
-msgstr "$ kcreg.sh create -s clientId=myclient -f client-template.json -s baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
+msgid ""
+"$ kcreg.sh create -s clientId=myclient -f client-template.json -s "
+"baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
+msgstr ""
+"$ kcreg.sh create -s clientId=myclient -f client-template.json -s "
+"baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:252
 #, no-wrap
-msgid "C:\\> kcreg create -s clientId=myclient -f client-template.json -s baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
-msgstr "C:\\> kcreg create -s clientId=myclient -f client-template.json -s baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
+msgid ""
+"C:\\> kcreg create -s clientId=myclient -f client-template.json -s "
+"baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
+msgstr ""
+"C:\\> kcreg create -s clientId=myclient -f client-template.json -s "
+"baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:256
 msgid "See `kcreg create --help` for more information about `kcreg create`."
-msgstr ""
+msgstr "`kcreg create` の詳細については、 `kcreg create --help` を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:261
@@ -612,12 +675,15 @@ msgid ""
 "up to you to specify proper values. Also note, that you should not have any "
 "`id` fields in your template or specify them as arguments to `kcreg create`."
 msgstr ""
+"`kcreg attrs` "
+"を使って、利用可能な属性の一覧を取得できます。多くの設定属性の妥当性や一貫性については、チェックされていないことに注意してください。適切な値を指定するのはあなた次第です。"
+" また、テンプレートに `id` フィールドを持たせない、あるいは `kcreg create` の引数として指定しないにように注意してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:264
 msgid ""
 "Once a new client is created you can retrieve it again by using `kcreg get`."
-msgstr ""
+msgstr "新しいクライアントが作成されると、 `kcreg get` を使って再度それを取得できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:269
@@ -636,9 +702,7 @@ msgstr "C:\\> kcreg get myclient\n"
 msgid ""
 "You can also get an adapter configuration which you can drop into your web "
 "application in order to integrate with Keycloak server."
-msgstr ""
-"また、{project_name}サーバーと統合するために、webアプリケーションに組み込める"
-"アダプターの設定を取得できます。"
+msgstr "また、{project_name}サーバーと統合するために、webアプリケーションに組み込めるアダプターの設定を取得できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:284
@@ -655,21 +719,21 @@ msgstr "C:\\> kcreg get myclient -e install\n"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:293
 msgid "See `kcreg get --help` for more information about `kcreg get`."
-msgstr ""
+msgstr "`kcreg get` の詳細については、 `kcreg get --help` を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:296
 msgid ""
 "It's simple to update client configurations as well. There are two modes of "
 "updating."
-msgstr ""
+msgstr "クライアントの設定も簡単に更新できます。更新には2つのモードがあります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:298
 msgid ""
 "One is to submit a complete new state to the server after getting current "
 "configuration, saving it into a file, editing it, and posting it back."
-msgstr ""
+msgstr "1つは、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信することです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:305
@@ -700,7 +764,7 @@ msgstr ""
 msgid ""
 "Another is to get current client, set or delete fields on it, and post it "
 "back all in one single step."
-msgstr ""
+msgstr "別の方法は、現在のクライアントを取得し、そのフィールドを設定または削除し、すべてを1つのステップでポストバックすることです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:322
@@ -718,11 +782,13 @@ msgstr "C:\\> kcreg update myclient -s enabled=false -d redirectUris\n"
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:334
 msgid ""
 "You can even use a file that contains only changes to be applied so you "
-"don't have to specify too many values as arguments.  In this case we specify "
-"`--merge` to tell `Client Registration CLI` that rather than treating "
+"don't have to specify too many values as arguments.  In this case we specify"
+" `--merge` to tell `Client Registration CLI` that rather than treating "
 "mychanges.json as full new configuration, it should see it as a set of "
 "attributes to be applied over existing configuration."
 msgstr ""
+"適用される変更のみを含むファイルを使用することもできるので、引数にあまりにも多くの値を指定する必要はありません。完全な新しい設定としてmychanges.jsonを扱うのではなく、"
+" `Client Registration CLI` に `--merge` を指定する場合、既存の設定に適用される属性のセットとして認識されます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:340
@@ -739,12 +805,12 @@ msgstr "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:349
 msgid "See `kcreg update --help` for more information about `kcreg update`."
-msgstr ""
+msgstr "`kcreg update` の詳細については、 `kcreg update --help` を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:352
 msgid "You may sometimes also need to delete a client."
-msgstr ""
+msgstr "クライアントを削除する必要がある場合もあります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:357
@@ -761,13 +827,13 @@ msgstr "C:\\> kcreg delete myclient\n"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:366
 msgid "See `kcreg delete --help` for more information about `kcreg delete`."
-msgstr ""
+msgstr "`kcreg delete` の詳細については、 `kcreg delete --help` を参照してください。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:370
 #, no-wrap
 msgid "Refreshing Invalid Registration Access Tokens"
-msgstr ""
+msgstr "無効な登録アクセストークンのリフレッシュ"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:375
@@ -779,6 +845,10 @@ msgid ""
 "operations on that client without using credentials of an account with "
 "'manage-clients' permissions."
 msgstr ""
+"`no-config` モードを使用してCRUD操作を実行すると、 `Client Registration CLI` "
+"は登録アクセストークンを処理できなくなります。その場合、最も最近クライアントに発行された登録アクセストークンを追跡できない可能性があり、そのため、 "
+"'manage-clients' "
+"権限を持つアカウントのクレデンシャルを使用せずに、そのクライアント上でそれ以上のCRUD操作を実行することは不可能になります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:380
@@ -788,17 +858,22 @@ msgid ""
 "choice. If not you have to ask realm administrator to reissue a new "
 "Registration Access Token for your client, and send it to you. You can then "
 "use the token by passing it to any CRUD command via `--token` option. You "
-"can also use `kcreg config registration-token` command to save the new token "
-"in configuration file, and have `Client Registration CLI` automatically "
+"can also use `kcreg config registration-token` command to save the new token"
+" in configuration file, and have `Client Registration CLI` automatically "
 "handle it for you from that point on."
 msgstr ""
+"アクセス権がある場合は、クライアントの新しい登録アクセストークンを再発行し、標準出力に出力するか、または自分が選択した設定ファイルに保存することができます。"
+" アクセス権が無い場合は、レルム管理者にクライアントの新しい登録アクセストークンを再発行してもらうように依頼する必要があります。その際は、 "
+"`--token` オプション付きの任意のCRUDコマンドにトークンを渡すことができます。また、 `kcreg config registration-"
+"token` コマンドを使って新しいトークンを設定ファイルに保存し、 `Client Registration CLI` "
+"が自動的にそれを処理するようにすることもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:382
 msgid ""
 "See `kcreg update-token --help` for more information about `kcreg update-"
 "token`."
-msgstr ""
+msgstr "`kcreg update-token` の詳細については、 `kcreg update-token --help` を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:389
@@ -806,10 +881,14 @@ msgid ""
 "Q: When logging in I get an error: `Parameter client_assertion_type is "
 "missing [invalid_client]`"
 msgstr ""
+"Q: ログインすると、次のエラーが表示されます: `Parameter client_assertion_type is missing "
+"[invalid_client]`"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:390
 msgid ""
-"A: Your client is configured with `Signed JWT` token credentials which means "
-"you have to use `--keystore` parameter when logging in."
+"A: Your client is configured with `Signed JWT` token credentials which means"
+" you have to use `--keystore` parameter when logging in."
 msgstr ""
+"A: クライアントが `Signed JWT` のトークン証明書で設定されています。つまり、ログイン時に `--keystore` "
+"パラメータを使用する必要があります。"

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +17,7 @@ msgstr ""
 
 #. type: Title ###
 #: source/server_installation/topics/clustering/troubleshooting.adoc:2
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:386
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:391
 #: source/securing_apps/topics/saml/java/debugging.adoc:2
 #: source/server_admin/topics/authentication/kerberos.adoc:191
 #: source/server_admin/topics/authentication/x509.adoc:201
@@ -34,33 +34,30 @@ msgstr "クライアント登録CLI"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:6
 msgid ""
-"Client Registration CLI is a Technology Preview feature and is not fully "
-"supported."
-msgstr "クライアント登録CLIはテクニカル・プレビュー機能であり、完全にはサポートされていません。"
+"`Client Registration CLI` is a command line interface tool for application "
+"developers to configure new clients in self-service manner when integrating "
+"with {project_name}. It is specifically designed to interact with "
+"{project_name} Client Registration REST endpoints."
+msgstr ""
+"`Client Registration CLI` は、アプリケーション開発者が {project_name} "
+"と統合する際にセルフ・サービスで新しいクライアントを設定するためのコマンドライン・インタフェース・ツールです。 これは、 {project_name} "
+"クライアント登録RESTエンドポイントと対話するように特別に設計されています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:10
 msgid ""
-"`Client Registration CLI` is a command line interface tool that can be used "
-"by application developers to configure new clients to integrate with "
-"{project_name}. It is specifically designed to interact with {project_name} "
-"Client Registration REST endpoints."
+"In order for any application to be able to use {project_name} it is "
+"necessary to create or obtain a client configuration. Usually a new client "
+"is configured for each new application hosted on a unique hostname. When "
+"application interacts with {project_name} it needs to identify itself with a"
+" `client_id` in order for {project_name} to be able to provide login page, "
+"SSO session management, and other services."
 msgstr ""
-"`Client Registration CLI` "
-"は、{project_name}と統合する新しいクライアントを設定するために、アプリケーション開発者が使用できるコマンドライン・インターフェイス・ツールです。{project_name}クライアント登録RESTエンドポイントと対話するためだけに設計されています。"
+"アプリケーションが{project_name}を使用できるようにするには、クライアントの設定を作成または取得する必要があります。通常、新しいクライアントは一意なホスト名でホストされる新しいアプリケーションごとに設定されます。アプリケーションが{project_name}と対話する際に、{project_name}がログインページ、SSOセッション管理、およびその他のサービスを提供できるようにするために、自身を"
+" `client_id` で識別する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:13
-msgid ""
-"It is necessary to create a new client configuration for each new "
-"application hosted on a unique hostname in order for Keycloak to be able to "
-"interact with the application (and vice-versa) and perform its function of "
-"providing a login page, SSO session management etc."
-msgstr ""
-"{project_name}がアプリケーションと相互に対話したり、ログイン・ページやSSOセッション管理などを提供する機能を実行できるようにするには、一意なホスト名でホストされるアプリケーション毎にクライアントの設定を作成する必要があります。"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:15
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:12
 msgid ""
 "`Client Registration CLI` allows you to configure application clients from a"
 " command line, and can be used in shell scripts as well."
@@ -69,178 +66,175 @@ msgstr ""
 "では、コマンドラインからアプリケーション・クライアントを設定することができます。シェルスクリプトでも使用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:18
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:15
 #, no-wrap
 msgid ""
-"To allow a particular user to use `Client Registration CLI` a {project_name} administrator will typically use `Admin Console` to configure\n"
-" a new user, or configure a new client, and a client secret, to protect access to `Client Registration REST API`.\n"
+"To allow a particular user to use `Client Registration CLI` the {project_name} administrator will typically use `Admin Console` to configure\n"
+" a new user with proper roles, or configure a new client and client secret to grant access to `Client Registration REST API`.\n"
 msgstr ""
 "特定のユーザーが `Client Registration CLI` を使用できるようにするため、通常、{project_name}管理者は "
-"`Admin Console` を使って、 `Client Registration REST API` "
-"へのアクセスを保護するために、新しいユーザー(またはクライアント)とクライアントシークレットを設定します。\n"
+"`管理コンソール` を使って新しいユーザーを適切なロールで設定するか、`Client Registration REST API` "
+"へのアクセス権を与えるように新しいクライアントとクライアント・シークレットを設定します 。\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:21
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:18
 #, no-wrap
 msgid "Configuring a new regular user for use with Client Registration CLI"
 msgstr "クライアント登録CLIで使用するための新しい正規ユーザーの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:29
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:27
 msgid ""
 "Login as `admin` into `Admin Console` (e.g. "
 "`http://localhost:8080/auth/admin`). Select a realm you want to administer."
-"  If you want to use existing user, select it for edit, otherwise create a "
-"new user. Go to `Role Mappings` tab. Under `Client Roles` select `realm-"
-"management`. Under `Available Roles` select `manage-client` for full set of "
-"client management permissions. Alternatively you can choose `view-clients` "
-"for read-only or `create-client` for ability to create new clients.  These "
-"permissions grant user the capability to perform operations without the use "
-"of `Initial Access Token` or `Registration Access Token`."
+"  If you want to use existing user, select that user for edit, otherwise "
+"create a new user. Go to `Role Mappings` tab. Under `Client Roles` select "
+"`realm-management` (if in master realm, select `NAME-realm` where NAME is "
+"name of the target realm - users in master realm can have access to any "
+"other realms).  Under `Available Roles` select `manage-client` for full set "
+"of client management permissions. Alternatively you can choose `view-"
+"clients` for read-only or `create-client` for ability to create new clients."
+"  These permissions grant user the capability to perform operations without "
+"the use of <<_initial_access_token,Initial Access Token>> or "
+"<<_registration_access_token,Registration Access Token>>."
 msgstr ""
-"`Admin Console` にログインしてください(例: "
-"`http://localhost:8080/auth/admin`)。管理するレルムを選択します。既存のユーザーを使用する場合は編集を選択し、そうでない場合は新規ユーザーを作成します。`Role"
-" Mappings` タブをクリックします。 `Client Roles`  以下の `realm-management` "
-"を選択します。`Available Roles`  以下のクライアント管理権限のフルセットの `manage-client` "
-"を選択します。あるいは、読み取り専用の場合は `view-clients` を、新しいクライアントを作成する場合は `create-client` "
-"を選択できます。これらのアクセス権は、 `Initial Access Token` または `Registration Access Token` "
-"を使用せずに、ユーザーに操作を実行する機能を付与します。"
+"管理コンソールにログインしてください(例：`http://localhost:8080/auth/admin`)。管理するレルムを選択します。既存のユーザーを使用する場合は、編集するユーザーを選択し、そうでない場合は新しいユーザーを作成します。`ロールマッピング`のタブに行きます。`クライアントロール`の下で、`レルム管理`を選択します(マスター・レルムの場合、NAMEは対象のレルムの名前で、マスター・レルムのユーザーは他のレルムにアクセスできます)。`利用可能なロール`で、クライアント管理権限のフルセットに対して`クライアント管理`を選択します。あるいは、読み取り専用の場合は"
+" `クライアント参照`を、新しいクライアントを作成する場合は` "
+"クライアント作成`を選択できます。これらのアクセス権は、ユーザーに<<_initial_access_token,Initial Access "
+"Token>>または<<_registration_access_token,Registration Access "
+"Token>>を使用せずに操作を実行できるようにします。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:31
+msgid ""
+"It's possible to not assign users any of `realm-management` roles. In that "
+"case user can still login with `Registration Client CLI` but will not be "
+"able to use it without being in possession of an `Initial Access Token`. "
+"Trying to perform any operations without it will result in `403 Forbidden` "
+"error."
+msgstr ""
+"ユーザーに `レルム管理`ロールを割り当てないことも可能です。その場合、ユーザーは`Registration Client "
+"CLI`でまだログインすることができますが、`Initial Access "
+"Token`を所有していなければそれを使用することはできません。それなしで何らかの操作を実行しようとすると`403 "
+"Forbidden`エラーが発生します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:33
 msgid ""
-"It's possible to not assign users any of `realm-management` roles. In that "
-"case user can still login with `Registration Client CLI` but will not be "
-"able to use it without having possession of an `Initial Access Token`. "
-"Trying to perform any operations without it will result in `403 Forbidden` "
-"error."
-msgstr ""
-"ユーザーに `realm-management` ロールを割り当てないことも可能です。その場合、ユーザーは `Initial Access Token`"
-" を所有していなくても、 `Registration Client CLI` "
-"でログインすることはできますが、それを使用することはできません。所有せずに何らかの操作を実行しようとすると、 `403 Forbidden`  "
-"エラーが発生します。"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:35
-msgid ""
 "Administrator can issue `Initial Access Tokens` from `Admin Console` by "
-"selecting `Initial Access Token` tab under `Realm Settings`."
+"selecting `Client Registration` tab under `Realm Settings`, then `Initial "
+"Access Token` sub-tab."
 msgstr ""
-"管理者は `Realm Settings` 以下の `Initial Access Tokens` タブを選択することで、 `Admin "
-"Console` から `Initial Access Tokens` を発行することができます。"
+"管理者は、`レルム設定`の下の`クライアント登録`タブを選択し、 "
+"`初期アクセストークン`サブ・タブを選択することによって管理者コンソールから`初期アクセストークン`を発行することができます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:37
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:35
 #, no-wrap
 msgid "Configuring a client for use with Client Registration CLI"
-msgstr "クライアント登録CLIで使用するためのクライアントの設定"
+msgstr "クライアント登録CLIで使用するためのクライアント設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:43
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:41
 msgid ""
-"By default the `Client Registration CLI` identifies as `admin-cli` client "
-"which is automatically configured for every new realm.  No additional client"
-" configuration is required when using login with a username. You may wish to"
-" strengthen security by configuring the client `Access Type` as "
-"`Confidential`, and under `Credentials` tab select `ClientId and Secret`. "
-"When running `kcreg config credentials` you would then also have to provide "
-"a secret e.g. by using `--secret`."
+"By default the `Client Registration CLI` identifies to the server as `admin-"
+"cli` client which is automatically configured for every new realm.  No "
+"additional client configuration is necessary when logging in with username. "
+"You may wish to strengthen security by configuring the client `Access Type` "
+"as `Confidential`, and under `Credentials` tab select `ClientId and Secret`."
+" When running `kcreg config credentials` you would then also have to provide"
+" a secret by using `--secret` option."
 msgstr ""
-"デフォルトでは、 `Client Registration CLI` は `admin-cli` "
-"クライアントとして識別されます。これは新しいレルムごとに自動的に設定されます。ユーザー名でのログインを使用する場合、追加のクライアント設定は必要ありません。クライアントの"
-" `Access Type` を `Confidential` に設定することでセキュリティを強化したい場合は、 `Credentials` タブで "
-"`ClientId and Secret` を選択できます。 `kcreg config credentials` "
-"を実行する際に、シークレット(例えば、 `--secret` を使用)を提供する必要があります。"
+"デフォルトでは、`Client Registration CLI`はサーバーに`admin-"
+"cli`クライアントとして指定します。これは新しいレルムごとに自動的に設定されます。ユーザー名でログインする場合、追加のクライアント設定は不要です。クライアントの`アクセス・タイプ`を`コンフィデンシャル`に設定してセキュリティを強化し、`クレデンシャル`タブで`クライアントIDとシークレット`を選択することができます。`kcreg"
+" config credentials`を実行するときには` --secret`オプションを使ってシークレットを提供する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:46
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:44
 msgid ""
 "If you want to use a separate client configuration for `Registration Client "
-"CLI` then you can create a new client - for example you can call it `reg-"
-"cli`. When running `kcreg config credentials` you then need to specify a "
-"`clientId` to use e.g. `--client reg-cli`."
+"CLI` then you can create a new client - you can call it `reg-cli` for "
+"example. When running `kcreg config credentials` you then need to specify "
+"which `clientId` to use e.g. `--client reg-cli`."
 msgstr ""
-"`Registration Client CLI` とは別のクライアント設定を使いたい場合は、新しいクライアントを作成できます。例えば `reg-"
-"cli` を呼ぶことができます。 `kcreg config credentials` を実行中に、 `clientId` "
-"を指定する必要があります(例えば、 `--client reg-cli` を使用)。"
+"`Registration Client "
+"CLI`に対して別のクライアント設定を使いたい場合は、新しいクライアントを作成することができます。例えば、それを`reg-"
+"cli`と呼ぶことができます。`kcreg config credentials`を実行するときは、`--client reg-"
+"cli`のように、どの`clientId`を使用するかを指定する必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:48
+msgid ""
+"If you want to use a service account associated with the client, you first "
+"need to enable service accounts. In `Admin Console` go to `Clients` section,"
+" and select a client for edit. Then under `Settings` change the `Access "
+"Type` to `Confidential`, and toggle `Service Accounts Enabled` setting to "
+"`On`. Make sure to `Save` the configuration."
+msgstr ""
+"クライアントに関連付けられたサービス・アカウントを使用する場合は、まずサービス・アカウントを有効にする必要があります。管理者コンソールで`クライアント`のセクションに行き、編集するクライアントを選択します。"
+" "
+"次に、`設定`の下で、`アクセスタイプ`を`コンフィデンシャル`に変更し、`サービス・アカウントの有効化`を`オン`に切り替えます。設定を`保存`することを忘れないでください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:50
-msgid ""
-"If you want to use a service account associated with the client, then you "
-"need to enable a service account. In `Admin Client` you go to `Clients` "
-"section, and select a client for edit. Then under `Settings` first change "
-"`Access Type` to `Confidential`.  Then toggle `Service Accounts Enabled` "
-"setting to `On`, and `Save` the configuration."
-msgstr ""
-"クライアントに関連付けられたサービス・アカウントを使用したい場合は、サービス・アカウントを有効にする必要があります。 `Admin Client` で "
-"`Clients` セクションに遷移し、編集するクライアントを選択します。次に、`Settings` の下の `Access Type` を "
-"`Confidential` に変更します。 次に、 `Service Accounts Enabled` "
-"設定を「オン」に切り替え、設定を「保存」します。"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:52
 msgid ""
 "Under `Credentials` tab you can choose to configure either `Client Id and "
 "Secret`, or `Signed JWT`."
 msgstr "`Credentials` タブで、`Client Id and Secret` か `Signed JWT` のどちらかを設定できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:54
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:52
 msgid ""
-"You can now avoid specifying user when using `kcreg config credentials` and "
-"only provide a client secret or keystore info."
+"Having done that you can then omit specifying user during `kcreg config "
+"credentials`, and only provide client secret or keystore info."
 msgstr ""
-" `kcreg config credentials` "
-"を使用すると、ユーザーを指定せずに、クライアントシークレットまたはキーストア情報のみを提供できるようになりました。"
+"これを行うと、`kcreg config "
+"credentials`の実行中にユーザーを指定することを省略し、クライアント・シークレットやキーストア情報のみを提供することができます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:56
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:54
 #, no-wrap
 msgid "Installing Client Registration CLI"
 msgstr "クライアント登録CLIのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:59
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:57
 msgid ""
 "Client Registration CLI is packaged inside Keycloak Server distribution. You"
 " can find execution scripts inside `bin` directory."
 msgstr ""
-"クライアント登録CLIは、{project_name}サーバーのディストリビューションの中にパッケージされています。 `bin` "
+"クライアント登録CLIは、{project_name}サーバーの配布物の中にパッケージされています。 `bin` "
 "ディレクトリ内に実行スクリプトがあります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:59
+msgid ""
+"The Linux script is called `kcreg.sh`, and the one for Windows is called "
+"`kcreg.bat`."
+msgstr "Linuxのスクリプトは `kcreg.sh` 、Windowsのスクリプトは `kcreg.bat` という名前です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:61
 msgid ""
-"The Linux script is called `kcreg.sh`, and the one for Windows is called "
-"`kcreg.bat`."
-msgstr "Linuxのスクリプトは `kcreg.sh` と呼ばれ、Windowsのスクリプトは `kcreg.bat` と呼ばれます。"
+"In order to setup the client for use from any location on the filesystem you"
+" may want to add Keycloak server directory to your PATH."
+msgstr ""
+"ファイル・システム上の任意の場所からクライアントを使用できるように設定するには、PATHにKeycloakサーバーのディレクトリを追加します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:63
-msgid ""
-"In order to setup the client to be used from any location on the filesystem "
-"you may want to add Keycloak server directory to your PATH."
-msgstr ""
-"ファイルシステム上の任意の場所から使用できるようにクライアントをセットアップするために、{project_name}サーバーのディレクトリをPATHに追加した方がいいです。"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:65
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:243
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:266
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:281
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:300
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:319
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:337
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:354
-#: source/server_admin/topics/admin-cli.adoc:21
-#: source/server_admin/topics/admin-cli.adoc:362
-#: source/server_admin/topics/admin-cli.adoc:373
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:244
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:304
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:341
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:359
+#: source/server_admin/topics/admin-cli.adoc:17
+#: source/server_admin/topics/admin-cli.adoc:381
+#: source/server_admin/topics/admin-cli.adoc:392
 msgid "On Linux:"
-msgstr "Linuxの場合:"
+msgstr "Linuxの場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:69
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:67
 #, no-wrap
 msgid ""
 "$ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
@@ -250,21 +244,21 @@ msgstr ""
 "$ kcreg.sh\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:72
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:203
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:249
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:272
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:287
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:308
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:325
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:343
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:360
-#: source/server_admin/topics/admin-cli.adoc:26
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:70
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:206
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:250
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:275
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:290
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:312
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:329
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:347
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:365
+#: source/server_admin/topics/admin-cli.adoc:22
 msgid "On Windows:"
-msgstr "Windowsの場合:"
+msgstr "Windowsの場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:76
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:74
 #, no-wrap
 msgid ""
 "c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
@@ -272,35 +266,44 @@ msgid ""
 msgstr ""
 "c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
 "c:\\> kcreg\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:77
+msgid ""
+"Where KEYCLOAK_HOME refers to a directory where Keycloak Server distribution"
+" was unpacked."
+msgstr "KEYCLOAK_HOMEは、Keycloakサーバーのディストリビューションが解凍されたディレクトリを示します。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:79
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:80
 #, no-wrap
 msgid "Using Client Registration CLI"
 msgstr "クライアント登録CLIの使用"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:82
-#: source/server_admin/topics/admin-cli.adoc:37
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:83
 msgid ""
-"Usually a user will first start an authenticated session by providing "
-"credentials, then perform some CRUD operations."
-msgstr "通常、ユーザーはまずクレデンシャルを提供して認証されたセッションを開始し、次にいくつかのCRUD操作を実行します。"
+"First you need to start an authenticated session (i.e. logging in) by "
+"providing credentials. Then you perform operations on Client Registration "
+"REST endpoint."
+msgstr ""
+"まず、クレデンシャルを提供して認証されたセッション(つまりログイン)を開始する必要があります。 "
+"次に、クライアント登録RESTエンドポイントで操作を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:84
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:107
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:142
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:188
-#: source/server_admin/topics/admin-cli.adoc:39
-#: source/server_admin/topics/admin-cli.adoc:59
-#: source/server_admin/topics/admin-cli.adoc:197
-#: source/server_admin/topics/admin-cli.adoc:282
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:85
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:108
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:144
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:191
+#: source/server_admin/topics/admin-cli.adoc:42
+#: source/server_admin/topics/admin-cli.adoc:62
+#: source/server_admin/topics/admin-cli.adoc:221
+#: source/server_admin/topics/admin-cli.adoc:301
 msgid "For example on Linux:"
-msgstr "例えば、Linux の場合:"
+msgstr "例えば、Linux の場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:90
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:91
 #, no-wrap
 msgid ""
 "$ kcreg.sh config credentials --server http://localhost:8080/auth --realm demo --user user --client reg-cli\n"
@@ -312,24 +315,24 @@ msgstr ""
 "$ kcreg.sh get my_client\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:93
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:113
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:149
-#: source/server_admin/topics/admin-cli.adoc:47
-#: source/server_admin/topics/admin-cli.adoc:63
-#: source/server_admin/topics/admin-cli.adoc:203
-#: source/server_admin/topics/admin-cli.adoc:286
-#: source/server_admin/topics/admin-cli.adoc:303
-#: source/server_admin/topics/admin-cli.adoc:324
-#: source/server_admin/topics/admin-cli.adoc:366
-#: source/server_admin/topics/admin-cli.adoc:377
-#: source/server_admin/topics/admin-cli.adoc:652
-#: source/server_admin/topics/admin-cli.adoc:704
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:94
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:114
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:151
+#: source/server_admin/topics/admin-cli.adoc:50
+#: source/server_admin/topics/admin-cli.adoc:66
+#: source/server_admin/topics/admin-cli.adoc:227
+#: source/server_admin/topics/admin-cli.adoc:305
+#: source/server_admin/topics/admin-cli.adoc:322
+#: source/server_admin/topics/admin-cli.adoc:343
+#: source/server_admin/topics/admin-cli.adoc:385
+#: source/server_admin/topics/admin-cli.adoc:396
+#: source/server_admin/topics/admin-cli.adoc:708
+#: source/server_admin/topics/admin-cli.adoc:760
 msgid "Or on Windows:"
-msgstr "またはWindowsの場合:"
+msgstr "またはWindowsの場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:99
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:100
 #, no-wrap
 msgid ""
 "c:\\> kcreg config credentials --server http://localhost:8080/auth --realm demo --user user --client reg-cli\n"
@@ -341,20 +344,18 @@ msgstr ""
 "c:\\> kcreg get my_client\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:105
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:106
 msgid ""
 "In a production environment Keycloak has to be accessed with `https:` to "
 "avoid exposing tokens to network sniffers. If server's certificate is not "
 "issued by one of the trusted CAs that are included in Java's default "
-"certificate truststore, then you will need to prepare a truststore.jks file,"
-" and instruct `Client Registration CLI` to use it."
+"certificate truststore, you will need to prepare a truststore.jks file, and "
+"instruct `Client Registration CLI` to use it."
 msgstr ""
-"本番環境では、ネットワーク・スニッファでトークンを解読されることを避けるために、{project_name}には `https:` "
-"でアクセスできなければなりません。サーバーの証明書がJavaのデフォルト証明書のトラスト・ストアに含まれる信頼できるCAによって発行されていない場合、truststore.jksファイルを用意し、それを使用するように"
-" `Client Registration CLI` に指示する必要があります。"
+"実稼働環境では、ネットワーク・スニファーへのトークンの公開を避けるため、Keycloakには`https:`でアクセスする必要があります。サーバー証明書が、Javaのデフォルトの証明書トラスト・ストアに含まれている信頼されたCAのいずれかによって発行されていない場合は、`truststore.jks`ファイルを準備し、それを使用するように、`クライアント登録CLI`に指示する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:110
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:111
 #, no-wrap
 msgid ""
 "$ kcreg.sh config truststore --trustpass $PASSWORD "
@@ -364,7 +365,7 @@ msgstr ""
 "~/.keycloak/truststore.jks\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:117
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:118
 #, no-wrap
 msgid ""
 "c:\\> kcreg config truststore --trustpass %PASSWORD% "
@@ -374,123 +375,119 @@ msgstr ""
 "%HOMEPATH%\\.keycloak\\truststore.jks\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:121
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:122
 #, no-wrap
 msgid "Logging In"
 msgstr "ログイン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:127
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:128
 msgid ""
 "When logging in with `Client Registration CLI` you specify a server endpoint"
-" url, and a realm. Then you specify a username, or alternatively you can "
-"only specify a client id, which will result in special service account being"
-" used. In the first case, a password for the specified user has to be used "
-"at login. In the latter case there is no user password - only client secret "
-"or a `Signed JWT` is used."
+" url, and a realm. Then you specify a username or, alternatively, a client "
+"id, which will result in special service account being used. In the first "
+"case, a password for the specified user has to be used at login. In the "
+"latter case there is no user password - only client secret or a `Signed JWT`"
+" is used."
 msgstr ""
-"`Client Registration CLI` "
-"でログインする際に、サーバー・エンドポイントURLとレルムを指定します。その後、ユーザー名を指定するか、またはクライアントIDのみを指定することができます。これにより、特別なサービスアカウントが使用されます。前者の場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。後者の場合、ユーザーパスワードはありません。クライアント・シークレットのみか"
-" `Signed JWT` が使用されます。"
+"`クライアント登録CLI`でログインするときに、サーバーのエンドポイントURLとレルムを指定します。次に、ユーザー名、またはクライアントIDを指定します。これにより、特別なサービス・アカウントが使用されます。最初のケースでは、ログイン時に指定されたユーザーのパスワードを使用する必要があります。後者の場合、ユーザー・パスワードはありません。クライアント・シークレットまたは`署名済みJWT`のみが使用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:131
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:133
 msgid ""
-"Regardless of the method, the account that logs in needs to have proper "
-"permissions in order to be able to perform client registration operations. "
-"Keep in mind that any account can only have permissions to manage clients "
-"within the same realm.  If you need to manage different realms, you need to "
-"configure users in different realms with permissions to manage clients."
+"Regardless of the method, the account that logs in needs proper permissions "
+"to be able to perform client registration operations. Keep in mind that any "
+"account in non-master realm can only have permissions to manage clients "
+"within the same realm.  If you need to manage different realms, you can "
+"either configure multiple users in different realms, or you can create a "
+"single user in `master` realm and add it roles for managing clients in "
+"different realms."
 msgstr ""
-"方法にかかわらず、ログインするアカウントは、クライアント登録操作を実行できるようにするために適切な権限を持っている必要があります。すべてのアカウントは、同じレルム内のクライアントを管理するための権限しか持たないことに注意してください。異なるレルムを管理する必要がある場合は、クライアントを管理する権限を持つ異なるレルムにユーザーを設定する必要があります。"
+"方法に関係なく、ログインするアカウントには、クライアント登録操作を実行できる適切な権限が必要です。非マスター・レルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムで設定するか、「マスター」レルムで1人のユーザーを作成して、異なるレルムのクライアントを管理するロールを追加できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:134
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:136
 msgid ""
-"`Client Registration CLI` by itself does not support configuring the users, "
-"for that you would need to use `Admin Console` web interface or `Admin "
-"Client CLI` once it's available."
+"`Client Registration CLI` by itself does not support configuring users, for "
+"that you would need to use `Admin Console` web interface or Admin Client CLI"
+" command line tool (see link:{adminguide_link}[{adminguide_name}] for more "
+"details)."
 msgstr ""
-"`Client Registration CLI` 自体はユーザーの設定をサポートしていません。利用できるようにするには、 `Admin "
-"Console` ウェブ・インタフェースや `Admin Client CLI` を使う必要があります。"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:137
-msgid ""
-"When `kcreg` successfully logs in it receives authorization tokens and saves"
-" them into a private config file so they can be used for subsequent "
-"invocations. See <<_working_with_alternative_configurations, next chapter>> "
-"for more info on configuration file."
-msgstr ""
-"`kcreg` "
-"が正常にログインすると、認証トークンを受け取り、それを後の呼び出しに使用できるようにプライベート設定ファイルに保存します。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
-" next chapter>>を参照してください。"
+"`クライアント登録CLI`自体はユーザーの設定をサポートしていません。そのためには、管理者コンソールのウェブ・インターフェースまたは管理者クライアントCLIコマンドライン・ツール(詳細はlink"
+" {adminguide_link} [{adminguide_name}]を使う必要があります)。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:139
+msgid ""
+"When `kcreg` successfully logs in it receives authorization tokens and saves"
+" them into private config file so they can be used for subsequent "
+"invocations. See <<_working_with_alternative_configurations, next chapter>> "
+"for more info on configuration file."
+msgstr ""
+"`kcreg`が正常にログインすると、認可トークンを受け取り、それらをプライベート設定ファイルに保存して、後続の呼び出しに使用できるようにします。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
+" next chapter>>を参照してください。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:141
 msgid ""
 "See built-in help for more information on using `Client Registration CLI`."
 msgstr "`Client Registration CLI` の使用方法の詳細については、組み込みのヘルプを参照してください。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:145
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:147
 #, no-wrap
 msgid "$ kcreg.sh help\n"
 msgstr "$ kcreg.sh help\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:152
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:154
 #, no-wrap
 msgid "c:\\> kcreg help\n"
 msgstr "c:\\> kcreg help\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:155
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:157
 msgid ""
 "See `kcreg config credentials --help` for more information about starting an"
 " authenticated session."
 msgstr "認証されたセッションの開始についての詳細は、 `kcreg config credentials --help` を参照してください。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:159
-#: source/server_admin/topics/admin-cli.adoc:113
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:161
+#: source/server_admin/topics/admin-cli.adoc:110
 #, no-wrap
 msgid "Working with alternative configurations"
 msgstr "代替設定の使用"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:163
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:165
 msgid ""
 "By default, `Client Registration CLI` automatically maintains a "
-"configuration file at a default location - `.keycloak/kcreg.config` under "
+"configuration file at a default location - `./.keycloak/kcreg.config` under "
 "user's home directory."
 msgstr ""
-"`Client Registration CLI` "
-"は、デフォルトの場所に設定ファイルを自動的に保持します（デフォルトでは、ユーザーのホーム・ディレクトリの下の "
-"`.keycloak/kcreg.config` ）。"
+"デフォルトで`クライアント登録CLI`は、ユーザーのホーム・ディレクトリの下にあるデフォルトの場所(`./.keycloak/kcreg.config`)に設定ファイルを自動的に保持します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:166
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:168
 msgid ""
-"You can use `--config` option at any time to point to a different file / "
+"You can always use `--config` option to point to a different file / "
 "location. This way you can mantain multiple authenticated sessions in "
 "parallel. It is safest to perform operations tied to a single config file "
 "from a single thread."
 msgstr ""
-" `--config` オプションを使うと、いつでも別のファイル/場所を指すことができます。 "
-"これにより、複数の認証済みセッションを並行して処理できます。 1つのスレッドから1つの設定ファイルに結び付けられた操作を実行することが最も安全です。"
+"`--config`オプションを使うと、いつでも別のファイル/場所を指すことができます。これにより、複数の認証済みセッションを並行して処理できます。1つのスレッドから1つの設定ファイルに結び付けられた操作を実行するのが最も安全です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:168
-#: source/server_admin/topics/admin-cli.adoc:122
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:170
 msgid ""
-"Make sure to not make a config file visible to other users on the system as "
-"it contains access tokens, and secrets that should be kept private."
+"Make sure to not make the config file visible to other users on the system "
+"as it contains access tokens, and secrets that should be kept private."
 msgstr ""
-"アクセストークンとプライベートにしておくべきシークレットを含んでいるため、システム上の他のユーザーに設定ファイルを表示しないようにしてください。"
+"システム上の他のユーザーには、アクセス・トークンとプライベートにしておかなければならないシークレットが含まれているため、設定ファイルを参照できないようにしてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:172
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:174
 msgid ""
 "You may want to avoid storing any secrets at all inside a config file for "
 "the price of less convenience and having to do more token requests.  In that"
@@ -501,42 +498,41 @@ msgstr ""
 " `--no-config` オプションを使用できます。 `kcreg` の呼び出しごとに、すべての認証情報を指定する必要があります。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:176
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:178
 #, no-wrap
 msgid "Initial Access and Registration Access Tokens"
 msgstr "初期アクセス・トークンと登録アクセス・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:182
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:185
 msgid ""
 "`Client Registration CLI` can be used by developers who don't have an "
 "account configured at Keycloak server they want to use.  That's possible "
 "when realm administrator issues developer an `Initial Access Token`. It is "
 "up to realm administrator to decide how to issue and distribute these "
-"tokens. Admin can limit an Initial Access Token by maximum age, and a total "
+"tokens. Admin can limit Initial Access Token's maximum age, and a total "
 "number of clients that can be created with it. Many Initial Access Tokens "
-"can be created, and it's up to realm administrator to distribute them."
+"can be created, and it's up to realm administrator to distribute them to "
+"application developers."
 msgstr ""
-"`Client Registration "
-"CLI`は、使用したい{project_name}サーバーで設定されたアカウントを持っていない開発者が使用できます。レルム管理者が開発者に "
-"`Initial Access Token` を発行するときに可能です。 これらのトークンを発行して配布する方法を決定するのは、レルム管理者次第です。 "
-"管理者は、初期アクセストークンを最大経過時間と作成できるクライアントの総数で制限できます。 "
-"多くの初期アクセストークンを作成することができ、また、それらを配布するのはレルム管理者の責任です。"
+"`クライアント登録CLI`は、使用したいKeycloakサーバーでアカウントを設定していない開発者が使うことができます。これは、レルム管理者が開発者に`初期アクセストークン`を発行するときに可能です。これらのトークンを発行して配布する方法を決定するのは、レルム管理者次第です。"
+" 管理者は、初期アクセス・トークンの最大経過時間とそれで作成できるクライアントの総数を制限できます。 "
+"レルム管理者は、たくさんの初期アクセス・トークンを作成することができ、アプリケーション開発者に配布することができます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:186
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:189
 msgid ""
 "Once a developer is in possession of Initial Access Token they can use it to"
 " create new clients without authenticating with `kcreg config credentials`. "
 "Rather, Initial Access Token can be stored in configuration, or specified as"
 " part of `kcreg create` command."
 msgstr ""
-"開発者が初期アクセストークンを所有すると、 `kcreg config credentials` "
-"で認証せずに新しいクライアントを作成できます。むしろ、初期アクセストークンは設定に保存することも、  `kcreg create` "
+"開発者が初期アクセス・トークンを所有すると、 `kcreg config credentials` "
+"で認証せずに新しいクライアントを作成できます。むしろ、初期アクセス・トークンは設定に保存することも、  `kcreg create` "
 "コマンドの一部として指定することもできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:192
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:195
 #, no-wrap
 msgid ""
 "$ kcreg.sh config initial-token $TOKEN\n"
@@ -546,19 +542,19 @@ msgstr ""
 "$ kcreg.sh create -s clientId=myclient\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:195
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:210
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:198
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:213
 msgid "or"
 msgstr "または"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:199
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:202
 #, no-wrap
 msgid "$ kcreg.sh create -s clientId=myclient -t $TOKEN\n"
 msgstr "$ kcreg.sh create -s clientId=myclient -t $TOKEN\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:207
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:210
 #, no-wrap
 msgid ""
 "c:\\> kcreg config initial-token %TOKEN%\n"
@@ -568,175 +564,186 @@ msgstr ""
 "c:\\> kcreg create -s clientId=myclient\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:214
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:217
 #, no-wrap
 msgid "c:\\> kcreg create -s clientId=myclient -t %TOKEN%\n"
 msgstr "c:\\> kcreg create -s clientId=myclient -t %TOKEN%\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:219
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:222
 msgid ""
 "When Initial Access Token is used, the server response will include a newly "
-"issued Registration Access Token for client that was just created. Any "
-"subsequent operation for that client needs to be performed by authenticating"
-" with that token."
+"issued Registration Access Token.  Any subsequent operation for that client "
+"needs to be performed by authenticating with that token which is only valid "
+"for that client."
 msgstr ""
-"初期アクセストークンが使用される場合、サーバーのレスポンスには、作成されたクライアントに対して新たに発行された登録アクセストークンが含まれます。その後のクライアントに対する操作は、登録アクセストークンで認証してから実行する必要があります。"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:223
-msgid ""
-"`Client Registration CLI` automatically uses its private configuration file "
-"to save, and make use of this token for each created client. As long as the "
-"same configuration file is used for all client operations, the developer "
-"will not need to authenticate in order to read, update, or delete a client "
-"they created."
-msgstr ""
-"`Client Registration CLI` "
-"は、自動的にプライベート設定ファイルを使用して保存し、作成されたクライアントごとにこのトークンを使用します。 "
-"すべてのクライアント操作で同じ設定ファイルが使用されている限り、開発者は作成したクライアントの読み取り、更新、または削除を行うために認証する必要はありません。"
+"初期アクセス・トークンが使用されると、サーバー・レスポンスに新たに発行された登録アクセス・トークンを含まれることになります。そのクライアントの後続の操作は、そのクライアントに対してのみ有効なトークンで、認証することによって実行する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:226
 msgid ""
+"`Client Registration CLI` automatically uses its private configuration file "
+"to save, and use this token with its associated client.  As long as the same"
+" configuration file is used for all client operations, the developer will "
+"not need to authenticate in order to read, update, or delete a client that "
+"was created this way."
+msgstr ""
+"クライアント登録CLIは自動的にプライベート設定ファイルを使用して保存し、このトークンを関連するクライアントと共に使用します。同じ設定ファイルがすべてのクライアント操作に使用されている限り、このように作成されたクライアントの読み取り、更新、削除を行うために、開発者は認証する必要はありません。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:229
+msgid ""
 "You can read more about Initial Access and Registration Access Tokens in "
 "<<_client_registration,Client Registration chapter>>."
 msgstr ""
-"<<_client_registration,Client Registration "
-"chapter>>の初期アクセス・トークンと登録アクセス・トークンの詳細については、こちらをご覧ください。"
+"初期アクセス・トークンと登録アクセス・トークンの詳細については、<<_client_registration,クライアント登録の章>>をご覧ください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:228
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:231
 msgid ""
 "See `kcreg config initial-token --help` and `kcreg config registration-token"
 " --help` for more information on how to configure them with `Client "
 "Registration CLI`."
 msgstr ""
-"`Client Registration CLI` でそれらを設定する方法の詳細については、 `kcreg config initial-token "
+"`Client Registration CLI` で設定する方法の詳細については、 `kcreg config initial-token "
 "--help` と `kcreg config registration-token --help` を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:232
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:235
 #, no-wrap
-msgid "Performing CRUD operations"
-msgstr "CRUD操作の実行"
+msgid "Creating client configuration"
+msgstr "クライアント設定の作成"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:236
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:238
 msgid ""
 "After authenticating with credentials or configuring Initial Access Token, "
 "the first operation will usually be to create a new client."
-msgstr "クレデンシャルで認証したり、初期アクセストークンを設定すると、通常は最初の操作で新しいクライアントが作成されます。"
+msgstr "クレデンシャルで認証したり、初期アクセス・トークンを設定した後に、通常は最初の操作で新しいクライアントを作成します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:241
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:242
 msgid ""
-"We've seen the simplest command to create a new client already. Often we may"
-" want to use a prepared JSON file as a template, and set / override some of "
-"the attributes. For example, this is how you read a JSON file in default "
-"client configuration format, override any clientId it may contain with a new"
-" one, override / set any other attributes as well, and after successful "
-"creation print the new client configuration to standard output."
+"We've seen the simplest create command already. Often we may want to use a "
+"prepared JSON file as a template and set / override some of the attributes. "
+"For example, here is how you read a JSON file, override any `clientId` it "
+"may contain, set any other attributes as well, and after successful creation"
+" print the configuration to standard output."
 msgstr ""
-"すでに新しいクライアントを作成するための最も簡単なコマンドを見てきました。テンプレートとして準備されたJSONファイルを使用し、いくつかの属性を設定/上書きしたいことはよくあります。"
-" "
-"たとえば、これはデフォルトのクライアント設定形式でJSONファイルを読み込み、新しいクライアントIDを含むクライアントIDを上書きし、他の属性もオーバーライド/設定し、作成後に新しいクライアントの設定を標準出力に出力する方法です。"
+"最もシンプルなcreateコマンドをすでに見てきました。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定/上書きすることはよくあります。たとえば、JSONファイルを読み込み、含まれる可能性のある`clientId`をオーバーライドし、他の属性も設定し、正常に作成した後に設定を標準出力に出力する方法があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:246
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:247
 #, no-wrap
 msgid ""
-"$ kcreg.sh create -s clientId=myclient -f client-template.json -s "
+"$ kcreg.sh create -f client-template.json -s clientId=myclient -s "
 "baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
 msgstr ""
-"$ kcreg.sh create -s clientId=myclient -f client-template.json -s "
+"$ kcreg.sh create -f client-template.json -s clientId=myclient -s "
 "baseUrl=/myclient -s 'redirectUris=[\"/myclient/*\"]' -o\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:252
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:253
 #, no-wrap
 msgid ""
-"C:\\> kcreg create -s clientId=myclient -f client-template.json -s "
+"C:\\> kcreg create -f client-template.json -s clientId=myclient -s "
 "baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
 msgstr ""
-"C:\\> kcreg create -s clientId=myclient -f client-template.json -s "
+"C:\\> kcreg create -f client-template.json -s clientId=myclient -s "
 "baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:256
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:257
 msgid "See `kcreg create --help` for more information about `kcreg create`."
 msgstr "`kcreg create` の詳細については、 `kcreg create --help` を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:261
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:262
 msgid ""
-"You can use `kcreg attrs` to list the available attributes. Note, that many "
-"configuration attributes are not checked for validity or consistency. It is "
-"up to you to specify proper values. Also note, that you should not have any "
-"`id` fields in your template or specify them as arguments to `kcreg create`."
+"You can use `kcreg attrs` to list available attributes. Keep in mind that "
+"many configuration attributes are not checked for validity or consistency. "
+"It is up to you to specify proper values. Also note that you should not have"
+" any `id` fields in your template and should not specify them as arguments "
+"to `kcreg create`."
 msgstr ""
-"`kcreg attrs` "
-"を使って、利用可能な属性の一覧を取得できます。多くの設定属性の妥当性や一貫性については、チェックされていないことに注意してください。適切な値を指定するのはあなた次第です。"
-" また、テンプレートに `id` フィールドを持たせない、あるいは `kcreg create` の引数として指定しないにように注意してください。"
+"`kcreg attrs`を使って利用可能な属性をリストすることができます。多くの設定属性の妥当性や一貫性はチェックされません。 "
+"適切な値を指定するかどうかに依存します。また、テンプレートには `id`フィールドを入れてはいけません。`kcreg "
+"create`の引数として指定すべきではありません。"
+
+#. type: Title ====
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:264
+#, no-wrap
+msgid "Retrieving client configuration"
+msgstr "クライアント設定の取得"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:264
-msgid ""
-"Once a new client is created you can retrieve it again by using `kcreg get`."
-msgstr "新しいクライアントが作成されると、 `kcreg get` を使って再度それを取得できます。"
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:267
+msgid "You can retrieve an existing client by using `kcreg get`."
+msgstr "既存のクライアントは、`kcreg get`を使用することで取得できます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:269
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:284
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:323
+msgid "For example, on Linux:"
+msgstr "例えば、Linux の場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:269
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:272
 #, no-wrap
 msgid "$ kcreg.sh get myclient\n"
 msgstr "$ kcreg.sh get myclient\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:275
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:278
 #, no-wrap
 msgid "C:\\> kcreg get myclient\n"
 msgstr "C:\\> kcreg get myclient\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:279
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:282
 msgid ""
-"You can also get an adapter configuration which you can drop into your web "
-"application in order to integrate with Keycloak server."
-msgstr "また、{project_name}サーバーと統合するために、webアプリケーションに組み込めるアダプターの設定を取得できます。"
+"You can also get client configuration as adapter configuration file which "
+"you can package with your web application."
+msgstr "また、Webアプリケーションでパッケージ化できるアダプター設定ファイルとしてクライアント設定を取得することもできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:284
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:287
 #, no-wrap
-msgid "$ kcreg.sh get myclient -e install\n"
-msgstr "$ kcreg.sh get myclient -e install\n"
+msgid "$ kcreg.sh get myclient -e install > keycloak.json\n"
+msgstr "$ kcreg.sh get myclient -e install > keycloak.json\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:290
-#, no-wrap
-msgid "C:\\> kcreg get myclient -e install\n"
-msgstr "C:\\> kcreg get myclient -e install\n"
-
-#. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:293
-msgid "See `kcreg get --help` for more information about `kcreg get`."
-msgstr "`kcreg get` の詳細については、 `kcreg get --help` を参照してください。"
+#, no-wrap
+msgid "C:\\> kcreg get myclient -e install > keycloak.json\n"
+msgstr "C:\\> kcreg get myclient -e install > keycloak.json\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:296
-msgid ""
-"It's simple to update client configurations as well. There are two modes of "
-"updating."
-msgstr "クライアントの設定も簡単に更新できます。更新には2つのモードがあります。"
+msgid "See `kcreg get --help` for more information about `kcreg get`."
+msgstr "`kcreg get` の詳細については、 `kcreg get --help` を参照してください。"
+
+#. type: Title ====
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:297
+#, no-wrap
+msgid "Modifying client configuration"
+msgstr "クライアント設定の更新"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:298
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:300
+msgid "There are two modes of updating client configuration."
+msgstr "クライアント設定の更新には2つのモードがあります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:302
 msgid ""
 "One is to submit a complete new state to the server after getting current "
 "configuration, saving it into a file, editing it, and posting it back."
 msgstr "1つは、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信することです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:305
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:309
 #, no-wrap
 msgid ""
 "$ kcreg.sh get myclient > myclient.json\n"
@@ -748,7 +755,7 @@ msgstr ""
 "$ kcreg.sh update myclient -f myclient.json\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:313
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:317
 #, no-wrap
 msgid ""
 "C:\\> kcreg get myclient > myclient.json\n"
@@ -760,135 +767,139 @@ msgstr ""
 "C:\\> kcreg update myclient -f myclient.json\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:317
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:321
 msgid ""
-"Another is to get current client, set or delete fields on it, and post it "
-"back all in one single step."
-msgstr "別の方法は、現在のクライアントを取得し、そのフィールドを設定または削除し、すべてを1つのステップでポストバックすることです。"
+"Another way is to fetch current client, set or delete fields on it, and post"
+" it back all in one single step."
+msgstr "別の方法は、現在のクライアントをフェッチし、そのフィールドを設定または削除し、全てを1つのステップでポストすることです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:322
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:326
 #, no-wrap
 msgid "$ kcreg.sh update myclient -s enabled=false -d redirectUris\n"
 msgstr "$ kcreg.sh update myclient -s enabled=false -d redirectUris\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:328
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:332
 #, no-wrap
 msgid "C:\\> kcreg update myclient -s enabled=false -d redirectUris\n"
 msgstr "C:\\> kcreg update myclient -s enabled=false -d redirectUris\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:334
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:338
 msgid ""
-"You can even use a file that contains only changes to be applied so you "
-"don't have to specify too many values as arguments.  In this case we specify"
-" `--merge` to tell `Client Registration CLI` that rather than treating "
-"mychanges.json as full new configuration, it should see it as a set of "
-"attributes to be applied over existing configuration."
+"You can even use a file that only contains changes to be applied so you "
+"don't have to specify too many values as arguments.  In this case specify "
+"`--merge` to tell `Client Registration CLI` that rather than treating JSON "
+"file as full new configuration, it should treat it as a set of attributes to"
+" be applied over existing configuration."
 msgstr ""
-"適用される変更のみを含むファイルを使用することもできるので、引数にあまりにも多くの値を指定する必要はありません。完全な新しい設定としてmychanges.jsonを扱うのではなく、"
-" `Client Registration CLI` に `--merge` を指定する場合、既存の設定に適用される属性のセットとして認識されます。"
+"適用される変更のみを含むファイルを使用することもできるので、引数として多すぎる値を指定する必要はありません。この場合、`--merge`を`クライアント登録CLI`に指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:340
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:344
 #, no-wrap
 msgid "$ kcreg.sh update myclient --merge -d redirectUris -f mychanges.json\n"
 msgstr "$ kcreg.sh update myclient --merge -d redirectUris -f mychanges.json\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:346
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:350
 #, no-wrap
 msgid "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 msgstr "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:349
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:353
 msgid "See `kcreg update --help` for more information about `kcreg update`."
 msgstr "`kcreg update` の詳細については、 `kcreg update --help` を参照してください。"
 
+#. type: Title ====
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:354
+#, no-wrap
+msgid "Deleting client configuration"
+msgstr "クライアント設定の削除"
+
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:352
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:357
 msgid "You may sometimes also need to delete a client."
 msgstr "クライアントを削除する必要がある場合もあります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:357
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:362
 #, no-wrap
 msgid "$ kcreg.sh delete myclient\n"
 msgstr "$ kcreg.sh delete myclient\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:363
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:368
 #, no-wrap
 msgid "C:\\> kcreg delete myclient\n"
 msgstr "C:\\> kcreg delete myclient\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:366
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:371
 msgid "See `kcreg delete --help` for more information about `kcreg delete`."
 msgstr "`kcreg delete` の詳細については、 `kcreg delete --help` を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:370
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:375
 #, no-wrap
 msgid "Refreshing Invalid Registration Access Tokens"
-msgstr "無効な登録アクセストークンのリフレッシュ"
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:375
-msgid ""
-"When performing CRUD operation using `no-config` mode `Client Registration "
-"CLI` can no longer handle Registration Access Tokens for you.  In that case "
-"it is possible to lose track of most recently issued Registration Access "
-"Token for a client, which makes it impossible to perform any further CRUD "
-"operations on that client without using credentials of an account with "
-"'manage-clients' permissions."
-msgstr ""
-"`no-config` モードを使用してCRUD操作を実行すると、 `Client Registration CLI` "
-"は登録アクセストークンを処理できなくなります。その場合、最も最近クライアントに発行された登録アクセストークンを追跡できない可能性があり、そのため、 "
-"'manage-clients' "
-"権限を持つアカウントのクレデンシャルを使用せずに、そのクライアント上でそれ以上のCRUD操作を実行することは不可能になります。"
+msgstr "無効な登録アクセス・トークンのリフレッシュ"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:380
 msgid ""
-"If you have permissions you can reissue a new Registration Access Token for "
-"the client, and have it printed to stdout or saved to a config file of your "
-"choice. If not you have to ask realm administrator to reissue a new "
-"Registration Access Token for your client, and send it to you. You can then "
-"use the token by passing it to any CRUD command via `--token` option. You "
-"can also use `kcreg config registration-token` command to save the new token"
-" in configuration file, and have `Client Registration CLI` automatically "
-"handle it for you from that point on."
+"When performing a CRUD operation using `--no-config` mode, `Client "
+"Registration CLI` can no longer handle Registration Access Tokens for you.  "
+"In that case it is possible to lose track of most recently issued "
+"Registration Access Token for a client, which makes it impossible to perform"
+" any further CRUD operations on that client without authenticating with "
+"account that has 'manage-clients' permissions."
 msgstr ""
-"アクセス権がある場合は、クライアントの新しい登録アクセストークンを再発行し、標準出力に出力するか、または自分が選択した設定ファイルに保存することができます。"
-" アクセス権が無い場合は、レルム管理者にクライアントの新しい登録アクセストークンを再発行してもらうように依頼する必要があります。その際は、 "
-"`--token` オプション付きの任意のCRUDコマンドにトークンを渡すことができます。また、 `kcreg config registration-"
-"token` コマンドを使って新しいトークンを設定ファイルに保存し、 `Client Registration CLI` "
-"が自動的にそれを処理するようにすることもできます。"
+"`--no-"
+"config`モードを使用してCRUD操作を実行すると、`クライアント登録CLI`は登録アクセス・トークンを処理できなくなります。その場合、クライアントのために最も最近発行された登録アクセス・トークンの追跡を失う可能性があり、"
+" 'クライアントの管理'権限を持つアカウントで認証せずに、そのクライアント上でそれ以上のCRUD操作を実行することは不可能になります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:382
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:385
+msgid ""
+"If you have permissions, you can issue a new Registration Access Token for "
+"the client, and have it printed to stdout or saved to a config file of your "
+"choice. Otherwise you have to ask realm administrator to issue new "
+"Registration Access Token for your client, and send it to you. You can then "
+"pass it to any CRUD command via `--token` option. You can also use `kcreg "
+"config registration-token` command to save the new token in configuration "
+"file, and have `Client Registration CLI` automatically handle it for you "
+"from that point on."
+msgstr ""
+"アクセス権を持っている場合は、クライアント用に新しい登録アクセス・トークンを発行し、標準出力に印刷するか、選択した設定ファイルに保存することができます。"
+" "
+"それ以外の場合は、レルム管理者にクライアントの新しい登録アクセス・トークンを発行して、それを送信するよう依頼する必要があります。`--token`オプションを使ってCRUDコマンドに渡すことができます。また、`kcreg"
+" config registration-"
+"token`コマンドを使って新しいトークンを設定ファイルに保存し、`クライアント登録CLI`が自動的にそれを処理するようにすることもできます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:387
 msgid ""
 "See `kcreg update-token --help` for more information about `kcreg update-"
 "token`."
 msgstr "`kcreg update-token` の詳細については、 `kcreg update-token --help` を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:389
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:394
 msgid ""
 "Q: When logging in I get an error: `Parameter client_assertion_type is "
 "missing [invalid_client]`"
 msgstr ""
-"Q: ログインすると、次のエラーが表示されます: `Parameter client_assertion_type is missing "
+"Q：ログインすると、次のエラーが表示されます： `Parameter client_assertion_type is missing "
 "[invalid_client]`"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:390
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:395
 msgid ""
 "A: Your client is configured with `Signed JWT` token credentials which means"
 " you have to use `--keystore` parameter when logging in."
 msgstr ""
-"A: クライアントが `Signed JWT` のトークン証明書で設定されています。つまり、ログイン時に `--keystore` "
+"A：クライアントが `Signed JWT` のトークン・クレデンシャルで設定されています。つまり、ログイン時に `--keystore` "
 "パラメータを使用する必要があります。"

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -39,9 +39,9 @@ msgid ""
 "with {project_name}. It is specifically designed to interact with "
 "{project_name} Client Registration REST endpoints."
 msgstr ""
-"`Client Registration CLI` は、アプリケーション開発者が {project_name} "
-"と統合する際にセルフ・サービスで新しいクライアントを設定するためのコマンドライン・インタフェース・ツールです。 これは、 {project_name} "
-"クライアント登録RESTエンドポイントと対話するように特別に設計されています。"
+"`Client Registration CLI` "
+"は、アプリケーション開発者が{project_name}と統合する際にセルフ・サービスで新しいクライアントを設定するためのコマンドライン・インターフェイス・ツールです。"
+" これは、{project_name}クライアント登録RESTエンドポイントと対話するように特別に設計されています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:10
@@ -98,11 +98,14 @@ msgid ""
 "the use of <<_initial_access_token,Initial Access Token>> or "
 "<<_registration_access_token,Registration Access Token>>."
 msgstr ""
-"管理コンソールにログインしてください(例：`http://localhost:8080/auth/admin`)。管理するレルムを選択します。既存のユーザーを使用する場合は、編集するユーザーを選択し、そうでない場合は新しいユーザーを作成します。`ロールマッピング`のタブに行きます。`クライアントロール`の下で、`レルム管理`を選択します(マスター・レルムの場合、NAMEは対象のレルムの名前で、マスター・レルムのユーザーは他のレルムにアクセスできます)。`利用可能なロール`で、クライアント管理権限のフルセットに対して`クライアント管理`を選択します。あるいは、読み取り専用の場合は"
-" `クライアント参照`を、新しいクライアントを作成する場合は` "
-"クライアント作成`を選択できます。これらのアクセス権は、ユーザーに<<_initial_access_token,Initial Access "
-"Token>>または<<_registration_access_token,Registration Access "
-"Token>>を使用せずに操作を実行できるようにします。"
+"`管理コンソール` （例： `http://localhost:8080/auth/admin` ）に `admin` "
+"としてログインしてください。管理するレルムを選択します。既存のユーザーを使用する場合は、編集するユーザーを選択し、そうでない場合は新しいユーザーを作成します。"
+" `Role Mappings` のタブに行きます。 `Client Roles` の下で、 `realm-management` "
+"を選択します（masterレルムの場合、 `NAME-realm` "
+"を選択します。NAMEは対象のレルムの名前で、masterレルムのユーザーは他のレルムにアクセスできます）。 `Available Roles` "
+"で、クライアント管理権限のフルセットである `manage-client` を選択します。あるいは、読み取り専用の場合は `view-clients` "
+"を、新しいクライアントを作成する場合は ` create-client` "
+"を選択できます。これらの権限により、ユーザーは<<_initial_access_token,初期アクセス・トークン>>または<<_registration_access_token,登録アクセス・トークン>>を使用せずに操作を実行できるようになります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:31
@@ -113,10 +116,9 @@ msgid ""
 "Trying to perform any operations without it will result in `403 Forbidden` "
 "error."
 msgstr ""
-"ユーザーに `レルム管理`ロールを割り当てないことも可能です。その場合、ユーザーは`Registration Client "
-"CLI`でまだログインすることができますが、`Initial Access "
-"Token`を所有していなければそれを使用することはできません。それなしで何らかの操作を実行しようとすると`403 "
-"Forbidden`エラーが発生します。"
+"ユーザーに `realm-management` ロールを割り当てないことも可能です。その場合、ユーザーは `Registration Client "
+"CLI` でまだログインすることができますが、 `初期アクセス・トークン` "
+"を所有していなければ使用することはできません。それなしで何らかの操作を実行しようとすると `403 Forbidden` エラーが発生します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:33
@@ -125,8 +127,8 @@ msgid ""
 "selecting `Client Registration` tab under `Realm Settings`, then `Initial "
 "Access Token` sub-tab."
 msgstr ""
-"管理者は、`レルム設定`の下の`クライアント登録`タブを選択し、 "
-"`初期アクセストークン`サブ・タブを選択することによって管理者コンソールから`初期アクセストークン`を発行することができます。"
+"管理者は、 `Realm Settings` の下の `Client Registration` タブを選択し、 `Initial Access "
+"Token` サブ・タブを選択することによって、管理コンソールから `初期アクセストークン` を発行することができます。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:35
@@ -145,9 +147,11 @@ msgid ""
 " When running `kcreg config credentials` you would then also have to provide"
 " a secret by using `--secret` option."
 msgstr ""
-"デフォルトでは、`Client Registration CLI`はサーバーに`admin-"
-"cli`クライアントとして指定します。これは新しいレルムごとに自動的に設定されます。ユーザー名でログインする場合、追加のクライアント設定は不要です。クライアントの`アクセス・タイプ`を`コンフィデンシャル`に設定してセキュリティを強化し、`クレデンシャル`タブで`クライアントIDとシークレット`を選択することができます。`kcreg"
-" config credentials`を実行するときには` --secret`オプションを使ってシークレットを提供する必要があります。"
+"デフォルトでは、 `クライアント登録CLI` はサーバーに `admin-cli` "
+"クライアントとして識別されます。これは新しいレルムごとに自動的に設定されます。ユーザー名でログインする場合、追加のクライアント設定は不要です。セキュリティを強化したい場合は、クライアントの"
+" `Access Type` を `Confidential` に設定し、 `Credentials` タブで `ClientId and "
+"Secret` を選択します。 `kcreg config credentials` を実行する際に、 ` --secret` "
+"オプションを使用してシークレットを提供する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:44
@@ -157,10 +161,9 @@ msgid ""
 "example. When running `kcreg config credentials` you then need to specify "
 "which `clientId` to use e.g. `--client reg-cli`."
 msgstr ""
-"`Registration Client "
-"CLI`に対して別のクライアント設定を使いたい場合は、新しいクライアントを作成することができます。例えば、それを`reg-"
-"cli`と呼ぶことができます。`kcreg config credentials`を実行するときは、`--client reg-"
-"cli`のように、どの`clientId`を使用するかを指定する必要があります。"
+"`クライアント登録CLI` に対して別のクライアント設定を使いたい場合は、新しいクライアントを作成することができます。例えば、それを `reg-cli`"
+" と呼びます。 `kcreg config credentials` を実行する際は、 `--client reg-cli` のように、どの "
+"`clientId` を使用するかを指定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:48
@@ -171,9 +174,10 @@ msgid ""
 "Type` to `Confidential`, and toggle `Service Accounts Enabled` setting to "
 "`On`. Make sure to `Save` the configuration."
 msgstr ""
-"クライアントに関連付けられたサービス・アカウントを使用する場合は、まずサービス・アカウントを有効にする必要があります。管理者コンソールで`クライアント`のセクションに行き、編集するクライアントを選択します。"
-" "
-"次に、`設定`の下で、`アクセスタイプ`を`コンフィデンシャル`に変更し、`サービス・アカウントの有効化`を`オン`に切り替えます。設定を`保存`することを忘れないでください。"
+"クライアントに関連付けられたサービス・アカウントを使用する場合は、まずサービス・アカウントを有効にする必要があります。 `管理者コンソール` で "
+"`Clients` のセクションに行き、編集するクライアントを選択します。 次に、`Settings` の下で、 `Access Type` を "
+"`Confidential` に変更し、 `Service Accounts Enabled` を `On` に切り替えます。設定を `Save` "
+"することを忘れないでください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:50
@@ -188,8 +192,8 @@ msgid ""
 "Having done that you can then omit specifying user during `kcreg config "
 "credentials`, and only provide client secret or keystore info."
 msgstr ""
-"これを行うと、`kcreg config "
-"credentials`の実行中にユーザーを指定することを省略し、クライアント・シークレットやキーストア情報のみを提供することができます。"
+"これを行うと、 `kcreg config credentials` "
+"の実行中にユーザーを指定することを省略し、クライアント・シークレットやキーストア情報のみを提供することができます。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:54
@@ -219,7 +223,7 @@ msgid ""
 "In order to setup the client for use from any location on the filesystem you"
 " may want to add Keycloak server directory to your PATH."
 msgstr ""
-"ファイル・システム上の任意の場所からクライアントを使用できるように設定するには、PATHにKeycloakサーバーのディレクトリを追加します。"
+"ファイルシステム上の任意の場所からクライアントを使用できるように設定するには、PATHにKeycloakサーバーのディレクトリを追加します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:63
@@ -272,7 +276,7 @@ msgstr ""
 msgid ""
 "Where KEYCLOAK_HOME refers to a directory where Keycloak Server distribution"
 " was unpacked."
-msgstr "KEYCLOAK_HOMEは、Keycloakサーバーのディストリビューションが解凍されたディレクトリを示します。"
+msgstr "KEYCLOAK_HOMEは、Keycloakサーバーの配布物が解凍されたディレクトリを示します。"
 
 #. type: Title ===
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:80
@@ -287,8 +291,7 @@ msgid ""
 "providing credentials. Then you perform operations on Client Registration "
 "REST endpoint."
 msgstr ""
-"まず、クレデンシャルを提供して認証されたセッション(つまりログイン)を開始する必要があります。 "
-"次に、クライアント登録RESTエンドポイントで操作を実行します。"
+"まず、クレデンシャルを提供して認証されたセッション（つまりログイン）を開始する必要があります。次に、クライアント登録RESTエンドポイントで操作を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:85
@@ -352,7 +355,9 @@ msgid ""
 "certificate truststore, you will need to prepare a truststore.jks file, and "
 "instruct `Client Registration CLI` to use it."
 msgstr ""
-"実稼働環境では、ネットワーク・スニファーへのトークンの公開を避けるため、Keycloakには`https:`でアクセスする必要があります。サーバー証明書が、Javaのデフォルトの証明書トラスト・ストアに含まれている信頼されたCAのいずれかによって発行されていない場合は、`truststore.jks`ファイルを準備し、それを使用するように、`クライアント登録CLI`に指示する必要があります。"
+"プロダクション環境では、ネットワーク・スニファーでトークンの解読を避けるため、Keycloakには `https:` "
+"でアクセスする必要があります。サーバー証明書が、Javaのデフォルトの証明書トラスト・ストアに含まれている信頼されたCAのいずれかによって発行されていない場合は、"
+" `truststore.jks` ファイルを準備し、それを使用するように、 `クライアント登録CLI` に指示する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:111
@@ -390,7 +395,9 @@ msgid ""
 "latter case there is no user password - only client secret or a `Signed JWT`"
 " is used."
 msgstr ""
-"`クライアント登録CLI`でログインするときに、サーバーのエンドポイントURLとレルムを指定します。次に、ユーザー名、またはクライアントIDを指定します。これにより、特別なサービス・アカウントが使用されます。最初のケースでは、ログイン時に指定されたユーザーのパスワードを使用する必要があります。後者の場合、ユーザー・パスワードはありません。クライアント・シークレットまたは`署名済みJWT`のみが使用されます。"
+"`クライアント登録CLI` "
+"でログインするときに、サーバーのエンドポイントURLとレルムを指定します。次に、ユーザー名、またはクライアントIDを指定します。これにより、特別なサービス・アカウントが使用されます。前者の場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。後者の場合、ユーザーのパスワードは使いません。クライアント・シークレットまたは"
+" `署名済みJWT` のみが使用されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:133
@@ -403,7 +410,8 @@ msgid ""
 "single user in `master` realm and add it roles for managing clients in "
 "different realms."
 msgstr ""
-"方法に関係なく、ログインするアカウントには、クライアント登録操作を実行できる適切な権限が必要です。非マスター・レルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムで設定するか、「マスター」レルムで1人のユーザーを作成して、異なるレルムのクライアントを管理するロールを追加できます。"
+"方法に関係なく、ログインするアカウントには、クライアント登録操作を実行できる適切な権限が必要です。非マスター・レルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムで設定するか、"
+" `master` レルムで1人のユーザーを作成して、異なるレルムのクライアントを管理するロールを追加します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:136
@@ -413,8 +421,9 @@ msgid ""
 " command line tool (see link:{adminguide_link}[{adminguide_name}] for more "
 "details)."
 msgstr ""
-"`クライアント登録CLI`自体はユーザーの設定をサポートしていません。そのためには、管理者コンソールのウェブ・インターフェースまたは管理者クライアントCLIコマンドライン・ツール(詳細はlink"
-" {adminguide_link} [{adminguide_name}]を使う必要があります)。"
+"インターフェイス`クライアント登録CLI` "
+"自体はユーザーの設定をサポートしていません。そのためには、管理者コンソールのWebインターフェイスまたは管理者クライアントCLIコマンドライン・ツール（詳細はlink:{adminguide_link}"
+" [{adminguide_name}]）を使う必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:139
@@ -424,8 +433,9 @@ msgid ""
 "invocations. See <<_working_with_alternative_configurations, next chapter>> "
 "for more info on configuration file."
 msgstr ""
-"`kcreg`が正常にログインすると、認可トークンを受け取り、それらをプライベート設定ファイルに保存して、後続の呼び出しに使用できるようにします。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
-" next chapter>>を参照してください。"
+"`kcreg` "
+"が正常にログインすると、認可トークンを受け取り、それらをプライベート設定ファイルに保存して、後続の呼び出しに使用できるようにします。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
+" 次の章>>を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:141
@@ -466,7 +476,8 @@ msgid ""
 "configuration file at a default location - `./.keycloak/kcreg.config` under "
 "user's home directory."
 msgstr ""
-"デフォルトで`クライアント登録CLI`は、ユーザーのホーム・ディレクトリの下にあるデフォルトの場所(`./.keycloak/kcreg.config`)に設定ファイルを自動的に保持します。"
+"デフォルトで `クライアント登録CLI` は、ユーザーのホーム・ディレクトリの下にあるデフォルトの場所（ "
+"`./.keycloak/kcreg.config` ）に設定ファイルを自動的に保持します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:168
@@ -476,7 +487,8 @@ msgid ""
 "parallel. It is safest to perform operations tied to a single config file "
 "from a single thread."
 msgstr ""
-"`--config`オプションを使うと、いつでも別のファイル/場所を指すことができます。これにより、複数の認証済みセッションを並行して処理できます。1つのスレッドから1つの設定ファイルに結び付けられた操作を実行するのが最も安全です。"
+"`--config` "
+"オプションを使うと、いつでも別のファイル/場所を指すことができます。これにより、複数の認証済みセッションを並行して処理できます。1つのスレッドから1つの設定ファイルに結び付けられた操作を実行するのが最も安全です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:170
@@ -484,7 +496,7 @@ msgid ""
 "Make sure to not make the config file visible to other users on the system "
 "as it contains access tokens, and secrets that should be kept private."
 msgstr ""
-"システム上の他のユーザーには、アクセス・トークンとプライベートにしておかなければならないシークレットが含まれているため、設定ファイルを参照できないようにしてください。"
+"アクセス・トークンとプライベートにしておかなければならないシークレットが含まれているため、設定ファイルをシステム上の他のユーザーには参照できないようにしてください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:174
@@ -515,9 +527,9 @@ msgid ""
 "can be created, and it's up to realm administrator to distribute them to "
 "application developers."
 msgstr ""
-"`クライアント登録CLI`は、使用したいKeycloakサーバーでアカウントを設定していない開発者が使うことができます。これは、レルム管理者が開発者に`初期アクセストークン`を発行するときに可能です。これらのトークンを発行して配布する方法を決定するのは、レルム管理者次第です。"
-" 管理者は、初期アクセス・トークンの最大経過時間とそれで作成できるクライアントの総数を制限できます。 "
-"レルム管理者は、たくさんの初期アクセス・トークンを作成することができ、アプリケーション開発者に配布することができます。"
+"`クライアント登録CLI` は、使用したいKeycloakサーバーで設定されたアカウントを持っていない開発者が使用できます。レルム管理者が開発者に "
+"`初期アクセストークン` "
+"を発行することにより、開発者は使用することができます。トークンを発行して配布する方法を決定するのは、レルム管理者次第です。管理者は、初期アクセス・トークンの最大有効期間と作成できるクライアントの総数を制限できます。レルム管理者は、たくさんの初期アクセス・トークンを作成することができますが、それをアプリケーション開発者に配布するのはレルム管理者次第となります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:189
@@ -528,7 +540,7 @@ msgid ""
 " part of `kcreg create` command."
 msgstr ""
 "開発者が初期アクセス・トークンを所有すると、 `kcreg config credentials` "
-"で認証せずに新しいクライアントを作成できます。むしろ、初期アクセス・トークンは設定に保存することも、  `kcreg create` "
+"で認証せずに新しいクライアントを作成できます。それどころか、初期アクセス・トークンは設定に保存することも、 `kcreg create` "
 "コマンドの一部として指定することもできます。"
 
 #. type: delimited block -
@@ -577,7 +589,7 @@ msgid ""
 "needs to be performed by authenticating with that token which is only valid "
 "for that client."
 msgstr ""
-"初期アクセス・トークンが使用されると、サーバー・レスポンスに新たに発行された登録アクセス・トークンを含まれることになります。そのクライアントの後続の操作は、そのクライアントに対してのみ有効なトークンで、認証することによって実行する必要があります。"
+"初期アクセス・トークンが使用されると、サーバー・レスポンスに新たに発行された登録アクセス・トークンを含まれます。そのクライアントの後続の操作は、そのクライアントに対してのみ有効な登録アクセス・トークンで認証し、実行する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:226
@@ -588,7 +600,8 @@ msgid ""
 "not need to authenticate in order to read, update, or delete a client that "
 "was created this way."
 msgstr ""
-"クライアント登録CLIは自動的にプライベート設定ファイルを使用して保存し、このトークンを関連するクライアントと共に使用します。同じ設定ファイルがすべてのクライアント操作に使用されている限り、このように作成されたクライアントの読み取り、更新、削除を行うために、開発者は認証する必要はありません。"
+"`クライアント登録CLI` "
+"は、自動的にプライベート設定ファイルを使用して保存し、このトークンを関連するクライアントと共に使用します。同じ設定ファイルがすべてのクライアント操作に使用されている限り、このように作成されたクライアントの読み取り、更新、削除を行うために、開発者は認証する必要はありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:229
@@ -630,7 +643,8 @@ msgid ""
 "may contain, set any other attributes as well, and after successful creation"
 " print the configuration to standard output."
 msgstr ""
-"最もシンプルなcreateコマンドをすでに見てきました。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定/上書きすることはよくあります。たとえば、JSONファイルを読み込み、含まれる可能性のある`clientId`をオーバーライドし、他の属性も設定し、正常に作成した後に設定を標準出力に出力する方法があります。"
+"最もシンプルなcreateコマンドをすでに見てきました。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定/上書きすることはよくあります。たとえば、JSONファイルを読み込み、含まれている"
+" `clientId` をオーバーライドし、他の属性も設定し、正常に作成した後に設定を標準出力に出力する方法があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:247
@@ -666,9 +680,9 @@ msgid ""
 " any `id` fields in your template and should not specify them as arguments "
 "to `kcreg create`."
 msgstr ""
-"`kcreg attrs`を使って利用可能な属性をリストすることができます。多くの設定属性の妥当性や一貫性はチェックされません。 "
-"適切な値を指定するかどうかに依存します。また、テンプレートには `id`フィールドを入れてはいけません。`kcreg "
-"create`の引数として指定すべきではありません。"
+"`kcreg attrs` "
+"を使って、利用可能な属性の一覧を取得できます。多くの設定属性の妥当性や一貫性はチェックされません。適切な値を指定する必要があります。また、テンプレートには"
+" `id` フィールドを持たせず、 `kcreg create` の引数としても指定しないように注意してください。"
 
 #. type: Title ====
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:264
@@ -679,7 +693,7 @@ msgstr "クライアント設定の取得"
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:267
 msgid "You can retrieve an existing client by using `kcreg get`."
-msgstr "既存のクライアントは、`kcreg get`を使用することで取得できます。"
+msgstr "既に存在するクライアントについては、 `kcreg get` を使用することで取得できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:269
@@ -705,7 +719,7 @@ msgstr "C:\\> kcreg get myclient\n"
 msgid ""
 "You can also get client configuration as adapter configuration file which "
 "you can package with your web application."
-msgstr "また、Webアプリケーションでパッケージ化できるアダプター設定ファイルとしてクライアント設定を取得することもできます。"
+msgstr "また、Webアプリケーションとパッケージ化できるアダプター設定ファイルとして、クライアント設定を取得することもできます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:287
@@ -740,7 +754,7 @@ msgstr "クライアント設定の更新には2つのモードがあります�
 msgid ""
 "One is to submit a complete new state to the server after getting current "
 "configuration, saving it into a file, editing it, and posting it back."
-msgstr "1つは、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信することです。"
+msgstr "1つは、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信する方法です。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:309
@@ -771,7 +785,7 @@ msgstr ""
 msgid ""
 "Another way is to fetch current client, set or delete fields on it, and post"
 " it back all in one single step."
-msgstr "別の方法は、現在のクライアントをフェッチし、そのフィールドを設定または削除し、全てを1つのステップでポストすることです。"
+msgstr "別の方法は、現在のクライアントをフェッチし、そのフィールドを設定または削除し、POST送信するという全てを1つのステップで行う方法です。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:326
@@ -794,7 +808,9 @@ msgid ""
 "file as full new configuration, it should treat it as a set of attributes to"
 " be applied over existing configuration."
 msgstr ""
-"適用される変更のみを含むファイルを使用することもできるので、引数として多すぎる値を指定する必要はありません。この場合、`--merge`を`クライアント登録CLI`に指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
+"適用される変更のみを含むファイルを使用することもできるので、引数として多すぎる値を指定する必要はありません。この場合、 `--merge` を "
+"`クライアント登録CLI` "
+"に指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:344
@@ -857,9 +873,9 @@ msgid ""
 " any further CRUD operations on that client without authenticating with "
 "account that has 'manage-clients' permissions."
 msgstr ""
-"`--no-"
-"config`モードを使用してCRUD操作を実行すると、`クライアント登録CLI`は登録アクセス・トークンを処理できなくなります。その場合、クライアントのために最も最近発行された登録アクセス・トークンの追跡を失う可能性があり、"
-" 'クライアントの管理'権限を持つアカウントで認証せずに、そのクライアント上でそれ以上のCRUD操作を実行することは不可能になります。"
+"`--no-config` モードを使用してCRUD操作を実行すると、 `クライアント登録CLI` "
+"は登録アクセス・トークンを処理できなくなります。その場合、クライアントのために最も最近発行された登録アクセス・トークンの追跡を失う可能性があり"
+"、'manage-clients'権限を持つアカウントで認証なしでは、そのクライアントでそれ以上のCRUD操作を実行することは不可能になります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:385
@@ -873,11 +889,9 @@ msgid ""
 "file, and have `Client Registration CLI` automatically handle it for you "
 "from that point on."
 msgstr ""
-"アクセス権を持っている場合は、クライアント用に新しい登録アクセス・トークンを発行し、標準出力に印刷するか、選択した設定ファイルに保存することができます。"
-" "
-"それ以外の場合は、レルム管理者にクライアントの新しい登録アクセス・トークンを発行して、それを送信するよう依頼する必要があります。`--token`オプションを使ってCRUDコマンドに渡すことができます。また、`kcreg"
-" config registration-"
-"token`コマンドを使って新しいトークンを設定ファイルに保存し、`クライアント登録CLI`が自動的にそれを処理するようにすることもできます。"
+"アクセス権を持っている場合は、クライアント用に新しい登録アクセス・トークンを発行し、標準出力に出力するか、選択した設定ファイルに保存することができます。それ以外の場合は、レルム管理者にクライアントの新しい登録アクセス・トークンを発行して、それを送信するよう依頼する必要があります。その際は、"
+" `--token` オプションを使ってCRUDコマンドに渡すことができます。また、 `kcreg config registration-token`"
+" コマンドを使って新しいトークンを設定ファイルに保存し、 `クライアント登録CLI` が自動的にそれを処理するようにすることもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/client-registration/client-registration-cli.adoc:387


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration__client-registration-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__client-registration__client-registration-cli/ja_JP/index.html
