### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
@@ -37,19 +36,18 @@ msgstr "password"
 msgid "resource"
 msgstr "resource"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:4
-msgid "====== KeyStore element"
-msgstr "====== KeyStore要素"
+#. type: Title ======
+#: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:3
+#, no-wrap
+msgid "KeyStore element"
+msgstr "KeyStore要素"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:7
 msgid ""
-"Within the `Key` element you can load your keys and certificates from a Java "
-"Keystore.  This is declared within a `KeyStore` element."
-msgstr ""
-"`Key` 要素内でJavaのキーストアから鍵と証明書を読み込むことができます。これは "
-"`KeyStore` 要素内で宣言されています。"
+"Within the `Key` element you can load your keys and certificates from a Java"
+" Keystore.  This is declared within a `KeyStore` element."
+msgstr "`Key` 要素内でJavaのキーストアから鍵と証明書を読み込むことができます。これは `KeyStore` 要素内で宣言されています。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:19
@@ -83,11 +81,9 @@ msgstr "`KeyStore` 要素に定義されているXML設定属性を示します�
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:25
 msgid ""
-"File path to the key store. This option is _OPTIONAL_.  The file or resource "
-"attribute must be set."
-msgstr ""
-"キーストアのファイル・パス。このオプションは _OPTIONAL_ です。ファイル属性ま"
-"たはリソース属性を設定する必要があります。"
+"File path to the key store. This option is _OPTIONAL_.  The file or resource"
+" attribute must be set."
+msgstr "キーストアのファイル・パス。このオプションは _OPTIONAL_ です。ファイル属性またはリソース属性を設定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:29
@@ -96,9 +92,8 @@ msgid ""
 "ServletContext.getResourceAsStream(). This option is _OPTIONAL_.  The file "
 "or resource attribute must be set."
 msgstr ""
-"キーストアへのWARリソース・パス。これは、ServletContext.getResourceAsStream()"
-"へのメソッド呼び出しで使用されるパスです。このオプションは _OPTIONAL_ です。"
-"ファイル属性またはリソース属性を設定する必要があります。"
+"キーストアへのWARリソース・パス。これは、ServletContext.getResourceAsStream()へのメソッド呼び出しで使用されるパスです。このオプションは"
+" _OPTIONAL_ です。ファイル属性またはリソース属性を設定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:32
@@ -112,13 +107,11 @@ msgid ""
 "also specify references to your private keys and certificates within the "
 "Java KeyStore.  The `PrivateKey` and `Certificate` elements in the above "
 "example define an `alias` that points to the key or cert within the "
-"keystore.  Keystores require an additional password to access private keys.  "
-"In the `PrivateKey` element you must define this password within a "
+"keystore.  Keystores require an additional password to access private keys."
+"  In the `PrivateKey` element you must define this password within a "
 "`password` attribute."
 msgstr ""
-"SPが文書の署名に使用する鍵を定義している場合、Javaのキーストア内の秘密鍵と証"
-"明書への参照も指定する必要があります。上記の例の `PrivateKey` 要素と "
-"`Certificate` 要素はキーストア内の鍵または証明書を指す `alias` を定義します。"
-"キーストアには、秘密鍵にアクセスするための追加パスワードが必要です。 "
-"`PrivateKey` 要素では、このパスワードを `password` 属性の中で定義する必要があ"
-"ります。"
+"SPが文書の署名に使用する鍵を定義している場合、Javaのキーストア内の秘密鍵と証明書への参照も指定する必要があります。上記の例の "
+"`PrivateKey` 要素と `Certificate` 要素はキーストア内の鍵または証明書を指す `alias` "
+"を定義します。キーストアには、秘密鍵にアクセスするための追加パスワードが必要です。 `PrivateKey` 要素では、このパスワードを "
+"`password` 属性の中で定義する必要があります。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.ja_JP.po
@@ -83,7 +83,8 @@ msgstr "`KeyStore` 要素に定義されているXML設定属性を示します�
 msgid ""
 "File path to the key store. This option is _OPTIONAL_.  The file or resource"
 " attribute must be set."
-msgstr "キーストアのファイル・パス。このオプションは _OPTIONAL_ です。ファイル属性またはリソース属性を設定する必要があります。"
+msgstr ""
+"キーストアのファイルパスです。このオプションは _OPTIONAL_ です。file属性またはresource属性を設定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:29
@@ -92,13 +93,13 @@ msgid ""
 "ServletContext.getResourceAsStream(). This option is _OPTIONAL_.  The file "
 "or resource attribute must be set."
 msgstr ""
-"キーストアへのWARリソース・パス。これは、ServletContext.getResourceAsStream()へのメソッド呼び出しで使用されるパスです。このオプションは"
-" _OPTIONAL_ です。ファイル属性またはリソース属性を設定する必要があります。"
+"キーストアへのWARリソース・パスです。これは、ServletContext.getResourceAsStream()へのメソッド呼び出しで使用されるパスです。このオプションは"
+" _OPTIONAL_ です。file属性またはresource属性を設定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:32
 msgid "The password of the KeyStore. This option is _REQUIRED_."
-msgstr "キーストアのパスワード。このオプションは _REQUIRED_ です。"
+msgstr "キーストアのパスワードです。このオプションは _REQUIRED_ です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:37
@@ -111,7 +112,7 @@ msgid ""
 "  In the `PrivateKey` element you must define this password within a "
 "`password` attribute."
 msgstr ""
-"SPが文書の署名に使用する鍵を定義している場合、Javaのキーストア内の秘密鍵と証明書への参照も指定する必要があります。上記の例の "
+"SPがドキュメントの署名に使用する鍵を定義している場合、Javaのキーストア内の秘密鍵と証明書への参照も指定する必要があります。上記の例の "
 "`PrivateKey` 要素と `Certificate` 要素はキーストア内の鍵または証明書を指す `alias` "
-"を定義します。キーストアには、秘密鍵にアクセスするための追加パスワードが必要です。 `PrivateKey` 要素では、このパスワードを "
+"を定義します。キーストアには、秘密鍵にアクセスするための追加のパスワードが必要です。 `PrivateKey` 要素では、このパスワードを "
 "`password` 属性の中で定義する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp-keys__keystore_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__sp-keys__keystore_element/ja_JP/index.html
