### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -25,11 +24,10 @@ msgstr "管理者アカウントの作成"
 #. type: Plain text
 #: source/getting_started/topics/first-boot/initial-user.adoc:5
 msgid ""
-"After the server boots, open your browser and go to the http://"
-"localhost:8080/auth URL. The page should look like this:"
+"After the server boots, open your browser and go to the "
+"http://localhost:8080/auth URL. The page should look like this:"
 msgstr ""
-"サーバーが起動したあと、ブラウザーを開きURL http://localhost:8080/auth へ移動"
-"します。ページは以下のようになります。"
+"サーバーが起動したあと、ブラウザーを開きURL http://localhost:8080/auth へ移動します。ページは以下のようになります。"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/initial-user.adoc:6
@@ -47,17 +45,15 @@ msgstr "image:{project_images}/initial-welcome-page.png[]"
 #. type: Plain text
 #: source/getting_started/topics/first-boot/initial-user.adoc:12
 msgid ""
-"{project_name} does not have a configured admin account by default. You must "
-"create one on the Welcome page.  This account will allow you to create an "
+"{project_name} does not have a configured admin account by default. You must"
+" create one on the Welcome page.  This account will allow you to create an "
 "admin that can log into the _master_ realm's administration console so that "
 "you can start creating realms and users and registering applications to be "
 "secured by {project_name}."
 msgstr ""
-"{project_name}にはデフォルト設定された管理者アカウントはありません。ウェルカ"
-"ムページにて作成する必要があります。当アカウントを使用して、 _master_ レルム"
-"の管理コンソールへのログインが可能となる管理者を作成できます。それにより、レ"
-"ルムとユーザーの作成および{project_name}に保護されるアプリケーションの登録を"
-"はじめることができます。"
+"{project_name}にはデフォルト設定された管理者アカウントはありません。ウェルカムページにて作成する必要があります。当アカウントを使用して、 "
+"_master_ "
+"レルムの管理コンソールへのログインが可能となる管理者を作成できます。それにより、レルムとユーザーの作成および{project_name}に保護されるアプリケーションの登録をはじめることができます。"
 
 #. type: Plain text
 #: source/getting_started/topics/first-boot/initial-user.adoc:16
@@ -66,4 +62,7 @@ msgid ""
 "You can only create an initial admin user on the Welcome Page if you connect using `localhost`. This is a security\n"
 "       precaution. You can also create the initial admin user at the command line with the `add-user-keycloak.sh` script. For more details see\n"
 "       link:{installguide_link}[{installguide_name}] and link:{adminguide_link}[{adminguide_name}].\n"
-msgstr "`localhost` を使用して接続する場合は、初期管理者ユーザーのみを作成できます。これはセキュリティ対策のためです。また、スクリプト `add-user-keycloak.sh` を使用してコマンドラインにて初期管理者ユーザーの作成をすることも可能です。詳しくはlink:{installguide_link}[{installguide_name}]ならびにlink:{adminguide_link}[{adminguide_name}]をご覧ください。\n"
+msgstr ""
+"`localhost` を使用して接続する場合は、初期管理者ユーザーのみを作成できます。これはセキュリティ対策のためです。また、スクリプト `add-"
+"user-keycloak.sh` "
+"を使用してコマンドラインにて初期管理者ユーザーの作成をすることも可能です。詳しくはlink:{installguide_link}[{installguide_name}]ならびにlink:{adminguide_link}[{adminguide_name}]をご覧ください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__initial-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__first-boot__initial-user/ja_JP/index.html
