### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__config-"
-"subsystem.ja_JP.po\n"
 
 #. type: Title ==
 #: source/server_installation/topics/config-subsystem.adoc:3
@@ -28,7 +29,10 @@ msgid ""
 " `standalone.xml`, `standalone-ha.xml`, or `domain.xml` file \n"
 "in your distribution.  The location of this file \n"
 "depends on your <<_operating-mode, operating mode>>.\n"
-msgstr "{project_name}の低レベル設定は、配布物に含まれている `standalone.xml` 、 `standalone-ha.xml` 、または `domain.xml` ファイルを編集して行います。このファイルの場所は<<_operating-mode, operating mode>>によって異なります。\n"
+msgstr ""
+"{project_name}の低レベル設定は、配布物に含まれている `standalone.xml` 、 `standalone-ha.xml` "
+"、または `domain.xml` ファイルを編集して行います。このファイルの場所は<<_operating-mode, "
+"動作モード>>によって異なります。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem.adoc:13
@@ -38,18 +42,15 @@ msgid ""
 "configuration file you are using, configuration of the _keycloak-server_ "
 "subsystem is the same."
 msgstr ""
-"ここで設定可能なセッティングは無限にありますが、このセクションでは  "
-"_keycloak-server_ サブシステムの設定についてご説明します。どの設定ファイルを"
-"使用していても、 _keycloak-server_ サブシステムの設定は同じです。"
+"ここで設定可能なセッティングは無限にありますが、このセクションでは  _keycloak-server_ "
+"サブシステムの設定についてご説明します。どの設定ファイルを使用していても、 _keycloak-server_ サブシステムの設定は同じです。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem.adoc:15
 msgid ""
 "The keycloak-server subsystem is typically declared toward the end of the "
 "file like this:"
-msgstr ""
-"keycloakサーバー・サブシステムは通常、以下のようにファイルの末尾で宣言されて"
-"います。"
+msgstr "keycloakサーバー・サブシステムは通常、以下のようにファイルの末尾で宣言されています。"
 
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem.adoc:21
@@ -70,6 +71,4 @@ msgstr ""
 msgid ""
 "Note that anything changed in this subsystem will not take effect until the "
 "server is rebooted."
-msgstr ""
-"このサブシステム内での変更はサーバーが再起動されるまで有効になりませんので、"
-"ご注意ください。"
+msgstr "このサブシステム内での変更はサーバーが再起動されるまで有効になりませんので、ご注意ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__config-subsystem/ja_JP/index.html
