### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po
@@ -32,7 +32,7 @@ msgid ""
 msgstr ""
 "`Key` 要素の中では、 `PrivateKeyPem` 、 `PublicKeyPem` 、 ` CertificatePem` "
 "というサブ要素を使って、鍵と証明書を直接宣言します。これらの要素に含まれる値は、PEM鍵形式に準拠している必要があります。 `openssl` "
-"などのコマンドラインツールを使用して鍵を生成する場合は、通常このオプションを使用します。"
+"などのコマンドライン・ツールを使用して鍵を生成する場合は、通常このオプションを使用します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.adoc:21

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.adoc:3
-msgid "====== Key PEMS"
-msgstr "====== Key PEMS"
+#. type: Title ======
+#: source/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.adoc:2
+#, no-wrap
+msgid "Key PEMS"
+msgstr "Key PEMS"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.adoc:8
@@ -31,9 +31,8 @@ msgid ""
 "using `openssl` or similar command line tool."
 msgstr ""
 "`Key` 要素の中では、 `PrivateKeyPem` 、 `PublicKeyPem` 、 ` CertificatePem` "
-"というサブ要素を使って、鍵と証明書を直接宣言します。これらの要素に含まれる値"
-"は、PEM鍵形式に準拠している必要があります。 `openssl` などのコマンドライン"
-"ツールを使用して鍵を生成する場合は、通常このオプションを使用します。"
+"というサブ要素を使って、鍵と証明書を直接宣言します。これらの要素に含まれる値は、PEM鍵形式に準拠している必要があります。 `openssl` "
+"などのコマンドラインツールを使用して鍵を生成する場合は、通常このオプションを使用します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.adoc:21


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp-keys__key_pems
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__sp-keys__key_pems/ja_JP/index.html
