### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,8 +31,8 @@ msgid ""
 "Here's what the config looks like initially.\n"
 msgstr ""
 "レルムまたはユーザー・キャッシュを無効にするには、配布物内の `standalone.xml` 、 `standalone-ha.xml` または "
-"`domain.xml` を編集する必要があります。このファイルの場所は、<<_operating-mode, operating "
-"mode>>によって異なります。設定については、初回は以下のようになっています。\n"
+"`domain.xml` を編集する必要があります。このファイルの場所は、<<_operating-mode, "
+"動作モード>>によって異なります。初期状態の設定は以下のようになっています。\n"
 
 #. type: delimited block -
 #: source/server_installation/topics/cache/disable.adoc:16
@@ -42,9 +42,9 @@ msgid ""
 "        <provider name=\"default\" enabled=\"true\"/>\n"
 "    </spi>\n"
 msgstr ""
-"<spi name=\"userCache\">\n"
-" <provider name=\"default\" enabled=\"true\"/>\n"
-" </spi>\n"
+"    <spi name=\"userCache\">\n"
+"        <provider name=\"default\" enabled=\"true\"/>\n"
+"    </spi>\n"
 
 #. type: delimited block -
 #: source/server_installation/topics/cache/disable.adoc:20
@@ -54,9 +54,9 @@ msgid ""
 "        <provider name=\"default\" enabled=\"true\"/>\n"
 "    </spi>\n"
 msgstr ""
-"<spi name=\"realmCache\">\n"
-" <provider name=\"default\" enabled=\"true\"/>\n"
-" </spi>\n"
+"    <spi name=\"realmCache\">\n"
+"        <provider name=\"default\" enabled=\"true\"/>\n"
+"    </spi>\n"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/disable.adoc:25
@@ -65,5 +65,5 @@ msgid ""
 "want to disable.  You must reboot your server for this change to take "
 "effect."
 msgstr ""
-"キャッシュを無効にするには、無効にするキャッシュ用に `enabled` "
+"キャッシュを無効にするには、無効にするキャッシュの `enabled` "
 "属性をfalseに設定します。この変更を有効にするには、サーバーを再起動する必要があります。"

--- a/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__cache__disable.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/cache/disable.adoc:2
 #, no-wrap
 msgid "Disabling Caching"
-msgstr ""
+msgstr "キャッシングの無効化"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/disable.adoc:8
@@ -29,6 +30,9 @@ msgid ""
 "depends on your <<_operating-mode, operating mode>>.  \n"
 "Here's what the config looks like initially.\n"
 msgstr ""
+"レルムまたはユーザー・キャッシュを無効にするには、配布物内の `standalone.xml` 、 `standalone-ha.xml` または "
+"`domain.xml` を編集する必要があります。このファイルの場所は、<<_operating-mode, operating "
+"mode>>によって異なります。設定については、初回は以下のようになっています。\n"
 
 #. type: delimited block -
 #: source/server_installation/topics/cache/disable.adoc:16
@@ -38,6 +42,9 @@ msgid ""
 "        <provider name=\"default\" enabled=\"true\"/>\n"
 "    </spi>\n"
 msgstr ""
+"<spi name=\"userCache\">\n"
+" <provider name=\"default\" enabled=\"true\"/>\n"
+" </spi>\n"
 
 #. type: delimited block -
 #: source/server_installation/topics/cache/disable.adoc:20
@@ -47,10 +54,16 @@ msgid ""
 "        <provider name=\"default\" enabled=\"true\"/>\n"
 "    </spi>\n"
 msgstr ""
+"<spi name=\"realmCache\">\n"
+" <provider name=\"default\" enabled=\"true\"/>\n"
+" </spi>\n"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/disable.adoc:25
 msgid ""
 "To disable the cache set the `enabled` attribute to false for the cache you "
-"want to disable.  You must reboot your server for this change to take effect."
+"want to disable.  You must reboot your server for this change to take "
+"effect."
 msgstr ""
+"キャッシュを無効にするには、無効にするキャッシュ用に `enabled` "
+"属性をfalseに設定します。この変更を有効にするには、サーバーを再起動する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__disable
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__cache__disable/ja_JP/index.html
