### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -27,9 +26,7 @@ msgstr "IDP要素"
 msgid ""
 "Everything in the IDP element describes the settings for the identity "
 "provider (authentication server) the SP is communicating with."
-msgstr ""
-"IDP要素のすべては、SPと通信しているアイデンティティー・プロバイダー(認証サー"
-"バー)の設定について説明しています。"
+msgstr "IDP要素内には、SPと通信しているアイデンティティー・プロバイダー（認証サーバー）の設定を記述します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:14
@@ -80,14 +77,12 @@ msgid ""
 "If set to `true`, the client adapter will sign every document it sends to "
 "the IDP.  Also, the client will expect that the IDP will be signing any "
 "documents sent to it.  This switch sets the default for all request and "
-"response types, but you will see later that you have some fine grain control "
-"over this.  This setting is _OPTIONAL_ and will default to `false`."
+"response types, but you will see later that you have some fine grain control"
+" over this.  This setting is _OPTIONAL_ and will default to `false`."
 msgstr ""
-" `true` に設定すると、クライアント・アダプターはIDPに送信する全ての文書に署名"
-"します。 また、クライアントは、送信されたすべてのドキュメントにIDPが署名して"
-"いることを期待します。このスイッチは、すべての要求と応答の種類に対してデフォ"
-"ルト値を設定しますが、それ以上に細かい制御ができることが後で分かります。この"
-"設定は _OPTIONAL_ で、 `false` がデフォルトとなります。"
+" `true` に設定すると、クライアント・アダプターはIDPに送信する全ての文書に署名します。 "
+"また、クライアントは、送信されたすべてのドキュメントにIDPが署名していることを期待します。このスイッチは、すべての要求と応答の種類に対してデフォルト値を設定しますが、それ以上に細かい制御ができることが後で分かります。この設定は"
+" _OPTIONAL_ で、 `false` がデフォルトとなります。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:26
@@ -102,9 +97,8 @@ msgid ""
 "use.  Allowed values are: `RSA_SHA1`, `RSA_SHA256`, `RSA_SHA512`, and "
 "`DSA_SHA1`.  This setting is _OPTIONAL_ and defaults to `RSA_SHA256`."
 msgstr ""
-"IDPが署名済みドキュメントに使用することを想定している署名アルゴリズムです。許"
-"可値は、 `RSA_SHA1` 、 `RSA_SHA256` 、 `RSA_SHA512` 、 `DSA_SHA1` です。 この"
-"設定は _OPTIONAL_ で、デフォルトは `RSA_SHA256` です。"
+"IDPが署名済みドキュメントに使用することを想定している署名アルゴリズムです。許可値は、 `RSA_SHA1` 、 `RSA_SHA256` 、 "
+"`RSA_SHA512` 、 `DSA_SHA1` です。 この設定は _OPTIONAL_ で、デフォルトは `RSA_SHA256` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:31
@@ -116,9 +110,9 @@ msgstr "signatureCanonicalizationMethod"
 #: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:34
 msgid ""
 "This is the signature canonicalization method that the IDP expects signed "
-"documents to use.  This setting is _OPTIONAL_.  The default value is `"
-"\\http://www.w3.org/2001/10/xml-exc-c14n#` and should be good for most IDPs."
+"documents to use.  This setting is _OPTIONAL_.  The default value is "
+"`\\http://www.w3.org/2001/10/xml-exc-c14n#` and should be good for most "
+"IDPs."
 msgstr ""
-"IDPが署名済みのドキュメントに使用することを想定している署名の正規化方法です。"
-"この設定は _OPTIONAL_ です。デフォルトは `\\http://www.w3.org/2001/10/xml-"
-"exc-c14n#` で、ほとんどのIDPに対して変更が不要です。"
+"IDPが署名済みのドキュメントに使用することを想定している署名の正規化方法です。この設定は _OPTIONAL_ です。デフォルトは "
+"`\\http://www.w3.org/2001/10/xml-exc-c14n#` で、ほとんどのIDPに対して変更が不要です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__idp_element/ja_JP/index.html
