### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/assertion-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/assertion-api.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/assertion-api.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
@@ -26,18 +25,18 @@ msgstr "アサーション属性の取得"
 #: source/securing_apps/topics/saml/java/assertion-api.adoc:8
 msgid ""
 "After a successful SAML login, your application code may want to obtain "
-"attribute values passed with the SAML assertion.  `HttpServletRequest."
-"getUserPrincipal()` returns a `Principal` object that you can typecast into "
-"a {project_name} specific class called `org.keycloak.adapters.saml."
-"SamlPrincipal`.  This object allows you to look at the raw assertion and "
-"also has convenience functions to look up attribute values."
+"attribute values passed with the SAML assertion.  "
+"`HttpServletRequest.getUserPrincipal()` returns a `Principal` object that "
+"you can typecast into a {project_name} specific class called "
+"`org.keycloak.adapters.saml.SamlPrincipal`.  This object allows you to look "
+"at the raw assertion and also has convenience functions to look up attribute"
+" values."
 msgstr ""
-"SAMLログインが成功したら、アプリケーションのコードで、SAMLアサーションに渡さ"
-"れた属性値を取得したい場合があるかもしれません。 `HttpServletRequest."
-"getUserPrincipal()` は、 `org.keycloak.adapters.saml.SamlPrincipal` と呼ばれ"
-"る{project_name}特有のクラスに、キャスト可能な `Principal` オブジェクトを返し"
-"ます。このオブジェクトには、未加工のアサーションを参照したり、属性値を取得す"
-"る便利な機能があります。"
+"SAMLログインが成功したら、アプリケーションのコードで、SAMLアサーションに渡された属性値を取得したい場合があるかもしれません。 "
+"`HttpServletRequest.getUserPrincipal()` は、 "
+"`org.keycloak.adapters.saml.SamlPrincipal` "
+"と呼ばれる{project_name}特有のクラスにキャスト可能な、 `Principal` "
+"オブジェクトを返します。このオブジェクトには、未加工のアサーションを参照したり、属性値を取得する便利な機能があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/assertion-api.adoc:13
@@ -159,6 +158,7 @@ msgstr ""
 #: source/server_development/topics/user-storage/provider-interfaces.adoc:50
 #: source/server_development/topics/user-storage/registration-query.adoc:109
 #: source/server_development/topics/user-storage/simple-example.adoc:146
+#: source/server_development/topics/auth-spi.adoc:460
 #: source/server_development/topics/providers.adoc:75
 #, no-wrap
 msgid "    }\n"
@@ -273,7 +273,6 @@ msgid ""
 "        ...\n"
 "    }\n"
 "}\n"
-"----    \n"
 msgstr ""
 "    /**\n"
 "     * Get set of all assertion friendly attribute names\n"
@@ -284,4 +283,3 @@ msgstr ""
 "        ...\n"
 "    }\n"
 "}\n"
-"----    \n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/assertion-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__assertion-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__assertion-api/ja_JP/index.html
