### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -2,40 +2,18 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
 "Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:99
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:109
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:39
-#: source/server_development/topics/providers.adoc:202
-msgid "[source]"
-msgstr "[source]"
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:89
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:31
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:56
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:66
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:23
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:23
-#: source/server_development/topics/auth-spi.adoc:148
-#: source/server_development/topics/preface.adoc:16
-#, no-wrap
-msgid "[source]\n"
-msgstr ""
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:126
@@ -44,7 +22,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:31
 #, no-wrap
 msgid "Required Per WAR Configuration"
-msgstr ""
+msgstr "WARごとに必要な設定"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:146
@@ -62,6 +40,36 @@ msgid ""
 "      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
 "      version=\"3.0\">\n"
 msgstr ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:186
+#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:146
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
+#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:50
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
+#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
+#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:60
+#, no-wrap
+msgid ""
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
+msgstr ""
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
@@ -69,11 +77,12 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
-msgstr ""
+msgstr "アダプターのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:38
@@ -85,6 +94,27 @@ msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr ""
+"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:59
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:48
+msgid ""
+"Next you must create a `keycloak.json` adapter config file within the `WEB-"
+"INF` directory of your WAR."
+msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:29
+#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:21
+msgid ""
+"Finally you must specify both a `login-config` and use standard servlet "
+"security to specify role-base constraints on your URLs.  Here's an example:"
+msgstr ""
+"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
+"と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
@@ -95,7 +125,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
-msgstr ""
+msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:138
@@ -109,42 +139,51 @@ msgid ""
 "        <realm-name>this is ignored currently</realm-name>\n"
 "    </login-config>\n"
 msgstr ""
+"    <login-config>\n"
+"        <auth-method>BASIC</auth-method>\n"
+"        <realm-name>this is ignored currently</realm-name>\n"
+"    </login-config>\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:3
 #, no-wrap
 msgid "Tomcat 6, 7 and 8 Adapters"
-msgstr ""
+msgstr "Tomcat  6、7、8アダプター"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:8
 msgid ""
-"To be able to secure WAR apps deployed on Tomcat 6, 7 and 8 you must install "
-"the Keycloak Tomcat 6, 7 or 8 adapter into your Tomcat installation.  You "
+"To be able to secure WAR apps deployed on Tomcat 6, 7 and 8 you must install"
+" the Keycloak Tomcat 6, 7 or 8 adapter into your Tomcat installation.  You "
 "then have to provide some extra configuration in each WAR you deploy to "
 "Tomcat.  Let's go over these steps."
 msgstr ""
+"Tomcat 6、7、8にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 6、7、8 "
+"アダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:15
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:8
 msgid ""
 "Adapters are no longer included with the appliance or war distribution.  "
-"Each adapter is a separate download on the Keycloak download site.  They are "
-"also available as a maven artifact."
+"Each adapter is a separate download on the Keycloak download site.  They are"
+" also available as a maven artifact."
 msgstr ""
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:18
 msgid ""
-"You must unzip the adapter distro into Tomcat's `lib/` directory.  Including "
-"adapter's jars within your WEB-INF/lib directory will not work! The Keycloak "
-"adapter is implemented as a Valve and valve code must reside in Tomcat's "
-"main lib/ directory."
+"You must unzip the adapter distro into Tomcat's `lib/` directory.  Including"
+" adapter's jars within your WEB-INF/lib directory will not work! The "
+"Keycloak adapter is implemented as a Valve and valve code must reside in "
+"Tomcat's main lib/ directory."
 msgstr ""
+"アダプターの配布物をTomcatの `lib/` ディレクトリに解凍する必要があります。WEB-"
+"INF/libディレクトリ内にアダプターのjarを含めても動作しません！KeycloakアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリに存在する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:30
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:29
 #, no-wrap
 msgid ""
 "$ cd $TOMCAT_HOME/lib\n"
@@ -153,8 +192,13 @@ msgid ""
 "$ unzip keycloak-tomcat7-adapter-dist.zip\n"
 "    or\n"
 "$ unzip keycloak-tomcat8-adapter-dist.zip\n"
-"----    \n"
 msgstr ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat6-adapter-dist.zip\n"
+"    or\n"
+"$ unzip keycloak-tomcat7-adapter-dist.zip\n"
+"    or\n"
+"$ unzip keycloak-tomcat8-adapter-dist.zip\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:37
@@ -164,8 +208,10 @@ msgid ""
 "WAR package.  This is a Tomcat specific config file and you must define a "
 "Keycloak specific Valve."
 msgstr ""
+"まず、WARパッケージに `META-INF/context.xml` ファイルを作成します。 "
+"これはTomcat固有の設定ファイルであり、Keycloak固有のValveを定義する必要があります。"
 
-#. type: Plain text
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:45
 #, no-wrap
 msgid ""
@@ -173,26 +219,18 @@ msgid ""
 "    <Valve className=\"org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve\"/>\n"
 "</Context>\n"
 msgstr ""
+"<Context path=\"/your-context-path\">\n"
+"    <Valve className=\"org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve\"/>\n"
+"</Context>\n"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:48
-#, no-wrap
-msgid "Next you must create a `keycloak.json` adapter config file within the `WEB-INF` directory of your WAR.\n"
-msgstr ""
-
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:50
 #, no-wrap
-msgid "The format of this config file is describe in the <<_java_adapter_config,Java adapter configuration>>           \n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
-#, no-wrap
 msgid ""
-"Finally you must specify both a `login-config` and use standard servlet security to specify role-base constraints on your URLs.\n"
-"Here's an example: \n"
+"The format of this config file is describe in the "
+"<<_java_adapter_config,Java adapter configuration>>           \n"
 msgstr ""
+"この設定ファイルの形式は　<<_java_adapter_config,Java adapter configuration>> で説明しています。\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:75
@@ -209,19 +247,12 @@ msgid ""
 "        </auth-constraint>\n"
 "    </security-constraint>\n"
 msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
-#, no-wrap
-msgid ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
-"----        \n"
-msgstr ""
+"    <security-constraint>\n"
+"        <web-resource-collection>\n"
+"            <web-resource-name>Customers</web-resource-name>\n"
+"            <url-pattern>/*</url-pattern>\n"
+"        </web-resource-collection>\n"
+"        <auth-constraint>\n"
+"            <role-name>user</role-name>\n"
+"        </auth-constraint>\n"
+"    </security-constraint>\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -171,8 +171,7 @@ msgstr ""
 msgid ""
 "The format of this config file is described in the "
 "<<_java_adapter_config,Java adapter configuration>>           \n"
-msgstr ""
-"この設定ファイルの形式は<<_java_adapter_config,Java adapter configuration>>で説明しています。\n"
+msgstr "この設定ファイルの形式は<<_java_adapter_config,Javaアダプターの設定>>で説明しています。\n"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -16,23 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:126
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:43
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:35
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:31
 #, no-wrap
 msgid "Required Per WAR Configuration"
 msgstr "WARごとに必要な設定"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:118
-#: source/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc:18
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:63
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:36
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:24
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:28
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:20
 #, no-wrap
 msgid ""
 "<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
@@ -46,13 +34,6 @@ msgstr ""
 "      version=\"3.0\">\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:186
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:50
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:60
 #, no-wrap
 msgid ""
 "    <security-role>\n"
@@ -72,24 +53,11 @@ msgstr ""
 "</web-app>\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
-#: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
 msgstr "アダプターのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:38
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:34
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:6
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:5
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:5
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
@@ -97,18 +65,12 @@ msgstr ""
 "このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:59
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:48
 msgid ""
 "Next you must create a `keycloak.json` adapter config file within the `WEB-"
 "INF` directory of your WAR."
 msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:29
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:21
 msgid ""
 "Finally you must specify both a `login-config` and use standard servlet "
 "security to specify role-base constraints on your URLs.  Here's an example:"
@@ -117,21 +79,11 @@ msgstr ""
 "と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:65
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:38
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:26
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:30
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
 msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:138
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:80
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:56
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:45
 #, no-wrap
 msgid ""
 "    <login-config>\n"
@@ -145,13 +97,11 @@ msgstr ""
 "    </login-config>\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:3
 #, no-wrap
 msgid "Tomcat 6, 7 and 8 Adapters"
 msgstr "Tomcat  6、7、8アダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:8
 msgid ""
 "To be able to secure WAR apps deployed on Tomcat 6, 7 and 8 you must install"
 " the Keycloak Tomcat 6, 7 or 8 adapter into your Tomcat installation.  You "
@@ -162,8 +112,6 @@ msgstr ""
 "アダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:15
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:8
 msgid ""
 "Adapters are no longer included with the appliance or war distribution.  "
 "Each adapter is a separate download on the Keycloak download site.  They are"
@@ -172,7 +120,6 @@ msgstr ""
 "アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:18
 msgid ""
 "You must unzip the adapter distro into Tomcat's `lib/` directory.  Including"
 " adapter's jars within your WEB-INF/lib directory will not work! The "
@@ -183,7 +130,6 @@ msgstr ""
 "INF/libディレクトリ内にアダプターのjarを含めても動作しません！KeycloakアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリに存在する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:29
 #, no-wrap
 msgid ""
 "$ cd $TOMCAT_HOME/lib\n"
@@ -201,8 +147,6 @@ msgstr ""
 "$ unzip keycloak-tomcat8-adapter-dist.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:37
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:8
 msgid ""
 "The first thing you must do is create a `META-INF/context.xml` file in your "
 "WAR package.  This is a Tomcat specific config file and you must define a "
@@ -212,7 +156,6 @@ msgstr ""
 "これはTomcat固有の設定ファイルであり、Keycloak固有のValveを定義する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:45
 #, no-wrap
 msgid ""
 "<Context path=\"/your-context-path\">\n"
@@ -224,17 +167,14 @@ msgstr ""
 "</Context>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:50
 #, no-wrap
 msgid ""
-"The format of this config file is describe in the "
+"The format of this config file is described in the "
 "<<_java_adapter_config,Java adapter configuration>>           \n"
 msgstr ""
-"この設定ファイルの形式は　<<_java_adapter_config,Java adapter configuration>> で説明しています。\n"
+"この設定ファイルの形式は<<_java_adapter_config,Java adapter configuration>>で説明しています。\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:75
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:40
 #, no-wrap
 msgid ""
 "    <security-constraint>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__tomcat-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__tomcat-adapter/ja_JP/index.html
