### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -170,7 +170,7 @@ msgid ""
 "starts as many {project_name} server instances as it was configured to do.  "
 "These server instances pull their configuration from the domain controller."
 msgstr ""
-"ドメイン・モードでは、マスタ・ノード上でドメイン・コントローラーが起動されます。クラスターの設定は、ドメイン・コントローラー内にあります。次に、ホスト・コントローラーがクラスター内の各マシンで起動されます。各ホスト・コントローラーのデプロイ設定では、そのマシンで起動する{project_name}サーバー・インスタンスの数を指定します。ホスト・コントローラがー起動すると、指定された数の{project_name}サーバー・インスタンスが起動します。これらのサーバー・インスタンスは、ドメイン・コントローラーから設定を取得します。"
+"ドメイン・モードでは、マスター・ノード上でドメイン・コントローラーが起動されます。クラスターの設定は、ドメイン・コントローラー内にあります。次に、ホスト・コントローラーがクラスター内の各マシンで起動されます。各ホスト・コントローラーのデプロイ設定では、そのマシンで起動する{project_name}サーバー・インスタンスの数を指定します。ホスト・コントローラがー起動すると、指定された数の{project_name}サーバー・インスタンスが起動します。これらのサーバー・インスタンスは、ドメイン・コントローラーから設定を取得します。"
 
 #. type: Title ====
 #: source/server_installation/topics/operating-mode/domain.adoc:41


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__operating-mode__domain/ja_JP/index.html
