### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -29,9 +28,8 @@ msgid ""
 "assertion received from the user should be used as role identifiers within "
 "the Java EE Security Context for the user."
 msgstr ""
-"`RoleIdentifiers`要素は、Java EEのセキュリティ・コンテキスト内でユーザーの"
-"ロール識別子として使用されるべきSAML属性が、ユーザーから受信したアサーション"
-"内のどれであるかを定義します。"
+"`RoleIdentifiers` 要素は、ユーザーから受信したアサーション内のどのSAML属性が、Java "
+"EEのセキュリティ・コンテキスト内のロール識別子として使用されるか定義します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/roleidentifiers_element.adoc:15
@@ -53,11 +51,10 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/general-config/roleidentifiers_element.adoc:20
 msgid ""
 "By default `Role` attribute values are converted to Java EE roles.  Some "
-"IdPs send roles using a `member` or `memberOf` attribute assertion.  You can "
-"define one or more `Attribute` elements to specify which SAML attributes "
+"IdPs send roles using a `member` or `memberOf` attribute assertion.  You can"
+" define one or more `Attribute` elements to specify which SAML attributes "
 "must be converted into roles."
 msgstr ""
-"デフォルトでは、 `Role` 属性の値はJava EEのロールに変換されます。いくつかの"
-"IdPは、 `member` または `memberOf` 属性アサーションを使用してロールを送信しま"
-"す。どのSAML属性をロールに変換すべきかを指定するため、1つ以上の `Attribute` "
+"デフォルトでは、 `Role` 属性の値はJava EEのロールに変換されます。いくつかのIdPは、 `member` または `memberOf` "
+"属性アサーションを使用してロールを送信します。どのSAML属性をロールに変換すべきかを指定するために、1つ以上の `Attribute` "
 "要素を定義できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__roleidentifiers_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__roleidentifiers_element/ja_JP/index.html
