### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -26,7 +26,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -42,7 +42,7 @@ msgstr "Linux/Unix"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__config-subsystem__start-cli/ja_JP/index.html
