### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -27,7 +26,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -43,15 +42,15 @@ msgstr "Linux/Unix"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
 
-#. type: Title ===
+#. type: Title =
 #: source/getting_started/topics/first-realm/before.adoc:2
 #: source/getting_started/topics/secure-jboss-app/before.adoc:2
-#: source/authorization_services/topics/getting-started/hello-world/before-start.adoc:1
+#: source/authorization_services/topics/hello-world-before-start.adoc:1
 #, no-wrap
 msgid "Before You Start"
 msgstr "はじめる前に"
@@ -60,26 +59,23 @@ msgstr "はじめる前に"
 #: source/getting_started/topics/secure-jboss-app/before.adoc:11
 msgid ""
 "Before you can participate in this tutorial, you need to complete the "
-"installation of {project_name} and create the initial admin user as shown in "
-"the <<_install-boot, Installing and Booting>> tutorial.  There is one caveat "
-"to this.  You have to run a separate {appserver_name} instance on the same "
-"machine as the {project_name} server.  This separate instance will run your "
-"Java Servlet application.  Because of this you will have to run the "
+"installation of {project_name} and create the initial admin user as shown in"
+" the <<_install-boot, Installing and Booting>> tutorial.  There is one "
+"caveat to this.  You have to run a separate {appserver_name} instance on the"
+" same machine as the {project_name} server.  This separate instance will run"
+" your Java Servlet application.  Because of this you will have to run the "
 "{project_name} under a different port so that there are no port conflicts "
 "when running on the same machine.  Use the `jboss.socket.binding.port-"
 "offset` system property on the command line.  The value of this property is "
 "a number that will be added to the base value of every port opened by the "
 "{project_name} server."
 msgstr ""
-"このチュートリアルの操作をはじめる前に、{project_name}のインストールを完了"
-"し、<<_install-boot, インストールと起動>>のチュートリアルに沿って初期管理者"
-"ユーザーを作成する必要があります。これには注意事項があります。{project_name}"
-"サーバーと同じマシンで、別途{appserver_name}インスタンスを起動する必要があり"
-"ます。この別インスタンスではJava Servletアプリケーションを起動します。そのた"
-"め、同じマシンで起動させる際にポートが競合しないように、異なるポートで"
-"{project_name}を起動する必要があります。コマンドラインで `jboss.socket."
-"binding.port-offset` システムプロパティを使います。当プロパティの値は、"
-"{project_name}サーバーで開いた全ポートの基準値に加算される数値です。"
+"このチュートリアルの操作をはじめる前に、{project_name}のインストールを完了し、<<_install-boot, "
+"インストールと起動>>のチュートリアルに沿って初期管理者ユーザーを作成する必要があります。これには注意事項があります。{project_name}サーバーと同じマシンで、別途{appserver_name}インスタンスを起動する必要があります。この別インスタンスではJava"
+" "
+"Servletアプリケーションを起動します。そのため、同じマシンで起動させる際にポートが競合しないように、異なるポートで{project_name}を起動する必要があります。コマンドラインで"
+" `jboss.socket.binding.port-offset` "
+"システムプロパティを使います。当プロパティの値は、{project_name}サーバーで開いた全ポートの基準値に加算される数値です。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/before.adoc:13
@@ -88,14 +84,14 @@ msgstr "{project_name}サーバーを起動します。"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/before.adoc:18
-#: source/authorization_services/topics/getting-started/overview.adoc:13
+#: source/authorization_services/topics/getting-started-overview.adoc:13
 #, no-wrap
 msgid "$ .../bin/standalone.sh -Djboss.socket.binding.port-offset=100\n"
 msgstr "$ .../bin/standalone.sh -Djboss.socket.binding.port-offset=100\n"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/before.adoc:24
-#: source/authorization_services/topics/getting-started/overview.adoc:19
+#: source/authorization_services/topics/getting-started-overview.adoc:19
 #, no-wrap
 msgid "> ...\\bin\\standalone.bat -Djboss.socket.binding.port-offset=100\n"
 msgstr "> ...\\bin\\standalone.bat -Djboss.socket.binding.port-offset=100\n"
@@ -106,5 +102,5 @@ msgid ""
 "After booting up {project_name}, you can then access the admin console at "
 "http://localhost:8180/auth/admin/"
 msgstr ""
-"{project_name}を起動したあと、http://localhost:8180/auth/admin/ にて管理コン"
-"ソールにアクセスすることができます。"
+"{project_name}を起動したあと、http://localhost:8180/auth/admin/ "
+"にて管理コンソールにアクセスすることができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__secure-jboss-app__before/ja_JP/index.html
