### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__clustering__booting.ja_JP.po\n"
 
 #. type: Block title
 #: source/server_installation/topics/operating-mode/standalone.adoc:3
@@ -25,7 +26,7 @@ msgstr "スタンドアロン・モード"
 #: source/server_installation/topics/clustering/booting.adoc:2
 #, no-wrap
 msgid "Booting the Cluster"
-msgstr ""
+msgstr "クラスターの起動"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/booting.adoc:5
@@ -33,18 +34,19 @@ msgid ""
 "Booting {project_name} in a cluster depends on your <<_operating-mode, "
 "operating mode>>"
 msgstr ""
+"クラスター内での{project_name}の起動は<<_operating-mode, operating mode>>によって異なります。"
 
 #. type: delimited block -
 #: source/server_installation/topics/clustering/booting.adoc:10
 #, no-wrap
 msgid "$ bin/standalone.sh --server-config=standalone-ha.xml\n"
-msgstr ""
+msgstr "$ bin/standalone.sh --server-config=standalone-ha.xml\n"
 
 #. type: Block title
 #: source/server_installation/topics/clustering/booting.adoc:12
 #, no-wrap
 msgid "Domain Mode"
-msgstr ""
+msgstr "ドメイン・モード"
 
 #. type: delimited block -
 #: source/server_installation/topics/clustering/booting.adoc:17
@@ -53,3 +55,5 @@ msgid ""
 "$ bin/domain.sh --host-config=host-master.xml\n"
 "$ bin/domain.sh --host-config=host-slave.xml\n"
 msgstr ""
+"$ bin/domain.sh --host-config=host-master.xml\n"
+"$ bin/domain.sh --host-config=host-slave.xml\n"

--- a/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
@@ -33,8 +33,7 @@ msgstr "クラスターの起動"
 msgid ""
 "Booting {project_name} in a cluster depends on your <<_operating-mode, "
 "operating mode>>"
-msgstr ""
-"クラスター内での{project_name}の起動は<<_operating-mode, operating mode>>によって異なります。"
+msgstr "クラスター内での{project_name}の起動は<<_operating-mode, 動作モード>>によって異なります。"
 
 #. type: delimited block -
 #: source/server_installation/topics/clustering/booting.adoc:10


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__booting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__clustering__booting/ja_JP/index.html
