### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -35,8 +35,8 @@ msgid ""
 "You must unzip the Jetty 8.1.x distro into Jetty 8.1.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
-"Jetty 8.1.xのディストリビューションをJetty 8.1.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
-"ディレクトリ内にアダプタのjarを含めても動作しません。"
+"Jetty 8.1.x用の配布物をJetty 8.1.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
+"ディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:28
@@ -44,8 +44,7 @@ msgstr ""
 msgid ""
 "Next, you will have to enable the keycloak option.  Edit start.ini and add "
 "keycloak to the options"
-msgstr ""
-"次に、keycloakオプションを有効にする必要があります。  `start.ini` を編集し、オプションに `keycloak` を追加します。"
+msgstr "次に、keycloakオプションを有効にする必要があります。start.iniを編集し、オプションにkeycloakを追加します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:41
@@ -81,8 +80,8 @@ msgid ""
 "install into your Jetty installation.  You then have to provide some extra "
 "configuration in each WAR you deploy to Jetty.  Let's go over these steps."
 msgstr ""
-"KeycloakにはJetty 8.1.x用のSAMLアダプタがあります。 "
-"Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。 これらのステップについて解説します。"
+"Keycloakには、Jettyのインストール先にインストールする必要のあるJetty "
+"8.1.x用のSAMLアダプターがあります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:18

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
@@ -2,31 +2,18 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:89
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:31
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:56
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:66
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:23
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:23
-#: source/server_development/topics/auth-spi.adoc:148
-#: source/server_development/topics/preface.adoc:16
-#, no-wrap
-msgid "[source]\n"
-msgstr ""
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
@@ -35,9 +22,11 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
 "Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also "
-"available as a maven artifact."
+"adapter is a separate download on the Keycloak download site.  They are also"
+" available as a maven artifact."
 msgstr ""
+"アダプターは、アプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。 "
+"それらは、Mavenアーティファクトとしても利用可能です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:17
@@ -46,10 +35,21 @@ msgid ""
 "You must unzip the Jetty 8.1.x distro into Jetty 8.1.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
+"Jetty 8.1.xのディストリビューションをJetty 8.1.xのルートディレクトリに解凍する必要があります。 `WEB-INF/lib` "
+"ディレクトリ内にアダプタのjarを含めても動作しません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:42
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:32
+#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:28
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:21
+msgid ""
+"Next, you will have to enable the keycloak option.  Edit start.ini and add "
+"keycloak to the options"
+msgstr ""
+"次に、keycloakオプションを有効にする必要があります。  `start.ini` を編集し、オプションに `keycloak` を追加します。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:41
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:31
 #, no-wrap
 msgid ""
 "#===========================================================\n"
@@ -59,14 +59,20 @@ msgid ""
 "#   java -jar start.jar --list-options\n"
 "#-----------------------------------------------------------\n"
 "OPTIONS=Server,jsp,jmx,resources,websocket,ext,plus,annotations,keycloak\n"
-"----        \n"
 msgstr ""
+"#===========================================================\n"
+"# Start classpath OPTIONS.\n"
+"# These control what classes are on the classpath\n"
+"# for a full listing do\n"
+"#   java -jar start.jar --list-options\n"
+"#-----------------------------------------------------------\n"
+"OPTIONS=Server,jsp,jmx,resources,websocket,ext,plus,annotations,keycloak\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:2
 #, no-wrap
 msgid "Jetty 8 Adapter Installation"
-msgstr ""
+msgstr "Jetty 8 アダプターのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:7
@@ -75,14 +81,15 @@ msgid ""
 "install into your Jetty installation.  You then have to provide some extra "
 "configuration in each WAR you deploy to Jetty.  Let's go over these steps."
 msgstr ""
+"KeycloakにはJetty 8.1.x用のSAMLアダプタがあります。 "
+"Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。 これらのステップについて解説します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:21
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:18
 #, no-wrap
 msgid ""
 "$ cd $JETTY_HOME\n"
 "$ unzip keycloak-saml-jetty81-adapter-dist.zip\n"
-"----    \n"
-"Next, you will have to enable the keycloak option.\n"
-"Edit start.ini and add keycloak to the options \n"
 msgstr ""
+"$ cd $JETTY_HOME\n"
+"$ unzip keycloak-saml-jetty81-adapter-dist.zip\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty8-installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty8-installation/ja_JP/index.html
