### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:1
 #, no-wrap
 msgid "Security Context"
-msgstr ""
+msgstr "セキュリティ・コンテキスト"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:5
@@ -29,13 +29,16 @@ msgid ""
 "additional details from the token (such as user profile information) or you "
 "want to invoke a RESTful service that is protected by {project_name}."
 msgstr ""
+"`KeycloakSecurityContext` "
+"インターフェースはトークンに直接アクセスする必要がある場合に利用できます。これは、トークンから追加の詳細情報(ユーザー・プロファイル情報など)を取得する場合や、{project_name}"
+" によって保護されているRESTfulサービスを呼び出す場合に便利です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:7
 msgid ""
 "In servlet environments it is available in secured invocations as an "
 "attribute in HttpServletRequest:"
-msgstr ""
+msgstr "サーブレット環境では、 `HttpServletRequest` の属性としてセキュアな呼び出しで利用できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:11
@@ -44,11 +47,14 @@ msgid ""
 "httpServletRequest\n"
 "    .getAttribute(KeycloakSecurityContext.class.getName());\n"
 msgstr ""
+"httpServletRequest\n"
+"    .getAttribute(KeycloakSecurityContext.class.getName());\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:14
-msgid "Or, it is available in secure and insecure requests in the HttpSession:"
-msgstr ""
+msgid ""
+"Or, it is available in secure and insecure requests in the HttpSession:"
+msgstr "または、安全でないリクエストでは `HttpSession` で利用できます："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:19
@@ -57,3 +63,5 @@ msgid ""
 "httpServletRequest.getSession()\n"
 "    .getAttribute(KeycloakSecurityContext.class.getName());\n"
 msgstr ""
+"httpServletRequest.getSession()\n"
+"    .getAttribute(KeycloakSecurityContext.class.getName());\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,15 +30,15 @@ msgid ""
 "want to invoke a RESTful service that is protected by {project_name}."
 msgstr ""
 "`KeycloakSecurityContext` "
-"インターフェースはトークンに直接アクセスする必要がある場合に利用できます。これは、トークンから追加の詳細情報(ユーザー・プロファイル情報など)を取得する場合や、{project_name}"
-" によって保護されているRESTfulサービスを呼び出す場合に便利です。"
+"インターフェイスはトークンに直接アクセスする必要がある場合に利用できます。これは、トークンから追加の詳細情報（ユーザー・プロファイル情報など）を取得する場合や、{project_name}によって保護されているRESTfulサービスを呼び出す場合に便利です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:7
 msgid ""
 "In servlet environments it is available in secured invocations as an "
 "attribute in HttpServletRequest:"
-msgstr "サーブレット環境では、 `HttpServletRequest` の属性としてセキュアな呼び出しで利用できます。"
+msgstr ""
+"サーブレット環境では、セキュアな呼び出しで `HttpServletRequest` の属性として以下のようにセキュリティ・コンテキストを利用できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:11
@@ -54,7 +54,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:14
 msgid ""
 "Or, it is available in secure and insecure requests in the HttpSession:"
-msgstr "または、安全でないリクエストでは `HttpSession` で利用できます："
+msgstr "または、セキュア・セキュアでないリクエストでは以下のように `HttpSession` からセキュリティ・コンテキストを利用できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:19


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__adapter-context
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__adapter-context/ja_JP/index.html
