### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/datasource.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/datasource.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/datasource.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__database__datasource.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/database/datasource.adoc:2
@@ -23,23 +24,20 @@ msgstr "{project_name}データソースの変更"
 #. type: Plain text
 #: source/server_installation/topics/database/datasource.adoc:8
 msgid ""
-"After declaring your JDBC driver, you have to modify the existing datasource "
-"configuration that {project_name} uses to connect it to your new external "
+"After declaring your JDBC driver, you have to modify the existing datasource"
+" configuration that {project_name} uses to connect it to your new external "
 "database.  You'll do this within the same configuration file and XML block "
-"that you registered your JDBC driver in.  Here's an example that sets up the "
-"connection to your new database:"
+"that you registered your JDBC driver in.  Here's an example that sets up the"
+" connection to your new database:"
 msgstr ""
-"JDBCドライバを宣言したら、{project_name}が新しい外部データベースに接続するた"
-"めに使用する既存のデータソース設定を変更する必要があります。これは、JDBCドラ"
-"イバを登録したのと同じ設定ファイルとXMLブロック内で行います。サンプルとして、"
-"新しいデータベースへの接続を設定すると以下のとおりになります。"
+"JDBCドライバーを宣言したら、{project_name}が新しい外部データベースに接続するために使用する既存のデータソース設定を変更する必要があります。これは、JDBCードライバを登録したのと同じ設定ファイルとXMLブロック内で行います。サンプルとして、新しいデータベースへの接続を設定すると以下のとおりになります。"
 
 #. type: Block title
 #: source/server_installation/topics/database/datasource.adoc:9
 #: source/server_installation/topics/database/jdbc.adoc:56
 #, no-wrap
 msgid "Declare Your JDBC Drivers"
-msgstr "JDBCドライバの宣言"
+msgstr "JDBCドライバーの宣言"
 
 #. type: delimited block -
 #: source/server_installation/topics/database/datasource.adoc:29
@@ -88,18 +86,15 @@ msgid ""
 "to modify the `connection-url`.  The documentation for your vendor's JDBC "
 "implementation should specify the format for this connection URL value."
 msgstr ""
-" `KeycloakDS` 用の `datasource` 定義を検索します。まず `connection-url` を変"
-"更する必要があります。この接続URL値の形式は、ベンダーのJDBC実装のドキュメント"
-"によって指定されます。"
+"`KeycloakDS` 用の `datasource` 定義を検索します。まず `connection-url` "
+"を変更する必要があります。この接続URL値の形式は、ベンダーのJDBC実装のドキュメントによって指定されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/datasource.adoc:36
 msgid ""
-"Next define the `driver` you will use.  This is the logical name of the JDBC "
-"driver you declared in the previous section of this chapter."
-msgstr ""
-"次に、使用する `driver` を定義します。これは、この章の前のセクションで宣言し"
-"たJDBCドライバの論理名になります。"
+"Next define the `driver` you will use.  This is the logical name of the JDBC"
+" driver you declared in the previous section of this chapter."
+msgstr "次に、使用する `driver` を定義します。これは、この章の前のセクションで宣言したJDBCドライバーの論理名になります。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/datasource.adoc:40
@@ -110,10 +105,8 @@ msgid ""
 "maximum number of connections it will pool.  You may want to change the "
 "value of this depending on the load of your system."
 msgstr ""
-"トランザクションを実行するたびにデータベースへの新しい接続を開くのは処理コス"
-"トがかかります。これを補うために、データソース実装はオープンな接続のプールを"
-"維持します。 `max-pool-size` によって、プールする接続の最大数が指定されます。"
-"システムの負荷に応じて、この値を変更することができます。"
+"トランザクションを実行するたびにデータベースへの新しい接続を開くのは処理コストがかかります。これを補うために、データソース実装は開いた接続のプールを維持します。"
+" `max-pool-size` によって、プールする接続の最大数が指定されます。システムの負荷に応じて、この値を変更することができます。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/datasource.adoc:44
@@ -123,18 +116,15 @@ msgid ""
 "that this is in clear text in the example.  There are methods to obfuscate "
 "this, but this is beyond the scope of this guide."
 msgstr ""
-"最後に、少なくともPostgreSQLでは、データベースへの接続に必要なデータベースの"
-"ユーザー名とパスワードを定義する必要があります。このサンプルでは、これが簡単"
-"なテキストであることを心配されるかもしれませんが、難読化する方法は複数ありま"
-"す。しかし、それはこのガイドの範囲外となります。"
+"最後に、少なくともPostgreSQLでは、データベースへの接続に必要なデータベースのユーザー名とパスワードを定義する必要があります。このサンプルでは、これが簡単なテキストであることを心配されるかもしれませんが、難読化する方法は複数あります。しかし、それはこのガイドの範囲外となります。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/datasource.adoc:45
 msgid ""
-"For more information about datasource features, see link:"
-"{appserver_datasource_link}[the datasource configuration chapter] in the "
-"_{appserver_admindoc_name}_."
+"For more information about datasource features, see "
+"link:{appserver_datasource_link}[the datasource configuration chapter] in "
+"the _{appserver_admindoc_name}_."
 msgstr ""
-"データソース機能について、詳しくは _{appserver_admindoc_name}_ 内のlink:"
-"{appserver_datasource_link}[the datasource configuration chapter]をご覧くださ"
-"い。"
+"データソース機能について、詳しくは _{appserver_admindoc_name}_ "
+"内のlink:{appserver_datasource_link}[the datasource configuration "
+"chapter]をご覧ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/datasource.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__datasource
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__database__datasource/ja_JP/index.html
