### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -1,35 +1,27 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__operating-mode__domain.ja_JP.po\n"
 
 #. type: Plain text
 #: source/getting_started/topics/first-boot/boot.adoc:10
 #: source/server_installation/topics/operating-mode/domain.adoc:186
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:36
 #: source/server_installation/topics/operating-mode/standalone.adoc:19
-#, fuzzy
 msgid "To boot the server:"
-msgstr ""
-"#-#-#-#-#  standalone-ha.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  domain.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  standalone.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  boot.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します"
+msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:11
@@ -42,7 +34,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -58,7 +50,7 @@ msgstr "Linux/Unix"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
@@ -74,9 +66,7 @@ msgstr "ドメイン・クラスター・モード"
 msgid ""
 "Domain mode is a way to centrally manage and publish the configuration for "
 "your servers."
-msgstr ""
-"ドメイン・モードとは、サーバーの設定を一元管理し、クラスター内の各サーバーに"
-"反映させる方法です。"
+msgstr "ドメイン・モードとは、サーバーの設定を一元管理し、クラスター内の各サーバーに反映させる方法です。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:11
@@ -84,18 +74,12 @@ msgid ""
 "Running a cluster in standard mode can quickly become aggravating as the "
 "cluster grows in size.  Every time you need to make a configuration change, "
 "you have perform it on each node in the cluster.  Domain mode solves this "
-"problem by providing a central place to store and publish configuration.  It "
-"can be quite complex to set up, but it is worth it in the end.  This "
+"problem by providing a central place to store and publish configuration.  It"
+" can be quite complex to set up, but it is worth it in the end.  This "
 "capability is built into the {appserver_name} Application Server which "
 "{project_name} derives from."
 msgstr ""
-"標準モードでクラスターを実行すると、クラスターが大きくなり、煩雑化する可能性"
-"があります。クラスター内の各ノードにおいて、都度設定を変更する必要がでてきて"
-"しまいます。一方、ドメイン・モードの場合は、設定を保存しパブリッシュするため"
-"に一元管理する場所を提供することで、この問題を解決できます。セットアップには"
-"かなり手間がかかりますが、最終的にはその工数は見合うことになります。この機能"
-"は{project_name}が構成される{appserver_name}アプリケーション・サーバーに組み"
-"込まれています。"
+"標準モードでクラスターを実行すると、クラスターが大きくなり、煩雑化する可能性があります。クラスター内の各ノードにおいて、都度設定を変更する必要がでてきてしまいます。一方、ドメイン・モードの場合は、設定を保存しパブリッシュするために一元管理する場所を提供することで、この問題を解決できます。セットアップにはかなり手間がかかりますが、最終的にはその工数は見合うことになります。この機能は{project_name}が構成される{appserver_name}アプリケーション・サーバーに組み込まれています。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:14
@@ -103,7 +87,8 @@ msgstr ""
 msgid ""
 "The guide will go over the very basics of domain mode.  Detailed steps on how to set up domain mode in a cluster should be obtained from the\n"
 "       link:{appserver_admindoc_link}[_{appserver_admindoc_name}_].\n"
-msgstr "このガイドでは、ドメイン・モードの初歩的なところをご説明します。クラスター内でのドメイン・モードのセットアップ手順について、詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
+msgstr ""
+"このガイドでは、ドメイン・モードの初歩的なところをご説明します。クラスター内でのドメイン・モードのセットアップ手順について、詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:16
@@ -124,9 +109,7 @@ msgid ""
 "cluster.  This process is the central point from which nodes in a cluster "
 "obtain their configuration."
 msgstr ""
-"ドメイン・コントローラーとは、クラスター内の各ノードの一般的な設定を保存、管"
-"理、パブリッシュする役割をもつ、プロセスのことです。また、クラスター内の各"
-"ノードが取得する設定を一元管理するデータベースでもあります。"
+"ドメイン・コントローラーとは、クラスター内の各ノードの一般的な設定を保存、管理、パブリッシュする役割をもつ、プロセスのことです。また、クラスター内の各ノードが取得する設定を一元管理するデータベースでもあります。"
 
 #. type: Labeled list
 #: source/server_installation/topics/operating-mode/domain.adoc:21
@@ -143,12 +126,7 @@ msgid ""
 "machine to manage the cluster.  To reduce the number of running process, a "
 "domain controller also acts as a host controller on the machine it runs on."
 msgstr ""
-"ホスト・コントローラーの役割は、特定のマシン内のサーバー・インスタンスを管理"
-"することです。1つ以上のサーバー・インスタンスを実行できるよう、ホスト・コント"
-"ローラーを設定することになります。しかし、ドメイン・コントローラーも、各マシ"
-"ン内のホスト・コントローラーと連携してクラスターを管理することができます。そ"
-"のため、実行プロセスを減らす目的で、ドメイン・コントローラーに、特定のマシン"
-"内のホスト・コントローラーとしての役割を担わせることができます。"
+"ホスト・コントローラーの役割は、特定のマシン内のサーバー・インスタンスを管理することです。1つ以上のサーバー・インスタンスを実行できるよう、ホスト・コントローラーを設定することになります。また、ドメイン・コントローラーはクラスターを管理するために、各マシン内のホスト・コントローラーと連携します。実行プロセスを減らすために、ドメイン・コントローラーに、特定のマシン内のホスト・コントローラーとしての役割を担わせることもできます。"
 
 #. type: Labeled list
 #: source/server_installation/topics/operating-mode/domain.adoc:27
@@ -163,10 +141,7 @@ msgid ""
 "server to boot from.  A domain controller can define multiple domain "
 "profiles that are consumed by different servers."
 msgstr ""
-"ドメイン・プロファイルとは、サーバーを起動するために使用する、倫理名付きの設"
-"定セットです。ドメイン・コントローラで、複数のドメイン・プロファイルを定義す"
-"ることができます。そして、さまざまなサーバーがこのドメイン・プロファイルを消"
-"費することになります。"
+"ドメイン・プロファイルとは、サーバーを起動するために使用する、名前付きの設定セットです。ドメイン・コントローラーで、複数のドメイン・プロファイルを定義することができます。そして、さまざまなサーバーがこのドメイン・プロファイルを使うことになります。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:31
@@ -179,32 +154,23 @@ msgstr "サーバーグループ"
 #: source/server_installation/topics/operating-mode/domain.adoc:34
 msgid ""
 "A server group is a collection of servers.  They are managed and configured "
-"as one.  You can assign a domain profile to a server group and every service "
-"in that group will use that domain profile as their configuration."
+"as one.  You can assign a domain profile to a server group and every service"
+" in that group will use that domain profile as their configuration."
 msgstr ""
-"サーバーグループとは、サーバーの集合体です。ひとつの集合体として管理、設定さ"
-"れます。サーバーグループに、ドメイン・プロファイルを割り当てることができま"
-"す。そして、そのドメイン・プロファイルはサーバーグループ内のサービスの設定と"
-"して使用されます。"
+"サーバーグループとは、サーバーの集合体です。ひとつの集合体として管理、設定されます。サーバーグループに、ドメイン・プロファイルを割り当てることができます。そして、そのドメイン・プロファイルはサーバーグループ内のサービスの設定として使用されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:40
 msgid ""
 "In domain mode, a domain controller is started on a master node.  The "
-"configuration for the cluster resides in the domain controller.  Next a host "
-"controller is started on each machine in the cluster.  Each host controller "
-"deployment configuration specifies how many {project_name} server instances "
-"will be started on that machine.  When the host controller boots up, it "
+"configuration for the cluster resides in the domain controller.  Next a host"
+" controller is started on each machine in the cluster.  Each host controller"
+" deployment configuration specifies how many {project_name} server instances"
+" will be started on that machine.  When the host controller boots up, it "
 "starts as many {project_name} server instances as it was configured to do.  "
 "These server instances pull their configuration from the domain controller."
 msgstr ""
-"ドメイン・モードでは、マスタ・ノード上でドメイン・コントローラが起動されま"
-"す。クラスタの設定は、ドメイン・コントローラ内にあります。次に、ホスト・コン"
-"トローラがクラスタ内の各マシンで起動されます。各ホスト・コントローラーのデプ"
-"ロイ設定では、そのマシンで起動する{project_name}サーバー・インスタンスの数を"
-"指定します。ホスト・コントローラが起動すると、指定された数の{project_name}"
-"サーバー・インスタンスが起動します。これらのサーバー・インスタンスは、ドメイ"
-"ン・コントローラから設定を取得します。"
+"ドメイン・モードでは、マスタ・ノード上でドメイン・コントローラーが起動されます。クラスターの設定は、ドメイン・コントローラー内にあります。次に、ホスト・コントローラーがクラスター内の各マシンで起動されます。各ホスト・コントローラーのデプロイ設定では、そのマシンで起動する{project_name}サーバー・インスタンスの数を指定します。ホスト・コントローラがー起動すると、指定された数の{project_name}サーバー・インスタンスが起動します。これらのサーバー・インスタンスは、ドメイン・コントローラーから設定を取得します。"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/domain.adoc:41
@@ -217,17 +183,15 @@ msgstr "ドメイン設定"
 msgid ""
 "Various other chapters in this guide walk you through configuring various "
 "aspects like databases, HTTP network connections, caches, and other "
-"infrastructure related things.  While standalone mode uses the _standalone."
-"xml_ file to configure these things, domain mode uses the _.../domain/"
-"configuration/domain.xml_ configuration file.  This is where the domain "
-"profile and server group for the {project_name} server are defined."
+"infrastructure related things.  While standalone mode uses the "
+"_standalone.xml_ file to configure these things, domain mode uses the "
+"_.../domain/configuration/domain.xml_ configuration file.  This is where the"
+" domain profile and server group for the {project_name} server are defined."
 msgstr ""
-"このガイドの各章では、データベース、HTTPネットワーク接続、キャッシュ、および"
-"その他の基盤関連のさまざまな設定について、ご説明します。これらを設定するため"
-"に、スタンドアロン・モードでは  _standalone.xml_ ファイルを使用するのに対し"
-"て、ドメイン・モードでは _.../domain/configuration/domain.xml_ を使用します。"
-"Keycloakサーバーのドメイン・プロファイルとサーバーグループは、以下で定義され"
-"ます。"
+"このガイドの各章では、データベース、HTTPネットワーク接続、キャッシュ、およびその他の基盤関連のさまざまな設定について、ご説明します。これらを設定するために、スタンドアロン・モードでは"
+"  _standalone.xml_ ファイルを使用するのに対して、ドメイン・モードでは "
+"_.../domain/configuration/domain.xml_ "
+"を使用します。Keycloakサーバーのドメイン・プロファイルとサーバーグループは、以下で定義されます。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:49
@@ -247,7 +211,8 @@ msgid ""
 "Any changes you make to this file while the domain controller is running will not take effect and may even be overwritten\n"
 "      by the server.  Instead use the the command line scripting or the web console of {appserver_name}.  See\n"
 "      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
-msgstr "ドメイン・コントローラの実行中にこのファイルに変更を加えても、変更されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
+msgstr ""
+"ドメイン・コントローラーの実行中にこのファイルに変更を加えても、変更されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:58
@@ -258,10 +223,9 @@ msgid ""
 "configuring things here like network connections, caches, and database "
 "connections."
 msgstr ""
-"この _domain.xml_ ファイルの特徴を確認していきましょう。 `auth-server-"
-"standalone` と `auth-server-clustered` `profile` XMLブロックでは、どのような"
-"設定にするかの大半を定義します。そして、ネットワーク接続、キャッシュ、データ"
-"ベース接続などを設定します。"
+"この _domain.xml_ ファイルの特徴を確認していきましょう。 `auth-server-standalone` と `auth-server-"
+"clustered` `profile` "
+"XMLブロックでは、どのような設定にするかの大半を定義します。そして、ネットワーク接続、キャッシュ、データベース接続などを設定します。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:60
@@ -295,24 +259,21 @@ msgid ""
 "The `auth-server-standalone` profile is a non-clustered setup.  The `auth-"
 "server-clustered` profile is the clustered setup."
 msgstr ""
-" `auth-server-standalone` プロファイルは、非クラスタ構成のセットアップです。"
-"一方 `auth-server-clustered` プロファイルは、クラスタ構成されたセットアップで"
-"す。"
+"`auth-server-standalone` プロファイルは、非クラスター構成のセットアップ用です。一方 `auth-server-"
+"clustered` プロファイルは、クラスター構成のセットアップ用です。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:75
 msgid ""
 "If you scroll down further, you'll see various `socket-binding-groups` "
 "defined."
-msgstr ""
-"スクロールダウンしていくと、定義済みの `socket-binding-groups` が表示されま"
-"す。"
+msgstr "スクロールダウンしていくと、定義済みの `socket-binding-groups` が表示されます。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:76
 #, no-wrap
 msgid "socket-binding-groups"
-msgstr "ソケット接続グループ"
+msgstr "socket-binding-groups"
 
 #. type: delimited block -
 #: source/server_installation/topics/operating-mode/domain.adoc:91
@@ -352,9 +313,8 @@ msgid ""
 "contains `${...}` is a value that can be overriden on the command line with "
 "the `-D` switch, i.e."
 msgstr ""
-"この設定により、各{project_name}サーバー・インスタンスによって開かれる、さま"
-"ざまなコネクタのデフォルトのポート・マッピング機能が実行されます。つま"
-"り、${...}を含む値はコマンドラインの `-D` スイッチで上書きできる数値です。"
+"この設定では、各{project_name}サーバー・インスタンスによって開かれる、さまざまなコネクターのデフォルトのポート・マッピングを定義します。 "
+"`${...}` を含む値はコマンドラインの `-D` スイッチで上書きできる値です。すなわち、以下のように上書きできます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/operating-mode/domain.adoc:100
@@ -365,17 +325,16 @@ msgstr "$ domain.sh -Djboss.http.port=80\n"
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:105
 msgid ""
-"The definition of the server group for {project_name} resides in the `server-"
-"groups` XML block.  It specifies the domain profile that is used (`default`) "
-"and also some default boot arguments for the Java VM when the host "
-"controller boots an instance.  It also binds a `socket-binding-group` to the "
-"server group."
+"The definition of the server group for {project_name} resides in the "
+"`server-groups` XML block.  It specifies the domain profile that is used "
+"(`default`) and also some default boot arguments for the Java VM when the "
+"host controller boots an instance.  It also binds a `socket-binding-group` "
+"to the server group."
 msgstr ""
-"{project_name}のサーバーグループの定義は、 `server-groups` XMLブロックにあり"
-"ます。ホスト・コントローラがインスタンスを起動する場合、この定義により、 "
-"`default` で使用されているドメイン・プロファイル、およびJava VMのデフォルト起"
-"動引数が指定されます。また、 `socket-binding-group` をサーバーグループにバイ"
-"ンドします。"
+"{project_name}のサーバーグループの定義は、 `server-groups` "
+"XMLブロックにあります。ホスト・コントローラーがインスタンスを起動する場合、この定義により、 `default` "
+"で使用されているドメイン・プロファイル、およびJava VMのデフォルト起動引数が指定されます。また、 `socket-binding-group` "
+"はサーバーグループにバインドされます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/operating-mode/domain.adoc:124
@@ -429,12 +388,11 @@ msgid ""
 "slave.xml_ is configured to talk to the domain controller and boot up one "
 "{project_name} server instance."
 msgstr ""
-"{project_name}には、 _.../domain/configuration/_ ディレクトリにある、 _host-"
-"master.xml_ と _host-slave.xml_ の2つのホスト・コントローラ設定ファイルが付属"
-"しています。 _host-master.xml_ はドメイン・コントローラ、ロード・バランサ、お"
-"よび1つの{project_name}サーバー・インスタンスを起動するように設定されていま"
-"す。一方、 _host-slave.xml_ はドメイン・コントローラと通信し、1つの"
-"{project_name}サーバー・インスタンスを起動するように設定されています。"
+"{project_name}には、 _.../domain/configuration/_ ディレクトリにある、 _host-master.xml_ と"
+" _host-slave.xml_ の2つのホスト・コントローラー設定ファイルが付属しています。 _host-master.xml_ "
+"はドメイン・コントローラー、ロードバランサー、および1つの{project_name}サーバー・インスタンスを起動するように設定されています。一方、 "
+"_host-slave.xml_ "
+"はドメイン・コントローラーと通信し、1つの{project_name}サーバー・インスタンスを起動するように設定されています。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:138
@@ -443,13 +401,14 @@ msgid ""
 "The load balancer is not a required service.  It exists so that you can easily test drive clustering on your development\n"
 "       machine.  While usable in production, you have the option of replacing it if you have a different hardware or software\n"
 "       based load balancer you want to use.\n"
-msgstr "ロード・バランサは必須サービスではありません。これは、開発マシン上でクラスタリングを簡単にテストできるようにするものです。プロダクション環境では有効ですが、使用するハードウェアまたはソフトウェアベースのロードバランサが異なる場合は、置き換えるかどうかを選択できます。\n"
+msgstr ""
+"ロードバランサーは必須サービスではありません。これは、開発マシン上でクラスタリングを簡単にテストできるようにするものです。プロダクション環境で使用可能ですが、使いたい別のハードウェアまたはソフトウェアベースのロードバランサーがあるなら、置き換えるかどうかを選択できます。\n"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:139
 #, no-wrap
 msgid "Host Controller Config"
-msgstr "ホスト・コントローラ設定"
+msgstr "ホスト・コントローラー設定"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:141
@@ -462,8 +421,8 @@ msgid ""
 "To disable the load balancer server instance, edit _host-master.xml_ and "
 "comment out or remove the `\"load-balancer\"` entry."
 msgstr ""
-"ロード・バランサ・サーバー・インスタンスを無効にするには、 _host-master.xml_ "
-"を編集し、 \"load-balancer\" エントリをコメント化または削除します。"
+"ロードバランサー・サーバー・インスタンスを無効にするには、 _host-master.xml_ を編集し、 \"load-balancer\" "
+"エントリーをコメントアウトまたは削除します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/operating-mode/domain.adoc:151
@@ -492,12 +451,9 @@ msgid ""
 "server don't conflict with the authentication server instance that is "
 "started."
 msgstr ""
-"このファイルに関してもう１つ興味深い点は、認証サーバーインスタンスによる宣言"
-"です。これには `port-offset` の番号が設定されています。 _domain.xml_ `socket-"
-"binding-group` またはサーバー・グループで定義されたネットワークポートには、"
-"port-offsetの値が追加されます。このサンプルでは、ロード・バランサ・サーバーに"
-"よって開かれたポートが、起動中の認証サーバー・インスタンスと競合しないよう"
-"に、ドメイン設定を行います。"
+"このファイルに関してもう1つ興味深い点は、認証サーバー・インスタンスの宣言です。これには `port-offset` が設定されています。 "
+"_domain.xml_ `socket-binding-group` またはサーバー・グループで定義されたネットワークポートには、port-"
+"offsetの値が加算されます。このサンプルでは、ロードバランサ・サーバーによって開かれたポートが、起動中の認証サーバー・インスタンスと競合しないように設定を行います。"
 
 #. type: delimited block -
 #: source/server_installation/topics/operating-mode/domain.adoc:166
@@ -533,12 +489,9 @@ msgid ""
 "server directories ends up looking like any other {appserver_name} booted "
 "server."
 msgstr ""
-"ホスト・ファイルに定義されている各{project_name}サーバー・インスタンスによ"
-"り、 _.../domain/servers/{SERVER NAME}_ の下に作業ディレクトリが作成されま"
-"す。そこに追加の設定を保存でき、サーバー・インスタンスが必要とする、または作"
-"成する一時ファイル、ログファイル、データファイルも保存することができます。こ"
-"れらのサーバー・ディレクトリごとの構造は、他の{appserver_name}ブートサーバー"
-"と同じようなものになります。"
+"ホスト・ファイルに定義されている各{project_name}サーバー・インスタンスにより、 _.../domain/servers/{SERVER "
+"NAME}_ "
+"の下に作業ディレクトリが作成されます。そこに追加の設定を保存でき、サーバー・インスタンスが必要とする、または作成する一時ファイル、ログファイル、データファイルも保存することができます。これらのサーバー・ディレクトリごとの構造は、他の{appserver_name}ブートサーバーと同じようなものになります。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:174
@@ -562,11 +515,10 @@ msgstr "ドメイン起動スクリプト"
 #: source/server_installation/topics/operating-mode/domain.adoc:181
 msgid ""
 "When running the server in domain mode, there is a specific script you need "
-"to run to boot the server depending on your operating system.  These scripts "
-"live in the _bin/_ directory of the server distribution."
+"to run to boot the server depending on your operating system.  These scripts"
+" live in the _bin/_ directory of the server distribution."
 msgstr ""
-"ドメイン・モードでサーバーを実行する場合、オペレーティングシステム固有の起動"
-"スクリプトを実行する必要があります。これらのスクリプトは、サーバー配布物の "
+"ドメイン・モードでサーバーを実行する場合、オペレーティングシステム固有の起動スクリプトを実行する必要があります。これらのスクリプトは、サーバー配布物の "
 "_bin/_ ディレクトリにあります。"
 
 #. type: Plain text
@@ -591,25 +543,23 @@ msgstr "> ...\\bin\\domain.bat --host-config=host-slave.xml\n"
 msgid ""
 "When running the boot script you will need pass in the host controlling "
 "configuration file you are going to use via the `--host-config` switch."
-msgstr ""
-"ブート・スクリプトを実行する場合、 `--host-config` スイッチ経由で使用するホス"
-"ト制御設定ファイルを渡す必要があります 。"
+msgstr "ブート・スクリプトを実行する場合、 `--host-config` スイッチ経由で、使用するホスト制御設定ファイルを渡す必要があります 。"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/domain.adoc:203
 #, no-wrap
 msgid "Clustered Domain Example"
-msgstr "クラスタ構成ドメインのサンプル"
+msgstr "クラスター構成ドメインのサンプル"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:207
 msgid ""
 "You can test drive clustering using the out-of-the-box _domain.xml_ "
-"configuration.  This example domain is meant to run on one machine and boots "
-"up:"
+"configuration.  This example domain is meant to run on one machine and boots"
+" up:"
 msgstr ""
-"そのまま利用可能な _domain.xml_ 設定を使用してクラスタリングをテストできま"
-"す。このサンプルドメインは、1台のマシンで実行され、以下を起動します。"
+"そのまま利用可能な _domain.xml_ "
+"設定を使用してクラスタリングをテストできます。このサンプルドメインは、1台のマシンで実行され、以下を起動します。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:209
@@ -619,7 +569,7 @@ msgstr "ドメイン・コントローラー"
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:210
 msgid "an HTTP load balancer"
-msgstr "HTTPロード・バランサ"
+msgstr "HTTPロードバランサー"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:211
@@ -632,16 +582,12 @@ msgid ""
 "To simulate running a cluster on two machines, you'll run the `domain.sh` "
 "script twice to start two separate host controllers.  The first will be the "
 "master host controller which will start a domain controller, an HTTP load "
-"balancer, and one {project_name} authentication server instance.  The second "
-"will be a slave host controller that only starts up an authentication server "
-"instance."
+"balancer, and one {project_name} authentication server instance.  The second"
+" will be a slave host controller that only starts up an authentication "
+"server instance."
 msgstr ""
-"2台のマシンでのクラスターの実行をシミュレートするには、 `domain.sh` スクリプ"
-"トを2回実行して2つの別々のホスト・コントローラを起動させます。はじめに、ドメ"
-"イン・コントローラー、HTTPロード・バランサー、および1つの{project_name}認証"
-"サーバー・インスタンスを起動するマスター・ホスト・コントローラーを起動させま"
-"す。つぎに、認証サーバー・インスタンスを起動するだけのスレーブ・ホスト・コン"
-"トローラを起動させます。"
+"2台のマシンでのクラスターの実行をシミュレートするには、 `domain.sh` "
+"スクリプトを2回実行して2つの別々のホスト・コントローラを起動させます。はじめに、ドメイン・コントローラー、HTTPロード・バランサー、および1つの{project_name}認証サーバー・インスタンスを起動するマスター・ホスト・コントローラーを起動させます。つぎに、認証サーバー・インスタンスを起動するだけのスレーブ・ホスト・コントローラを起動させます。"
 
 #. type: Title =====
 #: source/server_installation/topics/operating-mode/domain.adoc:217
@@ -653,19 +599,15 @@ msgstr "ドメイン・コントローラーへのスレーブ接続セットア
 #: source/server_installation/topics/operating-mode/domain.adoc:223
 msgid ""
 "Before you can boot things up though, you have to configure the slave host "
-"controller so that it can talk securely to the domain controller.  If you do "
-"not do this, then the slave host will not be able to obtain the centralized "
-"configuration from the domain controller.  To set up a secure connection, "
+"controller so that it can talk securely to the domain controller.  If you do"
+" not do this, then the slave host will not be able to obtain the centralized"
+" configuration from the domain controller.  To set up a secure connection, "
 "you have to create a server admin user and a secret that will be shared "
 "between the master and the slave.  You do this by running the `.../bin/add-"
 "user.sh` script."
 msgstr ""
-"ホスト・コントローラーを起動する前に、スレーブ・ホスト・コントローラをドメイ"
-"ン・コントローラと安全に通信できるように設定する必要があります。これを設定し"
-"なかった場合、スレーブ・ホストはドメイン・コントローラから一元管理された設定"
-"を取得できなくなります。安全な接続をセットアップするには、マスターとスレーブ"
-"の間で共有されるサーバー管理ユーザーとシークレットを作成する必要があります。"
-"これを作成するには、 `.../bin/add-user.sh` スクリプトを実行します。"
+"ホスト・コントローラーを起動する前に、スレーブ・ホスト・コントローラをドメイン・コントローラーと安全に通信できるように設定する必要があります。これを設定しなかった場合、スレーブ・ホストはドメイン・コントローラーから一元管理された設定を取得できなくなります。安全な接続をセットアップするには、マスターとスレーブの間で共有されるサーバー管理ユーザーとシークレットを作成する必要があります。これを作成するには、"
+" `.../bin/add-user.sh` スクリプトを実行します。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:227
@@ -675,10 +617,10 @@ msgid ""
 "to another.  This will generate a secret that you'll need to cut and paste "
 "into the _.../domain/configuration/host-slave.xml_ file."
 msgstr ""
-"スクリプトを実行する場合は `Management User` を選び、新規ユーザーがASプロセス"
-"を別のプロセスに接続するかどうかを尋ねるメッセージが表示された場合はyes "
-"`yes` と回答します。これにより、 _.../domain/configuration/host-slave.xml_ "
-"ファイルをカットアンドペーストする必要があるシークレットが生成されます。"
+"スクリプトを実行する場合は `Management User` "
+"を選び、新規ユーザーがASプロセスを別のプロセスに接続するかどうかを尋ねるメッセージが表示された場合は `yes` と回答します。これにより、 "
+"_.../domain/configuration/host-slave.xml_ "
+"ファイルにカットアンドペーストする必要があるシークレットが生成されます。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:228
@@ -750,10 +692,8 @@ msgid ""
 "generated in the above script are only for example purpose. Please use the "
 "ones generated on your system."
 msgstr ""
-"add-user.shにより、{project_name}サーバーにではなく、基盤となるJBoss "
-"Enterpriseアプリケーション・プラットホームにユーザーが追加されます。上記のス"
-"クリプトで使用、生成された証明書は、あくまでサンプルです。実際お使いのシステ"
-"ムで生成されたものをご使用ください。"
+"add-user.shにより、{project_name}サーバーにではなく、基盤となるJBoss Enterprise Application "
+"Platformにユーザーが追加されます。上記のスクリプトで使用、生成された証明書は、あくまでサンプルです。お使いのシステムで生成されたものをご使用ください。"
 
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:261
@@ -761,8 +701,8 @@ msgid ""
 "Now cut and paste the secret value into the _.../domain/configuration/host-"
 "slave.xml_ file as follows:"
 msgstr ""
-" _.../domain/configuration/host-slave.xml_ ファイルにシークレットの値をカット"
-"アンドペーストすると、以下のようになります。"
+" _.../domain/configuration/host-slave.xml_ "
+"ファイルにシークレットの値をカットアンドペーストすると、以下のようになります。"
 
 #. type: delimited block -
 #: source/server_installation/topics/operating-mode/domain.adoc:270
@@ -791,11 +731,9 @@ msgstr "起動スクリプトの実行"
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:275
 msgid ""
-"Since we're simulating a two node cluster on one development machine, you'll "
-"run the boot script twice:"
-msgstr ""
-"1つの開発マシンで2つのノード・クラスタをシミュレートしますので、以下の通り、"
-"ブート・スクリプトを2回実行します。"
+"Since we're simulating a two node cluster on one development machine, you'll"
+" run the boot script twice:"
+msgstr "1つの開発マシンで2つのノード・クラスタをシミュレートしますので、以下の通り、起動スクリプトを2回実行します。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/domain.adoc:276
@@ -824,6 +762,4 @@ msgstr "$ domain.sh --host-config=host-slave.xml\n"
 #. type: Plain text
 #: source/server_installation/topics/operating-mode/domain.adoc:288
 msgid "To try it out, open your browser and go to http://localhost:8080/auth"
-msgstr ""
-"これを試すには、ブラウザーを開いてhttp://localhost:8080/authに移動してくださ"
-"い。"
+msgstr "これを試すには、ブラウザーを開いてhttp://localhost:8080/authに移動してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__operating-mode__domain/ja_JP/index.html
