### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -30,19 +29,17 @@ msgid ""
 "_standalone/configuration_ directory of the application server instance on "
 "which your application is deployed."
 msgstr ""
-"いまインストールページからXMLテンプレートをコピーしたところですが、これを "
-"_standalone.xml_ ファイルにペーストする必要があります。_standalone.xml_ ファ"
-"イルはアプリケーションをデプロイしたアプリケーション・サーバー・インスタンス"
-"の _standalone/configuration_ ディレクトリにあります。"
+"いまインストールページからXMLテンプレートをコピーしたところですが、これを _standalone.xml_ "
+"ファイルにペーストする必要があります。_standalone.xml_ "
+"ファイルはアプリケーションをデプロイしたアプリケーション・サーバー・インスタンスの _standalone/configuration_ "
+"ディレクトリにあります。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:8
 msgid ""
 "Open the standalone/configuration/standalone.xml file and search for the "
 "following text:"
-msgstr ""
-"standalone/configuration/standalone.xml ファイルを開き、以下のテキストを検索"
-"します。"
+msgstr "standalone/configuration/standalone.xml ファイルを開き、以下のテキストを検索します。"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:12
@@ -53,11 +50,9 @@ msgstr "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\"/>\n"
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:15
 msgid ""
-"Modify this to prepare it for pasting in your template from the Installation "
-"page:"
-msgstr ""
-"インストールページからテンプレートをペーストするために、以下のとおりに修正し"
-"ます。"
+"Modify this to prepare it for pasting in your template from the Installation"
+" page:"
+msgstr "インストールページからテンプレートをペーストするために、以下のとおりに修正します。"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:20
@@ -74,9 +69,7 @@ msgstr ""
 msgid ""
 "Within the <subsystem> element, paste in the template. It will look "
 "something like this:"
-msgstr ""
-"<subsystem> エレメントの要素内で、テンプレートを貼り付けます。そうすると、以"
-"下のようになります。"
+msgstr "<subsystem> エレメントの要素内で、テンプレートを貼り付けます。そうすると、以下のようになります。"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:35
@@ -105,9 +98,7 @@ msgstr ""
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:38
 msgid "Change the *WAR MODULE NAME* text to *vanilla* as follows:"
-msgstr ""
-"*WAR MODULE NAME* を *vanilla* に書き換えます。そうすると、以下のとおりになり"
-"ます。"
+msgstr "*WAR MODULE NAME* を *vanilla* に書き換えます。そうすると、以下のとおりになります。"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:45
@@ -132,9 +123,9 @@ msgstr "アプリケーション・サーバーを起動します。"
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:50
 msgid ""
 "Go to http://localhost:8080/vanilla and click *login*. The {project_name} "
-"login page opens. You can log in using the user you created in the <<_create-"
-"new-user, Creating a New User>> chapter."
+"login page opens. You can log in using the user you created in the "
+"<<_create-new-user, Creating a New User>> chapter."
 msgstr ""
-"http://localhost:8080/vanilla に移動して *login* をクリックします。"
-"{project_name}ログインページが開きます。<<_create-new-user, 新規ユーザーの作"
-"成>>の章で作成したユーザーを使用してログインすることができます。"
+"http://localhost:8080/vanilla に移動して *login* "
+"をクリックします。{project_name}ログインページが開きます。<<_create-new-user, "
+"新規ユーザーの作成>>の章で作成したユーザーを使用してログインすることができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__secure-jboss-app__subsystem/ja_JP/index.html
