### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.adoc:2
 #, no-wrap
 msgid "Jetty 8 Per WAR Configuration"
-msgstr ""
+msgstr "Jetty 8 WAR ごとの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.adoc:5
@@ -27,3 +27,5 @@ msgid ""
 "Enabling Keycloak for your WARs is the same as the Jetty 9.x adapter.  See "
 "<<_saml-jetty9-per-war, Jetty 9 Per War Configuration>>"
 msgstr ""
+"WARに対してKeycloakを有効にすることは、Jetty 9.xアダプターと同じす。 <<_saml-jetty9-per-war, Jetty 9"
+" Per War Configuration>> を参照下さい。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.adoc:2
 #, no-wrap
 msgid "Jetty 8 Per WAR Configuration"
-msgstr "Jetty 8 WAR ごとの設定"
+msgstr "Jetty 8 WARごとの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.adoc:5
@@ -27,5 +27,5 @@ msgid ""
 "Enabling Keycloak for your WARs is the same as the Jetty 9.x adapter.  See "
 "<<_saml-jetty9-per-war, Jetty 9 Per War Configuration>>"
 msgstr ""
-"WARに対してKeycloakを有効にすることは、Jetty 9.xアダプターと同じす。 <<_saml-jetty9-per-war, Jetty 9"
-" Per War Configuration>> を参照下さい。"
+"WARに対してKeycloakを有効にする方法は、Jetty 9.xアダプターと同じです。<<_saml-jetty9-per-war, Jetty 9"
+" WARごとの設定>>を参照下さい。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty8-per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty8-per_war_config/ja_JP/index.html
