### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
@@ -37,3 +36,8 @@ msgid ""
 "standard SAML, the Keycloak SAML client adapter should be able to integrate "
 "with it."
 msgstr ""
+"このドキュメントでは、Keycloak "
+"SAMLクライアント・アダプタと、それを様々なプラットフォーム用に設定する方法について説明します。Keycloak "
+"SAMLクライアント・アダプタは、Webアプリケーションに対して汎用的なSAML "
+"2.0サポートを提供するスタンドアローン・コンポーネントです。Keycloakサーバー・エクステンションは組み込まれていません。通信されるアイデンティティ・プロバイダ(IDP)が標準SAMLをサポートしている限り、Keycloak"
+" SAMLクライアント・アダプタは、SAMLクライアントと統合できます。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,12 +15,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ==
+#. type: Title =
 #: source/getting_started/topics/overview.adoc:2
 #: source/securing_apps/topics/overview/overview.adoc:1
 #: source/securing_apps/topics/saml/java/saml_adapter_overview.adoc:1
 #: source/server_admin/topics/overview.adoc:1
-#: source/authorization_services/topics/overview/overview.adoc:2
+#: source/authorization_services/topics/auth-services-overview.adoc:2
 #, no-wrap
 msgid "Overview"
 msgstr "概要"
@@ -37,7 +37,7 @@ msgid ""
 "with it."
 msgstr ""
 "このドキュメントでは、Keycloak "
-"SAMLクライアント・アダプタと、それを様々なプラットフォーム用に設定する方法について説明します。Keycloak "
-"SAMLクライアント・アダプタは、Webアプリケーションに対して汎用的なSAML "
-"2.0サポートを提供するスタンドアローン・コンポーネントです。Keycloakサーバー・エクステンションは組み込まれていません。通信されるアイデンティティ・プロバイダ(IDP)が標準SAMLをサポートしている限り、Keycloak"
-" SAMLクライアント・アダプタは、SAMLクライアントと統合できます。"
+"SAMLクライアント・アダプターと、それを様々なプラットフォーム用に設定する方法についてご説明します。Keycloak "
+"SAMLクライアント・アダプターは、Webアプリケーションに対して汎用的なSAML "
+"2.0サポートを提供するスタンドアロン・コンポーネントです。Keycloakサーバー・エクステンションは組み込まれていません。通信するアイデンティティー・プロバイダー（IDP）が標準SAMLをサポートしている限り、Keycloak"
+" SAMLクライアント・アダプターと統合することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__saml_adapter_overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__saml_adapter_overview/ja_JP/index.html
