### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -21,7 +20,7 @@ msgstr ""
 #: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:2
 #, no-wrap
 msgid "OpenID Connect vs. SAML"
-msgstr "OpenID Connect vs. SAML"
+msgstr "OpenID Connect 対 SAML"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:45
@@ -30,16 +29,14 @@ msgid ""
 "Choosing between OpenID Connect and SAML is not just a matter of using a "
 "newer protocol (OIDC) instead of the older more mature protocol (SAML)."
 msgstr ""
-"OpenID ConnectとSAMLの選択は、古いより成熟したプロトコル(SAML)の代わりに新し"
-"いプロトコル(OIDC)を使用するだけの問題ではありません。"
+"OpenID "
+"ConnectとSAMLの選択は、古いより成熟したプロトコル(SAML)の代わりに新しいプロトコル(OIDC)を使用するだけの問題ではありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:47
 #: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:7
 msgid "In most cases {project_name} recommends using OIDC."
-msgstr ""
-"ほとんどの場合において、{project_name}ではOIDCを使用することをおすすめしま"
-"す。"
+msgstr "ほとんどの場合において、{project_name}ではOIDCを使用することをおすすめします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:49
@@ -51,26 +48,24 @@ msgstr "SAMLは、OIDCよりも少し冗長になる傾向があります。"
 #: source/securing_apps/topics/overview/supported-protocols.adoc:54
 #: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:14
 msgid ""
-"Beyond verbosity of exchanged data, if you compare the specifications you'll "
-"find that OIDC was designed to work with the web while SAML was retrofitted "
-"to work on top of the web.  For example, OIDC is also more suited for HTML5/"
-"JavaScript applications because it is easier to implement on the client side "
-"than SAML. As tokens are in the JSON format, they are easier to consume by "
-"JavaScript. You will also find several nice features that make implementing "
-"security in your web applications easier. For example, check out the link:"
-"http://openid.net/specs/openid-connect-session-1_0."
-"html#ChangeNotification[iframe trick] that the specification uses to easily "
-"determine if a user is still logged in or not."
+"Beyond verbosity of exchanged data, if you compare the specifications you'll"
+" find that OIDC was designed to work with the web while SAML was retrofitted"
+" to work on top of the web.  For example, OIDC is also more suited for "
+"HTML5/JavaScript applications because it is easier to implement on the "
+"client side than SAML. As tokens are in the JSON format, they are easier to "
+"consume by JavaScript. You will also find several nice features that make "
+"implementing security in your web applications easier. For example, check "
+"out the link:http://openid.net/specs/openid-connect-session-"
+"1_0.html#ChangeNotification[iframe trick] that the specification uses to "
+"easily determine if a user is still logged in or not."
 msgstr ""
-"交換するデータの詳細度を度外視して仕様を比較した場合、OIDCはもともとWebで動作"
-"するように設計されていますが、SAMLはWeb上で動作するように改造されていることが"
-"分かります。 例えば、SAMLよりもクライアントサイドに実装することが簡単なため、"
-"OIDCはHTML5/JavaScriptアプリケーションにも適しています。トークンはJSON形式な"
-"ので、JavaScript により簡単に扱うことができます。また、webアプリケーションに"
-"対してセキュリティの実装を容易にする、いくつかの素晴らしい機能があります。例"
-"えば、ユーザーがログインしているかどうかを容易に判断するために使用する link:"
-"http://openid.net/specs/openid-connect-session-1_0."
-"html#ChangeNotification[iframeトリック] の仕様をチェックして下さい。"
+"交換するデータの詳細度を度外視して仕様を比較した場合、OIDCはもともとWebで動作するように設計されていますが、SAMLはWeb上で動作するように改造されていることが分かります。"
+" "
+"例えば、SAMLよりもクライアントサイドに実装することが簡単なため、OIDCはHTML5/JavaScriptアプリケーションにも適しています。トークンはJSON形式なので、JavaScript"
+" "
+"により簡単に扱うことができます。また、webアプリケーションに対してセキュリティの実装を容易にする、いくつかの素晴らしい機能があります。例えば、ユーザーがログインしているかどうかを容易に判断するために使用する"
+" link:http://openid.net/specs/openid-connect-session-"
+"1_0.html#ChangeNotification[iframeトリック] の仕様をチェックして下さい。"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:56
@@ -82,7 +77,4 @@ msgid ""
 "it is more mature and also because they already have existing applications "
 "that are secured with it."
 msgstr ""
-"SAMLにも用途はあります。OIDCの仕様の進化を見ると、SAMLが長年に渡って実装して"
-"きた多数の機能がOIDCにも実装されていることが分かります。SAMLがOIDCより成熟し"
-"ているという認識と、SAMLによりセキュリティ保護されている既存のアプリケーショ"
-"ンが存在するという理由により、OIDCよりもSAMLが選ばれることは多々あります。"
+"SAMLにも用途はあります。OIDCの仕様の進化を見ると、SAMLが長年に渡って実装してきた多数の機能がOIDCにも実装されていることが分かります。SAMLがOIDCより成熟しているという認識と、SAMLによりセキュリティ保護されている既存のアプリケーションが存在するという理由により、OIDCよりもSAMLが選ばれることは多々あります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml-vs-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sso-protocols__saml-vs-oidc/ja_JP/index.html
