### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__operating-mode__standalone-ha.ja_JP.po\n"
 
 #. type: Plain text
 #: source/getting_started/topics/first-boot/boot.adoc:8
@@ -26,17 +27,8 @@ msgstr "image:{project_images}/standalone-boot-files.png[]"
 #: source/server_installation/topics/operating-mode/domain.adoc:186
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:36
 #: source/server_installation/topics/operating-mode/standalone.adoc:19
-#, fuzzy
 msgid "To boot the server:"
-msgstr ""
-"#-#-#-#-#  standalone-ha.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  domain.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  standalone.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します。\n"
-"#-#-#-#-#  boot.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"サーバーを起動するには下記を実行します"
+msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:11
@@ -49,7 +41,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -65,7 +57,7 @@ msgstr "Linux/Unix"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
@@ -80,19 +72,14 @@ msgstr "スタンドアロン・クラスター・モード"
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:10
 msgid ""
 "Standalone clustered operation mode is for when you want to run "
-"{project_name} within a cluster.  This mode requires that you have a copy of "
-"the {project_name} distribution on each machine you want to run a server "
+"{project_name} within a cluster.  This mode requires that you have a copy of"
+" the {project_name} distribution on each machine you want to run a server "
 "instance.  This mode can be very easy to deploy initially, but can become "
 "quite cumbersome. To make a configuration change you'll have to modify each "
 "distribution on each machine.  For a large cluster this can become time "
 "consuming and error prone."
 msgstr ""
-"スタンドアロン・クラスター動作モードは、クラスター内で{project_name}を実行す"
-"るためのものです。このモードでは、サーバー・インスタンスを実行する各マシンに"
-"{project_name}の配布物のコピーが保存されている必要があります。このモードは、"
-"最初は非常に簡単にデプロイできますが、後でかなり煩雑になる可能性があります。"
-"設定を変更するには、各マシンの配布物を修正する必要があります。大規模なクラス"
-"ターの場合、時間がかかり、エラーも発生しやすくなります。"
+"スタンドアロン・クラスター動作モードは、クラスター内で{project_name}を実行するためのものです。このモードでは、サーバー・インスタンスを実行する各マシンに{project_name}の配布物のコピーが保存されている必要があります。このモードは、最初は非常に簡単にデプロイできますが、後でかなり煩雑になる可能性があります。設定を変更するには、各マシンの配布物を修正する必要があります。大規模なクラスターの場合、時間がかかり、エラーも発生しやすくなります。"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:11
@@ -110,18 +97,12 @@ msgid ""
 "things missing from this configuration.  You can't run {project_name} in a "
 "cluster without a configuring a shared database connection.  You also need "
 "to deploy some type of load balancer in front of the cluster.  The "
-"<<_clustering,clustering>> and <<_database,database>> sections of this guide "
-"walk you though these things."
+"<<_clustering,clustering>> and <<_database,database>> sections of this guide"
+" walk you though these things."
 msgstr ""
-"この配布物には、クラスター内で実行するためのアプリケーション・サーバー設定"
-"ファイルが含まれており、その大半は設定が済んでいます。ネットワーク、データ"
-"ベース、キャッシュ、およびディスカバリーのための基盤設定がすべて含まれていま"
-"す。このファイルは _.../standalone/configuration/standalone-ha.xml_ にありま"
-"す。しかし、この設定だけでは足りません。共有データベース接続を設定せずに、ク"
-"ラスター内で{project_name}を実行することはできません。また、クラスターの前に"
-"数種類のロードバランサーをデプロイする必要があります。このガイドの"
-"<<_clustering,clustering>>と<<_database,database>>のセクションでは、これらの"
-"ことをご説明します。"
+"この配布物には、クラスター内で実行するためのアプリケーション・サーバーの設定ファイルが含まれており、その大半は設定が済んでいます。ネットワーク、データベース、キャッシュ、およびディスカバリーのための基盤設定がすべて含まれています。このファイルは"
+" _.../standalone/configuration/standalone-ha.xml_ "
+"にあります。しかし、この設定だけでは足りません。共有データベース接続を設定せずに、クラスター内で{project_name}を実行することはできません。また、クラスターのフロントにいくつかの種類のロードバランサーをデプロイする必要があります。このガイドの<<_clustering,クラスタリング>>と<<_database,データベース>>のセクションでは、これらのことをご説明します。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:20
@@ -142,7 +123,8 @@ msgid ""
 "Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
 "      by the server.  Instead use the the command line scripting or the web console of {appserver_name}.  See\n"
 "      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
-msgstr "サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
+msgstr ""
+"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。\n"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:27
@@ -157,9 +139,7 @@ msgid ""
 "standalone mode.  The difference is that you pass in an additional flag to "
 "point to the HA config file."
 msgstr ""
-"{project_name}を起動するには、スタンドアロン・モードで実行したのと同じ起動ス"
-"クリプトを使用します。スタンドアロン・モードとの違いは、HA設定ファイルを指し"
-"示す追加フラグを渡すという点になります。"
+"{project_name}を起動するには、スタンドアロン・モードで実行したのと同じ起動スクリプトを使用します。スタンドアロン・モードとの違いは、HA設定ファイルを指し示す追加フラグを渡すという点になります。"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/standalone-ha.adoc:32


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone-ha
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__operating-mode__standalone-ha/ja_JP/index.html
