### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__installation__directory-structure.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/installation/directory-structure.adoc:2
 #, no-wrap
 msgid "Distribution Directory Structure"
-msgstr "配布物ディレクトリ構造"
+msgstr "配布物のディレクトリ構造"
 
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:5
@@ -31,7 +32,7 @@ msgstr "この章では、サーバー配布物のディレクトリ構造につ
 #: source/server_installation/topics/installation/directory-structure.adoc:6
 #, no-wrap
 msgid "distribution directory structure"
-msgstr "配布物ディレクトリ構造"
+msgstr "配布物のディレクトリ構造"
 
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:8
@@ -54,9 +55,7 @@ msgstr "_bin/_"
 msgid ""
 "This contains various scripts to either boot the server or perform some "
 "other management action on the server."
-msgstr ""
-"サーバーの起動またはサーバー上でその他管理操作を行う、さまざまなスクリプトが"
-"含まれています。"
+msgstr "サーバーの起動またはサーバー上でその他管理操作を行う、さまざまなスクリプトが含まれています。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:14
@@ -70,8 +69,8 @@ msgid ""
 "This contains configuration files and working directory when running "
 "{project_name} in <<_domain-mode,domain mode>>."
 msgstr ""
-"{project_name}を<<_domain-mode,domain mode>>で実行する場合の、設定ファイルと"
-"ワーキング・ディレクトリが含まれています。"
+"{project_name}を<<_domain-"
+"mode,ドメイン・モード>>で実行する場合の、設定ファイルとワーキング・ディレクトリが含まれています。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:17
@@ -93,12 +92,11 @@ msgstr "_providers/_"
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:23
 msgid ""
-"If you are writing extensions to keycloak, you can put your extensions "
-"here.  See the link:{developerguide_link}[{developerguide_name}] for more "
+"If you are writing extensions to keycloak, you can put your extensions here."
+"  See the link:{developerguide_link}[{developerguide_name}] for more "
 "information on this."
 msgstr ""
-"keycloakに拡張子をつける場合、ここにその拡張子を保存することができます。詳し"
-"くは、link:{developerguide_link}[{developerguide_name}]をご覧ください。"
+"keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]をご覧ください。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:25
@@ -112,8 +110,8 @@ msgid ""
 "This contains configuration files and working directory when running "
 "{project_name} in <<_standalone-mode,standalone mode>>."
 msgstr ""
-"<<_standalone-mode,standalone mode>>で{project_name}を実行する場合、設定ファ"
-"イルとワーキング・ディレクトリは含まれません。"
+"<<_standalone-mode,standalone "
+"mode>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリは含まれません。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:28
@@ -126,11 +124,10 @@ msgstr "_themes/_"
 msgid ""
 "This directory contains all the html, style sheets, javascript files, and "
 "images used to display any UI screen displayed by the server.  Here you can "
-"modify an existing theme or create your own.  See the link:"
-"{developerguide_link}[{developerguide_name}] for more information on this."
+"modify an existing theme or create your own.  See the "
+"link:{developerguide_link}[{developerguide_name}] for more information on "
+"this."
 msgstr ""
-"このディレクトリは、サーバーにより指定されたUI画面を表示するために使用される"
-"html、スタイル・シート、 javascriptファイルおよびイメージ画像が含まれていま"
-"す。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることがで"
-"きます。詳しくは、link:{developerguide_link}[{developerguide_name}]をご覧くだ"
-"さい。 "
+"このディレクトリは、サーバーにより指定されたUI画面を表示するために使用されるhtml、スタイルシート、 "
+"javascriptファイルおよびイメージ画像が含まれています。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることができます。詳しくは、link:{developerguide_link}[{developerguide_name}]をご覧ください。"
+" "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__installation__directory-structure
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__installation__directory-structure/ja_JP/index.html
