### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
@@ -48,18 +47,17 @@ msgstr "responseBinding"
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:3
 #, no-wrap
 msgid "IDP SingleSignOnService sub element"
-msgstr "IDP SingleLogoutService サブ要素"
+msgstr "IDP SingleSignOnServiceサブ要素"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:8
 msgid ""
-"The `SingleSignOnService` sub element defines the login SAML endpoint of the "
-"IDP.  The client adapter will send requests to the IDP formatted via the "
+"The `SingleSignOnService` sub element defines the login SAML endpoint of the"
+" IDP.  The client adapter will send requests to the IDP formatted via the "
 "settings within this element when it wants to login."
 msgstr ""
-"`SingleSignOnService`サブ要素は、IDPのログインSAMLエンドポイントを定義しま"
-"す。クライアント・アダプターは、ログインしたいときに、この要素内の設定によっ"
-"て書式設定されたIDPにリクエストを送信します。"
+"`SingleSignOnService` "
+"サブ要素は、IDPのログインSAMLエンドポイントを定義します。クライアント・アダプターは、ログインしたいときに、この要素内の設定によって書式設定されたIDPにリクエストを送信します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:16
@@ -78,16 +76,16 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:19
 msgid "Here are the config attributes you can define on this element:"
-msgstr "この要素を定義できる設定属性は次の通りです。"
+msgstr "この要素に定義できる設定属性は次のとおりです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:23
 msgid ""
-"Should the client sign authn requests? This setting is _OPTIONAL_.  Defaults "
-"to whatever the IDP `signaturesRequired` element value is."
+"Should the client sign authn requests? This setting is _OPTIONAL_.  Defaults"
+" to whatever the IDP `signaturesRequired` element value is."
 msgstr ""
-"クライアントが認証リクエストに署名する必要があるかどうか 。この設定は "
-"_OPTIONAL_ です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
+"クライアントが認証リクエストに署名する必要があるかどうかの設定です。この設定は _OPTIONAL_ です。デフォルトはIDPの "
+"`signaturesRequired` 要素の値です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:27
@@ -96,9 +94,8 @@ msgid ""
 "sent back from an auhtn request? This setting _OPTIONAL_. Defaults to "
 "whatever the IDP `signaturesRequired` element value is."
 msgstr ""
-"クライアントが認証リクエストからのアサーション・レスポンス・ドキュメントが署"
-"名されていることを期待するかどうか 。この設定は _OPTIONAL_ です。デフォルトは"
-"IDPの `signaturesRequired` 要素の値です。"
+"クライアントが、認証リクエストからのアサーション・レスポンスのドキュメントが署名されていることを期待するかどうかの設定です。この設定は "
+"_OPTIONAL_ です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:31
@@ -107,21 +104,20 @@ msgid ""
 "setting is _OPTIONAL_.  The default value is `POST`, but you can set it to "
 "`REDIRECT` as well."
 msgstr ""
-"IDPとの通信に使用するSAMLバインディング・タイプです。この設定は _OPTIONAL_ で"
-"す。デフォルト値は `POST` ですが、 `REDIRECT` に設定することもできます。"
+"IDPとの通信に使用するSAMLバインディング・タイプです。この設定は _OPTIONAL_ です。デフォルト値は `POST` ですが、 "
+"`REDIRECT` に設定することもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:36
 msgid ""
-"SAML allows the client to request what binding type it wants authn responses "
-"to use.  The values of this can be `POST` or `REDIRECT`.  This setting is "
+"SAML allows the client to request what binding type it wants authn responses"
+" to use.  The values of this can be `POST` or `REDIRECT`.  This setting is "
 "_OPTIONAL_.  The default is that the client will not request a specific "
 "binding type for responses."
 msgstr ""
-"SAMLでは、クライアントが認証レスポンスに使用したいバインディング・タイプを要"
-"求することができます。この値には、 `POST` または `REDIRECT` を設定できます。"
-"この設定は _OPTIONAL_ です。デフォルトでは、クライアントはレスポンスに対して"
-"特定のバインディング・タイプを要求しません。"
+"SAMLでは、クライアントが認証レスポンスに使用したいバインディング・タイプを要求することができます。この値には、 `POST` または "
+"`REDIRECT` を設定できます。この設定は _OPTIONAL_ "
+"です。デフォルトでは、クライアントはレスポンスに対して特定のバインディング・タイプを要求しません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:37
@@ -134,18 +130,18 @@ msgstr "assertionConsumerServiceUrl"
 msgid ""
 "URL of the assertion consumer service (ACS) where the IDP login service "
 "should send responses to.  This setting is _OPTIONAL_. By default it is "
-"unset, relying on the configuration in the IdP.  When set, it must end in `/"
-"saml`, e.g. `\\http://sp.domain.com/my/endpoint/for/saml`. The value of this "
-"property is sent in `AssertionConsumerServiceURL` attribute of SAML "
+"unset, relying on the configuration in the IdP.  When set, it must end in "
+"`/saml`, e.g. `\\http://sp.domain.com/my/endpoint/for/saml`. The value of "
+"this property is sent in `AssertionConsumerServiceURL` attribute of SAML "
 "`AuthnRequest` message.  This property is typically accompanied by the "
 "`responseBinding` attribute."
 msgstr ""
-"IDPログイン・サービスがレスポンスを送信するアサーション・コンシューマー・サー"
-"ビス（ACS）のURL。この設定は _OPTIONAL_ です。デフォルトでは未設定で、idpの設"
-"定に依存します。設定されている場合、 `\\http://sp.domain.com/my/endpoint/for/"
-"saml` のように、 `/saml` で終わる必要があります。このプロパティの値は、SAML"
-"の `AuthnRequest` メッセージの `AssertionConsumerServiceURL` 属性で送信されま"
-"す。このプロパティは、通常 `responseBinding` 属性を伴います。"
+"IDPログイン・サービスがレスポンスを送信するアサーション・コンシューマー・サービス（ACS）のURLの設定です。この設定は _OPTIONAL_ "
+"です。デフォルトでは未設定で、IdPの設定に依存します。設定されている場合、 "
+"`\\http://sp.domain.com/my/endpoint/for/saml` のように、 `/saml` "
+"で終わる必要があります。このプロパティの値は、SAMLの `AuthnRequest` メッセージの "
+"`AssertionConsumerServiceURL` 属性で送信されます。このプロパティは、通常 `responseBinding` "
+"属性を伴います。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:44
@@ -156,8 +152,6 @@ msgstr "bindingUrl"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:46
 msgid ""
-"This is the URL for the IDP login service that the client will send requests "
-"to. This setting is _REQUIRED_."
-msgstr ""
-"これは、クライアントがリクエストを送信するIDPログイン・サービスのURLです。こ"
-"の設定は _REQUIRED_ です。"
+"This is the URL for the IDP login service that the client will send requests"
+" to. This setting is _REQUIRED_."
+msgstr "これは、クライアントがリクエストを送信するIDPログイン・サービスのURLです。この設定は _REQUIRED_ です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_singlesignonservice_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__idp_singlesignonservice_subelement/ja_JP/index.html
