### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -21,32 +21,37 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
-msgstr ""
+msgstr "アダプターのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:15
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:8
 msgid ""
 "Adapters are no longer included with the appliance or war distribution.  "
-"Each adapter is a separate download on the Keycloak download site.  They are "
-"also available as a maven artifact."
+"Each adapter is a separate download on the Keycloak download site.  They are"
+" also available as a maven artifact."
 msgstr ""
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとして利用できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:12
 msgid ""
-"You must unzip the adapter distro into Tomcat's `lib/` directory.  Including "
-"adapter's jars within your WEB-INF/lib directory will not work! The Keycloak "
-"SAML adapter is implemented as a Valve and valve code must reside in "
-"Tomcat's main lib/ directory."
+"You must unzip the adapter distro into Tomcat's `lib/` directory.  Including"
+" adapter's jars within your WEB-INF/lib directory will not work! The "
+"Keycloak SAML adapter is implemented as a Valve and valve code must reside "
+"in Tomcat's main lib/ directory."
 msgstr ""
+"アダプターの圧縮ファイルをTomcatの `lib/` ディレクトリに解凍する必要があります。 `WEB-INF/lib` "
+"ディレクトリ内にアダプターのjarを含めても動作しません！ Keycloak "
+"SAMLアダプターはバルブとして実装され、バルブのコードはTomcatのメインの `lib/` ディレクトリに存在する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:23
+#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:22
 #, no-wrap
 msgid ""
 "$ cd $TOMCAT_HOME/lib\n"
@@ -55,5 +60,10 @@ msgid ""
 "$ unzip keycloak-saml-tomcat7-adapter-dist.zip\n"
 "    or\n"
 "$ unzip keycloak-saml-tomcat8-adapter-dist.zip\n"
-"----    \n"
 msgstr ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-saml-tomcat6-adapter-dist.zip\n"
+"    or\n"
+"$ unzip keycloak-saml-tomcat7-adapter-dist.zip\n"
+"    or\n"
+"$ unzip keycloak-saml-tomcat8-adapter-dist.zip\n"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,7 +36,7 @@ msgid ""
 "Each adapter is a separate download on the Keycloak download site.  They are"
 " also available as a maven artifact."
 msgstr ""
-"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとして利用できます。"
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:12
@@ -47,8 +47,8 @@ msgid ""
 "in Tomcat's main lib/ directory."
 msgstr ""
 "アダプターの圧縮ファイルをTomcatの `lib/` ディレクトリに解凍する必要があります。 `WEB-INF/lib` "
-"ディレクトリ内にアダプターのjarを含めても動作しません！ Keycloak "
-"SAMLアダプターはバルブとして実装され、バルブのコードはTomcatのメインの `lib/` ディレクトリに存在する必要があります。"
+"ディレクトリ内にアダプターのjarを含めても動作しません！Keycloak SAMLアダプターは `Valve` として実装され、 `Valve` "
+"のコードはTomcatのメインの `lib/` ディレクトリに存在する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:22


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_installation/ja_JP/index.html
