### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/troubleshooting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/troubleshooting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/troubleshooting.ja_JP.po
@@ -1,24 +1,26 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__clustering__troubleshooting.ja_JP.po\n"
 
-#. type: Title ====
+#. type: Title ###
 #: source/server_installation/topics/clustering/troubleshooting.adoc:2
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:386
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:391
 #: source/securing_apps/topics/saml/java/debugging.adoc:2
 #: source/server_admin/topics/authentication/kerberos.adoc:191
+#: source/server_admin/topics/authentication/x509.adoc:201
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
@@ -28,7 +30,7 @@ msgstr "トラブルシューティング"
 msgid ""
 "Note that when you run cluster, you should see message similar to this in "
 "the log of both cluster nodes:"
-msgstr ""
+msgstr "クラスターを実行すると、両方のクラスター・ノードのログ内に以下のようなメッセージが表示されます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/clustering/troubleshooting.adoc:10
@@ -37,25 +39,29 @@ msgid ""
 "INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (Incoming-10,shared=udp)\n"
 "ISPN000094: Received new cluster view: [node1/keycloak|1] (2) [node1/keycloak, node2/keycloak]\n"
 msgstr ""
+"INFO  [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (Incoming-10,shared=udp)\n"
+"ISPN000094: Received new cluster view: [node1/keycloak|1] (2) [node1/keycloak, node2/keycloak]\n"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/troubleshooting.adoc:12
 msgid ""
 "If you see just one node mentioned, it's possible that your cluster hosts "
 "are not joined together."
-msgstr ""
+msgstr "ノードが1つだけ表示されている場合、クラスター・ホストが結合されていない可能性があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/troubleshooting.adoc:19
 msgid ""
 "Usually it's best practice to have your cluster nodes on private network "
 "without firewall for communication among them.  Firewall could be enabled "
-"just on public access point to your network instead.  If for some reason you "
-"still need to have firewall enabled on cluster nodes, you will need to open "
-"some ports.  Default values are UDP port 55200 and multicast port 45688 with "
-"multicast address 230.0.0.4.  Note that you may need more ports opened if "
-"you want to enable additional features like diagnostics for your JGroups "
-"stack.  {project_name} delegates most of the clustering work to Infinispan/"
-"JGroups.  For more information, see link:{appserver_jgroups_link}[JGroups] "
-"in the _{appserver_jgroups_name}_."
+"just on public access point to your network instead.  If for some reason you"
+" still need to have firewall enabled on cluster nodes, you will need to open"
+" some ports.  Default values are UDP port 55200 and multicast port 45688 "
+"with multicast address 230.0.0.4.  Note that you may need more ports opened "
+"if you want to enable additional features like diagnostics for your JGroups "
+"stack.  {project_name} delegates most of the clustering work to "
+"Infinispan/JGroups.  For more information, see "
+"link:{appserver_jgroups_link}[JGroups] in the _{appserver_jgroups_name}_."
 msgstr ""
+"通常、プライベートネットワーク上にクラスタノードを置き、ファイアウォールは置かずに通信するのが最善の方法です。その代わり、ネットワークへのパブリックアクセスポイントでは、ファイアウォールを有効にすることができます。何らかの理由でクラスター・ノードでファイアウォールを有効にする場合、ポートをいくつか開く必要があります。デフォルト値は、マルチキャスト・アドレス230.0.0.4のUDPポート55200とマルチキャスト・ポート45688です。JGroupsスタックの診断のような追加機能を有効にするには、ポートをさらに開く必要があるので、その点はご注意ください。Keycloakは、InfinispanまたはJGroupsにクラスタリング作業のほとんどをデリゲートします。詳しくは、WildFly"
+" 10ドキュメントのJGroupsをご覧ください。"

--- a/i18n/po/ja_JP/server_installation/topics/clustering/troubleshooting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/troubleshooting.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,7 +30,7 @@ msgstr "トラブルシューティング"
 msgid ""
 "Note that when you run cluster, you should see message similar to this in "
 "the log of both cluster nodes:"
-msgstr "クラスターを実行すると、両方のクラスター・ノードのログ内に以下のようなメッセージが表示されます。"
+msgstr "クラスターを実行すると、両方のクラスター・ノードのログに以下のようなメッセージが表示されます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/clustering/troubleshooting.adoc:10
@@ -47,7 +47,7 @@ msgstr ""
 msgid ""
 "If you see just one node mentioned, it's possible that your cluster hosts "
 "are not joined together."
-msgstr "ノードが1つだけ表示されている場合、クラスター・ホストが結合されていない可能性があります。"
+msgstr "ノードが1つだけ表示されている場合、クラスター・ホストが同じクラスターに参加していない可能性があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/troubleshooting.adoc:19
@@ -63,5 +63,5 @@ msgid ""
 "Infinispan/JGroups.  For more information, see "
 "link:{appserver_jgroups_link}[JGroups] in the _{appserver_jgroups_name}_."
 msgstr ""
-"通常、プライベートネットワーク上にクラスタノードを置き、ファイアウォールは置かずに通信するのが最善の方法です。その代わり、ネットワークへのパブリックアクセスポイントでは、ファイアウォールを有効にすることができます。何らかの理由でクラスター・ノードでファイアウォールを有効にする場合、ポートをいくつか開く必要があります。デフォルト値は、マルチキャスト・アドレス230.0.0.4のUDPポート55200とマルチキャスト・ポート45688です。JGroupsスタックの診断のような追加機能を有効にするには、ポートをさらに開く必要があるので、その点はご注意ください。Keycloakは、InfinispanまたはJGroupsにクラスタリング作業のほとんどをデリゲートします。詳しくは、WildFly"
-" 10ドキュメントのJGroupsをご覧ください。"
+"通常、プライベート・ネットワーク上にクラスター・ノードを置き、ファイアウォールは置かずに通信するのがベストプラクティスです。その代わり、ネットワークへのパブリック・アクセス・ポイントでは、ファイアウォールを有効にすることができます。何らかの理由でクラスター・ノードでファイアウォールを有効にする場合、ポートをいくつか開く必要があります。デフォルト値は、マルチキャスト・アドレス230.0.0.4のUDPポート55200とマルチキャスト・ポート45688です。JGroupsスタックの診断機能などの追加機能を有効にするには、ポートをさらに開く必要がありますので、その点はご注意ください。{project_name}は、InfinispanまたはJGroupsにクラスタリング作業のほとんどを委譲します。詳しくは、"
+" _{appserver_jgroups_name}_ のlink:{appserver_jgroups_link}[JGroups]をご覧ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/troubleshooting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__troubleshooting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__clustering__troubleshooting/ja_JP/index.html
