### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__operating-mode__standalone.ja_JP.po\n"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:6
@@ -33,17 +34,8 @@ msgstr "image:{project_images}/standalone-boot-files.png[]"
 #: source/server_installation/topics/operating-mode/domain.adoc:186
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:36
 #: source/server_installation/topics/operating-mode/standalone.adoc:19
-#, fuzzy
 msgid "To boot the server:"
-msgstr ""
-"#-#-#-#-#  standalone-ha.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  domain.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  standalone.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  boot.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します"
+msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:11
@@ -56,7 +48,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -80,7 +72,7 @@ msgstr "$ .../bin/standalone.sh\n"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
@@ -101,7 +93,8 @@ msgid ""
 "Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
 "      by the server.  Instead use the the command line scripting or the web console of {appserver_name}.  See\n"
 "      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
-msgstr "サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
+msgstr ""
+"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/standalone.adoc:3
@@ -121,13 +114,7 @@ msgid ""
 "will not be able to log in.  This mode is really only useful to test drive "
 "and play with the features of {project_name}"
 msgstr ""
-"スタンドアロン動作モードは、サーバーに１つの{project_name}サーバー・インスタ"
-"ンスを起動する場合にのみ有効です。クラスター構成には使用できません。また、"
-"キャッシュは分散されておらずローカル専用です。スタンドアロン・モードは単一障"
-"害点となりえるので、プロダクション環境での使用はおすすめしません。スタンドア"
-"ロン・モード・サーバーがダウンした場合、ユーザーはログインできなくなります。"
-"そのため、このモードはテストおよび{project_name}の機能を試す目的にのみ有効で"
-"す。"
+"スタンドアロン動作モードは、サーバーに1つの{project_name}サーバー・インスタンスを起動する場合にのみ有効です。クラスター構成には使用できません。また、キャッシュは分散されておらずローカル専用です。スタンドアロン・モードは単一障害点となりえるので、プロダクション環境での使用はおすすめしません。スタンドアロン・モードのサーバーがダウンした場合、ユーザーはログインできなくなります。そのため、このモードはテストおよび{project_name}の機能を試す目的にのみ有効です。"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/standalone.adoc:10
@@ -142,9 +129,8 @@ msgid ""
 "need to run to boot the server depending on your operating system.  These "
 "scripts live in the _bin/_ directory of the server distribution."
 msgstr ""
-"スタンドアロン・モードでサーバーを実行する場合、オペレーティングシステム固有"
-"の起動スクリプトを実行する必要があります。これらのスクリプトはサーバー配布物"
-"の _bin/_ ディレクトリにあります。"
+"スタンドアロン・モードでサーバーを実行する場合、オペレーティングシステム固有の起動スクリプトを実行する必要があります。これらのスクリプトはサーバー配布物の"
+" _bin/_ ディレクトリにあります。"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/standalone.adoc:32
@@ -163,12 +149,9 @@ msgid ""
 "also used to configure non-infrastructure level things that are specific to "
 "{project_name} components."
 msgstr ""
-"このガイドの大半は、{project_name}の基盤レベルの設定についてご説明します。こ"
-"のレベルの設定は、{project_name}が構築されたアプリケーション・サーバーに特化"
-"した設定ファイル内で実行されます。スタンドアロン動作モードでは、このファイル"
-"は _.../standalone/configuration/standalone.xml_ にあります。また、このファイ"
-"ルは{project_name}のコンポーネントに特化した非基盤レベルの設定にも使用されま"
-"す。"
+"このガイドの大半は、{project_name}の基盤レベルの設定についてご説明します。このレベルの設定は、{project_name}が構築されたアプリケーション・サーバーに特化した設定ファイル内で実行されます。スタンドアロン動作モードでは、このファイルは"
+" _.../standalone/configuration/standalone.xml_ "
+"にあります。また、このファイルは{project_name}のコンポーネントに特化した非基盤レベルの設定にも使用されます。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/standalone.adoc:39


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__operating-mode__standalone/ja_JP/index.html
