### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po
@@ -2,25 +2,25 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title ###
 #: source/server_installation/topics/clustering/troubleshooting.adoc:2
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:386
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:391
 #: source/securing_apps/topics/saml/java/debugging.adoc:2
 #: source/server_admin/topics/authentication/kerberos.adoc:191
+#: source/server_admin/topics/authentication/x509.adoc:201
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
@@ -30,12 +30,10 @@ msgstr "トラブルシューティング"
 msgid ""
 "The best way to troubleshoot problems is to turn on debugging for SAML in "
 "both the client adapter and {project_name} Server. Using your logging "
-"framework, set the log level to `DEBUG` for the `org.keycloak.saml` package. "
-"Turning this on allows you to see the SAML requests and response documents "
+"framework, set the log level to `DEBUG` for the `org.keycloak.saml` package."
+" Turning this on allows you to see the SAML requests and response documents "
 "being sent to and from the server."
 msgstr ""
-"問題を解決する最善の方法は、SAMLクライアント・アダプターと{project_name}サー"
-"バーの両方でデバッギングを有効にすることです。ロギング・フレームワークを使用"
-"して、'org.keycloak.saml'パッケージのログ・レベルを'DEBUG'に設定します。これ"
-"を有効にすることで、サーバー間で送信されるSAMLの要求/応答ドキュメントを見るこ"
-"とができます。"
+"問題を解決する最善の方法は、SAMLクライアント・アダプターと{project_name}サーバーの両方でデバッギングを有効にすることです。ロギング・フレームワークを使用して、"
+" `org.keycloak.saml` パッケージのログ・レベルを `DEBUG` "
+"に設定します。これを有効にすることで、サーバー間で送信されるSAMLの要求/応答ドキュメントを見ることができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__debugging
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__debugging/ja_JP/index.html
