### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
@@ -46,7 +46,7 @@ msgid ""
 "Keycloak SAML adapter is implemented as a Valve and valve code must reside "
 "in Tomcat's main lib/ directory."
 msgstr ""
-"アダプターの圧縮ファイルをTomcatの `lib/` ディレクトリに解凍する必要があります。WEB-"
+"アダプターの配布物をTomcatの `lib/` ディレクトリに解凍する必要があります。WEB-"
 "INF/libディレクトリ内にアダプターのjarを含めても動作しません！Keycloak "
 "SAMLアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリに存在する必要があります。"
 

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
@@ -46,9 +46,9 @@ msgid ""
 "Keycloak SAML adapter is implemented as a Valve and valve code must reside "
 "in Tomcat's main lib/ directory."
 msgstr ""
-"アダプターの圧縮ファイルをTomcatの `lib/` ディレクトリに解凍する必要があります。 `WEB-INF/lib` "
-"ディレクトリ内にアダプターのjarを含めても動作しません！Keycloak SAMLアダプターは `Valve` として実装され、 `Valve` "
-"のコードはTomcatのメインの `lib/` ディレクトリに存在する必要があります。"
+"アダプターの圧縮ファイルをTomcatの `lib/` ディレクトリに解凍する必要があります。WEB-"
+"INF/libディレクトリ内にアダプターのjarを含めても動作しません！Keycloak "
+"SAMLアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリに存在する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:22


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_installation/ja_JP/index.html
