### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
@@ -31,6 +30,6 @@ msgid ""
 "OpenID Connect using either {project_name} adapters or generic OpenID "
 "Connect Resource Provider libraries."
 msgstr ""
-"このセクションでは、{project_name}アダプターまたは汎用OpenID Connectリソー"
-"ス・プロバイダーのライブラリを使用して、アプリケーションとサービスをOpenID "
+"このセクションでは、{project_name}アダプターまたは汎用OpenID "
+"Connectリソース・プロバイダーのライブラリを使用して、アプリケーションとサービスをOpenID "
 "Connectでセキュリティ保護する方法について説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__oidc-overview/ja_JP/index.html
