### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -112,8 +112,7 @@ msgid ""
 "go over these steps."
 msgstr ""
 "Keycloakには、Jetty 9.1.x、Jetty 9.2.x、Jetty "
-"9.3.x用の個別のアダプターがあります。これは、Jettyにインストールする必要があります。 "
-"Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。 "
+"9.3.x用の個別のアダプターがあります。これらをJettyにインストールする必要があります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:18
@@ -126,8 +125,8 @@ msgid ""
 msgstr ""
 "Jetty 9.x用の配布物をJetty "
 "9.xのlink:https://www.eclipse.org/jetty/documentation/current/startup-base-"
-"and-home.html[base directory] に解凍する必要があります。WEB-"
-"INF/libディレクトリ内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base`です:"
+"and-home.html[base directory]に解凍する必要があります。WEB-"
+"INF/libディレクトリ内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base`です。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:24
@@ -143,7 +142,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:27
 msgid ""
 "Next, you will have to enable the `keycloak` module for your Jetty base:"
-msgstr "次に、Jettyベースの `keycloak` モジュールを有効にする必要があります："
+msgstr "次に、Jettyベースの `keycloak` モジュールを有効にする必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:32
@@ -214,9 +213,7 @@ msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダ�
 msgid ""
 "The format of this config file is describe in the "
 "<<_java_adapter_config,Java adapter configuration>>            section.\n"
-msgstr ""
-"この設定ファイルの形式は、 <<_java_adapter_config,Java adapter configuration>> "
-"のセクションで説明しています。\n"
+msgstr "この設定ファイルの形式は、<<_java_adapter_config,Javaアダプターの設定>>のセクションで説明しています。\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:64
@@ -235,8 +232,8 @@ msgid ""
 "Instead of using keycloak.json, you can define everything within the `jetty-web.xml`.\n"
 "You'll just have to figure out how the json settings match to the `org.keycloak.representations.adapters.config.AdapterConfig`            class.\n"
 msgstr ""
-"keycloak.jsonを使用する代わりに、  `jetty-web.xml' 内にすべてを定義することができます。\n"
-"json設定が `org.keycloak.representations.adapters.config.AdapterConfig` クラスとどのようにマッチするかを把握するだけです。\n"
+"keycloak.jsonを使用する代わりに、 `jetty-web.xml' 内にすべてを定義することができます。\n"
+"json設定が `org.keycloak.representations.adapters.config.AdapterConfig` クラスとどのようにマッチするかを把握する必要があります。\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:99
@@ -304,9 +301,9 @@ msgid ""
 "yourwar.xml.  Jetty should pick it up.  In this mode, you'll have to declare"
 " keycloak.json configuration directly within the xml file."
 msgstr ""
-"keycloakでWARを保護するために、WARをオープンする必要はありません。 代わりに、yourwar"
-".xmlという名前でwebappsディレクトリにjetty-web.xmlファイルを作成します。 Jettyはそれをピックアップします。 "
-"このモードでは、keycloak.jsonの設定をxmlファイル内で直接宣言する必要があります。"
+"keycloakでWARを保護するために、WARをオープンする必要はありません。代わりに、yourwar"
+".xmlという名前でwebappsディレクトリにjetty-"
+"web.xmlファイルを作成します。Jettyはそれをピックアップします。このモードでは、keycloak.jsonの設定をxmlファイル内で直接宣言する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
@@ -22,7 +22,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:31
 #, no-wrap
 msgid "Required Per WAR Configuration"
-msgstr ""
+msgstr "WAR設定ごとに必要"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:146
@@ -40,11 +40,18 @@ msgid ""
 "      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
 "      version=\"3.0\">\n"
 msgstr ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:186
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:146
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
 #: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:50
+#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
+#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
 #: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:60
 #, no-wrap
 msgid ""
@@ -56,6 +63,13 @@ msgid ""
 "    </security-role>\n"
 "</web-app>\n"
 msgstr ""
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
@@ -63,11 +77,12 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
-msgstr ""
+msgstr "アダプターのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
@@ -76,33 +91,43 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
 "Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also "
-"available as a maven artifact."
+"adapter is a separate download on the Keycloak download site.  They are also"
+" available as a maven artifact."
 msgstr ""
+"アダプターは、アプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。 "
+"それらは、Mavenアーティファクトとしても利用可能です。"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:3
 #, no-wrap
 msgid "Jetty 9.x Adapters"
-msgstr ""
+msgstr "Jetty 9.xアダプター"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:8
 msgid ""
-"Keycloak has a separate adapter for Jetty 9.1.x, Jetty 9.2.x and Jetty 9.3.x "
-"that you will have to install into your Jetty installation.  You then have "
+"Keycloak has a separate adapter for Jetty 9.1.x, Jetty 9.2.x and Jetty 9.3.x"
+" that you will have to install into your Jetty installation.  You then have "
 "to provide some extra configuration in each WAR you deploy to Jetty.  Let's "
 "go over these steps."
 msgstr ""
+"Keycloakには、Jetty 9.1.x、Jetty 9.2.x、Jetty "
+"9.3.x用の個別のアダプターがあります。これは、Jettyにインストールする必要があります。 "
+"Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。 "
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:18
 msgid ""
-"You must unzip the Jetty 9.x distro into Jetty 9.x's link:https://www."
-"eclipse.org/jetty/documentation/current/startup-base-and-home.html[base "
-"directory.] Including adapter's jars within your WEB-INF/lib directory will "
-"not work! In the example below, the Jetty base is named `your-base`:"
+"You must unzip the Jetty 9.x distro into Jetty 9.x's "
+"link:https://www.eclipse.org/jetty/documentation/current/startup-base-and-"
+"home.html[base directory.] Including adapter's jars within your WEB-INF/lib "
+"directory will not work! In the example below, the Jetty base is named "
+"`your-base`:"
 msgstr ""
+"Jetty 9.x用の配布物をJetty "
+"9.xのlink:https://www.eclipse.org/jetty/documentation/current/startup-base-"
+"and-home.html[base directory] に解凍する必要があります。WEB-"
+"INF/libディレクトリ内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base`です:"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:24
@@ -111,18 +136,20 @@ msgid ""
 "$ cd your-base\n"
 "$ unzip keycloak-jetty93-adapter-dist-2.5.0.Final.zip\n"
 msgstr ""
+"$ cd your-base\n"
+"$ unzip keycloak-jetty93-adapter-dist-2.5.0.Final.zip\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:27
 msgid ""
 "Next, you will have to enable the `keycloak` module for your Jetty base:"
-msgstr ""
+msgstr "次に、Jettyベースの `keycloak` モジュールを有効にする必要があります："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:32
 #, no-wrap
 msgid "$ java -jar $JETTY_HOME/start.jar --add-to-startd=keycloak\n"
-msgstr ""
+msgstr "$ java -jar $JETTY_HOME/start.jar --add-to-startd=keycloak\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:38
@@ -134,15 +161,18 @@ msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr ""
+"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:41
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:9
 msgid ""
-"The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your "
-"WAR package.  This is a Jetty specific config file and you must define a "
+"The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your"
+" WAR package.  This is a Jetty specific config file and you must define a "
 "Keycloak specific authenticator within it."
 msgstr ""
+"まず、WARパッケージに `WEB-INF/jetty-web.xml` "
+"ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のAuthenticatorを定義する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:56
@@ -159,27 +189,44 @@ msgid ""
 "    </Get>\n"
 "</Configure>\n"
 msgstr ""
+"<?xml version=\"1.0\"?>\n"
+"<!DOCTYPE Configure PUBLIC \"-//Mort Bay Consulting//DTD Configure//EN\" \"http://www.eclipse.org/jetty/configure_9_0.dtd\">\n"
+"<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n"
+"    <Get name=\"securityHandler\">\n"
+"        <Set name=\"authenticator\">\n"
+"            <New class=\"org.keycloak.adapters.jetty.KeycloakJettyAuthenticator\">\n"
+"            </New>\n"
+"        </Set>\n"
+"    </Get>\n"
+"</Configure>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:59
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:48
 msgid ""
 "Next you must create a `keycloak.json` adapter config file within the `WEB-"
 "INF` directory of your WAR."
-msgstr ""
+msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:61
 #, no-wrap
-msgid "The format of this config file is describe in the <<_java_adapter_config,Java adapter configuration>>            section.\n"
+msgid ""
+"The format of this config file is describe in the "
+"<<_java_adapter_config,Java adapter configuration>>            section.\n"
 msgstr ""
+"この設定ファイルの形式は、 <<_java_adapter_config,Java adapter configuration>> "
+"のセクションで説明しています。\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:64
 msgid ""
 "The Jetty 9.1.x adapter will not be able to find the `keycloak.json` file.  "
-"You will have to define all adapter settings within the `jetty-web.xml` file "
-"as described below."
+"You will have to define all adapter settings within the `jetty-web.xml` file"
+" as described below."
 msgstr ""
+"Jetty 9.1.xアダプターは、 `keycloak.json` ファイルを見つけることができません。下記のように `jetty-web.xml` "
+"ファイル内にすべてのアダプター設定を定義する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:67
@@ -188,6 +235,8 @@ msgid ""
 "Instead of using keycloak.json, you can define everything within the `jetty-web.xml`.\n"
 "You'll just have to figure out how the json settings match to the `org.keycloak.representations.adapters.config.AdapterConfig`            class.\n"
 msgstr ""
+"keycloak.jsonを使用する代わりに、  `jetty-web.xml' 内にすべてを定義することができます。\n"
+"json設定が `org.keycloak.representations.adapters.config.AdapterConfig` クラスとどのようにマッチするかを把握するだけです。\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:99
@@ -220,24 +269,56 @@ msgid ""
 "  </Get>\n"
 "</Configure>\n"
 msgstr ""
+"<?xml version=\"1.0\"?>\n"
+"<!DOCTYPE Configure PUBLIC \"-//Mort Bay Consulting//DTD Configure//EN\" \"http://www.eclipse.org/jetty/configure_9_0.dtd\">\n"
+"<Configure class=\"org.eclipse.jetty.webapp.WebAppContext\">\n"
+"  <Get name=\"securityHandler\">\n"
+"    <Set name=\"authenticator\">\n"
+"        <New class=\"org.keycloak.adapters.jetty.KeycloakJettyAuthenticator\">\n"
+"            <Set name=\"adapterConfig\">\n"
+"                <New class=\"org.keycloak.representations.adapters.config.AdapterConfig\">\n"
+"                    <Set name=\"realm\">tomcat</Set>\n"
+"                    <Set name=\"resource\">customer-portal</Set>\n"
+"                    <Set name=\"authServerUrl\">http://localhost:8081/auth</Set>\n"
+"                    <Set name=\"sslRequired\">external</Set>\n"
+"                    <Set name=\"credentials\">\n"
+"                        <Map>\n"
+"                            <Entry>\n"
+"                                <Item>secret</Item>\n"
+"                                <Item>password</Item>\n"
+"                            </Entry>\n"
+"                        </Map>\n"
+"                    </Set>\n"
+"                </New>\n"
+"            </Set>\n"
+"        </New>\n"
+"    </Set>\n"
+"  </Get>\n"
+"</Configure>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:105
 msgid ""
 "You do not have to crack open your WAR to secure it with keycloak.  Instead "
 "create the jetty-web.xml file in your webapps directory with the name of "
-"yourwar.xml.  Jetty should pick it up.  In this mode, you'll have to declare "
-"keycloak.json configuration directly within the xml file."
+"yourwar.xml.  Jetty should pick it up.  In this mode, you'll have to declare"
+" keycloak.json configuration directly within the xml file."
 msgstr ""
+"keycloakでWARを保護するために、WARをオープンする必要はありません。 代わりに、yourwar"
+".xmlという名前でwebappsディレクトリにjetty-web.xmlファイルを作成します。 Jettyはそれをピックアップします。 "
+"このモードでは、keycloak.jsonの設定をxmlファイル内で直接宣言する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
 #: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:29
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:21
 msgid ""
 "Finally you must specify both a `login-config` and use standard servlet "
 "security to specify role-base constraints on your URLs.  Here's an example:"
 msgstr ""
+"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
+"と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
@@ -248,7 +329,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
-msgstr ""
+msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:133
@@ -268,6 +349,18 @@ msgid ""
 "        </user-data-constraint>\n"
 "    </security-constraint>\n"
 msgstr ""
+"    <security-constraint>\n"
+"        <web-resource-collection>\n"
+"            <web-resource-name>Customers</web-resource-name>\n"
+"            <url-pattern>/*</url-pattern>\n"
+"        </web-resource-collection>\n"
+"        <auth-constraint>\n"
+"            <role-name>user</role-name>\n"
+"        </auth-constraint>\n"
+"        <user-data-constraint>\n"
+"            <transport-guarantee>CONFIDENTIAL</transport-guarantee>\n"
+"        </user-data-constraint>\n"
+"    </security-constraint>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:138
@@ -281,3 +374,7 @@ msgid ""
 "        <realm-name>this is ignored currently</realm-name>\n"
 "    </login-config>\n"
 msgstr ""
+"    <login-config>\n"
+"        <auth-method>BASIC</auth-method>\n"
+"        <realm-name>this is ignored currently</realm-name>\n"
+"    </login-config>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jetty9-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__jetty9-adapter/ja_JP/index.html
