### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
@@ -30,7 +30,7 @@ msgstr ""
 "アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
 "に設定する必要があります。 "
 "Webアプリケーションの未認証のユーザーをKeycloakログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
-" `401` ステータスコードを送信します。 Keycloakは、  `X-Requested-With` 、 `SOAPAction` 、 "
+" `401` ステータスコードを送信します。 Keycloakは、 `X-Requested-With` 、 `SOAPAction` 、 "
 "`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。 デフォルト値は _false_ です。"
 
 #. type: Labeled list
@@ -80,7 +80,7 @@ msgid ""
 "determine who the client is that is communicating with it. This setting is "
 "_REQUIRED_."
 msgstr ""
-"このクライアントの識別子です。 IdPは、IdPと通信しているクライアントを特定するため、この値を必要とします。この設定は、_REQUIRED_ です。"
+"このクライアントの識別子です。IdPは、IdPと通信しているクライアントを特定するため、この値を必要とします。この設定は、_REQUIRED_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:22
@@ -97,10 +97,10 @@ msgid ""
 "HTTPS.  For `NONE`, no requests are required to come over via HTTPS.  This "
 "setting is _OPTIONAL_. Default value is `EXTERNAL`."
 msgstr ""
-"これは、アダプターが実施するSSLポリシーです。 有効な値は  `ALL` 、 `EXTERNAL` 、 `NONE` です。 `ALL` "
-"の場合、すべてのリクエストはHTTPSを経由しなければなりません。  `EXTERNAL` "
-"の場合、非プライベートIPアドレスだけがHTTPSを経由しなければなりません。  `NONE` "
-"の場合、HTTPS経由で送信されるリクエストはありません。 この設定は _OPTIONAL_ です。 デフォルト値は `EXTERNAL` です。"
+"これは、アダプターが実施するSSLポリシーです。有効な値は `ALL` 、 `EXTERNAL` 、 `NONE` です。 `ALL` "
+"の場合、すべてのリクエストはHTTPSを経由しなければなりません。 `EXTERNAL` "
+"の場合、非プライベートIPアドレスだけがHTTPSを経由しなければなりません。 `NONE` "
+"の場合、HTTPS経由であることは要求されません。この設定は _OPTIONAL_ です。デフォルト値は `EXTERNAL` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:30
@@ -116,9 +116,10 @@ msgid ""
 "identifier: `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.  This "
 "setting is _OPTIONAL_.  By default, no special format is requested."
 msgstr ""
-"SAMLクライアントは、特定のNameID Subject形式を要求できます。 特定の書式が必要な場合は、この値を入力します。 "
-"これは標準のSAML形式識別子でなければなりません： `urn:oasis:names:tc:SAML:2.0:nameid-"
-"format:transient` この設定は _OPTIONAL_ です。 デフォルトでは、特別な形式は要求されません。"
+"SAMLクライアントは、特定のNameID "
+"Subject形式を要求できます。特定の書式が必要な場合は、この値を入力します。これは標準のSAML形式の識別子である "
+"`urn:oasis:names:tc:SAML:2.0:nameid-format:transient` でなければなりません。この設定は "
+"_OPTIONAL_ です。デフォルトでは、特別な形式は要求されません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:37
@@ -133,8 +134,8 @@ msgid ""
 "already logged in at the IdP.  Set this to `true` to enable. This setting is"
 " _OPTIONAL_.  Default value is `false`."
 msgstr ""
-"SAMLクライアントは、すでにIdPにログインしていても、ユーザーが再認証されるように要求できます。 有効にするには、これを `true` "
-"に設定します。 この設定は _OPTIONAL_ です。 デフォルト値は `false` です。"
+"SAMLクライアントは、すでにIdPにログインしていても、ユーザーが再認証されるように要求できます。有効にするには、これを `true` "
+"に設定します。この設定は _OPTIONAL_ です。デフォルト値は `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:42
@@ -150,9 +151,9 @@ msgid ""
 " not use together with `forceAuthentication` as they are opposite. This "
 "setting is _OPTIONAL_.  Default value is `false`."
 msgstr ""
-"SAMLクライアントは、IdPにログインしていなくても、ユーザーに認証を要求することができます。 その場合は、 `true`に設定してください。  "
-"`forceAuthentication` と一緒に使用しないでください。この設定は _OPTIONAL_ です。 デフォルト値は `false` "
-"です。"
+"SAMLクライアントは、IdPにログインしていなくても、ユーザーに認証を要求しないようにすることができます。その場合は、 "
+"`true`に設定してください。 `forceAuthentication` と反対の設定なため一緒に使用しないでください。この設定は "
+"_OPTIONAL_ です。デフォルト値は `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:48
@@ -167,8 +168,8 @@ msgid ""
 " to plug a security attack vector.  Change this to `true` to disable this.  "
 "It is recommended you do not turn it off.  Default value is `false`."
 msgstr ""
-"デフォルトでは、セッションIDは、一部のプラットフォームで正常にログインすると変更され、セキュリティ攻撃のベクターが挿入されます。 "
-"これを無効にするには、これを `true` に変更してください。 それをオフにしないことをお勧めします。 デフォルト値は `false` です。"
+"セッションIDは、セキュリティ攻撃口とならないように、一部のプラットフォームで正常にログインするとデフォルトで変更されます。これを無効にするには、 "
+"`true` に変更してください。これは無効にしないことをお勧めします。デフォルト値は `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:53

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -21,13 +20,18 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:58
 msgid ""
 "This should be set to __true__ if your application serves both a web "
-"application and web services (e.g. SOAP or REST).  It allows you to redirect "
-"unauthenticated users of the web application to the Keycloak login page, but "
-"send an HTTP `401` status code to unauthenticated SOAP or REST clients "
-"instead as they would not understand a redirect to the login page.  Keycloak "
-"auto-detects SOAP or REST clients based on typical headers like `X-Requested-"
-"With`, `SOAPAction` or `Accept`.  The default value is _false_."
+"application and web services (e.g. SOAP or REST).  It allows you to redirect"
+" unauthenticated users of the web application to the Keycloak login page, "
+"but send an HTTP `401` status code to unauthenticated SOAP or REST clients "
+"instead as they would not understand a redirect to the login page.  Keycloak"
+" auto-detects SOAP or REST clients based on typical headers like `X"
+"-Requested-With`, `SOAPAction` or `Accept`.  The default value is _false_."
 msgstr ""
+"アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
+"に設定する必要があります。 "
+"Webアプリケーションの未認証のユーザーをKeycloakログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
+" `401` ステータスコードを送信します。 Keycloakは、  `X-Requested-With` 、 `SOAPAction` 、 "
+"`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。 デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:18
@@ -45,7 +49,7 @@ msgstr "SP要素"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:5
 msgid "Here is the explanation of the SP element attributes:"
-msgstr ""
+msgstr "ここでは、SP要素の属性の説明をします。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:17
@@ -76,6 +80,7 @@ msgid ""
 "determine who the client is that is communicating with it. This setting is "
 "_REQUIRED_."
 msgstr ""
+"このクライアントの識別子です。 IdPは、IdPと通信しているクライアントを特定するため、この値を必要とします。この設定は、_REQUIRED_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:22
@@ -92,6 +97,10 @@ msgid ""
 "HTTPS.  For `NONE`, no requests are required to come over via HTTPS.  This "
 "setting is _OPTIONAL_. Default value is `EXTERNAL`."
 msgstr ""
+"これは、アダプターが実施するSSLポリシーです。 有効な値は  `ALL` 、 `EXTERNAL` 、 `NONE` です。 `ALL` "
+"の場合、すべてのリクエストはHTTPSを経由しなければなりません。  `EXTERNAL` "
+"の場合、非プライベートIPアドレスだけがHTTPSを経由しなければなりません。  `NONE` "
+"の場合、HTTPS経由で送信されるリクエストはありません。 この設定は _OPTIONAL_ です。 デフォルト値は `EXTERNAL` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:30
@@ -107,6 +116,9 @@ msgid ""
 "identifier: `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`.  This "
 "setting is _OPTIONAL_.  By default, no special format is requested."
 msgstr ""
+"SAMLクライアントは、特定のNameID Subject形式を要求できます。 特定の書式が必要な場合は、この値を入力します。 "
+"これは標準のSAML形式識別子でなければなりません： `urn:oasis:names:tc:SAML:2.0:nameid-"
+"format:transient` この設定は _OPTIONAL_ です。 デフォルトでは、特別な形式は要求されません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:37
@@ -118,9 +130,11 @@ msgstr "forceAuthentication"
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:41
 msgid ""
 "SAML clients can request that a user is re-authenticated even if they are "
-"already logged in at the IdP.  Set this to `true` to enable. This setting is "
-"_OPTIONAL_.  Default value is `false`."
+"already logged in at the IdP.  Set this to `true` to enable. This setting is"
+" _OPTIONAL_.  Default value is `false`."
 msgstr ""
+"SAMLクライアントは、すでにIdPにログインしていても、ユーザーが再認証されるように要求できます。 有効にするには、これを `true` "
+"に設定します。 この設定は _OPTIONAL_ です。 デフォルト値は `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:42
@@ -132,10 +146,13 @@ msgstr "isPassive"
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:47
 msgid ""
 "SAML clients can request that a user is never asked to authenticate even if "
-"they are not logged in at the IdP.  Set this to `true` if you want this.  Do "
-"not use together with `forceAuthentication` as they are opposite. This "
+"they are not logged in at the IdP.  Set this to `true` if you want this.  Do"
+" not use together with `forceAuthentication` as they are opposite. This "
 "setting is _OPTIONAL_.  Default value is `false`."
 msgstr ""
+"SAMLクライアントは、IdPにログインしていなくても、ユーザーに認証を要求することができます。 その場合は、 `true`に設定してください。  "
+"`forceAuthentication` と一緒に使用しないでください。この設定は _OPTIONAL_ です。 デフォルト値は `false` "
+"です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:48
@@ -146,10 +163,12 @@ msgstr "turnOffChangeSessionIdOnLogin"
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:52
 msgid ""
-"The session ID is changed by default on a successful login on some platforms "
-"to plug a security attack vector.  Change this to `true` to disable this.  "
+"The session ID is changed by default on a successful login on some platforms"
+" to plug a security attack vector.  Change this to `true` to disable this.  "
 "It is recommended you do not turn it off.  Default value is `false`."
 msgstr ""
+"デフォルトでは、セッションIDは、一部のプラットフォームで正常にログインすると変更され、セキュリティ攻撃のベクターが挿入されます。 "
+"これを無効にするには、これを `true` に変更してください。 それをオフにしないことをお勧めします。 デフォルト値は `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:53


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__sp_element/ja_JP/index.html
