### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgid ""
 "to {project_name} servers sitting on a private network.  This isolates all "
 "clustering connections and provides a nice means of protecting the servers."
 msgstr ""
-"{project_name}をデプロイするためにネットワーク・アーキテクチャーには、プライベート・ネットワーク上にある{project_name}サーバーに要求をルーティングするパブリックIPアドレスに、HTTPまたはHTTPSロードバランサーを設定することが推奨されています。この設定によって、クラスタリング接続はすべて分離され、サーバーを保護する優れた手段が提供されます。"
+"{project_name}をデプロイするための推奨ネットワーク・アーキテクチャーは、パブリックIPアドレスを持つHTTP/HTTPSロードバランサーを配置し、プライベート・ネットワーク上の{project_name}サーバーへのリクエストをルーティングさせます。これにより、クラスタリング接続はすべて分離され、サーバーを保護する優れた手段が提供されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/recommended.adoc:10
@@ -38,4 +38,4 @@ msgid ""
 "By default, there is nothing to prevent unauthorized nodes from joining the cluster and broadcasting multicast messages.\n"
 "      This is why cluster nodes should be in a private network, with a firewall protecting them from outside attacks.\n"
 msgstr ""
-"デフォルトでは、認証されていないノードがクラスタに加わり、マルチキャスト・メッセージを公開するのを妨げるものはありません。このため、クラスター・ノードはプライベート・ネットワーク内に置かれ、ファイアウォールによって外部の攻撃から保護される必要があります。\n"
+"デフォルトでは、許可されていないノードがクラスターに加わり、マルチキャスト・メッセージをブロードキャストするのを防ぐものは何もありません。このため、クラスター・ノードはプライベート・ネットワーク内に置かれ、ファイアウォールによって外部の攻撃から保護される必要があります。\n"

--- a/i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__clustering__recommended.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/clustering/recommended.adoc:2
 #, no-wrap
 msgid "Recommended Network Architecture"
-msgstr ""
+msgstr "推奨ネットワーク・アーキテクチャー"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/recommended.adoc:7
@@ -28,6 +29,7 @@ msgid ""
 "to {project_name} servers sitting on a private network.  This isolates all "
 "clustering connections and provides a nice means of protecting the servers."
 msgstr ""
+"{project_name}をデプロイするためにネットワーク・アーキテクチャーには、プライベート・ネットワーク上にある{project_name}サーバーに要求をルーティングするパブリックIPアドレスに、HTTPまたはHTTPSロードバランサーを設定することが推奨されています。この設定によって、クラスタリング接続はすべて分離され、サーバーを保護する優れた手段が提供されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/clustering/recommended.adoc:10
@@ -36,3 +38,4 @@ msgid ""
 "By default, there is nothing to prevent unauthorized nodes from joining the cluster and broadcasting multicast messages.\n"
 "      This is why cluster nodes should be in a private network, with a firewall protecting them from outside attacks.\n"
 msgstr ""
+"デフォルトでは、認証されていないノードがクラスタに加わり、マルチキャスト・メッセージを公開するのを妨げるものはありません。このため、クラスター・ノードはプライベート・ネットワーク内に置かれ、ファイアウォールによって外部の攻撃から保護される必要があります。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__recommended
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__clustering__recommended/ja_JP/index.html
