### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__config-"
-"subsystem__cli-recipes.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:3
@@ -23,15 +24,12 @@ msgstr "CLIレシピ"
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:7
 msgid ""
-"Here are some configuration tasks and how to perform them with CLI "
-"commands.  Note that in all but the first example, we use the wildcard path "
-"`**` to mean you should substitute or the path to the keycloak-server "
-"subsystem."
+"Here are some configuration tasks and how to perform them with CLI commands."
+"  Note that in all but the first example, we use the wildcard path `**` to "
+"mean you should substitute or the path to the keycloak-server subsystem."
 msgstr ""
-"ここでは、設定タスクおよびそれらをCLIコマンドで実行する方法についてご説明しま"
-"す。最初の例以外はすべて、代入すべきという意味で、またはkeycloakサーバー・サ"
-"ブシステムという意味でパス名にワイルドカード `**` を使用します。その点はご注"
-"意ください。"
+"ここでは、設定タスクおよびそれらをCLIコマンドで実行する方法についてご説明します。代入すべきという意味で、またはkeycloak-"
+"serverサブシステムという意味でワイルドカード・パス `**` を使用しています。その点はご注意ください。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:9
@@ -62,8 +60,12 @@ msgstr "サーバーのwebコンテキストの変更"
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:20
 #, no-wrap
-msgid "/subsystem=keycloak-server/:write-attribute(name=web-context,value=myContext)\n"
-msgstr "/subsystem=keycloak-server/:write-attribute(name=web-context,value=myContext)\n"
+msgid ""
+"/subsystem=keycloak-server/:write-attribute(name=web-"
+"context,value=myContext)\n"
+msgstr ""
+"/subsystem=keycloak-server/:write-attribute(name=web-"
+"context,value=myContext)\n"
 
 #. type: Title ====
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:21
@@ -81,7 +83,7 @@ msgstr "**/theme=defaults/:write-attribute(name=default,value=myTheme)\n"
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:26
 #, no-wrap
 msgid "Add a new SPI and a provider"
-msgstr "新しいSPIとプロバイダの追加"
+msgstr "新しいSPIとプロバイダーの追加"
 
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:31
@@ -102,8 +104,12 @@ msgstr "プロバイダーの無効化"
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:36
 #, no-wrap
-msgid "**/spi=mySPI/provider=myProvider/:write-attribute(name=enabled,value=false)\n"
-msgstr "**/spi=mySPI/provider=myProvider/:write-attribute(name=enabled,value=false)\n"
+msgid ""
+"**/spi=mySPI/provider=myProvider/:write-"
+"attribute(name=enabled,value=false)\n"
+msgstr ""
+"**/spi=mySPI/provider=myProvider/:write-"
+"attribute(name=enabled,value=false)\n"
 
 #. type: Title ====
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:37
@@ -142,8 +148,12 @@ msgstr "プロバイダーのシングル・プロパティ値の追加または
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:52
 #, no-wrap
-msgid "**/spi=dblock/provider=jpa/:map-put(name=properties,key=lockWaitTimeout,value=3)\n"
-msgstr "**/spi=dblock/provider=jpa/:map-put(name=properties,key=lockWaitTimeout,value=3)\n"
+msgid ""
+"**/spi=dblock/provider=jpa/:map-"
+"put(name=properties,key=lockWaitTimeout,value=3)\n"
+msgstr ""
+"**/spi=dblock/provider=jpa/:map-"
+"put(name=properties,key=lockWaitTimeout,value=3)\n"
 
 #. type: Title ====
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:53
@@ -154,8 +164,12 @@ msgstr "プロバイダーからのシングル・プロパティの削除"
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:57
 #, no-wrap
-msgid "**/spi=dblock/provider=jpa/:map-remove(name=properties,key=lockRecheckTime)\n"
-msgstr "**/spi=dblock/provider=jpa/:map-remove(name=properties,key=lockRecheckTime)\n"
+msgid ""
+"**/spi=dblock/provider=jpa/:map-"
+"remove(name=properties,key=lockRecheckTime)\n"
+msgstr ""
+"**/spi=dblock/provider=jpa/:map-"
+"remove(name=properties,key=lockRecheckTime)\n"
 
 #. type: Title ====
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:58
@@ -166,5 +180,9 @@ msgstr " `List` 型のプロバイダー・プロパティ値の設定"
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:62
 #, no-wrap
-msgid "**/spi=eventsStore/provider=jpa/:map-put(name=properties,key=exclude-events,value=[EVENT1,EVENT2])\n"
-msgstr "**/spi=eventsStore/provider=jpa/:map-put(name=properties,key=exclude-events,value=[EVENT1,EVENT2])\n"
+msgid ""
+"**/spi=eventsStore/provider=jpa/:map-put(name=properties,key=exclude-"
+"events,value=[EVENT1,EVENT2])\n"
+msgstr ""
+"**/spi=eventsStore/provider=jpa/:map-put(name=properties,key=exclude-"
+"events,value=[EVENT1,EVENT2])\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__cli-recipes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__config-subsystem__cli-recipes/ja_JP/index.html
