### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,11 +33,9 @@ msgid ""
 "invocation basis. When you open the secured application URI, the particular "
 "parameter will be forwarded to the {project_name} authorization endpoint."
 msgstr ""
-"{project_name} の初期認可エンドポイント・リクエストは、さまざまなパラメーターをサポートしています。 ほとんどのパラメータは "
-"http://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[OIDC specification] に記述されています。 "
-"一部のパラメーターは、アダプターの設定に基づいて、アダプターにより自動的に追加されます。 ただし、呼び出しごとに追加できるパラメータもいくつかあります。"
-" 保護されたアプリケーションURIにアクセスすると、特定のパラメーターは {project_name} 認可エンドポイントに転送されます。"
+"{project_name}の初期認可エンドポイント・リクエストは、さまざまなパラメーターをサポートしています。ほとんどのパラメータはhttp://openid.net/specs"
+"/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[OIDC仕様]に記述されています。一部のパラメーターは、アダプターの設定に基づいて、アダプターにより自動的に追加されます。ただし、呼び出しごとに追加できるパラメータもいくつかあります。保護されたアプリケーションURIにアクセスすると、特定のパラメーターは{project_name}認可エンドポイントにフォワードされます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:10
@@ -45,7 +43,7 @@ msgid ""
 "For example, if you request an offline token, then you can open the secured "
 "application URI with the `scope` parameter like:"
 msgstr ""
-"たとえば、オフライン・トークンを要求した場合、  `scope` パラメータを使用して保護されたアプリケーションのURIにアクセスできます:"
+"たとえば、オフライン・トークンを要求する場合、以下のように `scope` パラメータを使用して保護されたアプリケーションのURIにアクセスできます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:14
@@ -58,12 +56,12 @@ msgstr "http://myappserver/mysecuredapp?scope=offline_access\n"
 msgid ""
 "and the parameter `scope=offline_access` will be automatically forwarded to "
 "the {project_name} authorization endpoint."
-msgstr "パラメータ `scope=offline_access` が自動的に {project_name} 認可エンドポイントに転送されます。"
+msgstr "パラメータ `scope=offline_access` が自動的に{project_name}認可エンドポイントにフォワードされます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:19
 msgid "The supported parameters are:"
-msgstr "サポートされるパラメーターは次のとおりです:"
+msgstr "サポートされるパラメーターは次のとおりです。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:21
@@ -102,8 +100,7 @@ msgid ""
 "more information see the `Identity Brokering` section in "
 "link:{adminguide_link}[{adminguide_name}]."
 msgstr ""
-"ほとんどのパラメータは http://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[OIDC specification] に記載されています。 唯一の例外はパラメータ "
-"{kc_idp_hint} です。これは {project_name} に固有で、使用するアイデンティティ・プロバイダの名前を自動的に含んでいます。 "
-"詳細は link:{adminguide_link}[{adminguide_name}] の  `Identity Brokering` "
-"のセクションを参照してください。"
+"ほとんどのパラメータはhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[OIDC仕様]に記載されています。唯一の例外はパラメータ `kc_idp_hint` "
+"です。これは{project_name}固有で、自動的に使用するアイデンティティー・プロバイダーの名前を含んでいます。詳細はlink:{adminguide_link}[{adminguide_name}]の"
+" `アイデンティティー・ブローカリング` のセクションを参照してください。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
@@ -33,8 +33,8 @@ msgid ""
 "invocation basis. When you open the secured application URI, the particular "
 "parameter will be forwarded to the {project_name} authorization endpoint."
 msgstr ""
-"{project_name}の初期認可エンドポイント・リクエストは、さまざまなパラメーターをサポートしています。ほとんどのパラメータはhttp://openid.net/specs"
-"/openid-connect-core-"
+"{project_name}の初期認可エンドポイント・リクエストは、さまざまなパラメーターをサポートしています。ほとんどのパラメータは "
+"http://openid.net/specs/openid-connect-core-"
 "1_0.html#AuthorizationEndpoint[OIDC仕様]に記述されています。一部のパラメーターは、アダプターの設定に基づいて、アダプターにより自動的に追加されます。ただし、呼び出しごとに追加できるパラメータもいくつかあります。保護されたアプリケーションURIにアクセスすると、特定のパラメーターは{project_name}認可エンドポイントにフォワードされます。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
@@ -2,37 +2,42 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:2
 #, no-wrap
 msgid "Parameters Forwarding"
-msgstr ""
+msgstr "パラメーター・フォワーディング"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:8
 msgid ""
 "The {project_name} initial authorization endpoint request has support for "
-"various parameters. Most of the parameters are described in http://openid."
-"net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint[OIDC "
-"specification]. Some parameters are added automatically by the adapter based "
-"on the adapter configuration. However, there are also a few parameters that "
-"can be added on a per-invocation basis. When you open the secured "
-"application URI, the particular parameter will be forwarded to the "
-"{project_name} authorization endpoint."
+"various parameters. Most of the parameters are described in "
+"http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[OIDC specification]. Some parameters are "
+"added automatically by the adapter based on the adapter configuration. "
+"However, there are also a few parameters that can be added on a per-"
+"invocation basis. When you open the secured application URI, the particular "
+"parameter will be forwarded to the {project_name} authorization endpoint."
 msgstr ""
+"{project_name} の初期認可エンドポイント・リクエストは、さまざまなパラメーターをサポートしています。 ほとんどのパラメータは "
+"http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[OIDC specification] に記述されています。 "
+"一部のパラメーターは、アダプターの設定に基づいて、アダプターにより自動的に追加されます。 ただし、呼び出しごとに追加できるパラメータもいくつかあります。"
+" 保護されたアプリケーションURIにアクセスすると、特定のパラメーターは {project_name} 認可エンドポイントに転送されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:10
@@ -40,49 +45,52 @@ msgid ""
 "For example, if you request an offline token, then you can open the secured "
 "application URI with the `scope` parameter like:"
 msgstr ""
+"たとえば、オフライン・トークンを要求した場合、  `scope` パラメータを使用して保護されたアプリケーションのURIにアクセスできます:"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:14
 #, no-wrap
 msgid "http://myappserver/mysecuredapp?scope=offline_access\n"
-msgstr ""
+msgstr "http://myappserver/mysecuredapp?scope=offline_access\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:17
 msgid ""
 "and the parameter `scope=offline_access` will be automatically forwarded to "
 "the {project_name} authorization endpoint."
-msgstr ""
+msgstr "パラメータ `scope=offline_access` が自動的に {project_name} 認可エンドポイントに転送されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:19
 msgid "The supported parameters are:"
-msgstr ""
+msgstr "サポートされるパラメーターは次のとおりです:"
 
-#. type: Plain text
+#. type: Labeled list
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:21
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:63
+#, no-wrap
 msgid "scope"
-msgstr ""
+msgstr "scope"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:23
 msgid "prompt"
-msgstr ""
+msgstr "prompt"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:25
 msgid "max_age"
-msgstr ""
+msgstr "max_age"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:27
 msgid "login_hint"
-msgstr ""
+msgstr "login_hint"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:29
 msgid "kc_idp_hint"
-msgstr ""
+msgstr "kc_idp_hint"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:32
@@ -91,6 +99,11 @@ msgid ""
 "connect-core-1_0.html#AuthorizationEndpoint[OIDC specification].  The only "
 "exception is parameter `kc_idp_hint`, which is specific to {project_name} "
 "and contains the name of the identity provider to automatically use.  For "
-"more information see the `Identity Brokering` section in link:"
-"{adminguide_link}[{adminguide_name}]."
+"more information see the `Identity Brokering` section in "
+"link:{adminguide_link}[{adminguide_name}]."
 msgstr ""
+"ほとんどのパラメータは http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[OIDC specification] に記載されています。 唯一の例外はパラメータ "
+"{kc_idp_hint} です。これは {project_name} に固有で、使用するアイデンティティ・プロバイダの名前を自動的に含んでいます。 "
+"詳細は link:{adminguide_link}[{adminguide_name}] の  `Identity Brokering` "
+"のセクションを参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__params_forwarding
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__params_forwarding/ja_JP/index.html
