### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__cache."
-"ja_JP.po\n"
 
 #. type: Title ==
 #: source/server_installation/topics/cache.adoc:2
 #, no-wrap
 msgid "Server Cache Configuration"
-msgstr ""
+msgstr "サーバー・キャッシュ設定"
 
 #. type: Plain text
 #: source/server_installation/topics/cache.adoc:11
@@ -32,27 +33,33 @@ msgid ""
 " should be evicted from local caches. This greatly reduces network traffic, makes things efficient, and avoids transmitting sensitive\n"
 "metadata over the wire.\n"
 msgstr ""
+"{project_name}には、2タイプのキャッシュがあります。1つ目は、データベースの前に置かれていて、DBの負荷を減らし、データをメモリに保持することで応答時間全体を増やします。レルム、クライアント、ロール、およびユーザー・メタデータは、この1つ目のタイプのキャッシュに保持されます。このキャッシュはローカルキャッシュです。クラスターにより多くの{project_name}サーバーがある場合でも、ローカルキャッシュはレプリケーションを使用しません。その代わり、ローカルキャッシュはローカルにのみコピーを保持し、エントリが更新された場合は無効メッセージが残りのクラスタに送られてエントリは追い出されます。別途レプリケートされたキャッシュ"
+" `work` "
+"がありますが、このタスクは、何のエントリがローカル・キャッシュから取り除かれるかについて、クラスタ全体に無効メッセージを送信するタスクになります。これによって、ネットワーク・トラフィックがかなり減り、効率化され、機密性の高いメタデータ通信の送信が回避されます。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/cache.adoc:15
 msgid ""
-"The second type of cache handles managing user sessions, offline tokens, and "
-"keeping track of login failures so that the server can detect password "
+"The second type of cache handles managing user sessions, offline tokens, and"
+" keeping track of login failures so that the server can detect password "
 "phishing and other attacks.  The data held in these caches is temporary, in "
 "memory only, but is possibly replicated across the cluster."
 msgstr ""
+"2つ目のキャッシュは、ユーザーセッション、オフライン・トークン、ログイン・エラーの履歴保持の管理を担当し、サーバーがパスワード・フィッシングやその他の攻撃を検出できるようにします。これらのキャッシュ内のデータは一時的で、メモリーにのみ保持されるものですが、クラスター全体にレプリケートされる可能性があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/cache.adoc:17
 msgid ""
 "This chapter discusses some configuration options for these caches for both "
 "clustered a non-clustered deployments."
-msgstr ""
+msgstr "この章では、クラスター構成と非クラスター構成の両方のためのキャッシュ用設定オプションについてご説明します。"
 
 #. type: Plain text
 #: source/server_installation/topics/cache.adoc:18
 msgid ""
-"More advanced configuration of these caches can be found in the link:"
-"{appserver_caching_link}[Infinispan] section of the _{appserver_caching_name}"
-"_."
+"More advanced configuration of these caches can be found in the "
+"link:{appserver_caching_link}[Infinispan] section of the "
+"_{appserver_caching_name}_."
 msgstr ""
+"これらのキャッシュのより詳しい設定については、_{appserver_caching_name}_ "
+"のlink:{appserver_caching_link}[Infinispan]のセクションをご覧ください。"

--- a/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,9 +33,9 @@ msgid ""
 " should be evicted from local caches. This greatly reduces network traffic, makes things efficient, and avoids transmitting sensitive\n"
 "metadata over the wire.\n"
 msgstr ""
-"{project_name}には、2タイプのキャッシュがあります。1つ目は、データベースの前に置かれていて、DBの負荷を減らし、データをメモリに保持することで応答時間全体を増やします。レルム、クライアント、ロール、およびユーザー・メタデータは、この1つ目のタイプのキャッシュに保持されます。このキャッシュはローカルキャッシュです。クラスターにより多くの{project_name}サーバーがある場合でも、ローカルキャッシュはレプリケーションを使用しません。その代わり、ローカルキャッシュはローカルにのみコピーを保持し、エントリが更新された場合は無効メッセージが残りのクラスタに送られてエントリは追い出されます。別途レプリケートされたキャッシュ"
+"{project_name}には、2タイプのキャッシュがあります。1つ目は、データベースの前に置かれていて、DBの負荷を減らし、データをメモリに保持することで全体の応答時間を短縮します。レルム、クライアント、ロール、およびユーザー・メタデータは、この1つ目のタイプのキャッシュに保持されます。このキャッシュはローカル・キャッシュです。クラスターにより多くの{project_name}サーバーがある場合でも、ローカル・キャッシュはレプリケーションを使用しません。その代わり、ローカル・キャッシュはローカルにのみコピーを保持し、エントリが更新された場合は無効化メッセージが残りのクラスターに送られてエントリは追い出されます。別途レプリケートされたキャッシュ"
 " `work` "
-"がありますが、このタスクは、何のエントリがローカル・キャッシュから取り除かれるかについて、クラスタ全体に無効メッセージを送信するタスクになります。これによって、ネットワーク・トラフィックがかなり減り、効率化され、機密性の高いメタデータ通信の送信が回避されます。\n"
+"がありますが、このタスクは、何のエントリがローカル・キャッシュから取り除かれるかについて、クラスター全体に無効化メッセージを送信するタスクになります。これによって、ネットワーク・トラフィックがかなり減り、効率化され、機密性の高いメタデータ通信の送信が回避されます。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/cache.adoc:15
@@ -45,7 +45,7 @@ msgid ""
 "phishing and other attacks.  The data held in these caches is temporary, in "
 "memory only, but is possibly replicated across the cluster."
 msgstr ""
-"2つ目のキャッシュは、ユーザーセッション、オフライン・トークン、ログイン・エラーの履歴保持の管理を担当し、サーバーがパスワード・フィッシングやその他の攻撃を検出できるようにします。これらのキャッシュ内のデータは一時的で、メモリーにのみ保持されるものですが、クラスター全体にレプリケートされる可能性があります。"
+"2つ目のキャッシュは、ユーザー・セッション、オフライン・トークン、ログイン・エラーの履歴保持の管理を担当し、サーバーがパスワード・フィッシングやその他の攻撃を検出できるようにします。これらのキャッシュ内のデータは一時的で、メモリーにのみ保持されるものですが、クラスター全体にレプリケートされる可能性があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/cache.adoc:17
@@ -61,5 +61,5 @@ msgid ""
 "link:{appserver_caching_link}[Infinispan] section of the "
 "_{appserver_caching_name}_."
 msgstr ""
-"これらのキャッシュのより詳しい設定については、_{appserver_caching_name}_ "
+"これらのキャッシュのより高度な設定については、　_{appserver_caching_name}_ "
 "のlink:{appserver_caching_link}[Infinispan]のセクションをご覧ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__cache/ja_JP/index.html
