### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
@@ -31,6 +31,36 @@ msgid ""
 "      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
 "      version=\"3.0\">\n"
 msgstr ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:186
+#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:146
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
+#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:50
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
+#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
+#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:60
+#, no-wrap
+msgid ""
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
+msgstr ""
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:38
@@ -42,24 +72,30 @@ msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr ""
+"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:41
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:9
 msgid ""
-"The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your "
-"WAR package.  This is a Jetty specific config file and you must define a "
+"The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your"
+" WAR package.  This is a Jetty specific config file and you must define a "
 "Keycloak specific authenticator within it."
 msgstr ""
+"まず、WARパッケージに `WEB-INF/jetty-web.xml` "
+"ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のオーセンティケーターを定義する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:29
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:21
 msgid ""
 "Finally you must specify both a `login-config` and use standard servlet "
 "security to specify role-base constraints on your URLs.  Here's an example:"
 msgstr ""
+"最後に、URLのロールベース制約を特定するために、 `login-config` "
+"と標準サーブレット・セキュリティの両方を指定する必要があります。ここに例があります:"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
@@ -70,7 +106,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
-msgstr ""
+msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:133
@@ -90,6 +126,18 @@ msgid ""
 "        </user-data-constraint>\n"
 "    </security-constraint>\n"
 msgstr ""
+"    <security-constraint>\n"
+"        <web-resource-collection>\n"
+"            <web-resource-name>Customers</web-resource-name>\n"
+"            <url-pattern>/*</url-pattern>\n"
+"        </web-resource-collection>\n"
+"        <auth-constraint>\n"
+"            <role-name>user</role-name>\n"
+"        </auth-constraint>\n"
+"        <user-data-constraint>\n"
+"            <transport-guarantee>CONFIDENTIAL</transport-guarantee>\n"
+"        </user-data-constraint>\n"
+"    </security-constraint>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:138
@@ -103,28 +151,16 @@ msgid ""
 "        <realm-name>this is ignored currently</realm-name>\n"
 "    </login-config>\n"
 msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
-#, no-wrap
-msgid ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
-"----        \n"
-msgstr ""
+"    <login-config>\n"
+"        <auth-method>BASIC</auth-method>\n"
+"        <realm-name>this is ignored currently</realm-name>\n"
+"    </login-config>\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:3
 #, no-wrap
 msgid "Jetty 9 Per WAR Configuration"
-msgstr ""
+msgstr "WARごとのJetty 9の設定"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:22
@@ -141,12 +177,25 @@ msgid ""
 "    </Get>\n"
 "</Configure>\n"
 msgstr ""
+"<?xml version=\"1.0\"?>\n"
+"<!DOCTYPE Configure PUBLIC \"-//Mort Bay Consulting//DTD Configure//EN\" \"http://www.eclipse.org/jetty/configure_9_0.dtd\">\n"
+"<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n"
+"    <Get name=\"securityHandler\">\n"
+"        <Set name=\"authenticator\">\n"
+"            <New class=\"org.keycloak.adapters.saml.jetty.KeycloakSamlAuthenticator\">\n"
+"            </New>\n"
+"        </Set>\n"
+"    </Get>\n"
+"</Configure>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:26
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:18
 msgid ""
 "Next you must create a `keycloak-saml.xml` adapter config file within the "
-"`WEB-INF` directory of your WAR.  The format of this config file is describe "
-"in the <<_saml-general-config,General Adapter Config>> section."
+"`WEB-INF` directory of your WAR.  The format of this config file is describe"
+" in the <<_saml-general-config,General Adapter Config>> section."
 msgstr ""
+"次に、WARの `WEB-INF` ディレクトリに `keycloak-saml.xml` アダプタ設定ファイルを作成する必要があります。 "
+"この設定ファイルの形式は、 <<_saml-general-config,General Adapter Config>> "
+"のセクションで説明しています。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -83,7 +83,7 @@ msgid ""
 "Keycloak specific authenticator within it."
 msgstr ""
 "まず、WARパッケージに `WEB-INF/jetty-web.xml` "
-"ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のオーセンティケーターを定義する必要があります。"
+"ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のAuthenticatorを定義する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
@@ -94,8 +94,8 @@ msgid ""
 "Finally you must specify both a `login-config` and use standard servlet "
 "security to specify role-base constraints on your URLs.  Here's an example:"
 msgstr ""
-"最後に、URLのロールベース制約を特定するために、 `login-config` "
-"と標準サーブレット・セキュリティの両方を指定する必要があります。ここに例があります:"
+"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
+"と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
@@ -196,6 +196,6 @@ msgid ""
 "`WEB-INF` directory of your WAR.  The format of this config file is describe"
 " in the <<_saml-general-config,General Adapter Config>> section."
 msgstr ""
-"次に、WARの `WEB-INF` ディレクトリに `keycloak-saml.xml` アダプタ設定ファイルを作成する必要があります。 "
-"この設定ファイルの形式は、 <<_saml-general-config,General Adapter Config>> "
-"のセクションで説明しています。"
+"次に、WARの `WEB-INF` ディレクトリに `keycloak-saml.xml` "
+"アダプター設定ファイルを作成する必要があります。この設定ファイルの形式は、<<_saml-general-"
+"config,共通アダプター設定>>のセクションで説明しています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty9_per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty9_per_war_config/ja_JP/index.html
