### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-realm/account.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-realm/account.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-realm/account.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
@@ -28,18 +27,14 @@ msgstr "ユーザー・アカウント・サービス"
 msgid ""
 "After creating the user, log out of the management console by clicking the "
 "right dropdown menu and selecting *Sign Off*."
-msgstr ""
-"ユーザーを作成したあと、右側のドロップメニューをクリックして *Sign Off* を選"
-"び、管理コンソールをログアウトします。"
+msgstr "ユーザーを作成したあと、右側のドロップメニューをクリックして *Sign Off* を選び、管理コンソールをログアウトします。"
 
 #. type: Plain text
 #: source/getting_started/topics/first-realm/account.adoc:7
 msgid ""
 "Log in to the User Account Service of your `demo` realm with the user you "
 "just created by clicking this link:"
-msgstr ""
-"以下のリンクをクリックして、いま作成したユーザーで `demo` レルムのユーザー・"
-"アカウント・サービスにログインします。"
+msgstr "以下のリンクをクリックして、いま作成したユーザーで `demo` レルムのユーザー・アカウント・サービスにログインします。"
 
 #. type: Labeled list
 #: source/getting_started/topics/first-realm/account.adoc:8
@@ -59,9 +54,8 @@ msgid ""
 "permanent password after you successfully log in if you didn't toggle the "
 "Temporary switch to *Off* previously."
 msgstr ""
-"以前に作成したユーザー名とパスワードを入力します。Temporaryのスイッチを以前 "
-"`Off` に切替えていなかった場合は、ログインしたあとに永続的なパスワードを作成"
-"する必要があります。"
+"以前に作成したユーザー名とパスワードを入力します。Temporaryのスイッチを以前 `Off` "
+"に切替えていなかった場合は、ログインしたあとに永続的なパスワードを作成する必要があります。"
 
 #. type: Labeled list
 #: source/getting_started/topics/first-realm/account.adoc:13
@@ -84,8 +78,4 @@ msgid ""
 "change or add additional credentials. For more information on this service "
 "see the link:{adminguide_link}[{adminguide_name}]."
 msgstr ""
-"ユーザー・アカウント・サービスのページが開きます。レルム内の全ユーザーはデ"
-"フォルトでこのアカウント・サービスにアクセスすることができます。ユーザーのプ"
-"ロファイル情報の更新および認証情報の変更または追加をすることができます。この"
-"サービスについての詳細は、link:{adminguide_link}[{adminguide_name}]をご覧くだ"
-"さい。"
+"ユーザー・アカウント・サービスのページが開きます。レルム内の全ユーザーはデフォルトでこのアカウント・サービスにアクセスすることができます。ユーザーのプロファイル情報の更新および認証情報の変更または追加をすることができます。このサービスについての詳細は、link:{adminguide_link}[{adminguide_name}]をご覧ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-realm/account.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-realm__account
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__first-realm__account/ja_JP/index.html
