### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -17,7 +17,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "For example:"
-msgstr "例えば:"
+msgstr "例："
 
 #. type: Title ===
 #, no-wrap
@@ -47,7 +47,7 @@ msgid ""
 "the server. If you copy the adapter to your web application instead, make "
 "sure you upgrade the adapter only after you have upgraded the server."
 msgstr ""
-"{project_name}サーバーをアップグレードする際に自動的にJavaScriptアダプターが更新されるため、ベスト・プラクティスは{project_name}サーバーからJavaScriptアダプターを直接ロードすることです。アダプターをWebアプリケーションにコピーする場合、サーバーをアップグレードした後だけ、アダプターもアップグレードしてください。"
+"{project_name}サーバーをアップグレードする際に自動的にJavaScriptアダプターが更新されるため、ベスト・プラクティスは{project_name}サーバーからJavaScriptアダプターを直接ロードすることです。そうではなくアダプターをWebアプリケーションにコピーする場合は、サーバーをアップグレードした後に、アダプターもアップグレードするようにしてください。"
 
 #. type: Plain text
 msgid ""
@@ -127,7 +127,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "If the `keycloak.json` file is in a different location you can specify it:"
-msgstr "`keycloak.json` ファイルが別の場所にある場合、それを指定することができます:"
+msgstr "`keycloak.json` ファイルが別の場所にある場合、以下のように指定することができます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -138,7 +138,7 @@ msgstr "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
 msgid ""
 "Alternatively, you can pass in a JavaScript object with the required "
 "configuration instead:"
-msgstr "または、必要な設定でJavaScriptオブジェクトを渡すこともできます:"
+msgstr "または、以下のように必要な設定でJavaScriptオブジェクトを渡すこともできます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -166,7 +166,7 @@ msgid ""
 "user is not logged-in the browser will be redirected back to the application"
 " and remain unauthenticated."
 msgstr ""
-"デフォルトでは `login` 関数を呼び出す必要があります。 ただし、アダプターを自動的に認証させるための2つのオプションがあります。 `init` "
+"デフォルトでは `login` 関数を呼び出す必要があります。ただし、アダプターを自動的に認証させるための2つのオプションがあります。 `init` "
 "関数に `login-required` または `check-sso` を渡すことができます。 `login-required` "
 "は、ユーザーが{project_name}にログインしていない場合にクライアントを認証し、そうでない場合にログインページを表示します。 `check-"
 "sso` "
@@ -177,8 +177,8 @@ msgid ""
 "To enable `login-required` set `onLoad` to `login-required` and pass to the "
 "init method:"
 msgstr ""
-"`login-required` を有効にするには、 `onLoad` に `login-required` を設定し、 `init` "
-"メソッドに渡します："
+"`login-required` を有効にするには、以下のように `onLoad` に `login-required` を設定し、 `init` "
+"メソッドに渡します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -192,8 +192,7 @@ msgid ""
 "`Authorization` header. For example:"
 msgstr ""
 "ユーザーが認証された後、アプリケーションは `Authorization` "
-"ヘッダーにベアラー・トークンを含めることによって、{project_name}によって保護されたRESTfulサービスへのリクエストを行うことができます。"
-" 例えば："
+"ヘッダーにベアラー・トークンを含めることによって、{project_name}によって保護されたRESTfulサービスへのリクエストを行うことができます。以下に例を示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -265,8 +264,8 @@ msgid ""
 msgstr ""
 "注意すべきことは、デフォルトではアクセス・トークンの有効期限が短いため、リクエストを送信する前にアクセス・トークンを更新する必要があることです。これは "
 "`updateToken` メソッドで行うことができます。 `updateToken` "
-"メソッドは、トークンが正常にリフレッシュされた場合にのみ、サービスの呼び出しを容易にするプロミス・オブジェクトを返し、そうでない場合は、例えば、ユーザーにエラーを表示します。"
-" 例えば："
+"メソッドは、トークンが正常にリフレッシュされた場合にのみ、サービスの呼び出しを容易にするプロミス・オブジェクトを返し、そうでない場合は、たとえば、ユーザーにエラーを表示します。"
+" 以下に例を示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -297,7 +296,7 @@ msgid ""
 "in the options passed to the `init` method."
 msgstr ""
 "デフォルトでは、JavaScriptアダプターは、シングル・サイン・アウトが発生したかどうかを検出するために使用される非表示のiframeを作成します。これはネットワーク・トラフィックを必要とせず、代わりに特殊なステータス・クッキーを調べることによってステータスを取得します。この機能は、"
-" `init` メソッドに渡されるオプションに `checkLoginIframe：false` を設定することで無効にできます。"
+" `init` メソッドに渡されるオプションに `checkLoginIframe: false` を設定することで無効にできます。"
 
 #. type: Plain text
 msgid ""
@@ -317,8 +316,8 @@ msgid ""
 "By default, the JavaScript adapter uses the http://openid.net/specs/openid-"
 "connect-core-1_0.html#CodeFlowAuth[Authorization Code] flow."
 msgstr ""
-"デフォルトで、JavaScriptアダプターはhttp://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[認可コード]フローを使用します。"
+"デフォルトで、JavaScriptアダプターは http://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[認可コード] フローを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -327,8 +326,8 @@ msgid ""
 "exchanges the `code` for an access token and a refresh token after the "
 "browser is redirected back to the application."
 msgstr ""
-"このフローにより、{project_name}サーバーは認証トークンではなく、認証コードをアプリケーションに返します。ブラウザがアプリケーションにリダイレクトされた後、JavaScriptアダプターはアクセス・トークンとリフレッシュ・トークンの"
-" `code` を交換します。"
+"このフローにより、{project_name}サーバーは認証トークンではなく、認可コードをアプリケーションに返します。ブラウザーがアプリケーションにリダイレクトされた後、JavaScriptアダプターは"
+"  `code`  をアクセス・トークンとリフレッシュ・トークンに交換します。"
 
 #. type: Plain text
 msgid ""
@@ -339,9 +338,10 @@ msgid ""
 "request to exchange the code for tokens, but it has implications when the "
 "access token expires."
 msgstr ""
-"{project_name}は、{project_name}での認証が成功した直後にアクセス・トークンが送信されるhttp://openid.net/specs"
-"/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[インプリシット]フローもサポートしています。これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに影響があります。"
+"{project_name}は、{project_name}での認証が成功した直後にアクセス・トークンが送信される "
+"http://openid.net/specs/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[インプリシット] "
+"フローもサポートしています。これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに影響があります。"
 
 #. type: Plain text
 msgid ""
@@ -349,7 +349,7 @@ msgid ""
 "vulnerability. For example the token could be leaked through web server logs"
 " and or browser history."
 msgstr ""
-"ただし、URLフラグメントにアクセス・トークンを送信することはセキュリティ上の脆弱性となります。たとえば、Webサーバーのログやブラウザの履歴からトークンが漏洩する可能性があります。"
+"ただし、URLフラグメントにアクセス・トークンを送信することはセキュリティ上の脆弱性となります。たとえば、Webサーバーのログやブラウザーの履歴からトークンが漏洩する可能性があります。"
 
 #. type: Plain text
 msgid ""
@@ -379,7 +379,7 @@ msgid ""
 "{project_name} also supports the http://openid.net/specs/openid-connect-"
 "core-1_0.html#HybridFlowAuth[Hybrid] flow."
 msgstr ""
-"{project_name}はhttp://openid.net/specs/openid-connect-core-"
+"{project_name}は http://openid.net/specs/openid-connect-core-"
 "1_0.html#HybridFlowAuth[ハイブリッド] ・フローもサポートしています。"
 
 #. type: Plain text
@@ -406,7 +406,8 @@ msgstr "ハイブリッド・フローの1つの利点は、アプリケーシ�
 msgid ""
 "For the Hybrid flow, you need to pass the parameter `flow` with value "
 "`hybrid` to the `init` method:"
-msgstr "ハイブリッド・フローの場合、パラメーター `flow` を値 `hybrid` で `init` メソッドに渡す必要があります："
+msgstr ""
+"ハイブリッド・フローの場合、以下のようにパラメーター `flow` を値 `hybrid` で `init` メソッドに渡す必要があります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -424,12 +425,12 @@ msgid ""
 "HTML5 History API.  If you need to support browsers that do not have these "
 "available (for example, IE9) you need to add polyfillers."
 msgstr ""
-"JavaScriptアダプターは、Base64（window.btoaとwindow.atob）とHTML5 History APIに依存しています。 "
-"これらが利用できないブラウザ（IE9など）をサポートする必要がある場合は、ポリフィラーを追加する必要があります。"
+"JavaScriptアダプターは、Base64（window.btoaとwindow.atob）とHTML5 History "
+"APIに依存しています。これらが利用できないブラウザ（IE9など）をサポートする必要がある場合は、Polyfillを追加する必要があります。"
 
 #. type: Plain text
 msgid "Example polyfill libraries:"
-msgstr "ポリフィル・ライブラリーの例："
+msgstr "Polyfillライブラリーの例："
 
 #. type: Plain text
 msgid "https://github.com/davidchambers/Base64.js"
@@ -464,7 +465,7 @@ msgstr ""
 #. type: Title =====
 #, no-wrap
 msgid "Properties"
-msgstr "プロパティ"
+msgstr "プロパティー"
 
 #. type: Labeled list
 #, no-wrap
@@ -484,7 +485,7 @@ msgstr "token"
 msgid ""
 "The base64 encoded token that can be sent in the `Authorization` header in "
 "requests to services."
-msgstr "サービスへのリクエストの `Authorization` ヘッダーで送信できるbase64でエンコードされたトークンです。"
+msgstr "サービスへのリクエストの `Authorization` ヘッダーで送信できるBase64でエンコードされたトークンです。"
 
 #. type: Labeled list
 #, no-wrap
@@ -548,7 +549,7 @@ msgstr "refreshToken"
 #. type: Plain text
 msgid ""
 "The base64 encoded refresh token that can be used to retrieve a new token."
-msgstr "新しいトークンを取得するために使用できるbase64でエンコードされたリフレッシュ・トークン。"
+msgstr "新しいトークンの取得に使用できるBase64でエンコードされたリフレッシュ・トークン。"
 
 #. type: Labeled list
 #, no-wrap
@@ -579,7 +580,7 @@ msgstr "responseMode"
 
 #. type: Plain text
 msgid "Response mode passed in init (default value is fragment)."
-msgstr "`init` に渡されるレスポンス・モード(デフォルトはフラグメント)。"
+msgstr "initに渡されるレスポンス・モード（デフォルト値はfragment）。"
 
 #. type: Labeled list
 #, no-wrap
@@ -588,7 +589,7 @@ msgstr "flow"
 
 #. type: Plain text
 msgid "Flow passed in init."
-msgstr "`init` に渡されるフロー。"
+msgstr "initに渡されるフロー。"
 
 #. type: Labeled list
 #, no-wrap
@@ -619,14 +620,14 @@ msgstr "アダプターを初期化するために呼び出されます。"
 
 #. type: Plain text
 msgid "Options is an Object, where:"
-msgstr "オプションはオブジェクトです:"
+msgstr "optionsはオブジェクトで、以下のプロパティーがあります。"
 
 #. type: Plain text
 msgid ""
 "onLoad - Specifies an action to do on load. Supported values are 'login-"
 "required' or 'check-sso'."
 msgstr ""
-"onLoad - ロード時に実行するアクションを指定します。 サポートされている値は'login-required'または'check-sso'です。"
+"onLoad - ロード時に実行するアクションを指定します。サポートされている値は'login-required'または'check-sso'です。"
 
 #. type: Plain text
 msgid "token - Set an initial value for the token."
@@ -640,7 +641,7 @@ msgstr "refreshToken - リフレッシュ・トークンの初期値を設定し
 msgid ""
 "idToken - Set an initial value for the id token (only together with token or"
 " refreshToken)."
-msgstr "idToken - IDトークンの初期値を設定します(tokenまたはrefreshTokenとともにする場合のみ)。"
+msgstr "idToken - IDトークンの初期値を設定します（tokenまたはrefreshTokenとともにする場合のみ）。"
 
 #. type: Plain text
 msgid ""
@@ -648,19 +649,19 @@ msgid ""
 "{project_name} server in seconds (only together with token or refreshToken)."
 msgstr ""
 "timeSkew - "
-"ローカルの時間と{project_name}サーバーとの間のスキューの初期値を秒単位で設定します(tokenまたはrefreshTokenとともにする場合のみ)。"
+"ローカルの時間と{project_name}サーバーとの間のスキューの初期値を秒単位で設定します（tokenまたはrefreshTokenとともにする場合のみ）。"
 
 #. type: Plain text
 msgid ""
 "checkLoginIframe - Set to enable/disable monitoring login state (default is "
 "true)."
-msgstr "checkLoginIframe - ログイン状態の監視を有効/無効に設定します(デフォルトはtrue)。"
+msgstr "checkLoginIframe - ログイン状態の監視を有効/無効に設定します（デフォルトはtrue）。"
 
 #. type: Plain text
 msgid ""
 "checkLoginIframeInterval - Set the interval to check login state (default is"
 " 5 seconds)."
-msgstr "checkLoginIframeInterval - ログイン状態を確認する間隔を設定します(デフォルトは5秒です)。"
+msgstr "checkLoginIframeInterval - ログイン状態を確認する間隔を設定します（デフォルトは5秒）。"
 
 #. type: Plain text
 msgid ""
@@ -684,7 +685,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Returns promise to set functions to be invoked on success or error."
-msgstr "成功した時またはエラーが発生した時に、呼び出される関数を設定することを約束します。"
+msgstr "成功またはエラー発生時に呼び出される関数を設定するPromiseを返します。"
 
 #. type: Title ======
 #, no-wrap
@@ -696,7 +697,7 @@ msgid ""
 "Redirects to login form on (options is an optional object with redirectUri "
 "and/or prompt fields)."
 msgstr ""
-"ログイン・フォームにリダイレクトします（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+"ログイン・フォームにリダイレクトします（optionsは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
 
 #. type: Plain text
 msgid "redirectUri - Specifies the uri to redirect to after login."
@@ -710,8 +711,8 @@ msgid ""
 "in, set this option to `none`. To always require re-authentication and "
 "ignore SSO, set this option to `login` ."
 msgstr ""
-"prompt - ユーザーが{project_name}にログインしていない場合、デフォルトでログイン画面が表示されます。 "
-"ユーザーがすでにログインしている場合にのみアプリケーションを認証し、ログインしていない場合にログイン・ページを表示しないようにするには、このオプションを"
+"prompt - "
+"ユーザーが{project_name}にログインしていない場合、デフォルトでログイン画面が表示されます。ユーザーがすでにログインしている場合にのみアプリケーションを認証し、ログインしていない場合にログイン・ページを表示しないようにするには、このオプションを"
 " `none` に設定します。 常に再認証が必要でSSOを無視するには、このオプションを `login` に設定します。"
 
 #. type: Plain text
@@ -750,13 +751,13 @@ msgid ""
 "Returns the URL to login form on (options is an optional object with "
 "redirectUri and/or prompt fields)."
 msgstr ""
-"ログイン・フォームへのURLを返します（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+"ログイン・フォームへのURLを返します（optionsは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
 
 #. type: Plain text
 msgid ""
 "Options is an Object, which supports same options like the function `login` "
 "."
-msgstr "オプションは、 `login` 関数と同様のオプションをサポートするObjectです。"
+msgstr "optionsはオブジェクトで、 `login` 関数と同様のオプションをサポートします。"
 
 #. type: Title ======
 #, no-wrap
@@ -789,12 +790,12 @@ msgstr "register(options)"
 msgid ""
 "Redirects to registration form. Shortcut for login with option action = "
 "'register'"
-msgstr "登録フォームにリダイレクトします。オプションaction = 'register' でログインするためのショートカット"
+msgstr "登録フォームにリダイレクトします。オプション action = 'register' でのloginメソッドのショートカットです。"
 
 #. type: Plain text
 msgid ""
 "Options are same as for the login method but 'action' is set to 'register'"
-msgstr "オプションは `login` メソッドと同じですが、 'action' は 'register' に設定されています"
+msgstr "optionsはloginメソッドと同じですが、 'action' は 'register' に設定されています。"
 
 #. type: Title ======
 #, no-wrap
@@ -805,13 +806,14 @@ msgstr "createRegisterUrl(options)"
 msgid ""
 "Returns the url to registration page. Shortcut for createLoginUrl with "
 "option action = 'register'"
-msgstr "登録ページのURLを返します。オプションaction = 'register' を含むcreateLoginUrlへのショートカット"
+msgstr ""
+"登録ページのURLを返します。オプション action = 'register' でのcreateLoginUrlメソッドのショートカットです。"
 
 #. type: Plain text
 msgid ""
 "Options are same as for the createLoginUrl method but 'action' is set to "
 "'register'"
-msgstr "オプションは `createLoginUrl` メソッドと同じですが、 'action' は 'register' に設定されています"
+msgstr "optionsは createLoginUrlメソッドと同じですが、 'action' は 'register' に設定されています。"
 
 #. type: Title ======
 #, no-wrap
@@ -838,7 +840,7 @@ msgstr "hasRealmRole(role)"
 
 #. type: Plain text
 msgid "Returns true if the token has the given realm role."
-msgstr "トークンに指定されたレルムのロールがある場合は、trueを返します。"
+msgstr "トークンに指定されたレルム・ロールがある場合は、trueを返します。"
 
 #. type: Title ======
 #, no-wrap
@@ -850,8 +852,7 @@ msgid ""
 "Returns true if the token has the given role for the resource (resource is "
 "optional, if not specified clientId is used)."
 msgstr ""
-"トークンにリソースのロールが指定されている場合は、trueを返します（指定されていない場合はリソースはオプションですが、 `clientId` "
-"が使用されます）。"
+"トークンに指定されたresourceのロールがある場合は、trueを返します（resourceはオプションであり、指定されていない場合はclientIdが使用されます）。"
 
 #. type: Title ======
 #, no-wrap
@@ -866,7 +867,7 @@ msgstr "ユーザーのプロファイルを読み込みます。"
 msgid ""
 "Returns promise to set functions to be invoked if the profile was loaded "
 "successfully, or if the profile could not be loaded."
-msgstr "プロファイルが正常にロードされた場合、またはプロファイルをロードできなかった場合に、呼び出される関数を設定するpromiseを返します。"
+msgstr "プロファイルが正常にロードされた場合、またはプロファイルをロードできなかった場合に、呼び出される関数を設定するPromiseを返します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -893,8 +894,7 @@ msgid ""
 "Returns true if the token has less than minValidity seconds left before it "
 "expires (minValidity is optional, if not specified 0 is used)."
 msgstr ""
-"トークンが期限切れになる前に `minValidity` 秒を下回っている場合はtrueを返します（指定されていない場合は `minValidity` "
-"はオプションです。0が使用されます）。"
+"トークンが期限切れになる前にminValidity秒を下回っている場合はtrueを返します（指定されていない場合はminValidityはオプションです。0が使用されます）。"
 
 #. type: Title ======
 #, no-wrap
@@ -907,15 +907,13 @@ msgid ""
 " not specified 5 is used) the token is refreshed.  If the session status "
 "iframe is enabled, the session status is also checked."
 msgstr ""
-"トークンが `minValidity` 秒以内に期限切れになると（ `minValidity` "
-"は省略可能です。指定されていない場合は5が使用されます）、トークンがリフレッシュされます。 "
-"セッション・ステータスiframeが有効な場合、セッション・ステータスもチェックされます。"
+"トークンがminValidity秒以内に期限切れになると（minValidityは省略可能です。指定されていない場合は5が使用されます）、トークンがリフレッシュされます。セッション・ステータスiframeが有効な場合、セッション・ステータスもチェックされます。"
 
 #. type: Plain text
 msgid ""
 "Returns promise to set functions that can be invoked if the token is still "
 "valid, or if the token is no longer valid.  For example:"
-msgstr "トークンが有効な場合、またはトークンがもはや有効でない場合に呼び出される関数を設定するpromiseを返します。 例えば："
+msgstr "トークンが有効な場合、またはトークンがもはや有効でない場合に呼び出される関数を設定するPromiseを返します。以下に例を示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -951,12 +949,11 @@ msgid ""
 "application has detected the session was expired, for example if updating "
 "token fails."
 msgstr ""
-"認証状態(トークンを含む)をクリアします。 "
-"これは、更新トークンが失敗した場合など、セッションが終了したことをアプリケーションが検出した場合に役立ちます。"
+"認証状態（トークンを含む）をクリアします。これは、トークンの更新が失敗した場合など、セッションが終了したことをアプリケーションが検出した場合に役立ちます。"
 
 #. type: Plain text
 msgid "Invoking this results in onAuthLogout callback listener being invoked."
-msgstr "これを呼び出すと、 `onAuthLogout` コールバック・リスナーが呼び出されます。"
+msgstr "これを呼び出すと、onAuthLogoutコールバック・リスナーが呼び出されます。"
 
 #. type: Title =====
 #, no-wrap
@@ -974,7 +971,7 @@ msgstr "keycloak.onAuthSuccess = function() { alert('authenticated'); }\n"
 
 #. type: Plain text
 msgid "The available events are:"
-msgstr "使用できるイベントは次のとおりです:"
+msgstr "使用できるイベントは次のとおりです。"
 
 #. type: Plain text
 msgid "onReady(authenticated) - Called when the adapter is initialized."
@@ -1014,4 +1011,4 @@ msgid ""
 " obtain a new access token."
 msgstr ""
 "onTokenExpired - "
-"アクセス・トークンが期限切れになったときに呼び出されます。リフレッシュ・トークンが利用可能な場合、トークンはupdateTokenでリフレッシュすることができます。トークンがリフレッシュされていない場合（つまり、インプリシット・フローがある場合）、ログイン画面にリダイレクトして新しいアクセス・トークンを取得できます。"
+"アクセス・トークンが期限切れになったときに呼び出されます。リフレッシュ・トークンが利用可能な場合、トークンはupdateTokenでリフレッシュすることができます。リフレッシュ・トークンが利用できない場合（つまり、インプリシット・フローの場合）、ログイン画面にリダイレクトして新しいアクセス・トークンを取得できます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -16,105 +16,40 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:22
-#: source/securing_apps/topics/oidc/java/fuse/camel.adoc:8
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:13
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:55
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:321
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:368
-#: source/server_admin/topics/admin-cli.adoc:101
-#: source/server_admin/topics/admin-cli.adoc:169
-#: source/server_admin/topics/admin-cli.adoc:281
-#: source/server_admin/topics/admin-cli.adoc:426
-#: source/server_admin/topics/admin-cli.adoc:452
-#: source/server_admin/topics/admin-cli.adoc:475
-#: source/server_admin/topics/admin-cli.adoc:485
-#: source/server_admin/topics/admin-cli.adoc:493
-#: source/server_admin/topics/admin-cli.adoc:504
-#: source/server_admin/topics/admin-cli.adoc:543
-#: source/server_admin/topics/admin-cli.adoc:550
-#: source/server_admin/topics/admin-cli.adoc:557
-#: source/server_admin/topics/admin-cli.adoc:569
-#: source/server_admin/topics/admin-cli.adoc:576
-#: source/server_admin/topics/admin-cli.adoc:583
-#: source/server_admin/topics/admin-cli.adoc:688
-#: source/server_admin/topics/admin-cli.adoc:697
-#: source/server_admin/topics/admin-cli.adoc:749
-#: source/server_admin/topics/admin-cli.adoc:784
-#: source/server_admin/topics/admin-cli.adoc:798
-#: source/server_admin/topics/admin-cli.adoc:805
-#: source/server_admin/topics/admin-cli.adoc:812
-#: source/server_admin/topics/admin-cli.adoc:824
-#: source/server_admin/topics/admin-cli.adoc:831
-#: source/server_admin/topics/admin-cli.adoc:838
-#: source/server_admin/topics/admin-cli.adoc:885
-#: source/server_admin/topics/admin-cli.adoc:932
-#: source/server_admin/topics/admin-cli.adoc:955
-#: source/server_admin/topics/admin-cli.adoc:973
-#: source/server_admin/topics/admin-cli.adoc:982
-#: source/server_admin/topics/admin-cli.adoc:991
-#: source/server_admin/topics/admin-cli.adoc:1004
-#: source/server_admin/topics/admin-cli.adoc:1011
-#: source/server_admin/topics/admin-cli.adoc:1018
-#: source/server_admin/topics/admin-cli.adoc:1030
-#: source/server_admin/topics/admin-cli.adoc:1037
-#: source/server_admin/topics/admin-cli.adoc:1044
-#: source/server_admin/topics/admin-cli.adoc:1073
-#: source/server_admin/topics/admin-cli.adoc:1091
-#: source/server_admin/topics/admin-cli.adoc:1106
-#: source/server_admin/topics/admin-cli.adoc:1173
-#: source/server_admin/topics/admin-cli.adoc:1201
-#: source/server_admin/topics/admin-cli.adoc:1211
-#: source/server_admin/topics/admin-cli.adoc:1220
-#: source/server_admin/topics/admin-cli.adoc:1229
-#: source/server_admin/topics/admin-cli.adoc:1242
-#: source/server_admin/topics/admin-cli.adoc:1252
-#: source/server_admin/topics/admin-cli.adoc:1262
-#: source/server_admin/topics/admin-cli.adoc:1272
-#: source/server_admin/topics/admin-cli.adoc:1282
 msgid "For example:"
 msgstr "例えば:"
 
 #. type: Title ===
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:2
 #, no-wrap
 msgid "Javascript Adapter"
 msgstr "Javascriptアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:5
 msgid ""
 "{project_name} comes with a client-side JavaScript library that can be used "
 "to secure HTML5/JavaScript applications. The JavaScript adapter has built-in"
 " support for Cordova applications."
 msgstr ""
-"{project_name} には、 HTML5/JavaScript "
-"アプリケーションを保護するために使用できるクライアント・サイドのJavaScriptライブラリが付属しています。 "
-"JavaScriptアダプターには、Cordovaアプリケーションのサポートが組み込まれています。"
+"{project_name}には、HTML5/JavaScriptアプリケーションをセキュリティ保護するために使用可能なクライアント・サイドのJavaScriptライブラリーが付属しています。JavaScriptアダプターには、Cordovaアプリケーションのサポートが組み込まれています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:7
 msgid ""
 "The library can be retrieved directly from the {project_name} server at "
 "`/auth/js/keycloak.js` and is also distributed as a ZIP archive."
 msgstr ""
-"ライブラリは `/auth/js/keycloak.js` の {project_name} "
-"サーバーから直接取得することができ、ZIPアーカイブとしても配布されます。"
+"ライブラリーは{project_name}サーバーの `/auth/js/keycloak.js` "
+"から直接取得することができ、ZIPアーカイブとしても配布されています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:9
 msgid ""
 "A best practice is to load the JavaScript adapter directly from "
 "{project_name} Server as it will automatically be updated when you upgrade "
 "the server. If you copy the adapter to your web application instead, make "
 "sure you upgrade the adapter only after you have upgraded the server."
 msgstr ""
-"ベストプラクティスは、サーバーをアップグレードするときに自動的に更新されるので、 {project_name} "
-"サーバーからJavaScriptアダプターを直接ロードすることです。 "
-"アダプターをWebアプリケーションにコピーする場合は、サーバーをアップグレードした後だけアダプターをアップグレードしてください。"
+"{project_name}サーバーをアップグレードする際に自動的にJavaScriptアダプターが更新されるため、ベスト・プラクティスは{project_name}サーバーからJavaScriptアダプターを直接ロードすることです。アダプターをWebアプリケーションにコピーする場合、サーバーをアップグレードした後だけ、アダプターもアップグレードしてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:12
 msgid ""
 "One important thing to note about using client-side applications is that the"
 " client has to be a public client as there is no secure way to store client "
@@ -122,32 +57,26 @@ msgid ""
 "make sure the redirect URIs you have configured for the client are correct "
 "and as specific as possible."
 msgstr ""
-"クライアント・サイドのアプリケーションを使用する際に注意すべき重要な点の1つは、クライアント・サイドのアプリケーションにクライアント・クレデンシャルを安全に保存する方法がないため、クライアントをパブリック・クライアントにする必要があることです。"
-" これにより、クライアント用に設定したリダイレクトURIが正しいか、できるだけ具体的であるかを確認することが非常に重要になります。"
+"クライアント・サイドのアプリケーションを使用する際に注意すべき重要な点の1つは、クライアント・サイドのアプリケーションにクライアント・クレデンシャルを安全に保存する方法がないため、クライアントをパブリック・クライアントにする必要があることです。これにより、クライアント用に設定したリダイレクトURIが正しいか、できるだけ具体的であるかを確認することが非常に重要になります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:15
 msgid ""
 "To use the JavaScript adapter you must first create a client for your "
 "application in the {project_name} Administration Console. Make sure `public`"
 " is selected for `Access Type`."
 msgstr ""
-"JavaScriptアダプターを使用するには、まず {project_name} "
-"管理コンソールでアプリケーション用のクライアントを作成する必要があります。  `Access Type` に `public` "
-"が選択されていることを確認してください。"
+"JavaScriptアダプターを使用するには、まず{project_name}管理コンソールでアプリケーション用のクライアントを作成する必要があります。"
+" `Access Type` に `public` が選択されていることを確認してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:17
 msgid ""
 "You also need to configure valid redirect URIs and valid web origins. Be as "
 "specific as possible as failing to do so may result in a security "
 "vulnerability."
 msgstr ""
-"また、有効なリダイレクトURIと有効なWebオリジンを設定する必要があります。 "
-"できるだけ具体的にする理由は、そうしなければセキュリティ上の脆弱性が生じる可能性があるためです。"
+"また、有効なリダイレクトURIと有効なWebオリジンを設定する必要があります。できるだけ具体的にする理由は、そうしなければセキュリティ上の脆弱性が生じる可能性があるためです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:20
 msgid ""
 "Once the client is created click on the `Installation` tab select `Keycloak "
 "OIDC JSON` for `Format Option` then click `Download`. The downloaded "
@@ -155,23 +84,20 @@ msgid ""
 "location as your HTML pages."
 msgstr ""
 "クライアントが作成されたら `Installation` タブをクリックし、 `Format Option` の `Keycloak OIDC "
-"JSON` を選択し、 `Download` をクリックします。 ダウンロードした `keycloak.json` "
-"ファイルは、HTMLページと同じ場所にあるWebサーバー上でホストされるべきです。"
+"JSON` を選択して、 `Download` をクリックします。ダウンロードした `keycloak.json` "
+"ファイルは、HTMLページと同じ場所にあるWebサーバー上にホストされるべきです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:22
 msgid ""
 "Alternatively, you can skip the configuration file and manually configure "
 "the adapter."
 msgstr "または、設定ファイルではなく、アダプターを手動で設定することもできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:24
 msgid "The following example shows how to initialize the JavaScript adapter:"
 msgstr "次の例は、JavaScriptアダプターを初期化する方法を示しています。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:38
 #, no-wrap
 msgid ""
 "<head>\n"
@@ -199,27 +125,22 @@ msgstr ""
 "</head>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:41
 msgid ""
 "If the `keycloak.json` file is in a different location you can specify it:"
 msgstr "`keycloak.json` ファイルが別の場所にある場合、それを指定することができます:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:45
 #, no-wrap
-msgid "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json'));\n"
-msgstr ""
-"var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json'));\n"
+msgid "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
+msgstr "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:48
 msgid ""
 "Alternatively, you can pass in a JavaScript object with the required "
 "configuration instead:"
 msgstr "または、必要な設定でJavaScriptオブジェクトを渡すこともできます:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:56
 #, no-wrap
 msgid ""
 "var keycloak = Keycloak({\n"
@@ -235,7 +156,6 @@ msgstr ""
 "});\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:62
 msgid ""
 "By default to authenticate you need to call the `login` function. However, "
 "there are two options available to make the adapter automatically "
@@ -246,13 +166,13 @@ msgid ""
 "user is not logged-in the browser will be redirected back to the application"
 " and remain unauthenticated."
 msgstr ""
-"デフォルトでは `login` 関数を呼び出す必要があります。 ただし、アダプターを自動的に認証させるための2つのオプションがあります。  `init`"
-" 関数に `login-required` または `check-sso` を渡すことができます。 `login-required` は、ユーザーが "
-"{project_name} にログインしていない場合にクライアントを認証し、そうでない場合にログインページを表示します。 `check-sso` "
+"デフォルトでは `login` 関数を呼び出す必要があります。 ただし、アダプターを自動的に認証させるための2つのオプションがあります。 `init` "
+"関数に `login-required` または `check-sso` を渡すことができます。 `login-required` "
+"は、ユーザーが{project_name}にログインしていない場合にクライアントを認証し、そうでない場合にログインページを表示します。 `check-"
+"sso` "
 "は、ユーザーが既にログインしている場合にのみクライアントを認証します。ユーザーがログインしていない場合、ブラウザーはアプリケーションにリダイレクトされ、未認証のままになります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:64
 msgid ""
 "To enable `login-required` set `onLoad` to `login-required` and pass to the "
 "init method:"
@@ -261,23 +181,21 @@ msgstr ""
 "メソッドに渡します："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:68
 #, no-wrap
 msgid "keycloak.init({ onLoad: 'login-required' })\n"
 msgstr "keycloak.init({ onLoad: 'login-required' })\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:72
 msgid ""
 "After the user is authenticated the application can make requests to RESTful"
 " services secured by {project_name} by including the bearer token in the "
 "`Authorization` header. For example:"
 msgstr ""
-"ユーザーが認証された後、アプリケーションは `Authorization` ヘッダーにベアラー・トークンを含めることによって、 "
-"{project_name} によって保護されたRESTfulサービスへのリクエストを行うことができます。 例えば："
+"ユーザーが認証された後、アプリケーションは `Authorization` "
+"ヘッダーにベアラー・トークンを含めることによって、{project_name}によって保護されたRESTfulサービスへのリクエストを行うことができます。"
+" 例えば："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:77
 #, no-wrap
 msgid ""
 "var loadData = function () {\n"
@@ -287,13 +205,11 @@ msgstr ""
 "    document.getElementById('username').innerText = keycloak.subject;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:79
 #, no-wrap
 msgid "    var url = 'http://localhost:8080/restful-service';\n"
 msgstr "    var url = 'http://localhost:8080/restful-service';\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:84
 #, no-wrap
 msgid ""
 "    var req = new XMLHttpRequest();\n"
@@ -307,7 +223,6 @@ msgstr ""
 "    req.setRequestHeader('Authorization', 'Bearer ' + keycloak.token);\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:94
 #, no-wrap
 msgid ""
 "    req.onreadystatechange = function () {\n"
@@ -331,7 +246,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:97
 #, no-wrap
 msgid ""
 "    req.send();\n"
@@ -341,7 +255,6 @@ msgstr ""
 "};\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:102
 msgid ""
 "One thing to keep in mind is that the access token by default has a short "
 "life expiration so you may need to refresh the access token prior to sending"
@@ -350,13 +263,12 @@ msgid ""
 "only if the token was successfully refreshed and for example display an "
 "error to the user if it wasn't. For example:"
 msgstr ""
-"注意すべきことは、デフォルトではアクセス・トークンの有効期限が短いため、リクエストを送信する前にアクセス・トークンを更新する必要があることです。 これは"
-" `updateToken` メソッドで行うことができます。  `updateToken` "
+"注意すべきことは、デフォルトではアクセス・トークンの有効期限が短いため、リクエストを送信する前にアクセス・トークンを更新する必要があることです。これは "
+"`updateToken` メソッドで行うことができます。 `updateToken` "
 "メソッドは、トークンが正常にリフレッシュされた場合にのみ、サービスの呼び出しを容易にするプロミス・オブジェクトを返し、そうでない場合は、例えば、ユーザーにエラーを表示します。"
 " 例えば："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:110
 #, no-wrap
 msgid ""
 "keycloak.updateToken(30).success(function() {\n"
@@ -372,13 +284,11 @@ msgstr ""
 "});\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:112
 #, no-wrap
 msgid "Session Status iframe"
 msgstr "セッション・ステータスiframe"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:117
 msgid ""
 "By default, the JavaScript adapter creates a hidden iframe that is used to "
 "detect if a Single-Sign Out has occurred.  This does not require any network"
@@ -386,49 +296,41 @@ msgid ""
 "cookie.  This feature can be disabled by setting `checkLoginIframe: false` "
 "in the options passed to the `init` method."
 msgstr ""
-"デフォルトでは、JavaScriptアダプターは、シングル・サイン・アウトが発生したかどうかを検出するために使用される非表示のiframeを作成します。"
-" これはネットワーク・トラフィックを必要とせず、代わりに特殊なステータス・クッキーを調べることによってステータスを取得します。 この機能は、 "
-"`init` メソッドに渡されるオプションに `checkLoginIframe：false` を設定することで無効にできます。"
+"デフォルトでは、JavaScriptアダプターは、シングル・サイン・アウトが発生したかどうかを検出するために使用される非表示のiframeを作成します。これはネットワーク・トラフィックを必要とせず、代わりに特殊なステータス・クッキーを調べることによってステータスを取得します。この機能は、"
+" `init` メソッドに渡されるオプションに `checkLoginIframe：false` を設定することで無効にできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:120
 msgid ""
 "You should not rely on looking at this cookie directly. It's format can "
 "change and it's also associated with the URL of the {project_name} server, "
 "not your application."
 msgstr ""
-"このクッキーを直接参照することに頼るべきではありません。 フォーマットは変更可能で、アプリケーションではなく {project_name} "
-"サーバーのURLに関連付けられています。"
+"このクッキーを直接参照することに頼るべきではありません。フォーマットは変更可能で、アプリケーションではなく{project_name}サーバーのURLに関連付けられています。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:122
 #, no-wrap
 msgid "Implicit and Hybrid Flow"
 msgstr "インプリシット・フローとハイブリッド・フロー"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:125
 msgid ""
 "By default, the JavaScript adapter uses the http://openid.net/specs/openid-"
 "connect-core-1_0.html#CodeFlowAuth[Authorization Code] flow."
 msgstr ""
-"デフォルトでは、JavaScriptアダプターは http://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[認可コード] フローを使用します。"
+"デフォルトで、JavaScriptアダプターはhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[認可コード]フローを使用します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:128
 msgid ""
 "With this flow the {project_name} server returns an authorization code, not "
 "an authentication token, to the application. The JavaScript adapter "
 "exchanges the `code` for an access token and a refresh token after the "
 "browser is redirected back to the application."
 msgstr ""
-"このフローにより、 {project_name} サーバーは認証トークンではなく、認証コードをアプリケーションに返します。 "
-"ブラウザがアプリケーションにリダイレクトされた後、JavaScriptアダプターはアクセス・トークンとリフレッシュ・トークンの `code` "
-"を交換します。"
+"このフローにより、{project_name}サーバーは認証トークンではなく、認証コードをアプリケーションに返します。ブラウザがアプリケーションにリダイレクトされた後、JavaScriptアダプターはアクセス・トークンとリフレッシュ・トークンの"
+" `code` を交換します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:132
 msgid ""
 "{project_name} also supports the http://openid.net/specs/openid-connect-"
 "core-1_0.html#ImplicitFlowAuth[Implicit] flow where an access token is sent "
@@ -437,60 +339,50 @@ msgid ""
 "request to exchange the code for tokens, but it has implications when the "
 "access token expires."
 msgstr ""
-"{project_name} は、 {project_name} での認証が成功した直後にアクセス・トークンが送信される "
-"http://openid.net/specs/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[Implicit] フローもサポートしています。 "
-"これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに意味を持ちます。"
+"{project_name}は、{project_name}での認証が成功した直後にアクセス・トークンが送信されるhttp://openid.net/specs"
+"/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[インプリシット]フローもサポートしています。これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに影響があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:135
 msgid ""
 "However, sending the access token in the URL fragment can be a security "
 "vulnerability. For example the token could be leaked through web server logs"
 " and or browser history."
 msgstr ""
-"ただし、URLフラグメントにアクセス・トークンを送信することはセキュリティ上の脆弱性となります。 "
-"たとえば、Webサーバーのログやブラウザの履歴からトークンが漏洩する可能性があります。"
+"ただし、URLフラグメントにアクセス・トークンを送信することはセキュリティ上の脆弱性となります。たとえば、Webサーバーのログやブラウザの履歴からトークンが漏洩する可能性があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:138
 msgid ""
 "To enable implicit flow, you need to enable the `Implicit Flow Enabled` flag"
 " for the client in the {project_name} Administration Console.  You also need"
 " to pass the parameter `flow` with value `implicit` to `init` method:"
 msgstr ""
-"インプリシット・フローを有効にするには、 {project_name} 管理コンソールでクライアントの `Implicit Flow Enabled` "
-"フラグを有効にする必要があります。  `init` メソッドに ` implicit` という値を持つ `flow` パラメータを渡す必要もあります："
+"インプリシット・フローを有効にするには、{project_name}管理コンソールでクライアントの `Implicit Flow Enabled` "
+"フラグを有効にする必要があります。 `init` メソッドに `implicit` という値を持つ `flow` パラメータを渡す必要もあります："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:142
 #, no-wrap
 msgid "keycloak.init({ flow: 'implicit' })\n"
 msgstr "keycloak.init({ flow: 'implicit' })\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:146
 msgid ""
 "One thing to note is that only an access token is provided and there is no "
 "refresh token. This means that once the access token has expired the "
 "application has to do the redirect to the {project_name} again to obtain a "
 "new access token."
 msgstr ""
-"注意すべき点の1つは、アクセストークンのみが提供され、リフレッシュ・トークンがないことです。 "
-"つまり、アクセス・トークンが期限切れになると、アプリケーションは {project_name} "
-"へのリダイレクトを再度実行して、新しいアクセス・トークンを取得する必要があります。"
+"注意すべき点の1つは、アクセス・トークンのみが提供され、リフレッシュ・トークンがないことです。つまり、アクセス・トークンが期限切れになると、アプリケーションは{project_name}へのリダイレクトを再度実行して、新しいアクセス・トークンを取得する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:148
 msgid ""
 "{project_name} also supports the http://openid.net/specs/openid-connect-"
 "core-1_0.html#HybridFlowAuth[Hybrid] flow."
 msgstr ""
-"{project_name} は http://openid.net/specs/openid-connect-core-"
-"1_0.html#HybridFlowAuth[ハイブリッド] ・フローもサポトしています。"
+"{project_name}はhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#HybridFlowAuth[ハイブリッド] ・フローもサポートしています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:154
 msgid ""
 "This requires the client to have both the `Standard Flow Enabled` and "
 "`Implicit Flow Enabled` flags enabled in the admin console.  The "
@@ -502,39 +394,31 @@ msgid ""
 "vulnerability mentioned earlier may still apply."
 msgstr ""
 "これは、管理コンソールでクライアントの `Standard Flow Enabled` と `Implicit Flow Enabled` "
-"フラグを有効にする必要があります。  {project_name} サーバーはコードとトークンの両方をアプリケーションに送信します。 "
-"アクセス・トークンおリフレッシュ・トークンの交換ができる間、アクセス・トークンは即時使用できます。 "
-"インプリシット・フローと同様に、アクセス・トークンがすぐに利用できるため、ハイブリッド・フローはパフォーマンスに優れています。 "
-"しかし、トークンは引き続きURLに送信され、前述のセキュリティの脆弱性が当てはまる可能性があります。"
+"フラグを有効にすることを要求します。{project_name}サーバーはコードとトークンの両方をアプリケーションに送信します。アクセス・トークンとリフレッシュ・トークンの交換ができる間、アクセス・トークンは即時使用できます。インプリシット・フローと同様に、アクセス・トークンがすぐに利用できるため、ハイブリッド・フローはパフォーマンスに優れています。しかし、トークンは引き続きURLに送信され、前述のセキュリティの脆弱性が当てはまる可能性があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:156
 msgid ""
 "One advantage in the Hybrid flow is that the refresh token is made available"
 " to the application."
 msgstr "ハイブリッド・フローの1つの利点は、アプリケーションでリフレッシュ・トークンが利用可能になることです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:158
 msgid ""
 "For the Hybrid flow, you need to pass the parameter `flow` with value "
 "`hybrid` to the `init` method:"
-msgstr "ハイブリッド・フローの場合、 パラメーター `flow` を値 'hybrid' で `init` メソッドに渡す必要があります："
+msgstr "ハイブリッド・フローの場合、パラメーター `flow` を値 `hybrid` で `init` メソッドに渡す必要があります："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:162
 #, no-wrap
 msgid "keycloak.init({ flow: 'hybrid' })\n"
 msgstr "keycloak.init({ flow: 'hybrid' })\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:164
 #, no-wrap
 msgid "Earlier Browsers"
 msgstr "以前のブラウザー"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:168
 msgid ""
 "The JavaScript adapter depends on Base64 (window.btoa and window.atob) and "
 "HTML5 History API.  If you need to support browsers that do not have these "
@@ -544,35 +428,29 @@ msgstr ""
 "これらが利用できないブラウザ（IE9など）をサポートする必要がある場合は、ポリフィラーを追加する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:170
 msgid "Example polyfill libraries:"
-msgstr "ポリフィル・ライブラリの例："
+msgstr "ポリフィル・ライブラリーの例："
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:172
 msgid "https://github.com/davidchambers/Base64.js"
 msgstr "https://github.com/davidchambers/Base64.js"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:173
 #, no-wrap
 msgid "https://github.com/devote/HTML5-History-API        \n"
 msgstr "https://github.com/devote/HTML5-History-API        \n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:174
 #, no-wrap
 msgid "JavaScript Adapter Reference"
 msgstr "JavaScriptアダプター・リファレンス"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:176
 #, no-wrap
 msgid "Constructor"
 msgstr "コンストラクター"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:183
 #, no-wrap
 msgid ""
 "new Keycloak();\n"
@@ -584,254 +462,207 @@ msgstr ""
 "new Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: 'myApp' });\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:185
 #, no-wrap
 msgid "Properties"
 msgstr "プロパティ"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:187
 #, no-wrap
 msgid "authenticated"
 msgstr "authenticated"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:189
 msgid "Is `true` if the user is authenticated, `false` otherwise."
 msgstr "ユーザーが認証されている場合は `true` 、それ以外の場合は `false` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:190
 #, no-wrap
 msgid "token"
 msgstr "token"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:192
 msgid ""
 "The base64 encoded token that can be sent in the `Authorization` header in "
 "requests to services."
 msgstr "サービスへのリクエストの `Authorization` ヘッダーで送信できるbase64でエンコードされたトークンです。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:193
 #, no-wrap
 msgid "tokenParsed"
 msgstr "tokenParsed"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:195
 msgid "The parsed token as a JavaScript object."
 msgstr "JavaScriptオブジェクトとして解析されたトークン。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:196
 #, no-wrap
 msgid "subject"
 msgstr "subject"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:198
 msgid "The user id."
 msgstr "ユーザーID。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:199
 #, no-wrap
 msgid "idToken"
 msgstr "idToken"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:201
 msgid "The base64 encoded ID token."
 msgstr "Base64でエンコードされたIDトークン。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:202
 #, no-wrap
 msgid "idTokenParsed"
 msgstr "idTokenParsed"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:204
 msgid "The parsed id token as a JavaScript object."
 msgstr "JavaScriptオブジェクトとして解析されたIDトークン。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:205
 #, no-wrap
 msgid "realmAccess"
 msgstr "realmAccess"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:207
 msgid "The realm roles associated with the token."
 msgstr "トークンに関連付けられているレルムのロール。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:208
 #, no-wrap
 msgid "resourceAccess"
 msgstr "resourceAccess"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:210
 msgid "The resource roles associated with the token."
 msgstr "トークンに関連付けられているリソースのロール。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:211
 #, no-wrap
 msgid "refreshToken"
 msgstr "refreshToken"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:213
 msgid ""
 "The base64 encoded refresh token that can be used to retrieve a new token."
 msgstr "新しいトークンを取得するために使用できるbase64でエンコードされたリフレッシュ・トークン。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:214
 #, no-wrap
 msgid "refreshTokenParsed"
 msgstr "refreshTokenParsed"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:216
 msgid "The parsed refresh token as a JavaScript object."
 msgstr "JavaScriptオブジェクトとして解析されたリフレッシュ・トークン。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:217
 #, no-wrap
 msgid "timeSkew"
 msgstr "timeSkew"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:220
 msgid ""
 "The estimated time difference between the browser time and the "
 "{project_name} server in seconds. This value is just an estimation, but is "
 "accurate enough when determining if a token is expired or not."
 msgstr ""
-"ブラウザーと {project_name} サーバーの推定される時間差（秒単位）。 "
-"この値は単なる見積もりですが、トークンが期限切れになっているかどうかを判断するには十分正確です。"
+"ブラウザーと{project_name}サーバーの推定される時間差（秒単位）。この値は単なる見積もりですが、トークンが期限切れになっているかどうかを判断するには十分正確です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:221
 #, no-wrap
 msgid "responseMode"
 msgstr "responseMode"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:223
 msgid "Response mode passed in init (default value is fragment)."
-msgstr "`init` に渡されるレスポンスモード(デフォルトはフラグメント)。"
+msgstr "`init` に渡されるレスポンス・モード(デフォルトはフラグメント)。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:224
 #, no-wrap
 msgid "flow"
 msgstr "flow"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:226
 msgid "Flow passed in init."
 msgstr "`init` に渡されるフロー。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:227
 #, no-wrap
 msgid "responseType"
 msgstr "responseType"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:229
 msgid ""
 "Response type sent to {project_name} with login requests. This is determined"
 " based on the flow value used during initialization, but can be overridden "
 "by setting this value."
 msgstr ""
-"{project_name} にログイン・リクエストとともに送信されたレスポンスタイプ。 "
-"これは、初期化中に使用されたフロー値に基づいて決定されますが、この値を設定することで上書きできます。"
+"{project_name}にログイン・リクエストとともに送信されたレスポンスタイプ。これは、初期化中に使用されたフロー値に基づいて決定されますが、この値を設定することで上書きできます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:230
 #, no-wrap
 msgid "Methods"
-msgstr "Methods"
+msgstr "メソッド"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:232
 #, no-wrap
 msgid "init(options)"
 msgstr "init(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:235
 msgid "Called to initialize the adapter."
 msgstr "アダプターを初期化するために呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:237
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:255
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:274
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:282
 msgid "Options is an Object, where:"
 msgstr "オプションはオブジェクトです:"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:239
 msgid ""
 "onLoad - Specifies an action to do on load. Supported values are 'login-"
 "required' or 'check-sso'."
 msgstr ""
-"onLoad - ロード時に実行するアクションを指定します。 サポートされている値は 'login-required' または 'check-sso' "
-"です。"
+"onLoad - ロード時に実行するアクションを指定します。 サポートされている値は'login-required'または'check-sso'です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:240
 msgid "token - Set an initial value for the token."
 msgstr "token - トークンの初期値を設定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:241
 msgid "refreshToken - Set an initial value for the refresh token."
 msgstr "refreshToken - リフレッシュ・トークンの初期値を設定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:242
 msgid ""
 "idToken - Set an initial value for the id token (only together with token or"
 " refreshToken)."
-msgstr "idToken - IDトークンの初期値を設定しますtokenまたはrefreshTokenと一緒にのみ)。"
+msgstr "idToken - IDトークンの初期値を設定します(tokenまたはrefreshTokenとともにする場合のみ)。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:243
 msgid ""
 "timeSkew - Set an initial value for skew between local time and "
 "{project_name} server in seconds (only together with token or refreshToken)."
 msgstr ""
-"timeSkew - 現地時間と {project_name} "
-"サーバーとの間のスキューの初期値を秒単位で設定します(tokenまたはrefreshTokenとともに設定)。"
+"timeSkew - "
+"ローカルの時間と{project_name}サーバーとの間のスキューの初期値を秒単位で設定します(tokenまたはrefreshTokenとともにする場合のみ)。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:244
 msgid ""
 "checkLoginIframe - Set to enable/disable monitoring login state (default is "
 "true)."
 msgstr "checkLoginIframe - ログイン状態の監視を有効/無効に設定します(デフォルトはtrue)。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:245
 msgid ""
 "checkLoginIframeInterval - Set the interval to check login state (default is"
 " 5 seconds)."
 msgstr "checkLoginIframeInterval - ログイン状態を確認する間隔を設定します(デフォルトは5秒です)。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:246
 msgid ""
 "responseMode - Set the OpenID Connect response mode send to {project_name} "
 "server at login request. Valid values are query or fragment . Default value "
@@ -840,45 +671,38 @@ msgid ""
 "parameters added in URL fragment. This is generally safer and recommended "
 "over query."
 msgstr ""
-"responseMode - ログイン・リクエストの時に {project_name} サーバーに送信するOpenID "
-"Connectレスポンスモードを設定します。 有効な値は、queryまたはfragmentです。 "
-"デフォルト値はfragmentです。つまり、認証が成功した後、 {project_name} はURLフラグメントに追加されたOpenID "
-"Connectパラメーターとともにjavascriptアプリケーションにリダイレクトされます。 これは一般的にクエリよりも安全で推奨されます。"
+"responseMode - ログイン・リクエストの時に{project_name}サーバーに送信するOpenID "
+"Connectレスポンス・モードを設定します。有効な値は、queryまたはfragmentです。デフォルト値はfragmentです。つまり、認証が成功した後、{project_name}はURLフラグメントに追加されたOpenID"
+" Connectパラメーターとともに、JavaScriptアプリケーションにリダイレクトされます。これは一般的にクエリーよりも安全で推奨されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:247
 msgid ""
 "flow - Set the OpenID Connect flow. Valid values are standard, implicit or "
 "hybrid."
 msgstr ""
-"flow - OpenID Connectのフローを設定します。 有効な値は、standard、implicit、hybridのいずれかです。"
+"flow - OpenID Connectのフローを設定します。有効な値は、standard、implicit、hybridのいずれかです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:249
 msgid "Returns promise to set functions to be invoked on success or error."
 msgstr "成功した時またはエラーが発生した時に、呼び出される関数を設定することを約束します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:250
 #, no-wrap
 msgid "login(options)"
 msgstr "login(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:253
 msgid ""
 "Redirects to login form on (options is an optional object with redirectUri "
 "and/or prompt fields)."
 msgstr ""
-"ログインフォームにリダイレクトします（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+"ログイン・フォームにリダイレクトします（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:257
 msgid "redirectUri - Specifies the uri to redirect to after login."
 msgstr "redirectUri - ログイン後にリダイレクトするURIを指定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:258
 msgid ""
 "prompt - By default the login screen is displayed if the user is not logged-"
 "in to {project_name}. To only authenticate to the application if the user is"
@@ -886,169 +710,142 @@ msgid ""
 "in, set this option to `none`. To always require re-authentication and "
 "ignore SSO, set this option to `login` ."
 msgstr ""
-"prompt - ユーザーが {project_name} にログインしていない場合、デフォルトでログイン画面が表示されます。 "
-"ユーザーがすでにログインしている場合にのみアプリケーションを認証し、ログインしていない場合はログインページを表示しないようにするには、このオプションを "
-"`none` に設定します。 常に再認証が必要でSSOを無視するには、このオプションを `login` に設定します。"
+"prompt - ユーザーが{project_name}にログインしていない場合、デフォルトでログイン画面が表示されます。 "
+"ユーザーがすでにログインしている場合にのみアプリケーションを認証し、ログインしていない場合にログイン・ページを表示しないようにするには、このオプションを"
+" `none` に設定します。 常に再認証が必要でSSOを無視するには、このオプションを `login` に設定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:259
 msgid ""
 "maxAge - Used just if user is already authenticated. Specifies maximum time "
 "since the authentication of user happened. If user is already authenticated "
 "for longer time than `maxAge`, the SSO is ignored and he will need to re-"
 "authenticate again."
 msgstr ""
-"maxAge - ユーザーがすでに認証されている場合にのみ使用されます。 ユーザーの認証が行われてからの最大時間を指定します。 ユーザーがすでに "
-"`maxAge`よりも長い時間認証済みの場合、SSOは無視され、再度認証する必要があります。"
+"maxAge - ユーザーがすでに認証されている場合にのみ使用されます。ユーザーの認証が行われてからの最大時間を指定します。ユーザーがすでに "
+"`maxAge` よりも長い時間認証済みの場合、SSOは無視され、再度認証する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:260
 msgid ""
 "loginHint - Used to pre-fill the username/email field on the login form."
 msgstr "loginHint - ログイン・フォームのユーザー名/電子メール・フィールドを事前入力するために使用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:261
 msgid ""
 "action - If value is 'register' then user is redirected to registration "
 "page, otherwise to login page."
 msgstr ""
-"action - 値が 'register' の場合、ユーザーは登録ページにリダイレクトされ、そうでない場合はログインページにリダイレクトされます。"
+"action - 値が 'register' の場合、ユーザーは登録ページにリダイレクトされ、そうでない場合はログイン・ページにリダイレクトされます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:262
 msgid "locale - Specifies the desired locale for the UI."
 msgstr "locale - UIのロケールを指定します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:263
 #, no-wrap
 msgid "createLoginUrl(options)"
 msgstr "createLoginUrl(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:266
 msgid ""
 "Returns the URL to login form on (options is an optional object with "
 "redirectUri and/or prompt fields)."
 msgstr ""
-"ログインフォームにへのURLを返します（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+"ログイン・フォームへのURLを返します（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:268
 msgid ""
 "Options is an Object, which supports same options like the function `login` "
 "."
-msgstr "オプションは、  `login` 関数のように同じオプションをサポートするObjectです。"
+msgstr "オプションは、 `login` 関数と同様のオプションをサポートするObjectです。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:269
 #, no-wrap
 msgid "logout(options)"
 msgstr "logout(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:272
 msgid "Redirects to logout."
 msgstr "ログアウトにリダイレクトします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:276
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:284
 msgid "redirectUri - Specifies the uri to redirect to after logout."
 msgstr "redirectUri - ログアウト後にリダイレクトするURIを指定します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:277
 #, no-wrap
 msgid "createLogoutUrl(options)"
 msgstr "createLogoutUrl(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:280
 msgid "Returns the URL to logout the user."
 msgstr "ユーザーをログアウトするURLを返します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:285
 #, no-wrap
 msgid "register(options)"
 msgstr "register(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:288
 msgid ""
 "Redirects to registration form. Shortcut for login with option action = "
 "'register'"
-msgstr "登録フォームにリダイレクトします。 オプションaction = 'register' でログインするためのショートカット"
+msgstr "登録フォームにリダイレクトします。オプションaction = 'register' でログインするためのショートカット"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:290
 msgid ""
 "Options are same as for the login method but 'action' is set to 'register'"
 msgstr "オプションは `login` メソッドと同じですが、 'action' は 'register' に設定されています"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:291
 #, no-wrap
 msgid "createRegisterUrl(options)"
 msgstr "createRegisterUrl(options)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:294
 msgid ""
 "Returns the url to registration page. Shortcut for createLoginUrl with "
 "option action = 'register'"
-msgstr "登録ページのURLを返します。 オプションaction = 'register' を含むcreateLoginUrl へのショートカット"
+msgstr "登録ページのURLを返します。オプションaction = 'register' を含むcreateLoginUrlへのショートカット"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:296
 msgid ""
 "Options are same as for the createLoginUrl method but 'action' is set to "
 "'register'"
 msgstr "オプションは `createLoginUrl` メソッドと同じですが、 'action' は 'register' に設定されています"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:297
 #, no-wrap
 msgid "accountManagement()"
 msgstr "accountManagement()"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:300
 msgid "Redirects to the Account Management Console."
 msgstr "アカウント管理コンソールにリダイレクトします。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:301
 #, no-wrap
 msgid "createAccountUrl()"
 msgstr "createAccountUrl()"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:304
 msgid "Returns the URL to the Account Management Console."
 msgstr "アカウント管理コンソールのURLを返します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:305
 #, no-wrap
 msgid "hasRealmRole(role)"
 msgstr "hasRealmRole(role)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:308
 msgid "Returns true if the token has the given realm role."
 msgstr "トークンに指定されたレルムのロールがある場合は、trueを返します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:309
 #, no-wrap
 msgid "hasResourceRole(role, resource)"
 msgstr "hasResourceRole(role, resource)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:312
 msgid ""
 "Returns true if the token has the given role for the resource (resource is "
 "optional, if not specified clientId is used)."
@@ -1057,25 +854,21 @@ msgstr ""
 "が使用されます）。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:313
 #, no-wrap
 msgid "loadUserProfile()"
 msgstr "loadUserProfile()"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:316
 msgid "Loads the users profile."
 msgstr "ユーザーのプロファイルを読み込みます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:319
 msgid ""
 "Returns promise to set functions to be invoked if the profile was loaded "
 "successfully, or if the profile could not be loaded."
 msgstr "プロファイルが正常にロードされた場合、またはプロファイルをロードできなかった場合に、呼び出される関数を設定するpromiseを返します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:329
 #, no-wrap
 msgid ""
 "keycloak.loadUserProfile().success(function(profile) {\n"
@@ -1091,13 +884,11 @@ msgstr ""
 "    });\n"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:331
 #, no-wrap
 msgid "isTokenExpired(minValidity)"
 msgstr "isTokenExpired(minValidity)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:334
 msgid ""
 "Returns true if the token has less than minValidity seconds left before it "
 "expires (minValidity is optional, if not specified 0 is used)."
@@ -1106,13 +897,11 @@ msgstr ""
 "はオプションです。0が使用されます）。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:335
 #, no-wrap
 msgid "updateToken(minValidity)"
 msgstr "updateToken(minValidity)"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:339
 msgid ""
 "If the token expires within minValidity seconds (minValidity is optional, if"
 " not specified 5 is used) the token is refreshed.  If the session status "
@@ -1123,14 +912,12 @@ msgstr ""
 "セッション・ステータスiframeが有効な場合、セッション・ステータスもチェックされます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:342
 msgid ""
 "Returns promise to set functions that can be invoked if the token is still "
 "valid, or if the token is no longer valid.  For example:"
 msgstr "トークンが有効な場合、またはトークンがもはや有効でない場合に呼び出される関数を設定するpromiseを返します。 例えば："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:354
 #, no-wrap
 msgid ""
 "keycloak.updateToken(5).success(function(refreshed) {\n"
@@ -1154,13 +941,11 @@ msgstr ""
 "    });\n"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:356
 #, no-wrap
 msgid "clearToken()"
 msgstr "clearToken()"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:360
 msgid ""
 "Clear authentication state, including tokens.  This can be useful if "
 "application has detected the session was expired, for example if updating "
@@ -1170,61 +955,50 @@ msgstr ""
 "これは、更新トークンが失敗した場合など、セッションが終了したことをアプリケーションが検出した場合に役立ちます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:362
 msgid "Invoking this results in onAuthLogout callback listener being invoked."
 msgstr "これを呼び出すと、 `onAuthLogout` コールバック・リスナーが呼び出されます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:363
 #, no-wrap
 msgid "Callback Events"
 msgstr "コールバック・イベント"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:366
 msgid "The adapter supports setting callback listeners for certain events."
 msgstr "アダプターは、特定のイベントのコールバック・リスナーの設定をサポートします。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:371
 #, no-wrap
 msgid "keycloak.onAuthSuccess = function() { alert('authenticated'); }\n"
 msgstr "keycloak.onAuthSuccess = function() { alert('authenticated'); }\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:374
 msgid "The available events are:"
 msgstr "使用できるイベントは次のとおりです:"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:376
 msgid "onReady(authenticated) - Called when the adapter is initialized."
 msgstr "onReady(authenticated) - アダプターが初期化されたときに呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:377
 msgid "onAuthSuccess - Called when a user is successfully authenticated."
 msgstr "onAuthSuccess - ユーザーが正常に認証されたときに呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:378
 msgid "onAuthError - Called if there was an error during authentication."
 msgstr "onAuthError - 認証時にエラーが発生した場合に呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:379
 msgid "onAuthRefreshSuccess - Called when the token is refreshed."
 msgstr "onAuthRefreshSuccess - トークンがリフレッシュされたときに呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:380
 msgid ""
 "onAuthRefreshError - Called if there was an error while trying to refresh "
 "the token."
 msgstr "onAuthRefreshError - トークンをリフレッシュする際にエラーが発生した場合に呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:381
 msgid ""
 "onAuthLogout - Called if the user is logged out (will only be called if the "
 "session status iframe is enabled, or in Cordova mode)."
@@ -1233,12 +1007,11 @@ msgstr ""
 "ユーザーがログアウトしたときに呼び出されます（セッション・ステータスiframeが有効な場合、またはCordovaモードの場合にのみ、呼び出されます）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:381
 msgid ""
 "onTokenExpired - Called when the access token is expired. If a refresh token"
 " is available the token can be refreshed with updateToken, or in cases where"
 " it is not (that is, with implicit flow) you can redirect to login screen to"
 " obtain a new access token."
 msgstr ""
-"onTokenExpired - アクセス・トークンが期限切れになったときに呼び出されます。 "
-"リフレッシュ・トークンが利用可能な場合、トークンはupdateTokenでリフレッシュすることができます。トークンがリフレッシュされていない場合（つまり、インプリシット・フローがある場合）、ログイン画面にリダイレクトして新しいアクセス・トークンを取得できます。"
+"onTokenExpired - "
+"アクセス・トークンが期限切れになったときに呼び出されます。リフレッシュ・トークンが利用可能な場合、トークンはupdateTokenでリフレッシュすることができます。トークンがリフレッシュされていない場合（つまり、インプリシット・フローがある場合）、ログイン画面にリダイレクトして新しいアクセス・トークンを取得できます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -2,60 +2,104 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:22
+#: source/securing_apps/topics/oidc/java/fuse/camel.adoc:8
+#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:13
+#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:55
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:321
-#, no-wrap
-msgid "For example:\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:89
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:31
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:56
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:66
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:23
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:23
-#: source/server_development/topics/auth-spi.adoc:148
-#: source/server_development/topics/preface.adoc:16
-#, no-wrap
-msgid "[source]\n"
-msgstr ""
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:368
+#: source/server_admin/topics/admin-cli.adoc:101
+#: source/server_admin/topics/admin-cli.adoc:169
+#: source/server_admin/topics/admin-cli.adoc:281
+#: source/server_admin/topics/admin-cli.adoc:426
+#: source/server_admin/topics/admin-cli.adoc:452
+#: source/server_admin/topics/admin-cli.adoc:475
+#: source/server_admin/topics/admin-cli.adoc:485
+#: source/server_admin/topics/admin-cli.adoc:493
+#: source/server_admin/topics/admin-cli.adoc:504
+#: source/server_admin/topics/admin-cli.adoc:543
+#: source/server_admin/topics/admin-cli.adoc:550
+#: source/server_admin/topics/admin-cli.adoc:557
+#: source/server_admin/topics/admin-cli.adoc:569
+#: source/server_admin/topics/admin-cli.adoc:576
+#: source/server_admin/topics/admin-cli.adoc:583
+#: source/server_admin/topics/admin-cli.adoc:688
+#: source/server_admin/topics/admin-cli.adoc:697
+#: source/server_admin/topics/admin-cli.adoc:749
+#: source/server_admin/topics/admin-cli.adoc:784
+#: source/server_admin/topics/admin-cli.adoc:798
+#: source/server_admin/topics/admin-cli.adoc:805
+#: source/server_admin/topics/admin-cli.adoc:812
+#: source/server_admin/topics/admin-cli.adoc:824
+#: source/server_admin/topics/admin-cli.adoc:831
+#: source/server_admin/topics/admin-cli.adoc:838
+#: source/server_admin/topics/admin-cli.adoc:885
+#: source/server_admin/topics/admin-cli.adoc:932
+#: source/server_admin/topics/admin-cli.adoc:955
+#: source/server_admin/topics/admin-cli.adoc:973
+#: source/server_admin/topics/admin-cli.adoc:982
+#: source/server_admin/topics/admin-cli.adoc:991
+#: source/server_admin/topics/admin-cli.adoc:1004
+#: source/server_admin/topics/admin-cli.adoc:1011
+#: source/server_admin/topics/admin-cli.adoc:1018
+#: source/server_admin/topics/admin-cli.adoc:1030
+#: source/server_admin/topics/admin-cli.adoc:1037
+#: source/server_admin/topics/admin-cli.adoc:1044
+#: source/server_admin/topics/admin-cli.adoc:1073
+#: source/server_admin/topics/admin-cli.adoc:1091
+#: source/server_admin/topics/admin-cli.adoc:1106
+#: source/server_admin/topics/admin-cli.adoc:1173
+#: source/server_admin/topics/admin-cli.adoc:1201
+#: source/server_admin/topics/admin-cli.adoc:1211
+#: source/server_admin/topics/admin-cli.adoc:1220
+#: source/server_admin/topics/admin-cli.adoc:1229
+#: source/server_admin/topics/admin-cli.adoc:1242
+#: source/server_admin/topics/admin-cli.adoc:1252
+#: source/server_admin/topics/admin-cli.adoc:1262
+#: source/server_admin/topics/admin-cli.adoc:1272
+#: source/server_admin/topics/admin-cli.adoc:1282
+msgid "For example:"
+msgstr "例えば:"
 
 #. type: Title ===
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:2
 #, no-wrap
 msgid "Javascript Adapter"
-msgstr ""
+msgstr "Javascriptアダプター"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:5
 msgid ""
 "{project_name} comes with a client-side JavaScript library that can be used "
-"to secure HTML5/JavaScript applications. The JavaScript adapter has built-in "
-"support for Cordova applications."
+"to secure HTML5/JavaScript applications. The JavaScript adapter has built-in"
+" support for Cordova applications."
 msgstr ""
+"{project_name} には、 HTML5/JavaScript "
+"アプリケーションを保護するために使用できるクライアント・サイドのJavaScriptライブラリが付属しています。 "
+"JavaScriptアダプターには、Cordovaアプリケーションのサポートが組み込まれています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:7
 msgid ""
-"The library can be retrieved directly from the {project_name} server at `/"
-"auth/js/keycloak.js` and is also distributed as a ZIP archive."
+"The library can be retrieved directly from the {project_name} server at "
+"`/auth/js/keycloak.js` and is also distributed as a ZIP archive."
 msgstr ""
+"ライブラリは `/auth/js/keycloak.js` の {project_name} "
+"サーバーから直接取得することができ、ZIPアーカイブとしても配布されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:9
@@ -65,24 +109,32 @@ msgid ""
 "the server. If you copy the adapter to your web application instead, make "
 "sure you upgrade the adapter only after you have upgraded the server."
 msgstr ""
+"ベストプラクティスは、サーバーをアップグレードするときに自動的に更新されるので、 {project_name} "
+"サーバーからJavaScriptアダプターを直接ロードすることです。 "
+"アダプターをWebアプリケーションにコピーする場合は、サーバーをアップグレードした後だけアダプターをアップグレードしてください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:12
 msgid ""
-"One important thing to note about using client-side applications is that the "
-"client has to be a public client as there is no secure way to store client "
+"One important thing to note about using client-side applications is that the"
+" client has to be a public client as there is no secure way to store client "
 "credentials in a client-side application. This makes it very important to "
 "make sure the redirect URIs you have configured for the client are correct "
 "and as specific as possible."
 msgstr ""
+"クライアント・サイドのアプリケーションを使用する際に注意すべき重要な点の1つは、クライアント・サイドのアプリケーションにクライアント・クレデンシャルを安全に保存する方法がないため、クライアントをパブリック・クライアントにする必要があることです。"
+" これにより、クライアント用に設定したリダイレクトURIが正しいか、できるだけ具体的であるかを確認することが非常に重要になります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:15
 msgid ""
 "To use the JavaScript adapter you must first create a client for your "
-"application in the {project_name} Administration Console. Make sure `public` "
-"is selected for `Access Type`."
+"application in the {project_name} Administration Console. Make sure `public`"
+" is selected for `Access Type`."
 msgstr ""
+"JavaScriptアダプターを使用するには、まず {project_name} "
+"管理コンソールでアプリケーション用のクライアントを作成する必要があります。  `Access Type` に `public` "
+"が選択されていることを確認してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:17
@@ -91,6 +143,8 @@ msgid ""
 "specific as possible as failing to do so may result in a security "
 "vulnerability."
 msgstr ""
+"また、有効なリダイレクトURIと有効なWebオリジンを設定する必要があります。 "
+"できるだけ具体的にする理由は、そうしなければセキュリティ上の脆弱性が生じる可能性があるためです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:20
@@ -100,21 +154,24 @@ msgid ""
 "`keycloak.json` file should be hosted on your web server at the same "
 "location as your HTML pages."
 msgstr ""
+"クライアントが作成されたら `Installation` タブをクリックし、 `Format Option` の `Keycloak OIDC "
+"JSON` を選択し、 `Download` をクリックします。 ダウンロードした `keycloak.json` "
+"ファイルは、HTMLページと同じ場所にあるWebサーバー上でホストされるべきです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:22
 msgid ""
 "Alternatively, you can skip the configuration file and manually configure "
 "the adapter."
-msgstr ""
+msgstr "または、設定ファイルではなく、アダプターを手動で設定することもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:24
 msgid "The following example shows how to initialize the JavaScript adapter:"
-msgstr ""
+msgstr "次の例は、JavaScriptアダプターを初期化する方法を示しています。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:39
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:38
 #, no-wrap
 msgid ""
 "<head>\n"
@@ -128,38 +185,40 @@ msgid ""
 "        });\n"
 "    </script>\n"
 "</head>\n"
-"----        \n"
 msgstr ""
+"<head>\n"
+"    <script src=\"keycloak.js\"></script>\n"
+"    <script>\n"
+"        var keycloak = Keycloak();\n"
+"        keycloak.init().success(function(authenticated) {\n"
+"            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
+"        }).error(function() {\n"
+"            alert('failed to initialize');\n"
+"        });\n"
+"    </script>\n"
+"</head>\n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:41
-#, no-wrap
-msgid "If the `keycloak.json` file is in a different location you can specify it:\n"
-msgstr ""
+msgid ""
+"If the `keycloak.json` file is in a different location you can specify it:"
+msgstr "`keycloak.json` ファイルが別の場所にある場合、それを指定することができます:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:43
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:50
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:160
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:323
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:344
-#: source/securing_apps/topics/saml/java/error_handling.adoc:26
-#, no-wrap
-msgid "[source,javascript]\n"
-msgstr "[source,javascript]\n"
-
-#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:45
-msgid "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json'));"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:48
 #, no-wrap
-msgid "Alternatively, you can pass in a JavaScript object with the required configuration instead:\n"
+msgid "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json'));\n"
 msgstr ""
+"var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json'));\n"
 
 #. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:48
+msgid ""
+"Alternatively, you can pass in a JavaScript object with the required "
+"configuration instead:"
+msgstr "または、必要な設定でJavaScriptオブジェクトを渡すこともできます:"
+
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:56
 #, no-wrap
 msgid ""
@@ -169,38 +228,53 @@ msgid ""
 "    clientId: 'myapp'\n"
 "});\n"
 msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:62
-#, no-wrap
-msgid ""
-"By default to authenticate you need to call the `login` function. However, there are two options available to make the adapter automatically authenticate. You\n"
-"can pass `login-required` or `check-sso` to the init function. `login-required` will authenticate the client if the user is logged-in to {project_name}\n"
-"or display the login page if not. `check-sso` will only authenticate the client if the user is already logged-in, if the user is not logged-in the browser will be\n"
-"redirected back to the application and remain unauthenticated.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:64
-#, no-wrap
-msgid "To enable `login-required` set `onLoad` to `login-required` and pass to the init method:\n"
-msgstr ""
+"var keycloak = Keycloak({\n"
+"    url: 'http://keycloak-server/auth',\n"
+"    realm: 'myrealm',\n"
+"    clientId: 'myapp'\n"
+"});\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:69
-#, no-wrap
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:62
 msgid ""
-"keycloak.init({ onLoad: 'login-required' })\n"
-"----    \n"
+"By default to authenticate you need to call the `login` function. However, "
+"there are two options available to make the adapter automatically "
+"authenticate. You can pass `login-required` or `check-sso` to the init "
+"function. `login-required` will authenticate the client if the user is "
+"logged-in to {project_name} or display the login page if not. `check-sso` "
+"will only authenticate the client if the user is already logged-in, if the "
+"user is not logged-in the browser will be redirected back to the application"
+" and remain unauthenticated."
 msgstr ""
+"デフォルトでは `login` 関数を呼び出す必要があります。 ただし、アダプターを自動的に認証させるための2つのオプションがあります。  `init`"
+" 関数に `login-required` または `check-sso` を渡すことができます。 `login-required` は、ユーザーが "
+"{project_name} にログインしていない場合にクライアントを認証し、そうでない場合にログインページを表示します。 `check-sso` "
+"は、ユーザーが既にログインしている場合にのみクライアントを認証します。ユーザーがログインしていない場合、ブラウザーはアプリケーションにリダイレクトされ、未認証のままになります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:64
+msgid ""
+"To enable `login-required` set `onLoad` to `login-required` and pass to the "
+"init method:"
+msgstr ""
+"`login-required` を有効にするには、 `onLoad` に `login-required` を設定し、 `init` "
+"メソッドに渡します："
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:68
+#, no-wrap
+msgid "keycloak.init({ onLoad: 'login-required' })\n"
+msgstr "keycloak.init({ onLoad: 'login-required' })\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:72
 msgid ""
-"After the user is authenticated the application can make requests to RESTful "
-"services secured by {project_name} by including the bearer token in the "
+"After the user is authenticated the application can make requests to RESTful"
+" services secured by {project_name} by including the bearer token in the "
 "`Authorization` header. For example:"
 msgstr ""
+"ユーザーが認証された後、アプリケーションは `Authorization` ヘッダーにベアラー・トークンを含めることによって、 "
+"{project_name} によって保護されたRESTfulサービスへのリクエストを行うことができます。 例えば："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:77
@@ -209,12 +283,14 @@ msgid ""
 "var loadData = function () {\n"
 "    document.getElementById('username').innerText = keycloak.subject;\n"
 msgstr ""
+"var loadData = function () {\n"
+"    document.getElementById('username').innerText = keycloak.subject;\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:79
 #, no-wrap
 msgid "    var url = 'http://localhost:8080/restful-service';\n"
-msgstr ""
+msgstr "    var url = 'http://localhost:8080/restful-service';\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:84
@@ -225,6 +301,10 @@ msgid ""
 "    req.setRequestHeader('Accept', 'application/json');\n"
 "    req.setRequestHeader('Authorization', 'Bearer ' + keycloak.token);\n"
 msgstr ""
+"    var req = new XMLHttpRequest();\n"
+"    req.open('GET', url, true);\n"
+"    req.setRequestHeader('Accept', 'application/json');\n"
+"    req.setRequestHeader('Authorization', 'Bearer ' + keycloak.token);\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:94
@@ -240,6 +320,15 @@ msgid ""
 "        }\n"
 "    }\n"
 msgstr ""
+"    req.onreadystatechange = function () {\n"
+"        if (req.readyState == 4) {\n"
+"            if (req.status == 200) {\n"
+"                alert('Success');\n"
+"            } else if (req.status == 403) {\n"
+"                alert('Forbidden');\n"
+"            }\n"
+"        }\n"
+"    }\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:97
@@ -248,73 +337,85 @@ msgid ""
 "    req.send();\n"
 "};\n"
 msgstr ""
+"    req.send();\n"
+"};\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:102
 msgid ""
 "One thing to keep in mind is that the access token by default has a short "
-"life expiration so you may need to refresh the access token prior to sending "
-"the request. You can do this by the `updateToken` method. The `updateToken` "
-"method returns a promise object which makes it easy to invoke the service "
+"life expiration so you may need to refresh the access token prior to sending"
+" the request. You can do this by the `updateToken` method. The `updateToken`"
+" method returns a promise object which makes it easy to invoke the service "
 "only if the token was successfully refreshed and for example display an "
 "error to the user if it wasn't. For example:"
 msgstr ""
+"注意すべきことは、デフォルトではアクセス・トークンの有効期限が短いため、リクエストを送信する前にアクセス・トークンを更新する必要があることです。 これは"
+" `updateToken` メソッドで行うことができます。  `updateToken` "
+"メソッドは、トークンが正常にリフレッシュされた場合にのみ、サービスの呼び出しを容易にするプロミス・オブジェクトを返し、そうでない場合は、例えば、ユーザーにエラーを表示します。"
+" 例えば："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:111
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:110
 #, no-wrap
 msgid ""
 "keycloak.updateToken(30).success(function() {\n"
 "    loadData();\n"
 "}).error(function() {\n"
 "    alert('Failed to refresh token');\n"
-");\n"
-"----    \n"
+"});\n"
 msgstr ""
+"keycloak.updateToken(30).success(function() {\n"
+"    loadData();\n"
+"}).error(function() {\n"
+"    alert('Failed to refresh token');\n"
+"});\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:112
 #, no-wrap
 msgid "Session Status iframe"
-msgstr ""
+msgstr "セッション・ステータスiframe"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:117
 msgid ""
 "By default, the JavaScript adapter creates a hidden iframe that is used to "
-"detect if a Single-Sign Out has occurred.  This does not require any network "
-"traffic, instead the status is retrieved by looking at a special status "
+"detect if a Single-Sign Out has occurred.  This does not require any network"
+" traffic, instead the status is retrieved by looking at a special status "
 "cookie.  This feature can be disabled by setting `checkLoginIframe: false` "
 "in the options passed to the `init` method."
 msgstr ""
+"デフォルトでは、JavaScriptアダプターは、シングル・サイン・アウトが発生したかどうかを検出するために使用される非表示のiframeを作成します。"
+" これはネットワーク・トラフィックを必要とせず、代わりに特殊なステータス・クッキーを調べることによってステータスを取得します。 この機能は、 "
+"`init` メソッドに渡されるオプションに `checkLoginIframe：false` を設定することで無効にできます。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:120
 msgid ""
 "You should not rely on looking at this cookie directly. It's format can "
 "change and it's also associated with the URL of the {project_name} server, "
 "not your application."
 msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:122
-msgid "[[_javascript_implicit_flow]]"
-msgstr ""
+"このクッキーを直接参照することに頼るべきではありません。 フォーマットは変更可能で、アプリケーションではなく {project_name} "
+"サーバーのURLに関連付けられています。"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:122
 #, no-wrap
 msgid "Implicit and Hybrid Flow"
-msgstr ""
+msgstr "インプリシット・フローとハイブリッド・フロー"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:125
 msgid ""
 "By default, the JavaScript adapter uses the http://openid.net/specs/openid-"
 "connect-core-1_0.html#CodeFlowAuth[Authorization Code] flow."
 msgstr ""
+"デフォルトでは、JavaScriptアダプターは http://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[認可コード] フローを使用します。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:128
 msgid ""
 "With this flow the {project_name} server returns an authorization code, not "
@@ -322,8 +423,11 @@ msgid ""
 "exchanges the `code` for an access token and a refresh token after the "
 "browser is redirected back to the application."
 msgstr ""
+"このフローにより、 {project_name} サーバーは認証トークンではなく、認証コードをアプリケーションに返します。 "
+"ブラウザがアプリケーションにリダイレクトされた後、JavaScriptアダプターはアクセス・トークンとリフレッシュ・トークンの `code` "
+"を交換します。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:132
 msgid ""
 "{project_name} also supports the http://openid.net/specs/openid-connect-"
@@ -333,470 +437,644 @@ msgid ""
 "request to exchange the code for tokens, but it has implications when the "
 "access token expires."
 msgstr ""
+"{project_name} は、 {project_name} での認証が成功した直後にアクセス・トークンが送信される "
+"http://openid.net/specs/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[Implicit] フローもサポートしています。 "
+"これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに意味を持ちます。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:135
 msgid ""
 "However, sending the access token in the URL fragment can be a security "
-"vulnerability. For example the token could be leaked through web server logs "
-"and or browser history."
+"vulnerability. For example the token could be leaked through web server logs"
+" and or browser history."
 msgstr ""
+"ただし、URLフラグメントにアクセス・トークンを送信することはセキュリティ上の脆弱性となります。 "
+"たとえば、Webサーバーのログやブラウザの履歴からトークンが漏洩する可能性があります。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:138
 msgid ""
-"To enable implicit flow, you need to enable the `Implicit Flow Enabled` flag "
-"for the client in the {project_name} Administration Console.  You also need "
-"to pass the parameter `flow` with value `implicit` to `init` method:"
+"To enable implicit flow, you need to enable the `Implicit Flow Enabled` flag"
+" for the client in the {project_name} Administration Console.  You also need"
+" to pass the parameter `flow` with value `implicit` to `init` method:"
 msgstr ""
+"インプリシット・フローを有効にするには、 {project_name} 管理コンソールでクライアントの `Implicit Flow Enabled` "
+"フラグを有効にする必要があります。  `init` メソッドに ` implicit` という値を持つ `flow` パラメータを渡す必要もあります："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:140
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:179
-msgid "[source,javascript]"
-msgstr ""
-
-#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:142
-msgid "keycloak.init({ flow: 'implicit' })"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:146
 #, no-wrap
-msgid ""
-"One thing to note is that only an access token is provided and there is no refresh token. This means that once the access token has expired the application\n"
-"has to do the redirect to the {project_name} again to obtain a new access token.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:148
-#, no-wrap
-msgid "{project_name} also supports the http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth[Hybrid] flow.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:154
-#, no-wrap
-msgid ""
-"This requires the client to have both the `Standard Flow Enabled` and `Implicit Flow Enabled` flags enabled in the admin console.\n"
-"The {project_name} server will then send both the code and tokens to your application.\n"
-"The access token can be used immediately while the code can be exchanged for access and refresh tokens.\n"
-"Similar to the implicit flow, the hybrid flow is good for performance because the access token is available immediately.\n"
-"But, the token is still sent in the URL, and the security vulnerability mentioned earlier may still apply.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:156
-#, no-wrap
-msgid "One advantage in the Hybrid flow is that the refresh token is made available to the application.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:158
-#, no-wrap
-msgid "For the Hybrid flow, you need to pass the parameter `flow` with value `hybrid` to the `init` method:\n"
-msgstr ""
+msgid "keycloak.init({ flow: 'implicit' })\n"
+msgstr "keycloak.init({ flow: 'implicit' })\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:162
-msgid "keycloak.init({ flow: 'hybrid' })"
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:146
+msgid ""
+"One thing to note is that only an access token is provided and there is no "
+"refresh token. This means that once the access token has expired the "
+"application has to do the redirect to the {project_name} again to obtain a "
+"new access token."
 msgstr ""
+"注意すべき点の1つは、アクセストークンのみが提供され、リフレッシュ・トークンがないことです。 "
+"つまり、アクセス・トークンが期限切れになると、アプリケーションは {project_name} "
+"へのリダイレクトを再度実行して、新しいアクセス・トークンを取得する必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:148
+msgid ""
+"{project_name} also supports the http://openid.net/specs/openid-connect-"
+"core-1_0.html#HybridFlowAuth[Hybrid] flow."
+msgstr ""
+"{project_name} は http://openid.net/specs/openid-connect-core-"
+"1_0.html#HybridFlowAuth[ハイブリッド] ・フローもサポトしています。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:154
+msgid ""
+"This requires the client to have both the `Standard Flow Enabled` and "
+"`Implicit Flow Enabled` flags enabled in the admin console.  The "
+"{project_name} server will then send both the code and tokens to your "
+"application.  The access token can be used immediately while the code can be"
+" exchanged for access and refresh tokens.  Similar to the implicit flow, the"
+" hybrid flow is good for performance because the access token is available "
+"immediately.  But, the token is still sent in the URL, and the security "
+"vulnerability mentioned earlier may still apply."
+msgstr ""
+"これは、管理コンソールでクライアントの `Standard Flow Enabled` と `Implicit Flow Enabled` "
+"フラグを有効にする必要があります。  {project_name} サーバーはコードとトークンの両方をアプリケーションに送信します。 "
+"アクセス・トークンおリフレッシュ・トークンの交換ができる間、アクセス・トークンは即時使用できます。 "
+"インプリシット・フローと同様に、アクセス・トークンがすぐに利用できるため、ハイブリッド・フローはパフォーマンスに優れています。 "
+"しかし、トークンは引き続きURLに送信され、前述のセキュリティの脆弱性が当てはまる可能性があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:156
+msgid ""
+"One advantage in the Hybrid flow is that the refresh token is made available"
+" to the application."
+msgstr "ハイブリッド・フローの1つの利点は、アプリケーションでリフレッシュ・トークンが利用可能になることです。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:158
+msgid ""
+"For the Hybrid flow, you need to pass the parameter `flow` with value "
+"`hybrid` to the `init` method:"
+msgstr "ハイブリッド・フローの場合、 パラメーター `flow` を値 'hybrid' で `init` メソッドに渡す必要があります："
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:162
+#, no-wrap
+msgid "keycloak.init({ flow: 'hybrid' })\n"
+msgstr "keycloak.init({ flow: 'hybrid' })\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:164
 #, no-wrap
 msgid "Earlier Browsers"
-msgstr ""
+msgstr "以前のブラウザー"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:168
 msgid ""
 "The JavaScript adapter depends on Base64 (window.btoa and window.atob) and "
 "HTML5 History API.  If you need to support browsers that do not have these "
 "available (for example, IE9) you need to add polyfillers."
 msgstr ""
+"JavaScriptアダプターは、Base64（window.btoaとwindow.atob）とHTML5 History APIに依存しています。 "
+"これらが利用できないブラウザ（IE9など）をサポートする必要がある場合は、ポリフィラーを追加する必要があります。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:170
 msgid "Example polyfill libraries:"
-msgstr ""
+msgstr "ポリフィル・ライブラリの例："
 
-#. type: delimited block -
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:172
+msgid "https://github.com/davidchambers/Base64.js"
+msgstr "https://github.com/davidchambers/Base64.js"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:173
 #, no-wrap
-msgid ""
-"* https://github.com/davidchambers/Base64.js\n"
-"* https://github.com/devote/HTML5-History-API        \n"
-msgstr ""
+msgid "https://github.com/devote/HTML5-History-API        \n"
+msgstr "https://github.com/devote/HTML5-History-API        \n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:174
 #, no-wrap
 msgid "JavaScript Adapter Reference"
-msgstr ""
+msgstr "JavaScriptアダプター・リファレンス"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:176
 #, no-wrap
 msgid "Constructor"
-msgstr ""
+msgstr "コンストラクター"
 
-#. type: Plain text
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:183
+#, no-wrap
 msgid ""
-"new Keycloak(); new Keycloak('http://localhost/keycloak.json'); new "
-"Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: "
-"'myApp' });"
+"new Keycloak();\n"
+"new Keycloak('http://localhost/keycloak.json');\n"
+"new Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: 'myApp' });\n"
 msgstr ""
+"new Keycloak();\n"
+"new Keycloak('http://localhost/keycloak.json');\n"
+"new Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: 'myApp' });\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:185
 #, no-wrap
 msgid "Properties"
-msgstr ""
+msgstr "プロパティ"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:187
+#, no-wrap
+msgid "authenticated"
+msgstr "authenticated"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:189
-#, no-wrap
-msgid ""
-"authenticated::\n"
-"    Is `true` if the user is authenticated, `false` otherwise.\n"
-msgstr ""
+msgid "Is `true` if the user is authenticated, `false` otherwise."
+msgstr "ユーザーが認証されている場合は `true` 、それ以外の場合は `false` です。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:190
+#, no-wrap
+msgid "token"
+msgstr "token"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:192
-#, no-wrap
 msgid ""
-"token::\n"
-"    The base64 encoded token that can be sent in the `Authorization` header in requests to services.\n"
-msgstr ""
+"The base64 encoded token that can be sent in the `Authorization` header in "
+"requests to services."
+msgstr "サービスへのリクエストの `Authorization` ヘッダーで送信できるbase64でエンコードされたトークンです。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:193
+#, no-wrap
+msgid "tokenParsed"
+msgstr "tokenParsed"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:195
-#, no-wrap
-msgid ""
-"tokenParsed::\n"
-"    The parsed token as a JavaScript object.\n"
-msgstr ""
+msgid "The parsed token as a JavaScript object."
+msgstr "JavaScriptオブジェクトとして解析されたトークン。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:196
+#, no-wrap
+msgid "subject"
+msgstr "subject"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:198
-#, no-wrap
-msgid ""
-"subject::\n"
-"    The user id.\n"
-msgstr ""
+msgid "The user id."
+msgstr "ユーザーID。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:199
+#, no-wrap
+msgid "idToken"
+msgstr "idToken"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:201
-#, no-wrap
-msgid ""
-"idToken::\n"
-"    The base64 encoded ID token.\n"
-msgstr ""
+msgid "The base64 encoded ID token."
+msgstr "Base64でエンコードされたIDトークン。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:202
+#, no-wrap
+msgid "idTokenParsed"
+msgstr "idTokenParsed"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:204
-#, no-wrap
-msgid ""
-"idTokenParsed::\n"
-"    The parsed id token as a JavaScript object.\n"
-msgstr ""
+msgid "The parsed id token as a JavaScript object."
+msgstr "JavaScriptオブジェクトとして解析されたIDトークン。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:205
+#, no-wrap
+msgid "realmAccess"
+msgstr "realmAccess"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:207
-#, no-wrap
-msgid ""
-"realmAccess::\n"
-"    The realm roles associated with the token.\n"
-msgstr ""
+msgid "The realm roles associated with the token."
+msgstr "トークンに関連付けられているレルムのロール。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:208
+#, no-wrap
+msgid "resourceAccess"
+msgstr "resourceAccess"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:210
-#, no-wrap
-msgid ""
-"resourceAccess::\n"
-"    The resource roles associated with the token.\n"
-msgstr ""
+msgid "The resource roles associated with the token."
+msgstr "トークンに関連付けられているリソースのロール。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:211
+#, no-wrap
+msgid "refreshToken"
+msgstr "refreshToken"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:213
-#, no-wrap
 msgid ""
-"refreshToken::\n"
-"    The base64 encoded refresh token that can be used to retrieve a new token.\n"
-msgstr ""
+"The base64 encoded refresh token that can be used to retrieve a new token."
+msgstr "新しいトークンを取得するために使用できるbase64でエンコードされたリフレッシュ・トークン。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:214
+#, no-wrap
+msgid "refreshTokenParsed"
+msgstr "refreshTokenParsed"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:216
-#, no-wrap
-msgid ""
-"refreshTokenParsed::\n"
-"    The parsed refresh token as a JavaScript object.\n"
-msgstr ""
+msgid "The parsed refresh token as a JavaScript object."
+msgstr "JavaScriptオブジェクトとして解析されたリフレッシュ・トークン。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:217
+#, no-wrap
+msgid "timeSkew"
+msgstr "timeSkew"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:220
-#, no-wrap
 msgid ""
-"timeSkew::\n"
-"    The estimated time difference between the browser time and the {project_name} server in seconds. This value is just an estimation, but is accurate\n"
-"    enough when determining if a token is expired or not.\n"
+"The estimated time difference between the browser time and the "
+"{project_name} server in seconds. This value is just an estimation, but is "
+"accurate enough when determining if a token is expired or not."
 msgstr ""
+"ブラウザーと {project_name} サーバーの推定される時間差（秒単位）。 "
+"この値は単なる見積もりですが、トークンが期限切れになっているかどうかを判断するには十分正確です。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:221
+#, no-wrap
+msgid "responseMode"
+msgstr "responseMode"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:223
-#, no-wrap
-msgid ""
-"responseMode::\n"
-"    Response mode passed in init (default value is fragment).\n"
-msgstr ""
+msgid "Response mode passed in init (default value is fragment)."
+msgstr "`init` に渡されるレスポンスモード(デフォルトはフラグメント)。"
 
-#. type: delimited block -
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:224
+#, no-wrap
+msgid "flow"
+msgstr "flow"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:226
-#, no-wrap
-msgid ""
-"flow::\n"
-"    Flow passed in init.\n"
-msgstr ""
+msgid "Flow passed in init."
+msgstr "`init` に渡されるフロー。"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:229
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:227
 #, no-wrap
+msgid "responseType"
+msgstr "responseType"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:229
 msgid ""
-"responseType::\n"
-"    Response type sent to {project_name} with login requests. This is determined based on the flow value used during initialization, but can be overridden by setting this value.\n"
+"Response type sent to {project_name} with login requests. This is determined"
+" based on the flow value used during initialization, but can be overridden "
+"by setting this value."
 msgstr ""
+"{project_name} にログイン・リクエストとともに送信されたレスポンスタイプ。 "
+"これは、初期化中に使用されたフロー値に基づいて決定されますが、この値を設定することで上書きできます。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:230
 #, no-wrap
 msgid "Methods"
-msgstr ""
+msgstr "Methods"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:233
-msgid "====== init(options)"
-msgstr ""
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:232
+#, no-wrap
+msgid "init(options)"
+msgstr "init(options)"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:235
 msgid "Called to initialize the adapter."
-msgstr ""
+msgstr "アダプターを初期化するために呼び出されます。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:237
-msgid "Options is an Object, where:"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:247
-#, no-wrap
-msgid ""
-"* onLoad - Specifies an action to do on load. Supported values are 'login-required' or 'check-sso'.\n"
-"* token - Set an initial value for the token.\n"
-"* refreshToken - Set an initial value for the refresh token.\n"
-"* idToken - Set an initial value for the id token (only together with token or refreshToken).\n"
-"* timeSkew - Set an initial value for skew between local time and {project_name} server in seconds (only together with token or refreshToken).\n"
-"* checkLoginIframe - Set to enable/disable monitoring login state (default is true).\n"
-"* checkLoginIframeInterval - Set the interval to check login state (default is 5 seconds).\n"
-"* responseMode - Set the OpenID Connect response mode send to {project_name} server at login request. Valid values are query or fragment . Default value is fragment, which means that after successful authentication will {project_name} redirect to javascript application with OpenID Connect parameters added in URL fragment. This is generally safer and recommended over query.\n"
-"* flow - Set the OpenID Connect flow. Valid values are standard, implicit or hybrid.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:249
-#, no-wrap
-msgid "Returns promise to set functions to be invoked on success or error.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:251
-#, no-wrap
-msgid "====== login(options)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:253
-#, no-wrap
-msgid "Redirects to login form on (options is an optional object with redirectUri and/or prompt fields).\n"
-msgstr ""
-
-#. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:255
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:274
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:282
-#, no-wrap
-msgid "Options is an Object, where: \n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:262
-#, no-wrap
-msgid ""
-"* redirectUri - Specifies the uri to redirect to after login.\n"
-"* prompt - By default the login screen is displayed if the user is not logged-in to {project_name}. To only authenticate to the application if the user is already logged-in and not display the login page if the user is not logged-in, set this option to `none`. To always require re-authentication and ignore SSO, set this option to `login` .\n"
-"* maxAge - Used just if user is already authenticated. Specifies maximum time since the authentication of user happened. If user is already authenticated for longer time than `maxAge`, the SSO is ignored and he will need to re-authenticate again.\n"
-"* loginHint - Used to pre-fill the username/email field on the login form.\n"
-"* action - If value is 'register' then user is redirected to registration page, otherwise to login page.\n"
-"* locale - Specifies the desired locale for the UI.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:264
-#, no-wrap
-msgid "====== createLoginUrl(options)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:266
-#, no-wrap
-msgid "Returns the URL to login form on (options is an optional object with redirectUri and/or prompt fields).\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:268
-#, no-wrap
-msgid "Options is an Object, which supports same options like the function `login` .\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:270
-#, no-wrap
-msgid "====== logout(options)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:272
-#, no-wrap
-msgid "Redirects to logout.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:276
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:284
-#, no-wrap
-msgid "* redirectUri - Specifies the uri to redirect to after logout.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:278
-#, no-wrap
-msgid "====== createLogoutUrl(options)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:280
-#, no-wrap
-msgid "Returns the URL to logout the user.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:286
-#, no-wrap
-msgid "====== register(options)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:288
-#, no-wrap
-msgid "Redirects to registration form. Shortcut for login with option action = 'register'\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:290
-#, no-wrap
-msgid "Options are same as for the login method but 'action' is set to 'register'\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:292
-#, no-wrap
-msgid "====== createRegisterUrl(options)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:294
-#, no-wrap
-msgid "Returns the url to registration page. Shortcut for createLoginUrl with option action = 'register'\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:296
-#, no-wrap
-msgid "Options are same as for the createLoginUrl method but 'action' is set to 'register'\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:298
-#, no-wrap
-msgid "====== accountManagement()\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:300
-#, no-wrap
-msgid "Redirects to the Account Management Console.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:302
-#, no-wrap
-msgid "====== createAccountUrl()\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:304
-#, no-wrap
-msgid "Returns the URL to the Account Management Console.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:306
-#, no-wrap
-msgid "====== hasRealmRole(role)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:308
-#, no-wrap
-msgid "Returns true if the token has the given realm role.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:310
-#, no-wrap
-msgid "====== hasResourceRole(role, resource)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:312
-#, no-wrap
-msgid "Returns true if the token has the given role for the resource (resource is optional, if not specified clientId is used).\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:314
-#, no-wrap
-msgid "====== loadUserProfile()\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:316
-#, no-wrap
-msgid "Loads the users profile.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:319
-#, no-wrap
-msgid ""
-"Returns promise to set functions to be invoked if the profile was loaded successfully, or if the profile could not be\n"
-"loaded.\n"
-msgstr ""
+msgid "Options is an Object, where:"
+msgstr "オプションはオブジェクトです:"
 
 #. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:239
+msgid ""
+"onLoad - Specifies an action to do on load. Supported values are 'login-"
+"required' or 'check-sso'."
+msgstr ""
+"onLoad - ロード時に実行するアクションを指定します。 サポートされている値は 'login-required' または 'check-sso' "
+"です。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:240
+msgid "token - Set an initial value for the token."
+msgstr "token - トークンの初期値を設定します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:241
+msgid "refreshToken - Set an initial value for the refresh token."
+msgstr "refreshToken - リフレッシュ・トークンの初期値を設定します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:242
+msgid ""
+"idToken - Set an initial value for the id token (only together with token or"
+" refreshToken)."
+msgstr "idToken - IDトークンの初期値を設定しますtokenまたはrefreshTokenと一緒にのみ)。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:243
+msgid ""
+"timeSkew - Set an initial value for skew between local time and "
+"{project_name} server in seconds (only together with token or refreshToken)."
+msgstr ""
+"timeSkew - 現地時間と {project_name} "
+"サーバーとの間のスキューの初期値を秒単位で設定します(tokenまたはrefreshTokenとともに設定)。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:244
+msgid ""
+"checkLoginIframe - Set to enable/disable monitoring login state (default is "
+"true)."
+msgstr "checkLoginIframe - ログイン状態の監視を有効/無効に設定します(デフォルトはtrue)。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:245
+msgid ""
+"checkLoginIframeInterval - Set the interval to check login state (default is"
+" 5 seconds)."
+msgstr "checkLoginIframeInterval - ログイン状態を確認する間隔を設定します(デフォルトは5秒です)。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:246
+msgid ""
+"responseMode - Set the OpenID Connect response mode send to {project_name} "
+"server at login request. Valid values are query or fragment . Default value "
+"is fragment, which means that after successful authentication will "
+"{project_name} redirect to javascript application with OpenID Connect "
+"parameters added in URL fragment. This is generally safer and recommended "
+"over query."
+msgstr ""
+"responseMode - ログイン・リクエストの時に {project_name} サーバーに送信するOpenID "
+"Connectレスポンスモードを設定します。 有効な値は、queryまたはfragmentです。 "
+"デフォルト値はfragmentです。つまり、認証が成功した後、 {project_name} はURLフラグメントに追加されたOpenID "
+"Connectパラメーターとともにjavascriptアプリケーションにリダイレクトされます。 これは一般的にクエリよりも安全で推奨されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:247
+msgid ""
+"flow - Set the OpenID Connect flow. Valid values are standard, implicit or "
+"hybrid."
+msgstr ""
+"flow - OpenID Connectのフローを設定します。 有効な値は、standard、implicit、hybridのいずれかです。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:249
+msgid "Returns promise to set functions to be invoked on success or error."
+msgstr "成功した時またはエラーが発生した時に、呼び出される関数を設定することを約束します。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:250
+#, no-wrap
+msgid "login(options)"
+msgstr "login(options)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:253
+msgid ""
+"Redirects to login form on (options is an optional object with redirectUri "
+"and/or prompt fields)."
+msgstr ""
+"ログインフォームにリダイレクトします（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:257
+msgid "redirectUri - Specifies the uri to redirect to after login."
+msgstr "redirectUri - ログイン後にリダイレクトするURIを指定します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:258
+msgid ""
+"prompt - By default the login screen is displayed if the user is not logged-"
+"in to {project_name}. To only authenticate to the application if the user is"
+" already logged-in and not display the login page if the user is not logged-"
+"in, set this option to `none`. To always require re-authentication and "
+"ignore SSO, set this option to `login` ."
+msgstr ""
+"prompt - ユーザーが {project_name} にログインしていない場合、デフォルトでログイン画面が表示されます。 "
+"ユーザーがすでにログインしている場合にのみアプリケーションを認証し、ログインしていない場合はログインページを表示しないようにするには、このオプションを "
+"`none` に設定します。 常に再認証が必要でSSOを無視するには、このオプションを `login` に設定します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:259
+msgid ""
+"maxAge - Used just if user is already authenticated. Specifies maximum time "
+"since the authentication of user happened. If user is already authenticated "
+"for longer time than `maxAge`, the SSO is ignored and he will need to re-"
+"authenticate again."
+msgstr ""
+"maxAge - ユーザーがすでに認証されている場合にのみ使用されます。 ユーザーの認証が行われてからの最大時間を指定します。 ユーザーがすでに "
+"`maxAge`よりも長い時間認証済みの場合、SSOは無視され、再度認証する必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:260
+msgid ""
+"loginHint - Used to pre-fill the username/email field on the login form."
+msgstr "loginHint - ログイン・フォームのユーザー名/電子メール・フィールドを事前入力するために使用されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:261
+msgid ""
+"action - If value is 'register' then user is redirected to registration "
+"page, otherwise to login page."
+msgstr ""
+"action - 値が 'register' の場合、ユーザーは登録ページにリダイレクトされ、そうでない場合はログインページにリダイレクトされます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:262
+msgid "locale - Specifies the desired locale for the UI."
+msgstr "locale - UIのロケールを指定します。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:263
+#, no-wrap
+msgid "createLoginUrl(options)"
+msgstr "createLoginUrl(options)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:266
+msgid ""
+"Returns the URL to login form on (options is an optional object with "
+"redirectUri and/or prompt fields)."
+msgstr ""
+"ログインフォームにへのURLを返します（オプションは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:268
+msgid ""
+"Options is an Object, which supports same options like the function `login` "
+"."
+msgstr "オプションは、  `login` 関数のように同じオプションをサポートするObjectです。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:269
+#, no-wrap
+msgid "logout(options)"
+msgstr "logout(options)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:272
+msgid "Redirects to logout."
+msgstr "ログアウトにリダイレクトします。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:276
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:284
+msgid "redirectUri - Specifies the uri to redirect to after logout."
+msgstr "redirectUri - ログアウト後にリダイレクトするURIを指定します。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:277
+#, no-wrap
+msgid "createLogoutUrl(options)"
+msgstr "createLogoutUrl(options)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:280
+msgid "Returns the URL to logout the user."
+msgstr "ユーザーをログアウトするURLを返します。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:285
+#, no-wrap
+msgid "register(options)"
+msgstr "register(options)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:288
+msgid ""
+"Redirects to registration form. Shortcut for login with option action = "
+"'register'"
+msgstr "登録フォームにリダイレクトします。 オプションaction = 'register' でログインするためのショートカット"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:290
+msgid ""
+"Options are same as for the login method but 'action' is set to 'register'"
+msgstr "オプションは `login` メソッドと同じですが、 'action' は 'register' に設定されています"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:291
+#, no-wrap
+msgid "createRegisterUrl(options)"
+msgstr "createRegisterUrl(options)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:294
+msgid ""
+"Returns the url to registration page. Shortcut for createLoginUrl with "
+"option action = 'register'"
+msgstr "登録ページのURLを返します。 オプションaction = 'register' を含むcreateLoginUrl へのショートカット"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:296
+msgid ""
+"Options are same as for the createLoginUrl method but 'action' is set to "
+"'register'"
+msgstr "オプションは `createLoginUrl` メソッドと同じですが、 'action' は 'register' に設定されています"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:297
+#, no-wrap
+msgid "accountManagement()"
+msgstr "accountManagement()"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:300
+msgid "Redirects to the Account Management Console."
+msgstr "アカウント管理コンソールにリダイレクトします。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:301
+#, no-wrap
+msgid "createAccountUrl()"
+msgstr "createAccountUrl()"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:304
+msgid "Returns the URL to the Account Management Console."
+msgstr "アカウント管理コンソールのURLを返します。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:305
+#, no-wrap
+msgid "hasRealmRole(role)"
+msgstr "hasRealmRole(role)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:308
+msgid "Returns true if the token has the given realm role."
+msgstr "トークンに指定されたレルムのロールがある場合は、trueを返します。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:309
+#, no-wrap
+msgid "hasResourceRole(role, resource)"
+msgstr "hasResourceRole(role, resource)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:312
+msgid ""
+"Returns true if the token has the given role for the resource (resource is "
+"optional, if not specified clientId is used)."
+msgstr ""
+"トークンにリソースのロールが指定されている場合は、trueを返します（指定されていない場合はリソースはオプションですが、 `clientId` "
+"が使用されます）。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:313
+#, no-wrap
+msgid "loadUserProfile()"
+msgstr "loadUserProfile()"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:316
+msgid "Loads the users profile."
+msgstr "ユーザーのプロファイルを読み込みます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:319
+msgid ""
+"Returns promise to set functions to be invoked if the profile was loaded "
+"successfully, or if the profile could not be loaded."
+msgstr "プロファイルが正常にロードされた場合、またはプロファイルをロードできなかった場合に、呼び出される関数を設定するpromiseを返します。"
+
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:329
 #, no-wrap
 msgid ""
@@ -806,42 +1084,52 @@ msgid ""
 "        alert('Failed to load user profile');\n"
 "    });\n"
 msgstr ""
+"keycloak.loadUserProfile().success(function(profile) {\n"
+"        alert(JSON.stringify(test, null, \"  \"));\n"
+"    }).error(function() {\n"
+"        alert('Failed to load user profile');\n"
+"    });\n"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:332
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:331
 #, no-wrap
-msgid "====== isTokenExpired(minValidity)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:334
-#, no-wrap
-msgid "Returns true if the token has less than minValidity seconds left before it expires (minValidity is optional, if not specified 0 is used).\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:336
-#, no-wrap
-msgid "====== updateToken(minValidity)\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:339
-#, no-wrap
-msgid ""
-"If the token expires within minValidity seconds (minValidity is optional, if not specified 5 is used) the token is refreshed.\n"
-"If the session status iframe is enabled, the session status is also checked. \n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:342
-#, no-wrap
-msgid ""
-"Returns promise to set functions that can be invoked if the token is still valid, or if the token is no longer valid.\n"
-"For example:\n"
-msgstr ""
+msgid "isTokenExpired(minValidity)"
+msgstr "isTokenExpired(minValidity)"
 
 #. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:334
+msgid ""
+"Returns true if the token has less than minValidity seconds left before it "
+"expires (minValidity is optional, if not specified 0 is used)."
+msgstr ""
+"トークンが期限切れになる前に `minValidity` 秒を下回っている場合はtrueを返します（指定されていない場合は `minValidity` "
+"はオプションです。0が使用されます）。"
+
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:335
+#, no-wrap
+msgid "updateToken(minValidity)"
+msgstr "updateToken(minValidity)"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:339
+msgid ""
+"If the token expires within minValidity seconds (minValidity is optional, if"
+" not specified 5 is used) the token is refreshed.  If the session status "
+"iframe is enabled, the session status is also checked."
+msgstr ""
+"トークンが `minValidity` 秒以内に期限切れになると（ `minValidity` "
+"は省略可能です。指定されていない場合は5が使用されます）、トークンがリフレッシュされます。 "
+"セッション・ステータスiframeが有効な場合、セッション・ステータスもチェックされます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:342
+msgid ""
+"Returns promise to set functions that can be invoked if the token is still "
+"valid, or if the token is no longer valid.  For example:"
+msgstr "トークンが有効な場合、またはトークンがもはや有効でない場合に呼び出される関数を設定するpromiseを返します。 例えば："
+
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:354
 #, no-wrap
 msgid ""
@@ -855,63 +1143,102 @@ msgid ""
 "        alert('Failed to refresh the token, or the session has expired');\n"
 "    });\n"
 msgstr ""
+"keycloak.updateToken(5).success(function(refreshed) {\n"
+"        if (refreshed) {\n"
+"            alert('Token was successfully refreshed');\n"
+"        } else {\n"
+"            alert('Token is still valid');\n"
+"        }\n"
+"    }).error(function() {\n"
+"        alert('Failed to refresh the token, or the session has expired');\n"
+"    });\n"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:357
+#. type: Title ======
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:356
 #, no-wrap
-msgid "====== clearToken()\n"
-msgstr ""
+msgid "clearToken()"
+msgstr "clearToken()"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:360
-#, no-wrap
 msgid ""
-"Clear authentication state, including tokens.\n"
-"This can be useful if application has detected the session was expired, for example if updating token fails.\n"
+"Clear authentication state, including tokens.  This can be useful if "
+"application has detected the session was expired, for example if updating "
+"token fails."
 msgstr ""
+"認証状態(トークンを含む)をクリアします。 "
+"これは、更新トークンが失敗した場合など、セッションが終了したことをアプリケーションが検出した場合に役立ちます。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:362
-#, no-wrap
-msgid "Invoking this results in onAuthLogout callback listener being invoked. \n"
-msgstr ""
+msgid "Invoking this results in onAuthLogout callback listener being invoked."
+msgstr "これを呼び出すと、 `onAuthLogout` コールバック・リスナーが呼び出されます。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:363
 #, no-wrap
 msgid "Callback Events"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:366
-msgid "The adapter supports setting callback listeners for certain events."
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:369
-msgid "For example: [source,javascript]"
-msgstr ""
+msgstr "コールバック・イベント"
 
 #. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:366
+msgid "The adapter supports setting callback listeners for certain events."
+msgstr "アダプターは、特定のイベントのコールバック・リスナーの設定をサポートします。"
+
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:371
-msgid "keycloak.onAuthSuccess = function() { alert('authenticated'); }"
-msgstr ""
+#, no-wrap
+msgid "keycloak.onAuthSuccess = function() { alert('authenticated'); }\n"
+msgstr "keycloak.onAuthSuccess = function() { alert('authenticated'); }\n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/javascript-adapter.adoc:374
-#, no-wrap
-msgid "The available events are:\n"
-msgstr ""
+msgid "The available events are:"
+msgstr "使用できるイベントは次のとおりです:"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:381
-#, no-wrap
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:376
+msgid "onReady(authenticated) - Called when the adapter is initialized."
+msgstr "onReady(authenticated) - アダプターが初期化されたときに呼び出されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:377
+msgid "onAuthSuccess - Called when a user is successfully authenticated."
+msgstr "onAuthSuccess - ユーザーが正常に認証されたときに呼び出されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:378
+msgid "onAuthError - Called if there was an error during authentication."
+msgstr "onAuthError - 認証時にエラーが発生した場合に呼び出されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:379
+msgid "onAuthRefreshSuccess - Called when the token is refreshed."
+msgstr "onAuthRefreshSuccess - トークンがリフレッシュされたときに呼び出されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:380
 msgid ""
-"* onReady(authenticated) - Called when the adapter is initialized.\n"
-"* onAuthSuccess - Called when a user is successfully authenticated.\n"
-"* onAuthError - Called if there was an error during authentication.\n"
-"* onAuthRefreshSuccess - Called when the token is refreshed.\n"
-"* onAuthRefreshError - Called if there was an error while trying to refresh the token.\n"
-"* onAuthLogout - Called if the user is logged out (will only be called if the session status iframe is enabled, or in Cordova mode).\n"
-"* onTokenExpired - Called when the access token is expired. If a refresh token is available the token can be refreshed with updateToken, or in cases where it is not (that is, with implicit flow) you can redirect to login screen to obtain a new access token.\n"
+"onAuthRefreshError - Called if there was an error while trying to refresh "
+"the token."
+msgstr "onAuthRefreshError - トークンをリフレッシュする際にエラーが発生した場合に呼び出されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:381
+msgid ""
+"onAuthLogout - Called if the user is logged out (will only be called if the "
+"session status iframe is enabled, or in Cordova mode)."
 msgstr ""
+"onAuthLogout - "
+"ユーザーがログアウトしたときに呼び出されます（セッション・ステータスiframeが有効な場合、またはCordovaモードの場合にのみ、呼び出されます）。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:381
+msgid ""
+"onTokenExpired - Called when the access token is expired. If a refresh token"
+" is available the token can be refreshed with updateToken, or in cases where"
+" it is not (that is, with implicit flow) you can redirect to login screen to"
+" obtain a new access token."
+msgstr ""
+"onTokenExpired - アクセス・トークンが期限切れになったときに呼び出されます。 "
+"リフレッシュ・トークンが利用可能な場合、トークンはupdateTokenでリフレッシュすることができます。トークンがリフレッシュされていない場合（つまり、インプリシット・フローがある場合）、ログイン画面にリダイレクトして新しいアクセス・トークンを取得できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__javascript-adapter/ja_JP/index.html
