### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -28,11 +27,7 @@ msgid ""
 "{project_name} client adapters are libraries that makes it very easy to "
 "secure applications and services with {project_name}. We call them adapters "
 "rather than libraries as they provide a tight integration to the underlying "
-"platform and framework. This makes our adapters easy to use and they require "
-"less boilerplate code than what is typically required by a library."
+"platform and framework. This makes our adapters easy to use and they require"
+" less boilerplate code than what is typically required by a library."
 msgstr ""
-"{project_name}のクライアント・アダプターは、{project_name}とともに使用してア"
-"プリケーションとサービスを非常に簡単にセキュリティ保護できるライブラリです。"
-"基盤となるプラットフォームやフレームワークとのタイトな統合を提供するので、ラ"
-"イブラリではなく、アダプターと呼んでいます。これにより、アダプターは使いやす"
-"くなり、一般的にライブラリが必要とするよりも定型コードが少なくて済みます。"
+"{project_name}のクライアント・アダプターは、{project_name}とともに使用してアプリケーションとサービスを非常に簡単にセキュリティ保護できるライブラリです。基盤となるプラットフォームやフレームワークとのタイトな統合を提供するので、ライブラリではなく、アダプターと呼んでいます。これにより、アダプターは使いやすくなり、一般的にライブラリが必要とするよりも定型コードが少なくて済みます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__what-are-client-adapters
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__overview__what-are-client-adapters/ja_JP/index.html
