### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -17,6 +17,11 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
+msgid "Example using CURL"
+msgstr "CURLを使用した例"
+
+#. type: Title ===
+#, no-wrap
 msgid "Other OpenID Connect Libraries"
 msgstr "他のOpenID Connectライブラリー"
 
@@ -34,9 +39,9 @@ msgid ""
 msgstr ""
 "{project_name}は、使いやすくて、{project_name}と統合しやすい付属のアダプターにより、セキュリティ保護できます。ただし、使用するプログラミング言語、フレームワーク、プラットフォームでアダプターが使用できない場合は、代わりに一般的なOpenID"
 " Connect Resource "
-"Provider(RP)ライブラリを使用することができます。この章では、{project_name}固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。詳細については、http://openid.net/connect/[OpenID"
-" Connect specifications]とhttps://tools.ietf.org/html/rfc6749[OAuth2 "
-"specification]を参照してください。"
+"Provider（RP）ライブラリを使用することができます。この章では、{project_name}固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。詳細については、"
+" http://openid.net/connect/[OpenID Connect specifications] と "
+"https://tools.ietf.org/html/rfc6749[OAuth2 specification] を参照してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -62,7 +67,8 @@ msgid ""
 "To obtain the full URL, add the base URL for {project_name} and replace "
 "`{realm-name}` with the name of your realm. For example:"
 msgstr ""
-"完全なURLを取得するには、{project_name}のベースURLを追加し、 `{realm-name}` をレルム名で置換します。 例えば："
+"完全なURLを取得するには、{project_name}のベースURLを追加し、 `{realm-name}` "
+"をレルム名で置換します。以下に例を示します。"
 
 #. type: Plain text
 msgid ""
@@ -77,7 +83,7 @@ msgid ""
 "Some RP libraries retrieve all required endpoints from this endpoint, but "
 "for others you might need to list the endpoints individually."
 msgstr ""
-"一部のRPライブラリは、このエンドポイントから必要なすべてのエンドポイントを取得しますが、他はエンドポイントを個別に一覧化する必要があります。"
+"一部のRPライブラリーは、このエンドポイントから必要なすべてのエンドポイントを取得しますが、他はエンドポイントを個別に記載する必要があります。"
 
 #. type: Title =====
 #, no-wrap
@@ -102,8 +108,8 @@ msgid ""
 "1_0.html#AuthorizationEndpoint[Authorization Endpoint] section in the OpenID"
 " Connect specification."
 msgstr ""
-"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[Authorization Endpoint]を参照してください。"
+"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[Authorization Endpoint] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -122,7 +128,7 @@ msgid ""
 "depending on what flow is used.  The token endpoint is also used to obtain "
 "new access tokens when they expire."
 msgstr ""
-"トークン・エンドポイントは、トークンを取得するために使用されます。トークンは、認可コードを交換するか、使用されているフローに応じたクレデンシャルを直接指定することによって取得できます。トークン・エンドポイントは、有効期限が切れたときに新しいアクセス・トークンを取得するためにも使用されます。"
+"トークン・エンドポイントは、トークンを取得するために使用されます。トークンは、認可コードを交換するか、使用されているフロー次第ではクレデンシャルを直接指定することによって取得できます。トークン・エンドポイントは、有効期限が切れたときに新しいアクセス・トークンを取得するためにも使用されます。"
 
 #. type: Plain text
 msgid ""
@@ -130,8 +136,8 @@ msgid ""
 "1_0.html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
-"1_0.html#TokenEndpoint[Token Endpoint]を参照してください。"
+"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#TokenEndpoint[Token Endpoint] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -147,7 +153,7 @@ msgstr "/realms/{realm-name}/protocol/openid-connect/userinfo\n"
 msgid ""
 "The userinfo endpoint returns standard claims about the authenticated user, "
 "and is protected by a bearer token."
-msgstr "userinfoエンドポイントは、認証されたユーザーに関する標準クレームを返し、ベアラー・トークンによって保護されます。"
+msgstr "UserInfoエンドポイントは、認証されたユーザーに関する標準クレームを返します。また、ベアラー・トークンによって保護されています。"
 
 #. type: Plain text
 msgid ""
@@ -155,8 +161,8 @@ msgid ""
 "1_0.html#UserInfo[Userinfo Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
-"1_0.html#UserInfo[Userinfo Endpoint] を参照してください。"
+"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#UserInfo[Userinfo Endpoint]を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -178,7 +184,7 @@ msgid ""
 "user session is logged out. Afterward the user agent is redirected back to "
 "the application."
 msgstr ""
-"ユーザー・エージェントはエンドポイントにリダイレクトでき、その場合、アクティブ・ユーザー・セッションはログアウトされます。その後、ユーザー・エージェントはアプリケーションにリダイレクトされます。"
+"ユーザー・エージェントはこのエンドポイントにリダイレクトされた場合、アクティブ・ユーザー・セッションはログアウトされます。その後、ユーザー・エージェントはアプリケーションにリダイレクトされます。"
 
 #. type: Plain text
 msgid ""
@@ -186,7 +192,7 @@ msgid ""
 " endpoint directly the refresh token needs to be included as well as the "
 "credentials required to authenticate the client."
 msgstr ""
-"エンドポイントは、アプリケーションによって直接呼び出すこともできます。このエンドポイントを直接呼び出すには、リフレッシュ・トークンと、クライアントの認証に必要なクレデンシャルを含める必要があります。"
+"エンドポイントは、アプリケーションによって直接呼び出すこともできます。このエンドポイントを直接呼び出すには、リフレッシュ・トークンと、クライアント認証に必要なクレデンシャルを含める必要があります。"
 
 #. type: Title =====
 #, no-wrap
@@ -206,9 +212,10 @@ msgid ""
 "the link:{adminguide_link}[{adminguide_name}] and the "
 "https://tools.ietf.org/html/rfc7517[JSON Web Key specification]."
 msgstr ""
-"証明書のエンドポイントは、JSON Web Key "
-"(JWK)としてエンコードされ、レルムによって有効化された公開鍵を返します。レルム設定に応じて、トークンを検証するために1つ以上のキーを有効にすることができます。詳細については、link:{adminguide_link}[{adminguide_name}]とhttps://tools.ietf.org/html/rfc7517[JSON"
-" Web Key specification]のリンクを参照ください。"
+"証明書エンドポイントは、JSON Web "
+"Key（JWK）としてエンコードされ、レルムで有効化されている公開鍵を返します。レルム設定次第で、トークンを検証するために1つ以上のキーを有効にすることができます。詳細については、link:{adminguide_link}[{adminguide_name}]と"
+" https://tools.ietf.org/html/rfc7517[JSON Web Key specification] "
+"のリンクを参照ください。"
 
 #. type: Title =====
 #, no-wrap
@@ -232,8 +239,8 @@ msgid ""
 "For more details see https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token "
 "Introspection specification]."
 msgstr ""
-"詳細については、https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token Introspection "
-"specification]を参照してください。"
+"詳細については、 https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token Introspection "
+"specification] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -257,9 +264,9 @@ msgid ""
 "chapter>> and the https://openid.net/specs/openid-connect-registration-"
 "1_0.html[OpenID Connect Dynamic Client Registration specification]."
 msgstr ""
-"詳細については、<<_client_registration,Client Registration "
-"chapter>>とhttps://openid.net/specs/openid-connect-registration-"
-"1_0.html[OpenID Connect Dynamic Client Registration specification]を参照してください。"
+"詳細については、<<_client_registration,クライアントの登録の章>>と https://openid.net/specs"
+"/openid-connect-registration-1_0.html[OpenID Connect Dynamic Client "
+"Registration specification] を参照してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -296,8 +303,8 @@ msgid ""
 "1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[Authorization Code Flow]を参照してください。"
+"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[Authorization Code Flow] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -317,13 +324,13 @@ msgid ""
 "application only wants to authenticate the user and deals with logout "
 "itself."
 msgstr ""
-"インプリシット・フローのリダイレクトは、認可コード・フローと同様に機能しますが、認可コードが返される代わりに、アクセス・トークンとIDトークンが返されます。これにより、アクセス・トークンのために認可コードを交換するための余分な呼び出しの必要性が減ります。ただし、リフレッシュ・トークンは含まれません。その結果、長い有効期限を持つアクセス・トークンを許可する必要があります。これらのトークンを無効にするのは難しいため、問題があります。または、最初のアクセス・トークンが期限切れになったら、新しいアクセス・トークンを取得するために新しいリダイレクトが必要です。インプリシット・フローは、アプリケーションがユーザーの認証のみを行い、ログアウト自体を処理する場合に便利です。"
+"インプリシット・フローのリダイレクトは、認可コード・フローと同様に機能しますが、認可コードが返される代わりに、アクセス・トークンとIDトークンが返されます。これにより、アクセス・トークンのために認可コードを交換するための余分な呼び出しの必要性が減ります。ただし、リフレッシュ・トークンは含まれません。その結果、長い有効期限を持つアクセス・トークンを許可する必要があります。これらのトークンを無効にするのは難しいため、問題があります。または、最初のアクセス・トークンが期限切れになった場合は、新しいアクセス・トークンを取得するためにリダイレクトが必要です。インプリシット・フローは、アプリケーションがユーザーの認証のみを行い、自身でログアウトを処理する場合に便利です。"
 
 #. type: Plain text
 msgid ""
 "There's also a Hybrid flow where both the Access Token and an Authorization "
 "Code is returned."
-msgstr "アクセス・トークンと認可コードが返されるハイブリッドフローもあります。"
+msgstr "アクセス・トークンと認可コードが返されるハイブリッド・フローもあります。"
 
 #. type: Plain text
 msgid ""
@@ -332,7 +339,7 @@ msgid ""
 "server logs and browser history. This is somewhat mitigated by using short "
 "expiration for Access Tokens."
 msgstr ""
-"インプリシット・フローとハイブリッド・フローの両方で、Webサーバーのログとブラウザの履歴を通じてアクセス・トークンが漏洩する可能性があるため、潜在的なセキュリティ上のリスクがあることに注意してください。これは、アクセス・トークンの有効期限を短くすることでやや緩和されます。"
+"インプリシット・フローとハイブリッド・フローの両方で、Webサーバーのログとブラウザの履歴を通じてアクセス・トークンが漏洩する可能性があるため、潜在的なセキュリティ上のリスクがあることに注意してください。これは、アクセス・トークンの有効期限を短くすることで多少緩和されます。"
 
 #. type: Plain text
 msgid ""
@@ -340,8 +347,8 @@ msgid ""
 "1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[Implicit Flow]を参照してください。"
+"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[Implicit Flow] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -355,7 +362,7 @@ msgid ""
 "recommended to use this flow unless you absolutely need to. Examples where "
 "this could be useful are legacy applications and command-line interfaces."
 msgstr ""
-"リソース・オーナー・パスワード・クレデンシャル（{project_name}ではダイレクト・グラントと呼ばれる）は、トークンのユーザー・クレデンシャルの交換を可能にします。絶対に必要としない限り、このフローを使用することはお勧めしません。これが有用な場合の例は、レガシー・アプリケーションとコマンドライン・インターフェイスです。"
+"リソース・オーナー・パスワード・クレデンシャル（{project_name}ではダイレクト・グラントと呼ばれます）は、ユーザー・クレデンシャルとトークンの交換を可能にします。絶対に必要としない限り、このフローを使用することはお勧めしません。これが有用な場合の例は、レガシー・アプリケーションとコマンドライン・インターフェイスです。"
 
 #. type: Plain text
 msgid "There are a number of limitations of using this flow, including:"
@@ -379,12 +386,12 @@ msgstr "認証フローを変更するには、アプリケーションを変更
 
 #. type: Plain text
 msgid "No support for identity brokering or social login"
-msgstr "アイデンティティ・ブローキングまたはソーシャル・ログインのサポートなし"
+msgstr "アイデンティティー・ブローカリングまたはソーシャル・ログインはサポートされません"
 
 #. type: Plain text
 msgid ""
 "Flows are not supported (user self-registration, required actions, etc.)"
-msgstr "フローはサポートされていません（ユーザーの自己登録、必要な操作など）"
+msgstr "フローはサポートされていません（ユーザーの自己登録、必須アクションなど）"
 
 #. type: Plain text
 msgid ""
@@ -392,7 +399,7 @@ msgid ""
 "grant the client has to have the `Direct Access Grants Enabled` option "
 "enabled."
 msgstr ""
-"リソース・オーナー・パスワード・クレデンシャルの使用を許可されるためには、クライアントは `Direct Access Grants Enabled` "
+"リソース・オーナー・パスワード・クレデンシャルの使用が許可されるためには、クライアントは `Direct Access Grants Enabled` "
 "オプションを有効にする必要があります。"
 
 #. type: Plain text
@@ -407,13 +414,9 @@ msgid ""
 "https://tools.ietf.org/html/rfc6749#section-4.3[Resource Owner Password "
 "Credentials Grant] chapter in the OAuth 2.0 specification."
 msgstr ""
-"詳細については、OAuth 2.0仕様のhttps://tools.ietf.org/html/rfc6749#section-4.3[Resource"
-" Owner Password Credentials Grant]のセクションを参照してください。"
-
-#. type: Title ===
-#, no-wrap
-msgid "Example using CURL"
-msgstr "CURLを使用した例"
+"詳細については、OAuth 2.0仕様の "
+"https://tools.ietf.org/html/rfc6749#section-4.3[Resource Owner Password "
+"Credentials Grant] のセクションを参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -421,8 +424,9 @@ msgid ""
 "realm `master` with username `user` and password `password`. The example is "
 "using the confidential client `myclient`:"
 msgstr ""
-"次の例は、ユーザー名 `user` とパスワード `password` を使用して、レルム `master` "
-"にあるユーザーのアクセス・トークンを取得する方法を示しています。この例では、コンフィデンシャル・クライアント `myclient` を使用しています。"
+"次の例は、ユーザー名 `user` とパスワード `password` を使用して、 `master` "
+"レルムにあるユーザーのアクセス・トークンを取得する方法を示しています。この例では、コンフィデンシャル・クライアント `myclient` "
+"を使用しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -455,13 +459,13 @@ msgid ""
 " can for example be useful for background services that applies changes to "
 "the system in general rather than for a specific user."
 msgstr ""
-"クライアント・クレデンシャルは、クライアント（アプリケーションおよびサービス）がユーザーの代わりにではなく、自分のためにアクセス権を取得したい場合に使用されます。これは、たとえば、特定のユーザーではなく一般的にシステムに変更を適用するバックグラウンド・サービスに役立ちます。"
+"クライアント・クレデンシャルは、クライアント（アプリケーションおよびサービス）がユーザーの代わりにではなく、自分のためにアクセス権を取得したい場合に使用されます。これは、たとえば、特定のユーザーのためにではなく一般的にシステムに変更を適用するバックグラウンド・サービスに役立ちます。"
 
 #. type: Plain text
 msgid ""
 "{project_name} provides support for clients to authenticate either with a "
 "secret or with public/private keys."
-msgstr "{project_name}は、クライアントが秘密鍵または公開鍵/秘密鍵のいずれかで認証することをサポートします。"
+msgstr "{project_name}は、クライアントがシークレットまたは公開鍵/秘密鍵のいずれかで認証することをサポートします。"
 
 #. type: Plain text
 msgid ""
@@ -469,8 +473,8 @@ msgid ""
 "https://tools.ietf.org/html/rfc6749#section-4.4[Client Credentials Grant] "
 "chapter in the OAuth 2.0 specification."
 msgstr ""
-"詳細については、OAuth 2.0仕様のhttps://tools.ietf.org/html/rfc6749#section-4.4[Client "
-"Credentials Grant]のセクションを参照してください。"
+"詳細については、OAuth 2.0仕様の https://tools.ietf.org/html/rfc6749#section-4.4[Client "
+"Credentials Grant] のセクションを参照してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -484,13 +488,13 @@ msgid ""
 "This especially applies to client-side (public clients) applications. "
 "Failing to do so could result in:"
 msgstr ""
-"リダイレクト・ベースのフローを使用する場合は、クライアントに有効なリダイレクトURLを使用することが重要です。リダイレクトURLはできるだけ具体的にする必要があります。これは、特にクライアント・サイド（パブリック・クライアント）のアプリケーションに適用されます。そうしないと次のことが起こる可能性があります。"
+"リダイレクト・ベースのフローを使用する場合は、クライアントで有効なリダイレクトURLを使用することが重要です。リダイレクトURLはできるだけ具体的にする必要があります。これは、特にクライアント・サイド（パブリック・クライアント）のアプリケーションに適用されます。そうしないと次のことが起こる可能性があります。"
 
 #. type: Plain text
 msgid ""
 "Open redirects - this can allow attackers to create spoof links that looks "
 "like they are coming from your domain"
-msgstr "オープンリダイレクト - これにより、攻撃者はあなたのドメインから来ているような偽のリンクを作成することができます"
+msgstr "オープン・リダイレクト - これにより、攻撃者はあなたのドメインでできている偽のリンクを作成することができます"
 
 #. type: Plain text
 msgid ""
@@ -499,8 +503,8 @@ msgid ""
 "not be configured correctly to gain access by redirecting the user without "
 "the users knowledge"
 msgstr ""
-"未認可のエントリー - "
-"ユーザーが{project_name}で既に認証されている場合、攻撃者はリダイレクトURLが正しく設定されていない公開クライアントを使用して、ユーザーが知らないうちにユーザーをリダイレクトすることでアクセスできます"
+"不正侵入 - "
+"ユーザーが{project_name}で既に認証済みの場合、攻撃者はリダイレクトURLが正しく設定されていない公開クライアントを使用し、ユーザーを知らないうちにリダイレクトさせることで、アクセス権を得ます"
 
 #. type: Plain text
 msgid ""
@@ -512,7 +516,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "There's also a few special redirect URIs:"
-msgstr "また、特別なリダイレクトURIがいくつかあります："
+msgstr "また、次のような特別なリダイレクトURIがいくつかあります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -525,7 +529,7 @@ msgid ""
 "application to create a web server on a random port that can be used to "
 "obtain the authorization code. This redirect uri allows any port."
 msgstr ""
-"このリダイレクトURIはネイティブ・アプリケーションに役立ち、ネイティブ・アプリケーションが認証コードを取得するために使用できるランダムなポート上にWebサーバーを作成することを許可します。このリダイレクトURIは任意のポートを許可します。"
+"このリダイレクトURIはネイティブ・アプリケーションに役立ちます。ネイティブ・アプリケーションが認可コードを取得するために、ランダムなポート上にWebサーバーを作成することを許可します。このリダイレクトURIは任意のポートを許可します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -544,4 +548,4 @@ msgid ""
 " to the application."
 msgstr ""
 "クライアントでWebサーバーを起動できない（またはブラウザが利用できない）場合は、特殊な `urn:ietf:wg:oauth:2.0:oob` "
-"リダイレクトURIを使用することができます。このリダイレクトURIが使用されると、{project_name}はページのタイトルとボックスのコードを含むページを表示します。アプリケーションがブラウザーのタイトルが変更されたことを検出するか、ユーザーが手動でコードをアプリケーションにコピー/ペーストすることができます。このリダイレクトURIを使用すると、ユーザーが別のデバイスを使用してアプリケーションに貼り付けるコードを取得することもできます。"
+"リダイレクトURIを使用することができます。このリダイレクトURIが使用されると、{project_name}は認可コードをページのタイトルとボックスに含めたページを表示します。アプリケーションがブラウザーのタイトルが変更されたことを検出するか、ユーザーが手動でコードをアプリケーションにコピー/ペーストすることができます。このリダイレクトURIを使用すると、ユーザーが別のデバイスを使用してアプリケーションに貼り付けるコードを取得することもできます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:1
 #, no-wrap
 msgid "Other OpenID Connect Libraries"
 msgstr "他のOpenID Connectライブラリー"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:4
 msgid ""
 "{project_name} can be secured by supplied adapters that are usually easier "
 "to use and provide better integration with {project_name}. However, if an "
@@ -34,45 +32,39 @@ msgid ""
 "specifications] and https://tools.ietf.org/html/rfc6749[OAuth2 "
 "specification]."
 msgstr ""
-"{project_name} は、使いやすく、 {project_name} とのより良い統合を提供する付属のアダプターでセキュリティ保護できます。 "
-"ただし、プログラミング言語、フレームワーク、プラットフォームでアダプターが使用できない場合は、代わりに一般的なOpenID Connect "
-"Resource Provider（RP）ライブラリを使用することができます。 この章では、 {project_name} "
-"固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。 詳細については、 "
-"http://openid.net/connect/[OpenID Connect specifications] and "
-"https://tools.ietf.org/html/rfc6749[OAuth2 specification] を参照してください。"
+"{project_name}は、使いやすくて、{project_name}と統合しやすい付属のアダプターにより、セキュリティ保護できます。ただし、使用するプログラミング言語、フレームワーク、プラットフォームでアダプターが使用できない場合は、代わりに一般的なOpenID"
+" Connect Resource "
+"Provider(RP)ライブラリを使用することができます。この章では、{project_name}固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。詳細については、http://openid.net/connect/[OpenID"
+" Connect specifications]とhttps://tools.ietf.org/html/rfc6749[OAuth2 "
+"specification]を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:5
 #, no-wrap
 msgid "Endpoints"
 msgstr "エンドポイント"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:8
 msgid ""
 "The most important endpoint to understand is the `well-known` configuration "
 "endpoint. It lists endpoints and other configuration options relevant to the"
 " OpenID Connect implementation in {project_name}. The endpoint is:"
 msgstr ""
-"理解すべき最も重要なエンドポイントは、 `well-known` 設定エンドポイントです。 これは、 {project_name} のOpenID "
-"Connectの実装に関連するエンドポイントとその他の設定オプションを一覧化します。 エンドポイントは次のとおりです。"
+"理解すべき最も重要なエンドポイントは、 `well-known` 設定エンドポイントです。これは、{project_name}のOpenID "
+"Connectの実装に関連するエンドポイントとその他の設定オプションを一覧化します。エンドポイントは次のとおりです。"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:11
 #, no-wrap
 msgid "/realms/{realm-name}/.well-known/openid-configuration\n"
 msgstr "/realms/{realm-name}/.well-known/openid-configuration\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:14
 msgid ""
 "To obtain the full URL, add the base URL for {project_name} and replace "
 "`{realm-name}` with the name of your realm. For example:"
 msgstr ""
-"完全なURLを取得するには、 {project_name} のベースURLを追加し、  `{realm-name} 'をレルム名で置換します。 例えば："
+"完全なURLを取得するには、{project_name}のベースURLを追加し、 `{realm-name}` をレルム名で置換します。 例えば："
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:16
 msgid ""
 "$$http://localhost:8080/auth/realms/master/.well-known/openid-"
 "configuration$$"
@@ -81,7 +73,6 @@ msgstr ""
 "configuration$$"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:18
 msgid ""
 "Some RP libraries retrieve all required endpoints from this endpoint, but "
 "for others you might need to list the endpoints individually."
@@ -89,90 +80,76 @@ msgstr ""
 "一部のRPライブラリは、このエンドポイントから必要なすべてのエンドポイントを取得しますが、他はエンドポイントを個別に一覧化する必要があります。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:19
 #, no-wrap
 msgid "Authorization Endpoint"
 msgstr "認可エンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:22
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/auth\n"
 msgstr "/realms/{realm-name}/protocol/openid-connect/auth\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:25
 msgid ""
 "The authorization endpoint performs authentication of the end-user. This is "
 "done by redirecting the user agent to this endpoint."
 msgstr ""
-"認可エンドポイントは、エンドユーザーの認証を実行します。 これは、ユーザー・エージェントをこのエンドポイントにリダイレクトすることによって行われます。"
+"認可エンドポイントは、エンドユーザーの認証を実行します。これは、ユーザー・エージェントをこのエンドポイントにリダイレクトすることによって行われます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:27
 msgid ""
 "For more details see the http://openid.net/specs/openid-connect-core-"
 "1_0.html#AuthorizationEndpoint[Authorization Endpoint] section in the OpenID"
 " Connect specification."
 msgstr ""
-"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[Authorization Endpoint] を参照してください。"
+"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[Authorization Endpoint]を参照してください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:28
 #, no-wrap
 msgid "Token Endpoint"
 msgstr "トークン・エンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:31
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/token\n"
 msgstr "/realms/{realm-name}/protocol/openid-connect/token\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:35
 msgid ""
 "The token endpoint is used to obtain tokens. Tokens can either be obtained "
 "by exchanging an authorization code or by supplying credentials directly "
 "depending on what flow is used.  The token endpoint is also used to obtain "
 "new access tokens when they expire."
 msgstr ""
-"トークン・エンドポイントは、トークンを取得するために使用されます。 "
-"トークンは、認可コードを交換するか、使用されているフローに応じたクレデンシャルを直接指定することによって取得できます。 "
-"トークン・エンドポイントは、有効期限が切れたときに新しいアクセス・トークンを取得するためにも使用されます。"
+"トークン・エンドポイントは、トークンを取得するために使用されます。トークンは、認可コードを交換するか、使用されているフローに応じたクレデンシャルを直接指定することによって取得できます。トークン・エンドポイントは、有効期限が切れたときに新しいアクセス・トークンを取得するためにも使用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:37
 msgid ""
 "For more details see the http://openid.net/specs/openid-connect-core-"
 "1_0.html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
-"1_0.html#TokenEndpoint[Token Endpoint] を参照してください。"
+"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#TokenEndpoint[Token Endpoint]を参照してください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:38
 #, no-wrap
 msgid "Userinfo Endpoint"
 msgstr "Userinfoエンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:41
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/userinfo\n"
 msgstr "/realms/{realm-name}/protocol/openid-connect/userinfo\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:44
 msgid ""
 "The userinfo endpoint returns standard claims about the authenticated user, "
 "and is protected by a bearer token."
 msgstr "userinfoエンドポイントは、認証されたユーザーに関する標準クレームを返し、ベアラー・トークンによって保護されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:46
 msgid ""
 "For more details see the http://openid.net/specs/openid-connect-core-"
 "1_0.html#UserInfo[Userinfo Endpoint] section in the OpenID Connect "
@@ -182,56 +159,46 @@ msgstr ""
 "1_0.html#UserInfo[Userinfo Endpoint] を参照してください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:47
 #, no-wrap
 msgid "Logout Endpoint"
 msgstr "ログアウト・エンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:50
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/logout\n"
 msgstr "/realms/{realm-name}/protocol/openid-connect/logout\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:53
 msgid "The logout endpoint logs out the authenticated user."
 msgstr "ログアウト・エンドポイントは、認証されたユーザーをログアウトします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:55
 msgid ""
 "The user agent can be redirected to the endpoint, in which case the active "
 "user session is logged out. Afterward the user agent is redirected back to "
 "the application."
 msgstr ""
-"ユーザー・エージェントはエンドポイントにリダイレクトでき、その場合、アクティブ・ユーザー・セッションはログアウトされます。 "
-"その後、ユーザー・エージェントはアプリケーションにリダイレクトされます。"
+"ユーザー・エージェントはエンドポイントにリダイレクトでき、その場合、アクティブ・ユーザー・セッションはログアウトされます。その後、ユーザー・エージェントはアプリケーションにリダイレクトされます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:57
 msgid ""
 "The endpoint can also be invoked directly by the application. To invoke this"
 " endpoint directly the refresh token needs to be included as well as the "
 "credentials required to authenticate the client."
 msgstr ""
-"エンドポイントは、アプリケーションによって直接呼び出すこともできます。 "
-"このエンドポイントを直接呼び出すには、リフレッシュ・トークンと、クライアントの認証に必要なクレデンシャルを含める必要があります。"
+"エンドポイントは、アプリケーションによって直接呼び出すこともできます。このエンドポイントを直接呼び出すには、リフレッシュ・トークンと、クライアントの認証に必要なクレデンシャルを含める必要があります。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:58
 #, no-wrap
 msgid "Certificate Endpoint"
 msgstr "証明書エンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:61
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/certs\n"
 msgstr "/realms/{realm-name}/protocol/openid-connect/certs\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:64
 msgid ""
 "The certificate endpoint returns the public keys enabled by the realm, "
 "encoded as a JSON Web Key (JWK). Depending on the realm settings there can "
@@ -239,85 +206,72 @@ msgid ""
 "the link:{adminguide_link}[{adminguide_name}] and the "
 "https://tools.ietf.org/html/rfc7517[JSON Web Key specification]."
 msgstr ""
-"証明書のエンドポイントは、JSON Web Key (JWK)としてエンコードされ、レルムによって有効化された公開鍵を返します。 "
-"レルム設定に応じて、トークンを検証するために1つ以上のキーを有効にすることができます。 詳細については、 "
-"link:{adminguide_link}[{adminguide_name}] と "
-"https://tools.ietf.org/html/rfc7517[JSON Web Key specification] のリンクをご覧ください。"
+"証明書のエンドポイントは、JSON Web Key "
+"(JWK)としてエンコードされ、レルムによって有効化された公開鍵を返します。レルム設定に応じて、トークンを検証するために1つ以上のキーを有効にすることができます。詳細については、link:{adminguide_link}[{adminguide_name}]とhttps://tools.ietf.org/html/rfc7517[JSON"
+" Web Key specification]のリンクを参照ください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:65
 #, no-wrap
 msgid "Introspection Endpoint"
 msgstr "イントロスペクション・エンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:68
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/token/introspect\n"
 msgstr "/realms/{realm-name}/protocol/openid-connect/token/introspect\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:71
 msgid ""
 "The introspection endpoint is used to retrieve the active state of a token. "
-"It is can only be invoked by confidential clients."
+"It can only be invoked by confidential clients."
 msgstr ""
-"イントロスペクション・エンドポイントは、トークンのアクティブ状態を取得するために使用されます。 "
-"これは、コンフィデンシャル・クライアントによってのみ呼び出すことができます。"
+"イントロスペクション・エンドポイントは、トークンのアクティブ状態を取得するために使用されます。これは、コンフィデンシャル・クライアントによってのみ呼び出すことができます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:73
 msgid ""
 "For more details see https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token "
 "Introspection specification]."
 msgstr ""
 "詳細については、https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token Introspection "
-"specification] を参照してください。"
+"specification]を参照してください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:74
 #, no-wrap
 msgid "Dynamic Client Registration Endpoint"
 msgstr "動的クライアント登録エンドポイント"
 
 #. type: delimited block .
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:77
 #, no-wrap
 msgid "/realms/{realm-name}/clients-registrations/openid-connect\n"
 msgstr "/realms/{realm-name}/clients-registrations/openid-connect\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:80
 msgid ""
 "The dynamic client registration endpoint is used to dynamically register "
 "clients."
 msgstr "動的クライアント登録エンドポイントを使用して、クライアントを動的に登録します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:83
 msgid ""
 "For more details see the <<_client_registration,Client Registration "
 "chapter>> and the https://openid.net/specs/openid-connect-registration-"
 "1_0.html[OpenID Connect Dynamic Client Registration specification]."
 msgstr ""
-"詳細については、<<_client_registration,Client Registration chapter>> と "
-"https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect"
-" Dynamic Client Registration specification] を参照してください。"
+"詳細については、<<_client_registration,Client Registration "
+"chapter>>とhttps://openid.net/specs/openid-connect-registration-"
+"1_0.html[OpenID Connect Dynamic Client Registration specification]を参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:85
 #, no-wrap
 msgid "Flows"
 msgstr "フロー"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:87
 #, no-wrap
 msgid "Authorization Code"
 msgstr "認可コード"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:92
 msgid ""
 "The Authorization Code flow redirects the user agent to {project_name}. Once"
 " the user has successfully authenticated with {project_name} an "
@@ -326,13 +280,9 @@ msgid ""
 " credentials to obtain an Access Token, Refresh Token and ID Token from "
 "{project_name}."
 msgstr ""
-"認可コード・フローは、ユーザー・エージェントを {project_name} にリダイレクトします。 ユーザーが {project_name} "
-"で正常に認証されると、認可コードが作成され、ユーザー・エージェントはアプリケーションにリダイレクトされます。 "
-"次に、アプリケーションは、クレデンシャルとともに認可コードを使用して、 {project_name} "
-"からアクセス・トークン、リフレッシュ・トークン、IDトークンを取得します。"
+"認可コード・フローは、ユーザー・エージェントを{project_name}にリダイレクトします。ユーザーが{project_name}で正常に認証されると、認可コードが作成され、ユーザー・エージェントはアプリケーションにリダイレクトされます。次に、アプリケーションは、クレデンシャルとともに認可コードを使用して、{project_name}からアクセス・トークン、リフレッシュ・トークン、IDトークンを取得します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:95
 msgid ""
 "The flow is targeted towards web applications, but is also recommended for "
 "native applications, including mobile applications, where it is possible to "
@@ -341,23 +291,20 @@ msgstr ""
 "このフローはWebアプリケーションを対象としていますが、ユーザー・エージェントを組み込むことができるモバイルアプリケーションなどのネイティブアプリケーションにも推奨されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:97
 msgid ""
 "For more details refer to the http://openid.net/specs/openid-connect-core-"
 "1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[Authorization Code Flow]  を参照してください。"
+"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[Authorization Code Flow]を参照してください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:98
 #, no-wrap
 msgid "Implicit"
 msgstr "インプリシット"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:105
 msgid ""
 "The Implicit flow redirects works similarly to the Authorization Code flow, "
 "but instead of returning a Authorization Code the Access Token and ID Token "
@@ -370,96 +317,76 @@ msgid ""
 "application only wants to authenticate the user and deals with logout "
 "itself."
 msgstr ""
-"インプリシット・フローのリダイレクトは、認可コード・フローと同様に機能しますが、認可コードが返される代わりに、アクセス・トークンとIDトークンが返されます。"
-" これにより、アクセス・トークンのために認可コードを交換するための余分な呼び出しの必要性が減ります。 ただし、リフレッシュ・トークンは含まれません。 "
-"その結果、長い有効期限を持つアクセス・トークンを許可する必要があります。これらのトークンを無効にするのは難しいため、問題があります。 "
-"または、最初のアクセス・トークンが期限切れになったら、新しいアクセス・トークンを取得するために新しいリダイレクトが必要です。 "
-"インプリシット・フローは、アプリケーションがユーザーの認証のみを行い、ログアウト自体を処理する場合に便利です。"
+"インプリシット・フローのリダイレクトは、認可コード・フローと同様に機能しますが、認可コードが返される代わりに、アクセス・トークンとIDトークンが返されます。これにより、アクセス・トークンのために認可コードを交換するための余分な呼び出しの必要性が減ります。ただし、リフレッシュ・トークンは含まれません。その結果、長い有効期限を持つアクセス・トークンを許可する必要があります。これらのトークンを無効にするのは難しいため、問題があります。または、最初のアクセス・トークンが期限切れになったら、新しいアクセス・トークンを取得するために新しいリダイレクトが必要です。インプリシット・フローは、アプリケーションがユーザーの認証のみを行い、ログアウト自体を処理する場合に便利です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:107
 msgid ""
 "There's also a Hybrid flow where both the Access Token and an Authorization "
 "Code is returned."
 msgstr "アクセス・トークンと認可コードが返されるハイブリッドフローもあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:110
 msgid ""
 "One thing to note is that both the Implicit flow and Hybrid flow has "
 "potential security risks as the Access Token may be leaked through web "
 "server logs and browser history. This is somewhat mitigated by using short "
 "expiration for Access Tokens."
 msgstr ""
-"インプリシット・フローとハイブリッド・フローの両方で、Webサーバーのログとブラウザの履歴を通じてアクセス・トークンが漏洩する可能性があるため、潜在的なセキュリティ上のリスクがあることに注意してください。"
-" これは、アクセス・トークンの有効期限を短くすることでやや緩和されます。"
+"インプリシット・フローとハイブリッド・フローの両方で、Webサーバーのログとブラウザの履歴を通じてアクセス・トークンが漏洩する可能性があるため、潜在的なセキュリティ上のリスクがあることに注意してください。これは、アクセス・トークンの有効期限を短くすることでやや緩和されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:112
 msgid ""
 "For more details refer to the http://openid.net/specs/openid-connect-core-"
 "1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[Implicit Flow] を参照してください。"
+"詳細については、OpenID Connect仕様のhttp://openid.net/specs/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[Implicit Flow]を参照してください。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:114
 #, no-wrap
 msgid "Resource Owner Password Credentials"
 msgstr "リソース・オーナー・パスワード・クレデンシャル"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:118
 msgid ""
 "Resource Owner Password Credentials, referred to as Direct Grant in "
 "{project_name}, allows exchanging user credentials for tokens. It's not "
 "recommended to use this flow unless you absolutely need to. Examples where "
 "this could be useful are legacy applications and command-line interfaces."
 msgstr ""
-"リソース・オーナー・パスワード・クレデンシャル（ {project_name} "
-"ではダイレクト・グラントと呼ばれる）は、トークンのユーザー・クレデンシャルの交換を可能にします。絶対に必要としない限り、このフローを使用することはお勧めしません。"
-" これが有用な場合の例は、レガシー・アプリケーションとコマンドライン・インターフェイスです。"
+"リソース・オーナー・パスワード・クレデンシャル（{project_name}ではダイレクト・グラントと呼ばれる）は、トークンのユーザー・クレデンシャルの交換を可能にします。絶対に必要としない限り、このフローを使用することはお勧めしません。これが有用な場合の例は、レガシー・アプリケーションとコマンドライン・インターフェイスです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:120
 msgid "There are a number of limitations of using this flow, including:"
-msgstr "このフローの使用には次のような制限があります:"
+msgstr "このフローの使用には次のような制限があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:122
 msgid "User credentials are exposed to the application"
 msgstr "ユーザーのクレデンシャルがアプリケーションに公開されます"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:123
 msgid "Applications need login pages"
 msgstr "アプリケーションはログイン・ページが必要です"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:124
 msgid "Application needs to be aware of the authentication scheme"
 msgstr "アプリケーションは認証方式を意識する必要があります"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:125
 msgid "Changes to authentication flow requires changes to application"
 msgstr "認証フローを変更するには、アプリケーションを変更する必要があります"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:126
 msgid "No support for identity brokering or social login"
 msgstr "アイデンティティ・ブローキングまたはソーシャル・ログインのサポートなし"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:127
 msgid ""
 "Flows are not supported (user self-registration, required actions, etc.)"
 msgstr "フローはサポートされていません（ユーザーの自己登録、必要な操作など）"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:129
 msgid ""
 "For a client to be permitted to use the Resource Owner Password Credentials "
 "grant the client has to have the `Direct Access Grants Enabled` option "
@@ -469,43 +396,35 @@ msgstr ""
 "オプションを有効にする必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:131
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:158
 msgid ""
 "This flow is not included in OpenID Connect, but is a part of the OAuth 2.0 "
 "specification."
 msgstr "このフローはOpenID Connectには含まれていませんが、OAuth 2.0の仕様の一部です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:133
 msgid ""
 "For more details refer to the "
 "https://tools.ietf.org/html/rfc6749#section-4.3[Resource Owner Password "
 "Credentials Grant] chapter in the OAuth 2.0 specification."
 msgstr ""
 "詳細については、OAuth 2.0仕様のhttps://tools.ietf.org/html/rfc6749#section-4.3[Resource"
-" Owner Password Credentials Grant] のセクションを参照してください。"
+" Owner Password Credentials Grant]のセクションを参照してください。"
 
 #. type: Title ===
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:134
-#: source/securing_apps/topics/client-registration.adoc:126
-#: source/server_development/topics/admin-rest-api.adoc:13
 #, no-wrap
 msgid "Example using CURL"
 msgstr "CURLを使用した例"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:138
 msgid ""
 "The following example shows how to obtain an access token for a user in the "
 "realm `master` with username `user` and password `password`. The example is "
 "using the confidential client `myclient`:"
 msgstr ""
 "次の例は、ユーザー名 `user` とパスワード `password` を使用して、レルム `master` "
-"にあるユーザーのアクセス・トークンを取得する方法を示しています。 この例では、コンフィデンシャル・クライアント `myclient` を使用しています。"
+"にあるユーザーのアクセス・トークンを取得する方法を示しています。この例では、コンフィデンシャル・クライアント `myclient` を使用しています。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:148
 #, no-wrap
 msgid ""
 "curl \\\n"
@@ -525,113 +444,95 @@ msgstr ""
 "  \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:150
 #, no-wrap
 msgid "Client Credentials"
 msgstr "クライアント・クレデンシャル"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:154
 msgid ""
 "Client Credentials is used when clients (applications and services) wants to"
 " obtain access on behalf of themselves rather than on behalf of a user. This"
 " can for example be useful for background services that applies changes to "
 "the system in general rather than for a specific user."
 msgstr ""
-"クライアント・クレデンシャルは、クライアント（アプリケーションおよびサービス）がユーザーの代わりにではなく、自分のためにアクセス権を取得したい場合に使用されます。"
-" これは、たとえば、特定のユーザーではなく一般的にシステムに変更を適用するバックグラウンド・サービスに役立ちます。"
+"クライアント・クレデンシャルは、クライアント（アプリケーションおよびサービス）がユーザーの代わりにではなく、自分のためにアクセス権を取得したい場合に使用されます。これは、たとえば、特定のユーザーではなく一般的にシステムに変更を適用するバックグラウンド・サービスに役立ちます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:156
 msgid ""
 "{project_name} provides support for clients to authenticate either with a "
 "secret or with public/private keys."
-msgstr "{project_name} は、クライアントが秘密鍵または公開鍵/秘密鍵のいずれかで認証することをサポートします。"
+msgstr "{project_name}は、クライアントが秘密鍵または公開鍵/秘密鍵のいずれかで認証することをサポートします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:160
 msgid ""
 "For more details refer to the "
 "https://tools.ietf.org/html/rfc6749#section-4.4[Client Credentials Grant] "
 "chapter in the OAuth 2.0 specification."
 msgstr ""
 "詳細については、OAuth 2.0仕様のhttps://tools.ietf.org/html/rfc6749#section-4.4[Client "
-"Credentials Grant] のセクションを参照してください。"
+"Credentials Grant]のセクションを参照してください。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:161
 #, no-wrap
 msgid "Redirect URIs"
 msgstr "リダイレクトURI"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:165
 msgid ""
 "When using the redirect based flows it's important to use valid redirect "
 "uris for your clients. The redirect uris should be as specific as possible. "
 "This especially applies to client-side (public clients) applications. "
 "Failing to do so could result in:"
 msgstr ""
-"リダイレクト・ベースのフローを使用する場合は、クライアントに有効なリダイレクトURLを使用することが重要です。 "
-"リダイレクトURLはできるだけ具体的にする必要があります。 これは、特にクライアント側（パブリック・クライアント）アプリケーションに適用されます。 "
-"そうしないと次のことが起こる可能性があります。"
+"リダイレクト・ベースのフローを使用する場合は、クライアントに有効なリダイレクトURLを使用することが重要です。リダイレクトURLはできるだけ具体的にする必要があります。これは、特にクライアント・サイド（パブリック・クライアント）のアプリケーションに適用されます。そうしないと次のことが起こる可能性があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:167
 msgid ""
 "Open redirects - this can allow attackers to create spoof links that looks "
 "like they are coming from your domain"
 msgstr "オープンリダイレクト - これにより、攻撃者はあなたのドメインから来ているような偽のリンクを作成することができます"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:168
 msgid ""
 "Unauthorized entry - when users are already authenticated with "
 "{project_name} an attacker can use a public client where redirect uris have "
 "not be configured correctly to gain access by redirecting the user without "
 "the users knowledge"
 msgstr ""
-"未認可のエントリー - ユーザーが {project_name} "
-"で既に認証されている場合、攻撃者はリダイレクトURLが正しく設定されていない公開クライアントを使用して、ユーザーが知らないうちにユーザーをリダイレクトすることでアクセスできます"
+"未認可のエントリー - "
+"ユーザーが{project_name}で既に認証されている場合、攻撃者はリダイレクトURLが正しく設定されていない公開クライアントを使用して、ユーザーが知らないうちにユーザーをリダイレクトすることでアクセスできます"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:170
 msgid ""
 "In production for web applications always use `https` for all redirect URIs."
 " Do not allow redirects to http."
 msgstr ""
-"Webアプリケーション用のプロダクション環境では、常にすべてのリダイレクトURIに `https` を使用します。 "
-"httpへのリダイレクトは許可しないでください。"
+"Webアプリケーション用のプロダクション環境では、常にすべてのリダイレクトURIに `https` "
+"を使用します。httpへのリダイレクトは許可しないでください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:172
 msgid "There's also a few special redirect URIs:"
 msgstr "また、特別なリダイレクトURIがいくつかあります："
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:174
 #, no-wrap
 msgid "`$$http://localhost$$`"
 msgstr "`$$http://localhost$$`"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:178
 msgid ""
 "This redirect URI is useful for native applications and allows the native "
 "application to create a web server on a random port that can be used to "
 "obtain the authorization code. This redirect uri allows any port."
 msgstr ""
-"このリダイレクトURIはネイティブ・アプリケーションに役立ち、ネイティブ・アプリケーションが認証コードを取得するために使用できるランダムなポート上にWebサーバーを作成することを許可します。"
-" このリダイレクトURIは任意のポートを許可します。"
+"このリダイレクトURIはネイティブ・アプリケーションに役立ち、ネイティブ・アプリケーションが認証コードを取得するために使用できるランダムなポート上にWebサーバーを作成することを許可します。このリダイレクトURIは任意のポートを許可します。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:180
 #, no-wrap
 msgid "`urn:ietf:wg:oauth:2.0:oob`"
 msgstr "`urn:ietf:wg:oauth:2.0:oob`"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:185
 msgid ""
 "If its not possible to start a web server in the client (or a browser is not"
 " available) it is possible to use the special `urn:ietf:wg:oauth:2.0:oob` "
@@ -643,7 +544,4 @@ msgid ""
 " to the application."
 msgstr ""
 "クライアントでWebサーバーを起動できない（またはブラウザが利用できない）場合は、特殊な `urn:ietf:wg:oauth:2.0:oob` "
-"リダイレクトURIを使用することができます。 このリダイレクトURIが使用されると、 {project_name} "
-"はページのタイトルとボックスのコードを含むページを表示します。 "
-"アプリケーションがブラウザーのタイトルが変更されたことを検出するか、ユーザーが手動でコードをアプリケーションにコピー/ペーストすることができます。 "
-"このリダイレクトURIを使用すると、ユーザーが別のデバイスを使用してアプリケーションに貼り付けるコードを取得することもできます。"
+"リダイレクトURIを使用することができます。このリダイレクトURIが使用されると、{project_name}はページのタイトルとボックスのコードを含むページを表示します。アプリケーションがブラウザーのタイトルが変更されたことを検出するか、ユーザーが手動でコードをアプリケーションにコピー/ペーストすることができます。このリダイレクトURIを使用すると、ユーザーが別のデバイスを使用してアプリケーションに貼り付けるコードを取得することもできます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:1
 #, no-wrap
 msgid "Other OpenID Connect Libraries"
-msgstr ""
+msgstr "他のOpenID Connectライブラリー"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:4
@@ -34,26 +34,34 @@ msgid ""
 "specifications] and https://tools.ietf.org/html/rfc6749[OAuth2 "
 "specification]."
 msgstr ""
+"{project_name} は、使いやすく、 {project_name} とのより良い統合を提供する付属のアダプターでセキュリティ保護できます。 "
+"ただし、プログラミング言語、フレームワーク、プラットフォームでアダプターが使用できない場合は、代わりに一般的なOpenID Connect "
+"Resource Provider（RP）ライブラリを使用することができます。 この章では、 {project_name} "
+"固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。 詳細については、 "
+"http://openid.net/connect/[OpenID Connect specifications] and "
+"https://tools.ietf.org/html/rfc6749[OAuth2 specification] を参照してください。"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:5
 #, no-wrap
 msgid "Endpoints"
-msgstr ""
+msgstr "エンドポイント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:8
 msgid ""
 "The most important endpoint to understand is the `well-known` configuration "
-"endpoint. It lists endpoints and other configuration options relevant to the "
-"OpenID Connect implementation in {project_name}. The endpoint is:"
+"endpoint. It lists endpoints and other configuration options relevant to the"
+" OpenID Connect implementation in {project_name}. The endpoint is:"
 msgstr ""
+"理解すべき最も重要なエンドポイントは、 `well-known` 設定エンドポイントです。 これは、 {project_name} のOpenID "
+"Connectの実装に関連するエンドポイントとその他の設定オプションを一覧化します。 エンドポイントは次のとおりです。"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:11
 #, no-wrap
 msgid "/realms/{realm-name}/.well-known/openid-configuration\n"
-msgstr ""
+msgstr "/realms/{realm-name}/.well-known/openid-configuration\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:14
@@ -61,12 +69,16 @@ msgid ""
 "To obtain the full URL, add the base URL for {project_name} and replace "
 "`{realm-name}` with the name of your realm. For example:"
 msgstr ""
+"完全なURLを取得するには、 {project_name} のベースURLを追加し、  `{realm-name} 'をレルム名で置換します。 例えば："
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:16
 msgid ""
-"$$http://localhost:8080/auth/realms/master/.well-known/openid-configuration$$"
+"$$http://localhost:8080/auth/realms/master/.well-known/openid-"
+"configuration$$"
 msgstr ""
+"$$http://localhost:8080/auth/realms/master/.well-known/openid-"
+"configuration$$"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:18
@@ -74,18 +86,19 @@ msgid ""
 "Some RP libraries retrieve all required endpoints from this endpoint, but "
 "for others you might need to list the endpoints individually."
 msgstr ""
+"一部のRPライブラリは、このエンドポイントから必要なすべてのエンドポイントを取得しますが、他はエンドポイントを個別に一覧化する必要があります。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:19
 #, no-wrap
 msgid "Authorization Endpoint"
-msgstr ""
+msgstr "認可エンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:22
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/auth\n"
-msgstr ""
+msgstr "/realms/{realm-name}/protocol/openid-connect/auth\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:25
@@ -93,26 +106,29 @@ msgid ""
 "The authorization endpoint performs authentication of the end-user. This is "
 "done by redirecting the user agent to this endpoint."
 msgstr ""
+"認可エンドポイントは、エンドユーザーの認証を実行します。 これは、ユーザー・エージェントをこのエンドポイントにリダイレクトすることによって行われます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:27
 msgid ""
-"For more details see the http://openid.net/specs/openid-connect-core-1_0."
-"html#AuthorizationEndpoint[Authorization Endpoint] section in the OpenID "
-"Connect specification."
+"For more details see the http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[Authorization Endpoint] section in the OpenID"
+" Connect specification."
 msgstr ""
+"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[Authorization Endpoint] を参照してください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:28
 #, no-wrap
 msgid "Token Endpoint"
-msgstr ""
+msgstr "トークン・エンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:31
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/token\n"
-msgstr ""
+msgstr "/realms/{realm-name}/protocol/openid-connect/token\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:35
@@ -122,57 +138,65 @@ msgid ""
 "depending on what flow is used.  The token endpoint is also used to obtain "
 "new access tokens when they expire."
 msgstr ""
+"トークン・エンドポイントは、トークンを取得するために使用されます。 "
+"トークンは、認可コードを交換するか、使用されているフローに応じたクレデンシャルを直接指定することによって取得できます。 "
+"トークン・エンドポイントは、有効期限が切れたときに新しいアクセス・トークンを取得するためにも使用されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:37
 msgid ""
-"For more details see the http://openid.net/specs/openid-connect-core-1_0."
-"html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
+"For more details see the http://openid.net/specs/openid-connect-core-"
+"1_0.html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
+"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#TokenEndpoint[Token Endpoint] を参照してください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:38
 #, no-wrap
 msgid "Userinfo Endpoint"
-msgstr ""
+msgstr "Userinfoエンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:41
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/userinfo\n"
-msgstr ""
+msgstr "/realms/{realm-name}/protocol/openid-connect/userinfo\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:44
 msgid ""
 "The userinfo endpoint returns standard claims about the authenticated user, "
 "and is protected by a bearer token."
-msgstr ""
+msgstr "userinfoエンドポイントは、認証されたユーザーに関する標準クレームを返し、ベアラー・トークンによって保護されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:46
 msgid ""
-"For more details see the http://openid.net/specs/openid-connect-core-1_0."
-"html#UserInfo[Userinfo Endpoint] section in the OpenID Connect specification."
+"For more details see the http://openid.net/specs/openid-connect-core-"
+"1_0.html#UserInfo[Userinfo Endpoint] section in the OpenID Connect "
+"specification."
 msgstr ""
+"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#UserInfo[Userinfo Endpoint] を参照してください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:47
 #, no-wrap
 msgid "Logout Endpoint"
-msgstr ""
+msgstr "ログアウト・エンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:50
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/logout\n"
-msgstr ""
+msgstr "/realms/{realm-name}/protocol/openid-connect/logout\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:53
 msgid "The logout endpoint logs out the authenticated user."
-msgstr ""
+msgstr "ログアウト・エンドポイントは、認証されたユーザーをログアウトします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:55
@@ -181,26 +205,30 @@ msgid ""
 "user session is logged out. Afterward the user agent is redirected back to "
 "the application."
 msgstr ""
+"ユーザー・エージェントはエンドポイントにリダイレクトでき、その場合、アクティブ・ユーザー・セッションはログアウトされます。 "
+"その後、ユーザー・エージェントはアプリケーションにリダイレクトされます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:57
 msgid ""
-"The endpoint can also be invoked directly by the application. To invoke this "
-"endpoint directly the refresh token needs to be included as well as the "
+"The endpoint can also be invoked directly by the application. To invoke this"
+" endpoint directly the refresh token needs to be included as well as the "
 "credentials required to authenticate the client."
 msgstr ""
+"エンドポイントは、アプリケーションによって直接呼び出すこともできます。 "
+"このエンドポイントを直接呼び出すには、リフレッシュ・トークンと、クライアントの認証に必要なクレデンシャルを含める必要があります。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:58
 #, no-wrap
 msgid "Certificate Endpoint"
-msgstr ""
+msgstr "証明書エンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:61
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/certs\n"
-msgstr ""
+msgstr "/realms/{realm-name}/protocol/openid-connect/certs\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:64
@@ -208,21 +236,25 @@ msgid ""
 "The certificate endpoint returns the public keys enabled by the realm, "
 "encoded as a JSON Web Key (JWK). Depending on the realm settings there can "
 "be one or more keys enabled for verifying tokens. For more information see "
-"the link:{adminguide_link}[{adminguide_name}] and the https://tools.ietf.org/"
-"html/rfc7517[JSON Web Key specification]."
+"the link:{adminguide_link}[{adminguide_name}] and the "
+"https://tools.ietf.org/html/rfc7517[JSON Web Key specification]."
 msgstr ""
+"証明書のエンドポイントは、JSON Web Key (JWK)としてエンコードされ、レルムによって有効化された公開鍵を返します。 "
+"レルム設定に応じて、トークンを検証するために1つ以上のキーを有効にすることができます。 詳細については、 "
+"link:{adminguide_link}[{adminguide_name}] と "
+"https://tools.ietf.org/html/rfc7517[JSON Web Key specification] のリンクをご覧ください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:65
 #, no-wrap
 msgid "Introspection Endpoint"
-msgstr ""
+msgstr "イントロスペクション・エンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:68
 #, no-wrap
 msgid "/realms/{realm-name}/protocol/openid-connect/token/introspect\n"
-msgstr ""
+msgstr "/realms/{realm-name}/protocol/openid-connect/token/introspect\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:71
@@ -230,6 +262,8 @@ msgid ""
 "The introspection endpoint is used to retrieve the active state of a token. "
 "It is can only be invoked by confidential clients."
 msgstr ""
+"イントロスペクション・エンドポイントは、トークンのアクティブ状態を取得するために使用されます。 "
+"これは、コンフィデンシャル・クライアントによってのみ呼び出すことができます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:73
@@ -237,55 +271,65 @@ msgid ""
 "For more details see https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token "
 "Introspection specification]."
 msgstr ""
+"詳細については、https://tools.ietf.org/html/rfc7662[OAuth 2.0 Token Introspection "
+"specification] を参照してください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:74
 #, no-wrap
 msgid "Dynamic Client Registration Endpoint"
-msgstr ""
+msgstr "動的クライアント登録エンドポイント"
 
 #. type: delimited block .
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:77
 #, no-wrap
 msgid "/realms/{realm-name}/clients-registrations/openid-connect\n"
-msgstr ""
+msgstr "/realms/{realm-name}/clients-registrations/openid-connect\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:80
 msgid ""
 "The dynamic client registration endpoint is used to dynamically register "
 "clients."
-msgstr ""
+msgstr "動的クライアント登録エンドポイントを使用して、クライアントを動的に登録します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:83
 msgid ""
 "For more details see the <<_client_registration,Client Registration "
-"chapter>> and the https://openid.net/specs/openid-connect-registration-1_0."
-"html[OpenID Connect Dynamic Client Registration specification]."
+"chapter>> and the https://openid.net/specs/openid-connect-registration-"
+"1_0.html[OpenID Connect Dynamic Client Registration specification]."
 msgstr ""
+"詳細については、<<_client_registration,Client Registration chapter>> と "
+"https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect"
+" Dynamic Client Registration specification] を参照してください。"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:85
 #, no-wrap
 msgid "Flows"
-msgstr ""
+msgstr "フロー"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:87
 #, no-wrap
 msgid "Authorization Code"
-msgstr ""
+msgstr "認可コード"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:92
 msgid ""
-"The Authorization Code flow redirects the user agent to {project_name}. Once "
-"the user has successfully authenticated with {project_name} an Authorization "
-"Code is created and the user agent is redirected back to the application. "
-"The application then uses the authorization code along with its credentials "
-"to obtain an Access Token, Refresh Token and ID Token from {project_name}."
+"The Authorization Code flow redirects the user agent to {project_name}. Once"
+" the user has successfully authenticated with {project_name} an "
+"Authorization Code is created and the user agent is redirected back to the "
+"application. The application then uses the authorization code along with its"
+" credentials to obtain an Access Token, Refresh Token and ID Token from "
+"{project_name}."
 msgstr ""
+"認可コード・フローは、ユーザー・エージェントを {project_name} にリダイレクトします。 ユーザーが {project_name} "
+"で正常に認証されると、認可コードが作成され、ユーザー・エージェントはアプリケーションにリダイレクトされます。 "
+"次に、アプリケーションは、クレデンシャルとともに認可コードを使用して、 {project_name} "
+"からアクセス・トークン、リフレッシュ・トークン、IDトークンを取得します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:95
@@ -294,20 +338,23 @@ msgid ""
 "native applications, including mobile applications, where it is possible to "
 "embed a user agent."
 msgstr ""
+"このフローはWebアプリケーションを対象としていますが、ユーザー・エージェントを組み込むことができるモバイルアプリケーションなどのネイティブアプリケーションにも推奨されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:97
 msgid ""
-"For more details refer to the http://openid.net/specs/openid-connect-"
-"core-1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
+"For more details refer to the http://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
 "specification."
 msgstr ""
+"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#CodeFlowAuth[Authorization Code Flow]  を参照してください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:98
 #, no-wrap
 msgid "Implicit"
-msgstr ""
+msgstr "インプリシット"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:105
@@ -320,15 +367,21 @@ msgid ""
 "a long expiration, which is problematic as it's very hard to invalidate "
 "these. Or requires a new redirect to obtain new Access Token once the "
 "initial Access Token has expired. The Implicit flow is useful if the "
-"application only wants to authenticate the user and deals with logout itself."
+"application only wants to authenticate the user and deals with logout "
+"itself."
 msgstr ""
+"インプリシット・フローのリダイレクトは、認可コード・フローと同様に機能しますが、認可コードが返される代わりに、アクセス・トークンとIDトークンが返されます。"
+" これにより、アクセス・トークンのために認可コードを交換するための余分な呼び出しの必要性が減ります。 ただし、リフレッシュ・トークンは含まれません。 "
+"その結果、長い有効期限を持つアクセス・トークンを許可する必要があります。これらのトークンを無効にするのは難しいため、問題があります。 "
+"または、最初のアクセス・トークンが期限切れになったら、新しいアクセス・トークンを取得するために新しいリダイレクトが必要です。 "
+"インプリシット・フローは、アプリケーションがユーザーの認証のみを行い、ログアウト自体を処理する場合に便利です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:107
 msgid ""
 "There's also a Hybrid flow where both the Access Token and an Authorization "
 "Code is returned."
-msgstr ""
+msgstr "アクセス・トークンと認可コードが返されるハイブリッドフローもあります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:110
@@ -338,20 +391,24 @@ msgid ""
 "server logs and browser history. This is somewhat mitigated by using short "
 "expiration for Access Tokens."
 msgstr ""
+"インプリシット・フローとハイブリッド・フローの両方で、Webサーバーのログとブラウザの履歴を通じてアクセス・トークンが漏洩する可能性があるため、潜在的なセキュリティ上のリスクがあることに注意してください。"
+" これは、アクセス・トークンの有効期限を短くすることでやや緩和されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:112
 msgid ""
-"For more details refer to the http://openid.net/specs/openid-connect-"
-"core-1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
+"For more details refer to the http://openid.net/specs/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
 "specification."
 msgstr ""
+"詳細については、OpenID Connect仕様の http://openid.net/specs/openid-connect-core-"
+"1_0.html#ImplicitFlowAuth[Implicit Flow] を参照してください。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:114
 #, no-wrap
 msgid "Resource Owner Password Credentials"
-msgstr ""
+msgstr "リソース・オーナー・パスワード・クレデンシャル"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:118
@@ -361,42 +418,45 @@ msgid ""
 "recommended to use this flow unless you absolutely need to. Examples where "
 "this could be useful are legacy applications and command-line interfaces."
 msgstr ""
+"リソース・オーナー・パスワード・クレデンシャル（ {project_name} "
+"ではダイレクト・グラントと呼ばれる）は、トークンのユーザー・クレデンシャルの交換を可能にします。絶対に必要としない限り、このフローを使用することはお勧めしません。"
+" これが有用な場合の例は、レガシー・アプリケーションとコマンドライン・インターフェイスです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:120
 msgid "There are a number of limitations of using this flow, including:"
-msgstr ""
+msgstr "このフローの使用には次のような制限があります:"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:122
 msgid "User credentials are exposed to the application"
-msgstr ""
+msgstr "ユーザーのクレデンシャルがアプリケーションに公開されます"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:123
 msgid "Applications need login pages"
-msgstr ""
+msgstr "アプリケーションはログイン・ページが必要です"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:124
 msgid "Application needs to be aware of the authentication scheme"
-msgstr ""
+msgstr "アプリケーションは認証方式を意識する必要があります"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:125
 msgid "Changes to authentication flow requires changes to application"
-msgstr ""
+msgstr "認証フローを変更するには、アプリケーションを変更する必要があります"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:126
 msgid "No support for identity brokering or social login"
-msgstr ""
+msgstr "アイデンティティ・ブローキングまたはソーシャル・ログインのサポートなし"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:127
 msgid ""
 "Flows are not supported (user self-registration, required actions, etc.)"
-msgstr ""
+msgstr "フローはサポートされていません（ユーザーの自己登録、必要な操作など）"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:129
@@ -405,6 +465,8 @@ msgid ""
 "grant the client has to have the `Direct Access Grants Enabled` option "
 "enabled."
 msgstr ""
+"リソース・オーナー・パスワード・クレデンシャルの使用を許可されるためには、クライアントは `Direct Access Grants Enabled` "
+"オプションを有効にする必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:131
@@ -412,20 +474,25 @@ msgstr ""
 msgid ""
 "This flow is not included in OpenID Connect, but is a part of the OAuth 2.0 "
 "specification."
-msgstr ""
+msgstr "このフローはOpenID Connectには含まれていませんが、OAuth 2.0の仕様の一部です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:133
 msgid ""
-"For more details refer to the https://tools.ietf.org/html/"
-"rfc6749#section-4.3[Resource Owner Password Credentials Grant] chapter in "
-"the OAuth 2.0 specification."
+"For more details refer to the "
+"https://tools.ietf.org/html/rfc6749#section-4.3[Resource Owner Password "
+"Credentials Grant] chapter in the OAuth 2.0 specification."
 msgstr ""
+"詳細については、OAuth 2.0仕様のhttps://tools.ietf.org/html/rfc6749#section-4.3[Resource"
+" Owner Password Credentials Grant] のセクションを参照してください。"
 
-#. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:135
-msgid "====== Example using CURL"
-msgstr ""
+#. type: Title ===
+#: source/securing_apps/topics/oidc/oidc-generic.adoc:134
+#: source/securing_apps/topics/client-registration.adoc:126
+#: source/server_development/topics/admin-rest-api.adoc:13
+#, no-wrap
+msgid "Example using CURL"
+msgstr "CURLを使用した例"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:138
@@ -434,6 +501,8 @@ msgid ""
 "realm `master` with username `user` and password `password`. The example is "
 "using the confidential client `myclient`:"
 msgstr ""
+"次の例は、ユーザー名 `user` とパスワード `password` を使用して、レルム `master` "
+"にあるユーザーのアクセス・トークンを取得する方法を示しています。 この例では、コンフィデンシャル・クライアント `myclient` を使用しています。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:148
@@ -447,42 +516,53 @@ msgid ""
 "  -d \"grant_type=password\" \\\n"
 "  \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 msgstr ""
+"curl \\\n"
+"  -d \"client_id=myclient\" \\\n"
+"  -d \"client_secret=40cc097b-2a57-4c17-b36a-8fdf3fc2d578\" \\\n"
+"  -d \"username=user\" \\\n"
+"  -d \"password=password\" \\\n"
+"  -d \"grant_type=password\" \\\n"
+"  \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:150
 #, no-wrap
 msgid "Client Credentials"
-msgstr ""
+msgstr "クライアント・クレデンシャル"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:154
 msgid ""
-"Client Credentials is used when clients (applications and services) wants to "
-"obtain access on behalf of themselves rather than on behalf of a user. This "
-"can for example be useful for background services that applies changes to "
+"Client Credentials is used when clients (applications and services) wants to"
+" obtain access on behalf of themselves rather than on behalf of a user. This"
+" can for example be useful for background services that applies changes to "
 "the system in general rather than for a specific user."
 msgstr ""
+"クライアント・クレデンシャルは、クライアント（アプリケーションおよびサービス）がユーザーの代わりにではなく、自分のためにアクセス権を取得したい場合に使用されます。"
+" これは、たとえば、特定のユーザーではなく一般的にシステムに変更を適用するバックグラウンド・サービスに役立ちます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:156
 msgid ""
 "{project_name} provides support for clients to authenticate either with a "
 "secret or with public/private keys."
-msgstr ""
+msgstr "{project_name} は、クライアントが秘密鍵または公開鍵/秘密鍵のいずれかで認証することをサポートします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:160
 msgid ""
-"For more details refer to the https://tools.ietf.org/html/"
-"rfc6749#section-4.4[Client Credentials Grant] chapter in the OAuth 2.0 "
-"specification."
+"For more details refer to the "
+"https://tools.ietf.org/html/rfc6749#section-4.4[Client Credentials Grant] "
+"chapter in the OAuth 2.0 specification."
 msgstr ""
+"詳細については、OAuth 2.0仕様のhttps://tools.ietf.org/html/rfc6749#section-4.4[Client "
+"Credentials Grant] のセクションを参照してください。"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:161
 #, no-wrap
 msgid "Redirect URIs"
-msgstr ""
+msgstr "リダイレクトURI"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:165
@@ -492,13 +572,16 @@ msgid ""
 "This especially applies to client-side (public clients) applications. "
 "Failing to do so could result in:"
 msgstr ""
+"リダイレクト・ベースのフローを使用する場合は、クライアントに有効なリダイレクトURLを使用することが重要です。 "
+"リダイレクトURLはできるだけ具体的にする必要があります。 これは、特にクライアント側（パブリック・クライアント）アプリケーションに適用されます。 "
+"そうしないと次のことが起こる可能性があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:167
 msgid ""
 "Open redirects - this can allow attackers to create spoof links that looks "
 "like they are coming from your domain"
-msgstr ""
+msgstr "オープンリダイレクト - これにより、攻撃者はあなたのドメインから来ているような偽のリンクを作成することができます"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:168
@@ -508,24 +591,28 @@ msgid ""
 "not be configured correctly to gain access by redirecting the user without "
 "the users knowledge"
 msgstr ""
+"未認可のエントリー - ユーザーが {project_name} "
+"で既に認証されている場合、攻撃者はリダイレクトURLが正しく設定されていない公開クライアントを使用して、ユーザーが知らないうちにユーザーをリダイレクトすることでアクセスできます"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:170
 msgid ""
-"In production for web applications always use `https` for all redirect URIs. "
-"Do not allow redirects to http."
+"In production for web applications always use `https` for all redirect URIs."
+" Do not allow redirects to http."
 msgstr ""
+"Webアプリケーション用のプロダクション環境では、常にすべてのリダイレクトURIに `https` を使用します。 "
+"httpへのリダイレクトは許可しないでください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:172
 msgid "There's also a few special redirect URIs:"
-msgstr ""
+msgstr "また、特別なリダイレクトURIがいくつかあります："
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:174
 #, no-wrap
 msgid "`$$http://localhost$$`"
-msgstr ""
+msgstr "`$$http://localhost$$`"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:178
@@ -534,22 +621,29 @@ msgid ""
 "application to create a web server on a random port that can be used to "
 "obtain the authorization code. This redirect uri allows any port."
 msgstr ""
+"このリダイレクトURIはネイティブ・アプリケーションに役立ち、ネイティブ・アプリケーションが認証コードを取得するために使用できるランダムなポート上にWebサーバーを作成することを許可します。"
+" このリダイレクトURIは任意のポートを許可します。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:180
 #, no-wrap
 msgid "`urn:ietf:wg:oauth:2.0:oob`"
-msgstr ""
+msgstr "`urn:ietf:wg:oauth:2.0:oob`"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/oidc-generic.adoc:185
 msgid ""
-"If its not possible to start a web server in the client (or a browser is not "
-"available) it is possible to use the special `urn:ietf:wg:oauth:2.0:oob` "
-"redirect uri.  When this redirect uri is used {project_name} displays a page "
-"with the code in the title and in a box on the page.  The application can "
-"either detect that the browser title has changed, or the user can copy/paste "
-"the code manually to the application.  With this redirect uri it is also "
-"possible for a user to use a different device to obtain a code to paste back "
-"to the application."
+"If its not possible to start a web server in the client (or a browser is not"
+" available) it is possible to use the special `urn:ietf:wg:oauth:2.0:oob` "
+"redirect uri.  When this redirect uri is used {project_name} displays a page"
+" with the code in the title and in a box on the page.  The application can "
+"either detect that the browser title has changed, or the user can copy/paste"
+" the code manually to the application.  With this redirect uri it is also "
+"possible for a user to use a different device to obtain a code to paste back"
+" to the application."
 msgstr ""
+"クライアントでWebサーバーを起動できない（またはブラウザが利用できない）場合は、特殊な `urn:ietf:wg:oauth:2.0:oob` "
+"リダイレクトURIを使用することができます。 このリダイレクトURIが使用されると、 {project_name} "
+"はページのタイトルとボックスのコードを含むページを表示します。 "
+"アプリケーションがブラウザーのタイトルが変更されたことを検出するか、ユーザーが手動でコードをアプリケーションにコピー/ペーストすることができます。 "
+"このリダイレクトURIを使用すると、ユーザーが別のデバイスを使用してアプリケーションに貼り付けるコードを取得することもできます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__oidc-generic/ja_JP/index.html
