### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -1,31 +1,32 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__database__jdbc.ja_JP.po\n"
 
 #. type: Block title
 #: source/server_installation/topics/database/datasource.adoc:9
 #: source/server_installation/topics/database/jdbc.adoc:56
 #, no-wrap
 msgid "Declare Your JDBC Drivers"
-msgstr "JDBCドライバの宣言"
+msgstr "JDBCドライバーの宣言"
 
 #. type: Title ===
 #: source/server_installation/topics/database/jdbc.adoc:2
 #, no-wrap
 msgid "Package the JDBC Driver"
-msgstr "JDBCドライバのパッケージ化"
+msgstr "JDBCドライバーのパッケージ化"
 
 #. type: Plain text
 #: source/server_installation/topics/database/jdbc.adoc:5
@@ -36,27 +37,22 @@ msgid ""
 "classpath and the dependencies those JARs have on other modules. They are "
 "pretty simple to set up."
 msgstr ""
-"RDBMS用のJDBCドライバJARを検索してダウンロードします。ただし、このドライバを"
-"使用する前に、このドライバをモジュールにパッケージし、サーバーにインストール"
-"する必要があります。モジュールによって、{project_name}クラスパスにロードされ"
-"るJAR、およびこれらのJARが他のモジュール上に持つ依存関係が定義されます。これ"
-"らの設定は簡単です。"
+"RDBMS用のJDBCドライバーJARを検索してダウンロードします。このドライバーを使用する前に、モジュールにパッケージしてサーバーにインストールする必要があります。モジュールによって、{project_name}クラスパスにロードされるJAR、およびこれらのJARが他のモジュール上に持つ依存関係が定義されます。設定は非常に簡単です。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/jdbc.adoc:7
 msgid ""
-"Within the _.../modules/_ directory of your {project_name} distribution, you "
-"need to create a directory structure to hold your module definition.  The "
+"Within the _.../modules/_ directory of your {project_name} distribution, you"
+" need to create a directory structure to hold your module definition.  The "
 "convention is use the Java package name of the JDBC driver for the name of "
-"the directory structure. For PostgreSQL, create the directory _org/"
-"postgresql/main_. Copy your database driver JAR into this directory and "
-"create an empty _module.xml_ file within it too."
+"the directory structure. For PostgreSQL, create the directory "
+"_org/postgresql/main_. Copy your database driver JAR into this directory and"
+" create an empty _module.xml_ file within it too."
 msgstr ""
-" {project_name}の配布物の _.../modules/_ ディレクトリ内で、モジュール定義を保"
-"持するディレクトリ構造を作成する必要があります。規約では、ディレクトリ構造の"
-"名前にJDBCドライバのJavaパッケージ名を使用します。PostgreSQLの場合、 _org/"
-"postgresql/main_  ディレクトリを作成します。このディレクトリにデータベースド"
-"ライバJARをコピーし、その中に空の _module.xml_ ファイルも作成します。"
+" {project_name}の配布物の _.../modules/_ "
+"ディレクトリ内で、モジュール定義を保持するディレクトリ構造を作成する必要があります。規約では、ディレクトリ構造の名前にJDBCドライバーのJavaパッケージ名を使用します。PostgreSQLの場合、"
+" _org/postgresql/main_  ディレクトリを作成します。このディレクトリにデータベースドライバーのJARをコピーし、その中に空の "
+"_module.xml_ ファイルも作成します。"
 
 #. type: Block title
 #: source/server_installation/topics/database/jdbc.adoc:8
@@ -128,38 +124,35 @@ msgid ""
 "attribute should specify the JAR filename of the driver.  The rest are just "
 "the normal dependencies that any JDBC driver JAR would have."
 msgstr ""
-"モジュール名は、モジュールのディレクトリ構造と一致する必要があります。した"
-"がって、 _org/postgresql_ は `org.postgresql` にマッピングされます。ドライバ"
-"のJARファイル名は、 `resource-root path` の属性によって指定される必要がありま"
-"す。残りの部分は、JDBCドライバのJARが持つ通常の依存関係になります。"
+"モジュール名は、モジュールのディレクトリ構造と一致する必要があります。したがって、 _org/postgresql_ は "
+"`org.postgresql` にマッピングされます。ドライバーのJARファイル名は、 `resource-root path` "
+"の属性によって指定される必要があります。残りの部分は、JDBCドライバーのJARが持つ通常の依存関係になります。"
 
 #. type: Title ===
 #: source/server_installation/topics/database/jdbc.adoc:32
 #, no-wrap
 msgid "Declare and Load JDBC Driver"
-msgstr "JDBCドライバの宣言とロード"
+msgstr "JDBCドライバーの宣言とロード"
 
 #. type: Plain text
 #: source/server_installation/topics/database/jdbc.adoc:35
 msgid ""
 "The next thing you have to do is declare your newly packaged JDBC driver "
-"into your deployment profile so that it loads and becomes available when the "
-"server boots up. Where you perform this action depends on your <<_operating-"
-"mode, operating mode>>. If you're deploying in standard mode, edit _.../"
-"standalone/configuration/standalone.xml_.  If you're deploying in standard "
-"clustering mode, edit _.../standalone/configuration/standalone-ha.xml_.  If "
-"you're deploying in domain mode, edit _.../domain/configuration/domain.xml_. "
-"In domain mode, you'll need to make sure you edit the profile you are using: "
-"either `auth-server-standalone` or `auth-server-clustered`"
+"into your deployment profile so that it loads and becomes available when the"
+" server boots up. Where you perform this action depends on your "
+"<<_operating-mode, operating mode>>. If you're deploying in standard mode, "
+"edit _.../standalone/configuration/standalone.xml_.  If you're deploying in "
+"standard clustering mode, edit _.../standalone/configuration/standalone-"
+"ha.xml_.  If you're deploying in domain mode, edit "
+"_.../domain/configuration/domain.xml_. In domain mode, you'll need to make "
+"sure you edit the profile you are using: either `auth-server-standalone` or "
+"`auth-server-clustered`"
 msgstr ""
-"次に、新しくパッケージ化されたJDBCドライバをデプロイメント・プロファイルに宣"
-"言して、ロードし、サーバーの起動時に使用できるようにする必要があります。この"
-"操作を行う場所は、<<_operating-mode, operating mode>>によって異なります。標準"
-"モードでデプロイしている場合は、 _.../standalone/configuration/standalone."
-"xml_ を編集します。ドメイン・モードでデプロイしている場合は、 _.../domain/"
-"configuration/domain.xml_ を編集します。ドメイン・モードでは、 `auth-server-"
-"standalone` または `auth-server-clustered` のどちらか使用している方のプロファ"
-"イルを必ず編集する必要があります。"
+"次に、新しくパッケージ化されたJDBCドライバーをデプロイメント・プロファイルに宣言して、ロードし、サーバーの起動時に使用できるようにする必要があります。この操作を行う場所は"
+"、<<_operating-mode, 動作モード>>によって異なります。標準モードでデプロイしている場合は、 "
+"_.../standalone/configuration/standalone.xml_ を編集します。ドメイン・モードでデプロイしている場合は、 "
+"_.../domain/configuration/domain.xml_ を編集します。ドメイン・モードでは、 `auth-server-"
+"standalone` または `auth-server-clustered` のどちらか使用している方のプロファイルを必ず編集する必要があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/jdbc.adoc:37
@@ -169,15 +162,14 @@ msgid ""
 "the H2 JDBC driver. This is where you'll declare the JDBC driver for your "
 "external database."
 msgstr ""
-"プロファイル内で、 `datasources` サブシステム内の `drivers` XMLブロックを検索"
-"すると、H2JDBCドライバ用に宣言された定義済みのドライバが見つかります。ここ"
-"で、外部データベース用のJDBCドライバを宣言します。"
+"プロファイル内で、 `datasources` サブシステム内の `drivers` XMLブロックを検索すると、H2 "
+"JDBCドライバー用に宣言された定義済みのドライバーが見つかります。ここで、外部データベース用のJDBCドライバーを宣言します。"
 
 #. type: Block title
 #: source/server_installation/topics/database/jdbc.adoc:38
 #, no-wrap
 msgid "JDBC Drivers"
-msgstr "JDBCドライバ"
+msgstr "JDBCドライバー"
 
 #. type: delimited block -
 #: source/server_installation/topics/database/jdbc.adoc:51
@@ -211,15 +203,13 @@ msgid ""
 "Within the `drivers` XML block you'll need to declare an additional JDBC "
 "driver.  It needs to have a `name` which you can choose to be anything you "
 "want.  You specify the `module` attribute which points to the `module` "
-"package you created earlier for the driver JAR.  Finally you have to specify "
-"the driver's Java class.  Here's an example of installing PostgreSQL driver "
-"that lives in the module example defined earlier in this chapter."
+"package you created earlier for the driver JAR.  Finally you have to specify"
+" the driver's Java class.  Here's an example of installing PostgreSQL driver"
+" that lives in the module example defined earlier in this chapter."
 msgstr ""
-" `drivers` XMLブロック内で、追加のJDBCドライバを宣言する必要があります。それ"
-"に `name` を付けて、必要時に選択できるようにします。ドライバJAR用に以前作成し"
-"た `module` パッケージを指す、 `module` 属性を指定します。最後に、ドライバの"
-"Javaクラスを指定します。サンプルとして、この章で以前定義したモジュールのサン"
-"プル内にある、PostgreSQLドライバをインストールすると下記のとおりになります。"
+"`drivers` XMLブロック内で、追加のJDBCドライバーを宣言する必要があります。それに `name` "
+"を付けて、必要時に選択できるようにします。ドライバーのJAR用に以前作成した `module` パッケージを指す、 `module` "
+"属性を指定します。最後に、ドライバーのJavaクラスを指定します。サンプルとして、この章で以前定義したモジュールのサンプル内にある、PostgreSQLドライバーをインストールすると下記のとおりになります。"
 
 #. type: delimited block -
 #: source/server_installation/topics/database/jdbc.adoc:72


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__jdbc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__database__jdbc/ja_JP/index.html
