### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,7 +20,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:152
 #, no-wrap
 msgid "Multi Tenancy"
-msgstr "マルチ・テナント"
+msgstr "マルチテナンシー"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:6
@@ -29,8 +29,7 @@ msgid ""
 "can be secured with multiple {project_name} realms. The realms can be "
 "located one the same {project_name} instance or on different instances."
 msgstr ""
-"マルチ・テナンシーとは、複数の {project_name} のレルムを単一のターゲットアプリケーション(WAR)が保護できることを意味します。 "
-"レルムは、同じ {project_name} インスタンスまたは異なるインスタンスに配置できます。"
+"マルチテナンシーとは、単一のターゲット・アプリケーション（WAR）が複数の{project_name}のレルムで保護されることを意味します。レルムは、同じ{project_name}インスタンスまたは異なるインスタンスに配置できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:8
@@ -56,7 +55,7 @@ msgid ""
 "{project_name} makes it possible to have a custom config resolver so you can"
 " choose what adapter config is used for each request."
 msgstr ""
-"{project_name} はカスタムの設定リゾルバーを持つことができるので、各リクエストにどのアダプタ設定が使われるかを選ぶことができます。"
+"{project_name}はカスタムの設定リゾルバーを持つことができるので、各リクエストにどのアダプター設定が使われるかを選ぶことができます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:15
@@ -65,7 +64,7 @@ msgid ""
 "`org.keycloak.adapters.KeycloakConfigResolver`. For example:"
 msgstr ""
 "まずこれを達成するためには、 `org.keycloak.adapters.KeycloakConfigResolver` "
-"の実装を作成する必要があります。例えば："
+"の実装を作成する必要があります。例えば、以下のようになります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:19
@@ -142,8 +141,8 @@ msgid ""
 "You also need to configure which `KeycloakConfigResolver` implementation to "
 "use with the `keycloak.config.resolver` context-param in your `web.xml`:"
 msgstr ""
-"`web.xml` の `keycloak.config.resolver` のcontext-paramでどの "
-"`KeycloakConfigResolver` 実装を使うかを設定する必要もあります："
+"また、以下のように `web.xml` の `keycloak.config.resolver` のcontext-paramでどの "
+"`KeycloakConfigResolver` 実装を使うかを設定する必要もあります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:54

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -20,7 +20,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:152
 #, no-wrap
 msgid "Multi Tenancy"
-msgstr ""
+msgstr "マルチ・テナント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:6
@@ -29,42 +29,49 @@ msgid ""
 "can be secured with multiple {project_name} realms. The realms can be "
 "located one the same {project_name} instance or on different instances."
 msgstr ""
+"マルチ・テナンシーとは、複数の {project_name} のレルムを単一のターゲットアプリケーション(WAR)が保護できることを意味します。 "
+"レルムは、同じ {project_name} インスタンスまたは異なるインスタンスに配置できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:8
 msgid ""
 "In practice, this means that the application needs to have multiple "
 "`keycloak.json` adapter configuration files."
-msgstr ""
+msgstr "実際には、これはアプリケーションが複数の `keycloak.json` アダプター設定ファイルを持つ必要があることを意味します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:11
 msgid ""
 "You could have multiple instances of your WAR with different adapter "
 "configuration files deployed to different context-paths. However, this may "
-"be inconvenient and you may also want to select the realm based on something "
-"else than context-path."
+"be inconvenient and you may also want to select the realm based on something"
+" else than context-path."
 msgstr ""
+"さまざまなコンテキスト・パスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。 "
+"しかし、これは不便かもしれませんし、context-path以外のものに基づいてレルムを選択することもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:13
 msgid ""
-"{project_name} makes it possible to have a custom config resolver so you can "
-"choose what adapter config is used for each request."
+"{project_name} makes it possible to have a custom config resolver so you can"
+" choose what adapter config is used for each request."
 msgstr ""
+"{project_name} はカスタムの設定リゾルバーを持つことができるので、各リクエストにどのアダプタ設定が使われるかを選ぶことができます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:15
 msgid ""
-"To achieve this first you need to create an implementation of `org.keycloak."
-"adapters.KeycloakConfigResolver`. For example:"
+"To achieve this first you need to create an implementation of "
+"`org.keycloak.adapters.KeycloakConfigResolver`. For example:"
 msgstr ""
+"まずこれを達成するためには、 `org.keycloak.adapters.KeycloakConfigResolver` "
+"の実装を作成する必要があります。例えば："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:19
 #, no-wrap
 msgid "package example;\n"
-msgstr ""
+msgstr "package example;\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:23
@@ -74,12 +81,19 @@ msgid ""
 "import org.keycloak.adapters.KeycloakDeployment;\n"
 "import org.keycloak.adapters.KeycloakDeploymentBuilder;\n"
 msgstr ""
+"import org.keycloak.adapters.KeycloakConfigResolver;\n"
+"import org.keycloak.adapters.KeycloakDeployment;\n"
+"import org.keycloak.adapters.KeycloakDeploymentBuilder;\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:25
 #, no-wrap
-msgid "public class PathBasedKeycloakConfigResolver implements KeycloakConfigResolver {\n"
+msgid ""
+"public class PathBasedKeycloakConfigResolver implements "
+"KeycloakConfigResolver {\n"
 msgstr ""
+"public class PathBasedKeycloakConfigResolver implements "
+"KeycloakConfigResolver {\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:39
@@ -99,6 +113,19 @@ msgid ""
 "        }\n"
 "    }\n"
 msgstr ""
+"    @Override\n"
+"    public KeycloakDeployment resolve(OIDCHttpFacade.Request request) {\n"
+"        if (path.startsWith(\"alternative\")) {\n"
+"            KeycloakDeployment deployment = cache.get(realm);\n"
+"            if (null == deployment) {\n"
+"                InputStream is = getClass().getResourceAsStream(\"/tenant1-keycloak.json\");\n"
+"                return KeycloakDeploymentBuilder.build(is);\n"
+"            }\n"
+"        } else {\n"
+"            InputStream is = getClass().getResourceAsStream(\"/default-keycloak.json\");\n"
+"            return KeycloakDeploymentBuilder.build(is);\n"
+"        }\n"
+"    }\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:41
@@ -107,7 +134,7 @@ msgstr ""
 #: source/server_development/topics/providers.adoc:143
 #, no-wrap
 msgid "}\n"
-msgstr ""
+msgstr "}\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:44
@@ -115,6 +142,8 @@ msgid ""
 "You also need to configure which `KeycloakConfigResolver` implementation to "
 "use with the `keycloak.config.resolver` context-param in your `web.xml`:"
 msgstr ""
+"`web.xml` の `keycloak.config.resolver` のcontext-paramでどの "
+"`KeycloakConfigResolver` 実装を使うかを設定する必要もあります："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:54
@@ -128,3 +157,10 @@ msgid ""
 "    </context-param>\n"
 "</web-app>\n"
 msgstr ""
+"<web-app>\n"
+"    ...\n"
+"    <context-param>\n"
+"        <param-name>keycloak.config.resolver</param-name>\n"
+"        <param-value>example.PathBasedKeycloakConfigResolver</param-value>\n"
+"    </context-param>\n"
+"</web-app>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__multi-tenancy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__multi-tenancy/ja_JP/index.html
