### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -46,7 +46,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:3
 #, no-wrap
 msgid "Securing a Servlet Deployed as an OSGI Service"
-msgstr "OSGIサービスとしてのデプロイ・サーブレットのセキュリティ保護"
+msgstr "OSGIサービスとしてデプロイされたサーブレットのセキュリティ保護"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:6
@@ -55,14 +55,14 @@ msgid ""
 " project that is not deployed as a classic WAR application. Fuse uses Pax "
 "Web Whiteboard Extender to deploy such servlets as web applications."
 msgstr ""
-"クラシックなWARアプリケーションのようにデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、このメソッドを使用できます。"
+"クラシックなWARアプリケーションとしてデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、この方式を使用できます。"
 " FuseはPax Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:8
 msgid ""
 "To secure your servlet with {project_name}, complete the following steps:"
-msgstr "{project_name} でサーブレットを保護するには、次の手順を実行します。"
+msgstr "{project_name}でサーブレットを保護するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:11
@@ -73,10 +73,10 @@ msgid ""
 "file inside your application. Note that your servlet needs to depend on it."
 "  An example configuration:"
 msgstr ""
-"{project_name} はPaxWebIntegrationServiceを提供します。これにより、jetty-"
-"web.xmlを注入し、アプリケーションのセキュリティ制約を設定できます。 アプリケーション内の `OSGI-"
-"INF/blueprint/blueprint.xml` ファイルでそのようなサービスを宣言する必要があります。 "
-"サーブレットはそれに依存する必要があることに注意してください。 設定例："
+"{project_name}はPaxWebIntegrationServiceを提供します。これにより、jetty-"
+"web.xmlを注入し、アプリケーションのセキュリティ制約を設定できます。アプリケーション内の `OSGI-"
+"INF/blueprint/blueprint.xml` "
+"ファイルでそのようなサービスを宣言する必要があります。サーブレットはそれに依存する必要があることに注意してください。設定例は次のとおりです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:19
@@ -198,10 +198,10 @@ msgid ""
 "don't need the `web.xml` file as the security-constraints are declared in "
 "the blueprint configuration file."
 msgstr ""
-"プロジェクト内に `WEB-INF` ディレクトリ（プロジェクトがWebアプリケーションでない場合でも）を用意し、  "
-"<<_fuse_adapter_classic_war,Classic WAR application>> のセクションのように `/WEB-INF"
-"/jetty-web.xml` と `/WEB-INF/keycloak.json` "
-"ファイルを作成する必要があります。セキュリティ制約がブループリント設定ファイルで宣言されているので、 `web.xml`ファイルは必要ありません。"
+"プロジェクト内に `WEB-INF` "
+"ディレクトリ（プロジェクトがWebアプリケーションでない場合でも）を用意し、<<_fuse_adapter_classic_war,クラシックWARアプリケーション>>のセクションのように"
+" `/WEB-INF/jetty-web.xml` と `/WEB-INF/keycloak.json` ファイルを作成する必要があります"
+"。security-constraintsがblueprint設定ファイルで宣言されているので、 `web.xml` ファイルは必要ありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:66
@@ -209,4 +209,4 @@ msgid ""
 "The `Import-Package` in `META-INF/MANIFEST.MF` must contain at least these "
 "imports:"
 msgstr ""
-"`META-INF/MANIFEST.MF` の `Import-Package` は、少なくとも以下のインポートを含んでいなければなりません："
+"`META-INF/MANIFEST.MF` の `Import-Package` は、少なくとも以下のインポートを含んでいなければなりません。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
@@ -21,7 +21,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:60
 #, no-wrap
 msgid "</blueprint>\n"
-msgstr ""
+msgstr "</blueprint>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:86
@@ -35,37 +35,48 @@ msgid ""
 "org.keycloak.*;version=\"{project_versionMvn}\",\n"
 "*;resolution:=optional\n"
 msgstr ""
+"org.keycloak.adapters.jetty;version=\"{project_versionMvn}\",\n"
+"org.keycloak.adapters;version=\"{project_versionMvn}\",\n"
+"org.keycloak.constants;version=\"{project_versionMvn}\",\n"
+"org.keycloak.util;version=\"{project_versionMvn}\",\n"
+"org.keycloak.*;version=\"{project_versionMvn}\",\n"
+"*;resolution:=optional\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:3
 #, no-wrap
 msgid "Securing a Servlet Deployed as an OSGI Service"
-msgstr ""
+msgstr "OSGIサービスとしてのデプロイ・サーブレットのセキュリティ保護"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:6
 msgid ""
-"You can use this method if you have a servlet class inside your OSGI bundled "
-"project that is not deployed as a classic WAR application. Fuse uses https://"
-"ops4j1.jira.com/wiki/display/ops4j/Pax+Web+Extender+-+Whiteboard[Pax Web "
-"Whiteboard Extender] to deploy such servlets as web applications."
+"You can use this method if you have a servlet class inside your OSGI bundled"
+" project that is not deployed as a classic WAR application. Fuse uses Pax "
+"Web Whiteboard Extender to deploy such servlets as web applications."
 msgstr ""
+"クラシックなWARアプリケーションのようにデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、このメソッドを使用できます。"
+" FuseはPax Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:8
 msgid ""
 "To secure your servlet with {project_name}, complete the following steps:"
-msgstr ""
+msgstr "{project_name} でサーブレットを保護するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:11
 msgid ""
 "{project_name} provides PaxWebIntegrationService, which allows injecting "
-"jetty-web.xml and configuring security constraints for your application. You "
-"need to declare such services in the `OSGI-INF/blueprint/blueprint.xml` file "
-"inside your application. Note that your servlet needs to depend on it.  An "
-"example configuration:"
+"jetty-web.xml and configuring security constraints for your application. You"
+" need to declare such services in the `OSGI-INF/blueprint/blueprint.xml` "
+"file inside your application. Note that your servlet needs to depend on it."
+"  An example configuration:"
 msgstr ""
+"{project_name} はPaxWebIntegrationServiceを提供します。これにより、jetty-"
+"web.xmlを注入し、アプリケーションのセキュリティ制約を設定できます。 アプリケーション内の `OSGI-"
+"INF/blueprint/blueprint.xml` ファイルでそのようなサービスを宣言する必要があります。 "
+"サーブレットはそれに依存する必要があることに注意してください。 設定例："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:19
@@ -77,6 +88,11 @@ msgid ""
 "           xsi:schemaLocation=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\n"
 "           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\">\n"
 msgstr ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xsi:schemaLocation=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\n"
+"           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\">\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:36
@@ -99,6 +115,22 @@ msgid ""
 "        <property name=\"pathSpec\" value=\"/product-portal/*\"/>\n"
 "    </bean>\n"
 msgstr ""
+"    <!-- Using jetty bean just for the compatibility with other fuse services -->\n"
+"    <bean id=\"servletConstraintMapping\" class=\"org.eclipse.jetty.security.ConstraintMapping\">\n"
+"        <property name=\"constraint\">\n"
+"            <bean class=\"org.eclipse.jetty.util.security.Constraint\">\n"
+"                <property name=\"name\" value=\"cst1\"/>\n"
+"                <property name=\"roles\">\n"
+"                    <list>\n"
+"                        <value>user</value>\n"
+"                    </list>\n"
+"                </property>\n"
+"                <property name=\"authenticate\" value=\"true\"/>\n"
+"                <property name=\"dataConstraint\" value=\"0\"/>\n"
+"            </bean>\n"
+"        </property>\n"
+"        <property name=\"pathSpec\" value=\"/product-portal/*\"/>\n"
+"    </bean>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:47
@@ -115,6 +147,16 @@ msgid ""
 "        </property>\n"
 "    </bean>\n"
 msgstr ""
+"    <bean id=\"keycloakPaxWebIntegration\" class=\"org.keycloak.adapters.osgi.PaxWebIntegrationService\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"jettyWebXmlLocation\" value=\"/WEB-INF/jetty-web.xml\" />\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"constraintMappings\">\n"
+"            <list>\n"
+"                <ref component-id=\"servletConstraintMapping\" />\n"
+"            </list>\n"
+"        </property>\n"
+"    </bean>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:50
@@ -123,6 +165,8 @@ msgid ""
 "    <bean id=\"productServlet\" class=\"org.keycloak.example.ProductPortalServlet\" depends-on=\"keycloakPaxWebIntegration\">\n"
 "    </bean>\n"
 msgstr ""
+"    <bean id=\"productServlet\" class=\"org.keycloak.example.ProductPortalServlet\" depends-on=\"keycloakPaxWebIntegration\">\n"
+"    </bean>\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:58
@@ -136,17 +180,28 @@ msgid ""
 "        </service-properties>\n"
 "    </service>\n"
 msgstr ""
+"    <service ref=\"productServlet\" interface=\"javax.servlet.Servlet\">\n"
+"        <service-properties>\n"
+"            <entry key=\"alias\" value=\"/product-portal\" />\n"
+"            <entry key=\"servlet-name\" value=\"ProductServlet\" />\n"
+"            <entry key=\"keycloak.config.file\" value=\"/keycloak.json\" />\n"
+"        </service-properties>\n"
+"    </service>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:64
 msgid ""
 "You might need to have the `WEB-INF` directory inside your project (even if "
-"your project is not a web application) and create the `/WEB-INF/jetty-web."
-"xml` and `/WEB-INF/keycloak.json` files as in the "
+"your project is not a web application) and create the `/WEB-INF/jetty-"
+"web.xml` and `/WEB-INF/keycloak.json` files as in the "
 "<<_fuse_adapter_classic_war,Classic WAR application>> section.  Note you "
 "don't need the `web.xml` file as the security-constraints are declared in "
 "the blueprint configuration file."
 msgstr ""
+"プロジェクト内に `WEB-INF` ディレクトリ（プロジェクトがWebアプリケーションでない場合でも）を用意し、  "
+"<<_fuse_adapter_classic_war,Classic WAR application>> のセクションのように `/WEB-INF"
+"/jetty-web.xml` と `/WEB-INF/keycloak.json` "
+"ファイルを作成する必要があります。セキュリティ制約がブループリント設定ファイルで宣言されているので、 `web.xml`ファイルは必要ありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:66
@@ -154,3 +209,4 @@ msgid ""
 "The `Import-Package` in `META-INF/MANIFEST.MF` must contain at least these "
 "imports:"
 msgstr ""
+"`META-INF/MANIFEST.MF` の `Import-Package` は、少なくとも以下のインポートを含んでいなければなりません："


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__servlet-whiteboard
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__fuse__servlet-whiteboard/ja_JP/index.html
