### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -2,34 +2,32 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:153
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:33
 msgid ""
-"If the {project_name} server requires HTTPS and this config option is set to "
-"`true` you do not have to specify a truststore.  This setting should only be "
-"used during development and *never* in production as it will disable "
-"verification of SSL certificates.  This is _OPTIONAL_.  The default value is "
-"`false`."
+"If the {project_name} server requires HTTPS and this config option is set to"
+" `true` you do not have to specify a truststore.  This setting should only "
+"be used during development and *never* in production as it will disable "
+"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
+" `false`."
 msgstr ""
-"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` に設定す"
-"る場合は、トラスト・ストアを指定する必要はありません。この設定は、開発時にの"
-"み使用すべきで、 SSL証明書の検証を無効にできない本番環境では、 *決して使用し"
-"てはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
+"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、 本番環境では "
+"*決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:164
@@ -42,11 +40,11 @@ msgstr "truststore"
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:177
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:56
 msgid ""
-"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is "
-"set and the truststore requires a password."
+"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
+" set and the truststore requires a password."
 msgstr ""
-"トラスト・ストアのキーストアのパスワードです。これは _REQUIRED_ で、 "
-"`truststore` を設定すると、トラスト・ストアはパスワードを必要とします。"
+"トラストストアのキーストアのパスワードです。これは _REQUIRED_ で、 `truststore` "
+"を設定すると、トラストストアはパスワードを必要とします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:182
@@ -56,9 +54,8 @@ msgid ""
 "certificate for two-way SSL when the adapter makes HTTPS requests to the "
 "{project_name} server.  This is _OPTIONAL_."
 msgstr ""
-"キーストア・ファイルへのファイル・パスです。このキーストアには、アダプターが"
-"{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライア"
-"ント証明書が含まれます。これは _OPTIONAL_ です。"
+"キーストア・ファイルへのファイルパスです。このキーストアには、アダプターが{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライアント証明書を含めます。これは"
+" _OPTIONAL_ です。"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:3
@@ -74,9 +71,8 @@ msgid ""
 "signature verification via SAML descriptor of the IDP when <<_sp-idp-keys-"
 "automatic,enabled>>."
 msgstr ""
-"<<_sp-idp-keys-automatic,enabled>>の場合、オプションである `HttpClient` サブ"
-"要素は、IDPのSAML記述子による、IDP署名検証用の公開鍵を含む証明書の自動取得に"
-"使用されるHTTPクライアントのプロパティを定義します。"
+"オプションである `HttpClient` サブ要素は、HTTPクライアントのプロパティを定義します。<<_sp-idp-keys-"
+"automatic,enabled>>の場合、IDPのSAML記述子による、IDP署名検証用の公開鍵を含む証明書の自動取得に使用されるます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:20
@@ -109,15 +105,13 @@ msgstr "connectionPoolSize"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:27
 msgid ""
-"Adapters will make separate HTTP invocations to the {project_name} server to "
-"turn an access code into an access token.  This config option defines how "
+"Adapters will make separate HTTP invocations to the {project_name} server to"
+" turn an access code into an access token.  This config option defines how "
 "many connections to the {project_name} server should be pooled.  This is "
 "_OPTIONAL_.  The default value is `10`."
 msgstr ""
-"アダプターは、アクセス・コードをアクセス・トークンに変換するために、"
-"{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、"
-"{project_name}サーバーにプールすべきコネクション数を定義します。 これは "
-"_OPTIONAL_ です。デフォルトは `10` です。"
+"アダプターは、アクセス・コードをアクセス・トークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。"
+" これは _OPTIONAL_ です。デフォルトは `10` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:28
@@ -134,18 +128,17 @@ msgstr "allowAnyHostname"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:42
 msgid ""
-"If the {project_name} server requires HTTPS and this config option is set to "
-"`true` the {project_name} server's certificate is validated via the "
+"If the {project_name} server requires HTTPS and this config option is set to"
+" `true` the {project_name} server's certificate is validated via the "
 "truststore, but host name validation is not done.  This setting should only "
 "be used during development and *never* in production as it will partly "
-"disable verification of SSL certificates.  This seting may be useful in test "
-"environments. This is _OPTIONAL_.  The default value is `false`."
+"disable verification of SSL certificates.  This seting may be useful in test"
+" environments. This is _OPTIONAL_.  The default value is `false`."
 msgstr ""
-"{project_name}サーバーがHTTPSを必要とし、この設定オプションを'true' に設定す"
-"る場合、トラスト・ストア経由で{project_name}サーバーの証明書は検証されます"
-"が、ホスト名の検証は行われません。 この設定は、開発時にのみ使用すべきで、 本"
-"番環境でSSL証明書の検証を一部無効にする設定は *決して使用してはいけません* 。"
-"これは _OPTIONAL_ です。デフォルトは `false` です。"
+"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。 "
+"SSL証明書の検証が一部無効となるため、この設定は開発時にのみ使用すべきで、本番環境では *決して使用してはいけません* 。これは _OPTIONAL_"
+" です。デフォルトは `false` です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:52
@@ -154,20 +147,15 @@ msgid ""
 "`classpath:`, then the truststore will be obtained from the deployment's "
 "classpath instead.  Used for outgoing HTTPS communications to the "
 "{project_name} server.  Client making HTTPS requests need a way to verify "
-"the host of the server they are talking to.  This is what the trustore "
-"does.  The keystore contains one or more trusted host certificates or "
-"certificate authorities.  You can create this truststore by extracting the "
-"public certificate of the {project_name} server's SSL keystore.  This is "
-"_REQUIRED_ unless `disableTrustManager` is `true`."
+"the host of the server they are talking to.  This is what the trustore does."
+"  The keystore contains one or more trusted host certificates or certificate"
+" authorities.  You can create this truststore by extracting the public "
+"certificate of the {project_name} server's SSL keystore.  This is _REQUIRED_"
+" unless `disableTrustManager` is `true`."
 msgstr ""
-"キーストア・ファイルへのファイル・パスです。パスに `classpath:` を付けと、ト"
-"ラスト・ストアは配備されたクラスパスから取得されます。{project_name}サーバー"
-"へのHTTPS通信に使用されます。HTTPSリクエストを行っているクライアントは、通信"
-"しているサーバーのホストを検証する方法を必要とします。 これが、トラスト・スト"
-"アのすることです。キーストアには、1 つ以上の信頼されたホストの証明書または証"
-"明機関が含まれています。このトラスト・ストアは、{project_name}サーバーのSSL"
-"キーストアのパブリック証明書を抽出することで作成できます。これは、 "
-"`disableTrustManager` が `true` でない限り、 _REQUIRED_ です。"
+"キーストア・ファイルへのファイルパスです。パスに `classpath:` "
+"を付けると、トラストストアはデプロイメントのクラスパスから取得されます。これは{project_name}サーバーへのHTTPS通信に使用されます。HTTPSリクエストを行うクライアントは、通信を行うサーバーのホストを検証する必要があります。これがトラストストアの役割です。キーストアには、1つ以上の信頼されたホストの証明書または認証局が含まれています。このトラストストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。これは、"
+" `disableTrustManager` が `true` でない限り、 _REQUIRED_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:53
@@ -193,8 +181,7 @@ msgid ""
 "Password for the client keystore and for the client's key.  This is "
 "_REQUIRED_ if `clientKeystore` is set."
 msgstr ""
-"クライアントのキーとクライアントのキーストアのパスワード。 `clientKeystore` "
-"が設定されている場合は、 _REQUIRED_ です。"
+"クライアントのキーとクライアントのキーストアのパスワードです。 `clientKeystore` が設定されている場合は、 _REQUIRED_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:66
@@ -205,4 +192,4 @@ msgstr "proxyUrl"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:68
 msgid "URL to HTTP proxy to use for HTTP connections.  This is _OPTIONAL_."
-msgstr "HTTP接続に使用するHTTPプロキシのURL。これは _OPTIONAL_ です。"
+msgstr "HTTP接続に使用するHTTPプロキシのURLです。これは _OPTIONAL_ です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_httpclient_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__idp_httpclient_subelement/ja_JP/index.html
