### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/general-config.adoc:3
 #, no-wrap
 msgid "General Adapter Config"
-msgstr "一般的なアダプター設定"
+msgstr "共通アダプター設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config.adoc:7
@@ -138,4 +138,4 @@ msgid ""
 "`${jboss.server.config.dir}`."
 msgstr ""
 "これらの設定の中には、アダプター固有のものもあれば、すべてのアダプターに共通のものもあります。Javaアダプターの場合は、システムプロパティの置換に "
-"`${...}`  エンクロージャーを使用できます。 例えば、 `${jboss.server.config.dir}` 。"
+"`${...}`  エンクロージャーを使用できます。 例えば、 `${jboss.server.config.dir}` です。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
@@ -28,8 +27,7 @@ msgid ""
 "Each SAML client adapter supported by {project_name} can be configured by a "
 "simple XML text file.  This is what one might look like:"
 msgstr ""
-"{project_name}でサポートされているSAMLクライアント・アダプターは、いずれも簡"
-"単なXMLテキスト・ファイルで設定できます。これは以下のようなものです。"
+"{project_name}でサポートされているSAMLクライアント・アダプターは、いずれも簡単なXMLテキスト・ファイルで設定できます。これは以下のようなものです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config.adoc:38
@@ -94,7 +92,7 @@ msgstr ""
 "                    />\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config.adoc:56
+#: source/securing_apps/topics/saml/java/general-config.adoc:55
 #, no-wrap
 msgid ""
 "            <SingleLogoutService\n"
@@ -113,7 +111,6 @@ msgid ""
 "        </IDP>\n"
 "     </SP>\n"
 "</keycloak-saml-adapter>\n"
-"----    \n"
 msgstr ""
 "            <SingleLogoutService\n"
 "                    requestBinding=\"POST\"\n"
@@ -131,13 +128,14 @@ msgstr ""
 "        </IDP>\n"
 "     </SP>\n"
 "</keycloak-saml-adapter>\n"
-"----    \n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config.adoc:60
-#, no-wrap
 msgid ""
-"Some of these configuration switches may be adapter specific and some are common across all adapters.\n"
-"For Java adapters you can use `${...}` enclosure as System property replacement.\n"
-"For example `${jboss.server.config.dir}`.\n"
-msgstr "これらの設定のいくつかはすべてのアダプターに共通し、いくつかはアダプターに固有です。 Javaアダプターでは、システム・プロパティの置き換えとして `${...}` エンクロージャーを使用できます。例えば 、 `${jboss.server.config.dir}` です。\n"
+"Some of these configuration switches may be adapter specific and some are "
+"common across all adapters.  For Java adapters you can use `${...}` "
+"enclosure as System property replacement.  For example "
+"`${jboss.server.config.dir}`."
+msgstr ""
+"これらの設定の中には、アダプター固有のものもあれば、すべてのアダプターに共通のものもあります。Javaアダプターの場合は、システムプロパティの置換に "
+"`${...}`  エンクロージャーを使用できます。 例えば、 `${jboss.server.config.dir}` 。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config/ja_JP/index.html
