### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po
@@ -1,38 +1,39 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/enforcer-https.adoc:2
 #, no-wrap
 msgid "Setting Up TLS/HTTPS"
-msgstr ""
+msgstr "TLS/HTTPSの設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-https.adoc:5
 msgid ""
-"When the server is using HTTPS, ensure your adapter is configured as follows:"
-msgstr ""
+"When the server is using HTTPS, ensure your adapter is configured as "
+"follows:"
+msgstr "サーバーでHTTPSを使用する場合は、アダプターが次のように設定されていることを確認してください。"
 
 #. type: Block title
 #: source/authorization_services/topics/enforcer-https.adoc:6
 #: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:17
-#, fuzzy, no-wrap
-#| msgid "keycloak-images"
+#, no-wrap
 msgid "keycloak.json"
-msgstr "keycloak-images"
+msgstr "keycloak.json"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-https.adoc:12
@@ -43,6 +44,10 @@ msgid ""
 "  \"truststore-password\": \"trust_store_password\"\n"
 "}\n"
 msgstr ""
+"{\n"
+"  \"truststore\": \"トラストストアへのパス\",\n"
+"  \"truststore-password\": \"トラストストアのパスワード\"\n"
+"}\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-https.adoc:16
@@ -51,10 +56,11 @@ msgid ""
 "making possible to access a {project_name} Server remotely using the HTTPS "
 "scheme."
 msgstr ""
+"上記の設定により、認証クライアントでTLS/HTTPSが有効になり、HTTPSスキームを使用してリモートから{project_name}サーバーにアクセスできるようになります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-https.adoc:18
 msgid ""
 "It is strongly recommended that you enable TLS/HTTPS when accessing the "
 "{project_name} Server endpoints."
-msgstr ""
+msgstr "{project_name}サーバーのエンドポイントにアクセスする際は、TLS/HTTPSを有効にすること強くおすすめします。"

--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,7 +56,7 @@ msgid ""
 "making possible to access a {project_name} Server remotely using the HTTPS "
 "scheme."
 msgstr ""
-"上記の設定により、認証クライアントでTLS/HTTPSが有効になり、HTTPSスキームを使用してリモートから{project_name}サーバーにアクセスできるようになります。"
+"上記の設定により、認可クライアントでTLS/HTTPSが有効になり、HTTPSスキームを使用してリモートから{project_name}サーバーにアクセスできるようになります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-https.adoc:18


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__enforcer-https/ja_JP/index.html
