### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
@@ -24,32 +23,19 @@ msgid "Error Handling"
 msgstr "エラー処理"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:17
-#: source/securing_apps/topics/saml/java/error_handling.adoc:17
+#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:16
+#: source/securing_apps/topics/saml/java/error_handling.adoc:16
 #, no-wrap
 msgid ""
 "<error-page>\n"
 "    <error-code>403</error-code>\n"
 "    <location>/ErrorHandler</location>\n"
 "</error-page>\n"
-"----    \n"
 msgstr ""
 "<error-page>\n"
 "    <error-code>403</error-code>\n"
 "    <location>/ErrorHandler</location>\n"
 "</error-page>\n"
-"----    \n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:43
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:50
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:160
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:323
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:344
-#: source/securing_apps/topics/saml/java/error_handling.adoc:26
-#, no-wrap
-msgid "[source,javascript]\n"
-msgstr "[source,javascript]\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/error_handling.adoc:8
@@ -60,29 +46,26 @@ msgid ""
 "`error-page` within your `web.xml` file to handle the error however you "
 "want.  The client adapter can throw 400, 401, 403, and 500 errors."
 msgstr ""
-"{project_name}は、クライアント・アダプター・ベースのサーブレットのためのいく"
-"つかのエラー処理機能があります。認証でエラーが発生すると、クライアント・アダ"
-"プターは `HttpServletResponse.sendError()` を呼び出します。適切にエラーを処理"
-"するために、 `web.xml` ファイル内に'エラー・ページ' を設定できます。クライア"
-"ント・アダプターは、400、401、403、500のエラーをスローできます。"
-
-#. type: delimited block -
-#: source/securing_apps/topics/saml/java/error_handling.adoc:23
-#, no-wrap
-msgid ""
-"The client adapter also sets an `HttpServletRequest` attribute that you can retrieve.\n"
-"The attribute name is `org.keycloak.adapters.spi.AuthenticationError`.\n"
-"Typecast this object to: `org.keycloak.adapters.saml.SamlAuthenticationError`.\n"
-"This class can tell you exactly what happened.\n"
-"If this attribute is not set, then the adapter was not responsible for the error code. \n"
-msgstr ""
-"クライアント・アダプターはまた、取得可能な `HttpServletRequest` 属性を設定します。\n"
-"属性名は、 `org.keycloak.adapters.spi.AuthenticationError` です。\n"
-"このオブジェクトを `org.keycloak.adapters.saml.SamlAuthenticationError` にキャストします。\n"
-"このクラスは、正確に何が起こったかを伝えることができます。\n"
-"この属性が設定されない場合、アダプターはエラー・コードに対して何もしません。\n"
+"{project_name}には、サーブレットベースのクライアント・アダプター用のエラー処理機能があります。認証でエラーが発生すると、クライアント・アダプターは"
+" `HttpServletResponse.sendError()` を呼び出します。 `web.xml` ファイル内にerror-"
+"pageを設定してエラーを処理することができます。クライアント・アダプターは、400、401、403、500のエラーをスローできます。"
 
 #. type: Plain text
+#: source/securing_apps/topics/saml/java/error_handling.adoc:23
+msgid ""
+"The client adapter also sets an `HttpServletRequest` attribute that you can "
+"retrieve.  The attribute name is "
+"`org.keycloak.adapters.spi.AuthenticationError`.  Typecast this object to: "
+"`org.keycloak.adapters.saml.SamlAuthenticationError`.  This class can tell "
+"you exactly what happened.  If this attribute is not set, then the adapter "
+"was not responsible for the error code."
+msgstr ""
+"クライアント・アダプタは、取得可能な `HttpServletRequest` 属性も設定します。属性名は "
+"`org.keycloak.adapters.spi.AuthenticationError` です。このオブジェクトを "
+"`org.keycloak.adapters.saml.SamlAuthenticationError` に型変換して下さい。 "
+"このクラスは、何が起こったかを正確に伝えることができます。この属性が設定されていない場合、アダプターはエラー・コードを返すことができません。"
+
+#. type: delimited block -
 #: source/securing_apps/topics/saml/java/error_handling.adoc:33
 #, no-wrap
 msgid ""
@@ -100,8 +83,8 @@ msgstr ""
 "        ERROR_STATUS\n"
 "    }\n"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/java/error_handling.adoc:42
+#. type: delimited block -
+#: source/securing_apps/topics/saml/java/error_handling.adoc:41
 #, no-wrap
 msgid ""
 "    public Reason getReason() {\n"
@@ -111,7 +94,6 @@ msgid ""
 "        return status;\n"
 "    }\n"
 "}\n"
-"----    \n"
 msgstr ""
 "    public Reason getReason() {\n"
 "        return reason;\n"
@@ -120,4 +102,3 @@ msgstr ""
 "        return status;\n"
 "    }\n"
 "}\n"
-"----    \n"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,10 +60,10 @@ msgid ""
 "you exactly what happened.  If this attribute is not set, then the adapter "
 "was not responsible for the error code."
 msgstr ""
-"クライアント・アダプタは、取得可能な `HttpServletRequest` 属性も設定します。属性名は "
+"クライアント・アダプターはまた、取得可能な `HttpServletRequest` 属性を設定します。属性名は、 "
 "`org.keycloak.adapters.spi.AuthenticationError` です。このオブジェクトを "
-"`org.keycloak.adapters.saml.SamlAuthenticationError` に型変換して下さい。 "
-"このクラスは、何が起こったかを正確に伝えることができます。この属性が設定されていない場合、アダプターはエラー・コードを返すことができません。"
+"`org.keycloak.adapters.saml.SamlAuthenticationError` "
+"にキャストします。このクラスは、正確に何が起こったかを伝えることができます。この属性が設定されない場合、アダプターはエラー・コードに対して何もしません。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/error_handling.adoc:33


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__error_handling
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__error_handling/ja_JP/index.html
