### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po
@@ -33,7 +33,7 @@ msgid ""
 msgstr ""
 "IDPのKeysサブ要素は、IDPによって署名されたドキュメントの検証に使用する証明書や公開鍵を定義するために使用されます。Keysサブ要素は"
 "、<<_saml-sp-"
-"keys,SPの鍵とKeys要素>>と同じ方法で定義されます。しかし、証明書または公開鍵の参照を1つだけ定義する必要があります。IDPとSPが{project_name}サーバーとアダプターによって実現された場合、それぞれで、署名の検証のために鍵を指定する必要はないことに注意して下さい（以下を参照してください）。"
+"keys,SPの鍵とKeys要素>>と同じ方法で定義されます。しかし、証明書または公開鍵の参照を1つだけ定義する必要があります。IDPとSPが{project_name}サーバーとアダプターによって実現された場合、それぞれで、署名の検証のために鍵を指定する必要はないことに注意してください（以下を参照してください）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:22


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_keys_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__idp_keys_subelement/ja_JP/index.html
