### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -28,7 +27,8 @@ msgstr "IDP SingleLogoutServiceサブ要素"
 msgid ""
 "The `SingleLogoutService` sub element defines the logout SAML endpoint of the IDP.   The client adapter will send requests\n"
 "to the IDP formatted via the settings within this element when it wants to logout.\n"
-msgstr "`SingleLogoutService`サブ要素は、IDPのログアウトSAMLエンドポイントを定義します。クライアント・アダプターは、ログアウトしたいときに、この要素内の設定によって書式設定されたIDPにリクエストを送信します。\n"
+msgstr ""
+"`SingleLogoutService`サブ要素は、IDPのログアウトSAMLエンドポイントを定義します。クライアント・アダプターは、ログアウトしたいときに、この要素内の設定によって書式設定されたIDPにリクエストを送信します。\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:17
@@ -63,11 +63,11 @@ msgstr "signRequest"
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:22
 msgid ""
 "Should the client sign logout requests it makes to the IDP? This setting is "
-"_OPTIONAL_.  Defaults to whatever the IDP `signaturesRequired` element value "
-"is."
+"_OPTIONAL_.  Defaults to whatever the IDP `signaturesRequired` element value"
+" is."
 msgstr ""
-"クライアントがIDPへのログアウトリクエストに署名する必要があるかどうか 。この"
-"設定は _OPTIONAL_ です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
+"IDPへのログアウト・リクエストにクライアントが署名する必要があるかどうかの設定です。この設定は _OPTIONAL_ です。デフォルトはIDPの "
+"`signaturesRequired` 要素の値です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:23
@@ -82,8 +82,8 @@ msgid ""
 "setting is _OPTIONAL_.  Defaults to whatever the IDP `signaturesRequired` "
 "element value is."
 msgstr ""
-"クライアントがIDPへのログアウトレスポンスに署名する必要があるかどうか 。この"
-"設定は _OPTIONAL_ です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
+"IDPへのログアウト・レスポンスにクライアントが署名する必要があるかどうかの設定です。この設定は _OPTIONAL_ です。デフォルトはIDPの "
+"`signaturesRequired` 要素の値です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:27
@@ -98,9 +98,8 @@ msgid ""
 "setting is _OPTIONAL_. Defaults to whatever the IDP `signaturesRequired` "
 "element value is."
 msgstr ""
-"クライアントがIDPからのログアウトリクエストドキュメントが署名されていることを"
-"期待するかどうか 。この設定は _OPTIONAL_ です。デフォルトはIDPの "
-"`signaturesRequired` 要素の値です。"
+"IDPからのログアウト・リクエストのドキュメントが署名されていることをクライアントが期待するかどうかの設定です。この設定は _OPTIONAL_ "
+"です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:30
@@ -112,13 +111,12 @@ msgstr "validateResponseSignature"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:32
 msgid ""
-"Should the client expect signed logout response documents from the IDP? This "
-"setting is _OPTIONAL_. Defaults to whatever the IDP `signaturesRequired` "
+"Should the client expect signed logout response documents from the IDP? This"
+" setting is _OPTIONAL_. Defaults to whatever the IDP `signaturesRequired` "
 "element value is."
 msgstr ""
-"クライアントがIDPからのログアウトレスポンスドキュメントが署名されていることを"
-"期待するかどうか 。この設定は _OPTIONAL_ です。デフォルトはIDPの "
-"`signaturesRequired` 要素の値です。"
+"IDPからのログアウト・レスポンスのドキュメントが署名されていることをクライアントが期待するかどうかの設定です。この設定は _OPTIONAL_ "
+"です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:33
@@ -134,9 +132,8 @@ msgid ""
 "IDP. This setting is _OPTIONAL_.  The default value is `POST`, but you can "
 "set it to REDIRECT as well."
 msgstr ""
-"IDPとのSAMLリクエストでの通信に使用するSAMLバインディング・タイプです。この設"
-"定は _OPTIONAL_ です。デフォルト値は `POST` ですが、 `REDIRECT` に設定するこ"
-"ともできます。"
+"IDPとのSAMLリクエストでの通信に使用するSAMLバインディング・タイプです。この設定は _OPTIONAL_ です。デフォルト値は `POST` "
+"ですが、 `REDIRECT` に設定することもできます。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:37
@@ -153,9 +150,8 @@ msgid ""
 "_OPTIONAL_.  The default value is `POST`, but you can set it to `REDIRECT` "
 "as well."
 msgstr ""
-"IDPとのSAMLレスポンスでの通信に使用するSAMLバインディング・タイプです。この値"
-"は `POST` または `REDIRECT` にできます。この設定は _OPTIONAL_ です。デフォル"
-"ト値は `POST` ですが、 `REDIRECT` に設定することもできます。"
+"IDPとのSAMLレスポンスでの通信に使用するSAMLバインディング・タイプです。この値は `POST` または `REDIRECT` "
+"にできます。この設定は _OPTIONAL_ です。デフォルト値は `POST` ですが、 `REDIRECT` に設定することもできます。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:41
@@ -169,8 +165,8 @@ msgid ""
 "This is the URL for the IDP's logout service when using the POST binding. "
 "This setting is _REQUIRED_ if using the `POST` binding."
 msgstr ""
-"`POST` バインディングを使用する際のIDPのログアウトサービス用のURLです。 "
-"`POST` バインディングを使用する場合、この設定は _REQUIRED_ です。"
+"`POST` バインディングを使用する際のIDPのログアウト・サービス用のURLです。 `POST` バインディングを使用する場合、この設定は "
+"_REQUIRED_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:44
@@ -184,5 +180,5 @@ msgid ""
 "This is the URL for the IDP's logout service when using the REDIRECT "
 "binding. This setting is _REQUIRED_ if using the REDIRECT binding."
 msgstr ""
-"REDIRECTバインディングを使用する際のIDPのログアウトサービス用のURLです。"
-"REDIRECTバインディングを使用する場合、この設定は _REQUIRED_ です。"
+"REDIRECTバインディングを使用する際のIDPのログアウト・サービス用のURLです。REDIRECTバインディングを使用する場合、この設定は "
+"_REQUIRED_ です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_singlelogoutservice_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__idp_singlelogoutservice_subelement/ja_JP/index.html
