### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -25,8 +25,7 @@ msgid ""
 "adapter is a separate download on the Keycloak download site.  They are also"
 " available as a maven artifact."
 msgstr ""
-"アダプターは、アプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。 "
-"それらは、Mavenアーティファクトとしても利用可能です。"
+"アダプターはアプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。これらは、Mavenアーティファクトとしても利用可能です。"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:3

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -50,7 +50,7 @@ msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
-"Jetty 9.x向けの配布物をJetty 9.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
+"Jetty 9.x用の配布物をJetty 9.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
 "ディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: delimited block -

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -50,8 +50,8 @@ msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
-"Jetty 9.x用の配布物をJetty 9.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
-"ディレクトリ内にアダプターのjarを含めても動作しません！"
+"Jetty 9.x用の配布物をJetty 9.xのルートディレクトリに解凍する必要があります。WEB-"
+"INF/libディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:19

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,8 +41,8 @@ msgid ""
 "provide some extra configuration in each WAR you deploy to Jetty.  Let's go "
 "over these steps."
 msgstr ""
-"KeycloakにはJetty 9.x用のSAMLアダプタがあります。 Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。"
-" これらのステップについて解説します。"
+"KeycloakにはJetty "
+"9.x用のSAMLアダプターがあります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:14
@@ -50,8 +50,8 @@ msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
-"Jetty 9.xのディストリビューションをJetty 9.xのルートディレクトリに解凍する必要があります。  `WEB-INF/lib` "
-"ディレクトリ内にアダプタのjarを含めても動作しません！"
+"Jetty 9.x向けの配布物をJetty 9.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
+"ディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:19

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -2,31 +2,18 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:89
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:31
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:56
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:66
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:23
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:23
-#: source/server_development/topics/auth-spi.adoc:148
-#: source/server_development/topics/preface.adoc:16
-#, no-wrap
-msgid "[source]\n"
-msgstr ""
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
@@ -35,15 +22,17 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
 "Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also "
-"available as a maven artifact."
+"adapter is a separate download on the Keycloak download site.  They are also"
+" available as a maven artifact."
 msgstr ""
+"アダプターは、アプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。 "
+"それらは、Mavenアーティファクトとしても利用可能です。"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:3
 #, no-wrap
 msgid "Jetty 9 Adapter Installation"
-msgstr ""
+msgstr "Jetty 9アダプターのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:8
@@ -52,6 +41,8 @@ msgid ""
 "provide some extra configuration in each WAR you deploy to Jetty.  Let's go "
 "over these steps."
 msgstr ""
+"KeycloakにはJetty 9.x用のSAMLアダプタがあります。 Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。"
+" これらのステップについて解説します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:14
@@ -59,22 +50,30 @@ msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
+"Jetty 9.xのディストリビューションをJetty 9.xのルートディレクトリに解凍する必要があります。  `WEB-INF/lib` "
+"ディレクトリ内にアダプタのjarを含めても動作しません！"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:21
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:19
 #, no-wrap
 msgid ""
 "$ cd $JETTY_HOME\n"
 "$ unzip keycloak-saml-jetty92-adapter-dist.zip\n"
-"----    \n"
-"Next, you will have to enable the keycloak module for your jetty.base. \n"
 msgstr ""
+"$ cd $JETTY_HOME\n"
+"$ unzip keycloak-saml-jetty92-adapter-dist.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:27
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:21
+msgid "Next, you will have to enable the keycloak module for your jetty.base."
+msgstr "次に、jetty.base用のkeycloakモジュールを有効にする必要があります。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:26
 #, no-wrap
 msgid ""
 "$ cd your-base\n"
 "$ java -jar $JETTY_HOME/start.jar --add-to-startd=keycloak\n"
-"----        \n"
 msgstr ""
+"$ cd your-base\n"
+"$ java -jar $JETTY_HOME/start.jar --add-to-startd=keycloak\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty9_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty9_installation/ja_JP/index.html
