### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po
@@ -2,24 +2,23 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Title =
 #: source/getting_started/topics/first-realm/before.adoc:2
 #: source/getting_started/topics/secure-jboss-app/before.adoc:2
-#: source/authorization_services/topics/getting-started/hello-world/before-start.adoc:1
+#: source/authorization_services/topics/hello-world-before-start.adoc:1
 #, no-wrap
 msgid "Before You Start"
 msgstr "はじめる前に"
@@ -28,9 +27,8 @@ msgstr "はじめる前に"
 #: source/getting_started/topics/first-realm/before.adoc:6
 msgid ""
 "Before you can participate in this tutorial, you need to complete the "
-"installation of {project_name} and create the initial admin user as shown in "
-"the <<_install-boot, Installing and Booting>> tutorial."
+"installation of {project_name} and create the initial admin user as shown in"
+" the <<_install-boot, Installing and Booting>> tutorial."
 msgstr ""
-"このチュートリアルの操作をはじめる前に、{project_name}のインストールを完了"
-"し、<<_install-boot, インストールと起動>>のチュートリアルに沿って初期管理者"
-"ユーザーを作成する必要があります。"
+"このチュートリアルの操作をはじめる前に、{project_name}のインストールを完了し、<<_install-boot, "
+"インストールと起動>>のチュートリアルに沿って初期管理者ユーザーを作成する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-realm__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__first-realm__before/ja_JP/index.html
