### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -25,19 +24,16 @@ msgstr "IDP Keysサブ要素"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:9
 msgid ""
-"The Keys sub element of IDP is only used to define the certificate or public "
-"key to use to verify documents signed by the IDP.  It is defined in the same "
-"way as the <<_saml-sp-keys,SP's Keys element>>.  But again, you only have to "
-"define one certificate or public key reference. Note that, if both IDP and "
-"SP are realized by {project_name} server and adapter, respectively, there is "
-"no need to specify the keys for signature validation, see below."
+"The Keys sub element of IDP is only used to define the certificate or public"
+" key to use to verify documents signed by the IDP.  It is defined in the "
+"same way as the <<_saml-sp-keys,SP's Keys element>>.  But again, you only "
+"have to define one certificate or public key reference. Note that, if both "
+"IDP and SP are realized by {project_name} server and adapter, respectively, "
+"there is no need to specify the keys for signature validation, see below."
 msgstr ""
-"IDPのKeysサブ要素は、IDPによって署名されたドキュメントの検証に使用する証明書"
-"や公開鍵を定義するために使用されます。Keysサブ要素は、<<_saml-sp-keys,SP's "
-"Keys element>>と同じ方法で定義されます。しかし、証明書または公開鍵の参照を1つ"
-"だけ定義する必要があります。IDPとSPがともに{project_name}サーバーとアダプター"
-"によって実現された場合、それぞれで、署名の検証のために鍵を指定する必要はない"
-"ことに注意して下さい（以下を参照してください）。"
+"IDPのKeysサブ要素は、IDPによって署名されたドキュメントの検証に使用する証明書や公開鍵を定義するために使用されます。Keysサブ要素は"
+"、<<_saml-sp-"
+"keys,SPの鍵とKeys要素>>と同じ方法で定義されます。しかし、証明書または公開鍵の参照を1つだけ定義する必要があります。IDPとSPが{project_name}サーバーとアダプターによって実現された場合、それぞれで、署名の検証のために鍵を指定する必要はないことに注意して下さい（以下を参照してください）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:22
@@ -54,31 +50,23 @@ msgid ""
 "additional configuration, however it can be configured in the <<_sp-idp-"
 "httpclient,IDP HttpClient sub element>>."
 msgstr ""
-"{project_name}で実現されたSPとIDPの両方が提供された場合、公開された証明書から"
-"自動的にIDP署名検証用の公開鍵を取得するようにSPを設定できます。これは、Keysサ"
-"ブ要素内の署名検証鍵のすべての宣言を削除することによって行われます。Keysサブ"
-"要素を空のままにすると、完全に省略できます。鍵は、SAML記述子からSPによって自"
-"動的に取得されます。その場所は、<<_sp-idp-singlesignonservice,IDP "
-"SingleSignOnServiceサブ要素>>で指定したSAMLエンドポイントURLを基にします。"
-"SAML記述子の取得に使用されるHTTPクライアントの設定は、通常追加の設定は必要が"
-"ありませんが、<<_sp-idp-httpclient,IDP HttpClient sub element>>内に設定できま"
-"す。"
+"SPとIDPの両方が{project_name}で提供された場合、公開された証明書から自動的にIDP署名検証用の公開鍵を取得するようにSPを設定できます。これは、Keysサブ要素内の署名検証鍵のすべての宣言を削除することによって行われます。Keysサブ要素が空であれば、完全に省略できます。鍵は、SAML記述子からSPによって自動的に取得されます。その場所は"
+"、<<_sp-idp-singlesignonservice,IDP "
+"SingleSignOnServiceサブ要素>>で指定したSAMLエンドポイントURLが基になります。SAML記述子の取得に使用されるHTTPクライアントの設定は、通常追加の設定は必要がありませんが"
+"、<<_sp-idp-httpclient,IDP HttpClientサブ要素>>内に設定できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:28
 msgid ""
 "It is also possible to specify multiple keys for signature verification. "
-"This is done by declaring multiple Key elements within Keys sub element that "
-"have `signing` attribute set to `true`.  This is useful for example in "
+"This is done by declaring multiple Key elements within Keys sub element that"
+" have `signing` attribute set to `true`.  This is useful for example in "
 "situation when the IDP signing keys are rotated: There is usually a "
 "transition period when new SAML protocol messages and assertions are signed "
 "with the new key but those signed by previous key should still be accepted."
 msgstr ""
-"署名検証用の鍵を複数指定することもできます。 `signing` 属性を `true` に設定"
-"し、Keysサブ要素内に複数のKey要素を宣言することによって行います。これは、例え"
-"ばIDPの署名鍵をローテーションするような状況で役に立ちます。通常、新しいSAMLプ"
-"ロトコルのメッセージとアサーションが新しい鍵で署名されても、前の鍵で署名され"
-"たものを受け入れられる移行期間があります。"
+"署名検証用の鍵を複数指定することもできます。 `signing` 属性を `true` "
+"に設定し、Keysサブ要素内に複数のKey要素を宣言することによって行います。これは、例えばIDPの署名鍵をローテーションするような状況で役に立ちます。通常、新しいSAMLプロトコルのメッセージとアサーションが新しい鍵で署名されても、以前の鍵で署名されたものを受け入れられる移行期間があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:32
@@ -87,8 +75,7 @@ msgid ""
 "signature verification automatically and define additional static signature "
 "verification keys."
 msgstr ""
-"署名検証用の鍵を自動的に取得することと、追加の静的な署名検証の鍵を定義するこ"
-"との、両方を{project_name}を設定できません。"
+"署名検証用の鍵を自動的に取得することと、追加の静的な署名検証の鍵を定義することの、両方を{project_name}に設定することはできません。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:45


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_keys_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__idp_keys_subelement/ja_JP/index.html
