### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
@@ -65,7 +65,7 @@ msgstr ""
 " "
 "により簡単に扱うことができます。また、webアプリケーションに対してセキュリティの実装を容易にする、いくつかの素晴らしい機能があります。例えば、ユーザーがログインしているかどうかを容易に判断するために使用する"
 " link:http://openid.net/specs/openid-connect-session-"
-"1_0.html#ChangeNotification[iframeトリック] の仕様をチェックして下さい。"
+"1_0.html#ChangeNotification[iframeトリック] の仕様をチェックしてください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:56

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
@@ -63,9 +63,9 @@ msgstr ""
 " "
 "例えば、SAMLよりもクライアントサイドに実装することが簡単なため、OIDCはHTML5/JavaScriptアプリケーションにも適しています。トークンはJSON形式なので、JavaScript"
 " "
-"により簡単に扱うことができます。また、webアプリケーションに対してセキュリティの実装を容易にする、いくつかの素晴らしい機能があります。例えば、ユーザーがログインしているかどうかを容易に判断するために使用する"
-" link:http://openid.net/specs/openid-connect-session-"
-"1_0.html#ChangeNotification[iframeトリック] の仕様をチェックしてください。"
+"により簡単に扱うことができます。また、webアプリケーションに対してセキュリティの実装を容易にする、いくつかの素晴らしい機能があります。例えば、ユーザーがログインしているかどうかを容易に判断するために使用するlink:http://openid.net/specs"
+"/openid-connect-session-"
+"1_0.html#ChangeNotification[iframeトリック]の仕様をチェックしてください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:56


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml-vs-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sso-protocols__saml-vs-oidc/ja_JP/index.html
