### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter_error_handling.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter_error_handling.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter_error_handling.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
@@ -32,61 +31,110 @@ msgid ""
 "within your `web.xml` file to handle the error however you want.  "
 "{project_name} can throw 400, 401, 403, and 500 errors."
 msgstr ""
+"{project_name} には、サーブレットベースのクライアントアダプタ用のエラー処理機能があります。認証でエラーが発生すると、 "
+"{project_name} は `HttpServletResponse.sendError()` を呼び出します。 `web.xml` "
+"ファイル内にエラーページを設定して、エラーを処理できます。  {project_name} は400、401、403、500のエラーをスローできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:17
-#: source/securing_apps/topics/saml/java/error_handling.adoc:17
+#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:16
+#: source/securing_apps/topics/saml/java/error_handling.adoc:16
 #, no-wrap
 msgid ""
 "<error-page>\n"
 "    <error-code>403</error-code>\n"
 "    <location>/ErrorHandler</location>\n"
 "</error-page>\n"
-"----    \n"
 msgstr ""
 "<error-page>\n"
 "    <error-code>403</error-code>\n"
 "    <location>/ErrorHandler</location>\n"
 "</error-page>\n"
-"----    \n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:20
-#, no-wrap
 msgid ""
-"{project_name} also sets a `HttpServletRequest` attribute that you can retrieve.\n"
-"The attribute name is `org.keycloak.adapters.spi.AuthenticationError`, which should be casted to `org.keycloak.adapters.OIDCAuthenticationError`.\n"
+"{project_name} also sets a `HttpServletRequest` attribute that you can "
+"retrieve.  The attribute name is "
+"`org.keycloak.adapters.spi.AuthenticationError`, which should be casted to "
+"`org.keycloak.adapters.OIDCAuthenticationError`."
 msgstr ""
+"{project_name} は、取得できる  `HttpServletRequest` 属性も設定します。属性名は "
+"`org.keycloak.adapters.spi.AuthenticationError` です。これは "
+"`org.keycloak.adapters.OIDCAuthenticationError` にキャストする必要があります。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:22
+#: source/securing_apps/topics/oidc/java/fuse/camel.adoc:8
+#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:13
+#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:55
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:321
-#, no-wrap
-msgid "For example:\n"
-msgstr ""
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:368
+#: source/server_admin/topics/admin-cli.adoc:104
+#: source/server_admin/topics/admin-cli.adoc:168
+#: source/server_admin/topics/admin-cli.adoc:262
+#: source/server_admin/topics/admin-cli.adoc:407
+#: source/server_admin/topics/admin-cli.adoc:433
+#: source/server_admin/topics/admin-cli.adoc:453
+#: source/server_admin/topics/admin-cli.adoc:463
+#: source/server_admin/topics/admin-cli.adoc:471
+#: source/server_admin/topics/admin-cli.adoc:482
+#: source/server_admin/topics/admin-cli.adoc:522
+#: source/server_admin/topics/admin-cli.adoc:529
+#: source/server_admin/topics/admin-cli.adoc:536
+#: source/server_admin/topics/admin-cli.adoc:548
+#: source/server_admin/topics/admin-cli.adoc:555
+#: source/server_admin/topics/admin-cli.adoc:562
+#: source/server_admin/topics/admin-cli.adoc:632
+#: source/server_admin/topics/admin-cli.adoc:641
+#: source/server_admin/topics/admin-cli.adoc:693
+#: source/server_admin/topics/admin-cli.adoc:728
+#: source/server_admin/topics/admin-cli.adoc:744
+#: source/server_admin/topics/admin-cli.adoc:751
+#: source/server_admin/topics/admin-cli.adoc:758
+#: source/server_admin/topics/admin-cli.adoc:770
+#: source/server_admin/topics/admin-cli.adoc:777
+#: source/server_admin/topics/admin-cli.adoc:784
+#: source/server_admin/topics/admin-cli.adoc:831
+#: source/server_admin/topics/admin-cli.adoc:878
+#: source/server_admin/topics/admin-cli.adoc:901
+#: source/server_admin/topics/admin-cli.adoc:919
+#: source/server_admin/topics/admin-cli.adoc:928
+#: source/server_admin/topics/admin-cli.adoc:937
+#: source/server_admin/topics/admin-cli.adoc:951
+#: source/server_admin/topics/admin-cli.adoc:958
+#: source/server_admin/topics/admin-cli.adoc:965
+#: source/server_admin/topics/admin-cli.adoc:977
+#: source/server_admin/topics/admin-cli.adoc:984
+#: source/server_admin/topics/admin-cli.adoc:991
+#: source/server_admin/topics/admin-cli.adoc:1020
+#: source/server_admin/topics/admin-cli.adoc:1038
+#: source/server_admin/topics/admin-cli.adoc:1053
+#: source/server_admin/topics/admin-cli.adoc:1120
+#: source/server_admin/topics/admin-cli.adoc:1148
+#: source/server_admin/topics/admin-cli.adoc:1158
+#: source/server_admin/topics/admin-cli.adoc:1167
+#: source/server_admin/topics/admin-cli.adoc:1176
+#: source/server_admin/topics/admin-cli.adoc:1189
+#: source/server_admin/topics/admin-cli.adoc:1199
+#: source/server_admin/topics/admin-cli.adoc:1209
+#: source/server_admin/topics/admin-cli.adoc:1219
+#: source/server_admin/topics/admin-cli.adoc:1229
+msgid "For example:"
+msgstr "例えば:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:24
-#: source/server_development/topics/auth-spi.adoc:186
-#: source/server_development/topics/auth-spi.adoc:231
-#: source/server_development/topics/auth-spi.adoc:327
-#: source/server_development/topics/auth-spi.adoc:585
-#: source/server_development/topics/auth-spi.adoc:681
-#: source/server_development/topics/providers.adoc:323
-#, no-wrap
-msgid "[source,java]\n"
-msgstr "[source,java]\n"
-
-#. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:28
+#, no-wrap
 msgid ""
-"import org.keycloak.adapters.OIDCAuthenticationError; import org.keycloak."
-"adapters.OIDCAuthenticationError.Reason; ..."
+"import org.keycloak.adapters.OIDCAuthenticationError;\n"
+"import org.keycloak.adapters.OIDCAuthenticationError.Reason;\n"
+"...\n"
 msgstr ""
-"import org.keycloak.adapters.OIDCAuthenticationError; import org.keycloak."
-"adapters.OIDCAuthenticationError.Reason; ..."
+"import org.keycloak.adapters.OIDCAuthenticationError;\n"
+"import org.keycloak.adapters.OIDCAuthenticationError.Reason;\n"
+"...\n"
 
-#. type: Plain text
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:31
 #, no-wrap
 msgid ""
@@ -96,7 +144,12 @@ msgstr ""
 "OIDCAuthenticationError error = (OIDCAuthenticationError) httpServletRequest\n"
 "    .getAttribute('org.keycloak.adapters.spi.AuthenticationError');\n"
 
-#. type: Plain text
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:34
-msgid "Reason reason = error.getReason(); System.out.println(reason.name());"
-msgstr "Reason reason = error.getReason(); System.out.println(reason.name());"
+#, no-wrap
+msgid ""
+"Reason reason = error.getReason();\n"
+"System.out.println(reason.name());\n"
+msgstr ""
+"Reason reason = error.getReason();\n"
+"System.out.println(reason.name());\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter_error_handling.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter_error_handling.ja_JP.po
@@ -31,9 +31,9 @@ msgid ""
 "within your `web.xml` file to handle the error however you want.  "
 "{project_name} can throw 400, 401, 403, and 500 errors."
 msgstr ""
-"{project_name} には、サーブレットベースのクライアントアダプタ用のエラー処理機能があります。認証でエラーが発生すると、 "
-"{project_name} は `HttpServletResponse.sendError()` を呼び出します。 `web.xml` "
-"ファイル内にエラーページを設定して、エラーを処理できます。  {project_name} は400、401、403、500のエラーをスローできます。"
+"{project_name}には、サーブレットベースのクライアント・アダプター用のエラー処理機能があります。認証でエラーが発生すると、{project_name}は"
+" `HttpServletResponse.sendError()` を呼び出します。 `web.xml` ファイル内にerror-"
+"pageを設定してエラーを処理することができます。{project_name}は400、401、403、500のエラーをスローできます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:16
@@ -58,7 +58,7 @@ msgid ""
 "`org.keycloak.adapters.spi.AuthenticationError`, which should be casted to "
 "`org.keycloak.adapters.OIDCAuthenticationError`."
 msgstr ""
-"{project_name} は、取得できる  `HttpServletRequest` 属性も設定します。属性名は "
+"{project_name}はまた、取得可能な  `HttpServletRequest` 属性を設定します。属性名は、 "
 "`org.keycloak.adapters.spi.AuthenticationError` です。これは "
 "`org.keycloak.adapters.OIDCAuthenticationError` にキャストする必要があります。"
 
@@ -69,58 +69,58 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:55
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:321
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:368
-#: source/server_admin/topics/admin-cli.adoc:104
-#: source/server_admin/topics/admin-cli.adoc:168
-#: source/server_admin/topics/admin-cli.adoc:262
-#: source/server_admin/topics/admin-cli.adoc:407
-#: source/server_admin/topics/admin-cli.adoc:433
-#: source/server_admin/topics/admin-cli.adoc:453
-#: source/server_admin/topics/admin-cli.adoc:463
-#: source/server_admin/topics/admin-cli.adoc:471
-#: source/server_admin/topics/admin-cli.adoc:482
-#: source/server_admin/topics/admin-cli.adoc:522
-#: source/server_admin/topics/admin-cli.adoc:529
-#: source/server_admin/topics/admin-cli.adoc:536
-#: source/server_admin/topics/admin-cli.adoc:548
-#: source/server_admin/topics/admin-cli.adoc:555
-#: source/server_admin/topics/admin-cli.adoc:562
-#: source/server_admin/topics/admin-cli.adoc:632
-#: source/server_admin/topics/admin-cli.adoc:641
-#: source/server_admin/topics/admin-cli.adoc:693
-#: source/server_admin/topics/admin-cli.adoc:728
-#: source/server_admin/topics/admin-cli.adoc:744
-#: source/server_admin/topics/admin-cli.adoc:751
-#: source/server_admin/topics/admin-cli.adoc:758
-#: source/server_admin/topics/admin-cli.adoc:770
-#: source/server_admin/topics/admin-cli.adoc:777
+#: source/server_admin/topics/admin-cli.adoc:101
+#: source/server_admin/topics/admin-cli.adoc:169
+#: source/server_admin/topics/admin-cli.adoc:281
+#: source/server_admin/topics/admin-cli.adoc:426
+#: source/server_admin/topics/admin-cli.adoc:452
+#: source/server_admin/topics/admin-cli.adoc:475
+#: source/server_admin/topics/admin-cli.adoc:485
+#: source/server_admin/topics/admin-cli.adoc:493
+#: source/server_admin/topics/admin-cli.adoc:504
+#: source/server_admin/topics/admin-cli.adoc:543
+#: source/server_admin/topics/admin-cli.adoc:550
+#: source/server_admin/topics/admin-cli.adoc:557
+#: source/server_admin/topics/admin-cli.adoc:569
+#: source/server_admin/topics/admin-cli.adoc:576
+#: source/server_admin/topics/admin-cli.adoc:583
+#: source/server_admin/topics/admin-cli.adoc:688
+#: source/server_admin/topics/admin-cli.adoc:697
+#: source/server_admin/topics/admin-cli.adoc:749
 #: source/server_admin/topics/admin-cli.adoc:784
+#: source/server_admin/topics/admin-cli.adoc:798
+#: source/server_admin/topics/admin-cli.adoc:805
+#: source/server_admin/topics/admin-cli.adoc:812
+#: source/server_admin/topics/admin-cli.adoc:824
 #: source/server_admin/topics/admin-cli.adoc:831
-#: source/server_admin/topics/admin-cli.adoc:878
-#: source/server_admin/topics/admin-cli.adoc:901
-#: source/server_admin/topics/admin-cli.adoc:919
-#: source/server_admin/topics/admin-cli.adoc:928
-#: source/server_admin/topics/admin-cli.adoc:937
-#: source/server_admin/topics/admin-cli.adoc:951
-#: source/server_admin/topics/admin-cli.adoc:958
-#: source/server_admin/topics/admin-cli.adoc:965
-#: source/server_admin/topics/admin-cli.adoc:977
-#: source/server_admin/topics/admin-cli.adoc:984
+#: source/server_admin/topics/admin-cli.adoc:838
+#: source/server_admin/topics/admin-cli.adoc:885
+#: source/server_admin/topics/admin-cli.adoc:932
+#: source/server_admin/topics/admin-cli.adoc:955
+#: source/server_admin/topics/admin-cli.adoc:973
+#: source/server_admin/topics/admin-cli.adoc:982
 #: source/server_admin/topics/admin-cli.adoc:991
-#: source/server_admin/topics/admin-cli.adoc:1020
-#: source/server_admin/topics/admin-cli.adoc:1038
-#: source/server_admin/topics/admin-cli.adoc:1053
-#: source/server_admin/topics/admin-cli.adoc:1120
-#: source/server_admin/topics/admin-cli.adoc:1148
-#: source/server_admin/topics/admin-cli.adoc:1158
-#: source/server_admin/topics/admin-cli.adoc:1167
-#: source/server_admin/topics/admin-cli.adoc:1176
-#: source/server_admin/topics/admin-cli.adoc:1189
-#: source/server_admin/topics/admin-cli.adoc:1199
-#: source/server_admin/topics/admin-cli.adoc:1209
-#: source/server_admin/topics/admin-cli.adoc:1219
+#: source/server_admin/topics/admin-cli.adoc:1004
+#: source/server_admin/topics/admin-cli.adoc:1011
+#: source/server_admin/topics/admin-cli.adoc:1018
+#: source/server_admin/topics/admin-cli.adoc:1030
+#: source/server_admin/topics/admin-cli.adoc:1037
+#: source/server_admin/topics/admin-cli.adoc:1044
+#: source/server_admin/topics/admin-cli.adoc:1073
+#: source/server_admin/topics/admin-cli.adoc:1091
+#: source/server_admin/topics/admin-cli.adoc:1106
+#: source/server_admin/topics/admin-cli.adoc:1173
+#: source/server_admin/topics/admin-cli.adoc:1201
+#: source/server_admin/topics/admin-cli.adoc:1211
+#: source/server_admin/topics/admin-cli.adoc:1220
 #: source/server_admin/topics/admin-cli.adoc:1229
+#: source/server_admin/topics/admin-cli.adoc:1242
+#: source/server_admin/topics/admin-cli.adoc:1252
+#: source/server_admin/topics/admin-cli.adoc:1262
+#: source/server_admin/topics/admin-cli.adoc:1272
+#: source/server_admin/topics/admin-cli.adoc:1282
 msgid "For example:"
-msgstr "例えば:"
+msgstr "例："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:28


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter_error_handling.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__adapter_error_handling
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__adapter_error_handling/ja_JP/index.html
