### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgid ""
 "obtain from methods such as `HttpServletRequest.getUserPrincipal()`, you can"
 " define what name is returned by the `Principal.getName()` method."
 msgstr ""
-"この要素はオプションです。  `HttpServletRequest.getUserPrincipal()` などのメソッドから取得したJavaの "
+"この要素はオプションです。 `HttpServletRequest.getUserPrincipal()` などのメソッドから取得したJavaの "
 "`Principal` オブジェクトを作成するときに、  `Principal.getName()` メソッドが返す名前を定義することができます。"
 
 #. type: delimited block -
@@ -60,7 +60,7 @@ msgstr ""
 msgid ""
 "The `policy` attribute defines the policy used to populate this value.  The "
 "possible values for this attribute are:"
-msgstr "`policy` 属性は、この値を設定するためのポリシーを定義します。 この属性に指定できる値は次の通りです。"
+msgstr "`policy` 属性は、この値を設定するためのポリシーを定義します。 この属性に指定できる値は次のとおりです。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:23
@@ -73,7 +73,7 @@ msgstr "FROM_NAME_ID"
 msgid ""
 "This policy just uses whatever the SAML subject value is.  This is the "
 "default setting"
-msgstr "このポリシーはSAMLサブジェクトの値が何であれ使用します。 これはデフォルト設定です。"
+msgstr "このポリシーはSAMLサブジェクトの値が何であれ使用します。これはデフォルト設定です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:25
@@ -88,5 +88,5 @@ msgid ""
 "assertion received from the server.  You'll need to specify the name of the "
 "SAML assertion attribute to use within the `attribute` XML attribute."
 msgstr ""
-"これにより、サーバーから受け取ったSAMLアサーションで宣言された属性の1つから値が引き出されます。 `attribute` "
+"これにより、サーバーから受け取ったSAMLアサーションで宣言された属性の1つから、値が取得されます。 `attribute` "
 "XML属性内で使用するSAMLアサーション属性の名前を指定する必要があります。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.ja_JP.po
@@ -2,32 +2,34 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:2
 #, no-wrap
 msgid "SP PrincipalNameMapping element"
-msgstr ""
+msgstr "SP PrincipalNameMapping要素"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:6
 msgid ""
 "This element is optional.  When creating a Java Principal object that you "
-"obtain from methods such as `HttpServletRequest.getUserPrincipal()`, you can "
-"define what name is returned by the `Principal.getName()` method."
+"obtain from methods such as `HttpServletRequest.getUserPrincipal()`, you can"
+" define what name is returned by the `Principal.getName()` method."
 msgstr ""
+"この要素はオプションです。  `HttpServletRequest.getUserPrincipal()` などのメソッドから取得したJavaの "
+"`Principal` オブジェクトを作成するときに、  `Principal.getName()` メソッドが返す名前を定義することができます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:12
@@ -37,6 +39,9 @@ msgid ""
 "  <PrincipalNameMapping policy=\"FROM_NAME_ID\"/>\n"
 "</SP>\n"
 msgstr ""
+"<SP ...>\n"
+"  <PrincipalNameMapping policy=\"FROM_NAME_ID\"/>\n"
+"</SP>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:16
@@ -46,32 +51,35 @@ msgid ""
 "  <PrincipalNameMapping policy=\"FROM_ATTRIBUTE\" attribute=\"email\" />\n"
 "</SP>\n"
 msgstr ""
+"<SP ...>\n"
+"  <PrincipalNameMapping policy=\"FROM_ATTRIBUTE\" attribute=\"email\" />\n"
+"</SP>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:22
 msgid ""
 "The `policy` attribute defines the policy used to populate this value.  The "
 "possible values for this attribute are:"
-msgstr ""
+msgstr "`policy` 属性は、この値を設定するためのポリシーを定義します。 この属性に指定できる値は次の通りです。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:23
 #, no-wrap
 msgid "FROM_NAME_ID"
-msgstr ""
+msgstr "FROM_NAME_ID"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:25
 msgid ""
 "This policy just uses whatever the SAML subject value is.  This is the "
 "default setting"
-msgstr ""
+msgstr "このポリシーはSAMLサブジェクトの値が何であれ使用します。 これはデフォルト設定です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:25
 #, no-wrap
 msgid "FROM_ATTRIBUTE"
-msgstr ""
+msgstr "FROM_ATTRIBUTE"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.adoc:27
@@ -80,3 +88,5 @@ msgid ""
 "assertion received from the server.  You'll need to specify the name of the "
 "SAML assertion attribute to use within the `attribute` XML attribute."
 msgstr ""
+"これにより、サーバーから受け取ったSAMLアサーションで宣言された属性の1つから値が引き出されます。 `attribute` "
+"XML属性内で使用するSAMLアサーション属性の名前を指定する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_principalname_mapping_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp_principalname_mapping_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__sp_principalname_mapping_element/ja_JP/index.html
