### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -27,25 +26,22 @@ msgstr "管理コンソールへのログイン"
 msgid ""
 "After you create the initial admin account, you can log in to the Admin "
 "Console by completing the following steps:"
-msgstr ""
-"初期管理者アカウントを作成したあと、以下の手順に沿って、管理コンソールにログ"
-"インすることができます。"
+msgstr "初期管理者アカウントを作成したあと、以下の手順に沿って、管理コンソールにログインすることができます。"
 
 #. type: Plain text
 #: source/getting_started/topics/first-boot/admin-console.adoc:8
 msgid ""
 "At the bottom of the Welcome page click the _Administration Console_ link.  "
-"Alternatively you can go to the console URL directly at http://"
-"localhost:8080/auth/admin/"
+"Alternatively you can go to the console URL directly at "
+"http://localhost:8080/auth/admin/"
 msgstr ""
-"ウェルカムページの一番下にある _管理コンソール_ のリンクをクリックします。も"
-"しくは、 http://localhost:8080/auth/admin/ にてコンソールのURLに直接いくこと"
-"も可能です。"
+"ウェルカムページの一番下にある _管理コンソール_ のリンクをクリックします。もしくは、 "
+"http://localhost:8080/auth/admin/ にてコンソールのURLに直接いくことも可能です。"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/admin-console.adoc:9
 #: source/server_admin/topics/admin-console.adoc:7
-#: source/authorization_services/topics/getting-started/hello-world/deploy.adoc:77
+#: source/authorization_services/topics/hello-world-deploy.adoc:77
 #, no-wrap
 msgid "Login Page"
 msgstr "ログインページ"
@@ -61,9 +57,7 @@ msgstr "image:{project_images}/login-page.png[]"
 msgid ""
 "Type the username and password you created on the Welcome page. The "
 "{project_name} Admin Console page opens."
-msgstr ""
-"ウェルカムページにて作成したユーザー名とパスワードを入力します。"
-"{project_name}管理コンソールページが開きます。"
+msgstr "ウェルカムページにて作成したユーザー名とパスワードを入力します。{project_name}管理コンソールページが開きます。"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/admin-console.adoc:14


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__admin-console
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__first-boot__admin-console/ja_JP/index.html
