### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -27,7 +26,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -51,7 +50,7 @@ msgstr "$ .../bin/standalone.sh\n"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
@@ -75,33 +74,29 @@ msgstr "クライアント・アダプターのインストール"
 msgid ""
 "Download the {appserver_name} distribution and unzip it into a directory on "
 "your machine."
-msgstr ""
-"{appserver_name} の配布物をダウンロードし、マシンのディレクトリに解凍します。"
+msgstr "{appserver_name} の配布物をダウンロードし、マシンのディレクトリに解凍します。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:9
 msgid ""
-"Next download the WildFly OpenID Connect adapter distribution from link:"
-"http://www.keycloak.org/downloads.html[keycloak.org]."
+"Next download the WildFly OpenID Connect adapter distribution from "
+"link:http://www.keycloak.org/downloads.html[keycloak.org]."
 msgstr ""
-"次に、link:http://www.keycloak.org/downloads.html[keycloak.org]からWildFly "
-"OpenID Connectアダプターの配布物をダウンロードします。"
+"次に、link:http://www.keycloak.org/downloads.html[keycloak.org]からWildFly OpenID"
+" Connectアダプターの配布物をダウンロードします。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:13
 msgid ""
 "Next download the RH-SSO-{project_version}-eap7-adapter.zip distribution."
-msgstr ""
-"次に、RH-SSO-{project_version}-eap7-adapter.zip の配布物をダウンロードしま"
-"す。"
+msgstr "次に、RH-SSO-{project_version}-eap7-adapter.zip の配布物をダウンロードします。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:16
 msgid ""
 "Unzip this file into the root directory of your {appserver_name} "
 "distribution."
-msgstr ""
-"{appserver_name} 配布物のルートディレクトリに、このファイルを解凍します。"
+msgstr "{appserver_name} 配布物のルートディレクトリに、このファイルを解凍します。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:18
@@ -175,10 +170,10 @@ msgstr ""
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:51
 msgid ""
-"This script will make the appropriate edits to the _.../standalone/"
-"configuration/standalone.xml_ file of your app server distribution.  "
-"Finally, boot the application server."
+"This script will make the appropriate edits to the "
+"_.../standalone/configuration/standalone.xml_ file of your app server "
+"distribution.  Finally, boot the application server."
 msgstr ""
-"このスクリプトにより、アプリケーション・サーバーの配布物に含まれる _.../"
-"standalone/configuration/standalone.xml_ が適切に編集されます。最後に、アプリ"
-"ケーション・サーバーを起動します。"
+"このスクリプトにより、アプリケーション・サーバーの配布物に含まれる "
+"_.../standalone/configuration/standalone.xml_ "
+"が適切に編集されます。最後に、アプリケーション・サーバーを起動します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__install-client-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-getting_started__topics__secure-jboss-app__install-client-adapter/ja_JP/index.html
