### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__cache__clear.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/cache/clear.adoc:2
 #, no-wrap
 msgid "Clearing Caches at Runtime"
-msgstr ""
+msgstr "実行時でのキャッシュのクリア"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/clear.adoc:6
@@ -27,8 +28,9 @@ msgid ""
 "Realm Settings->Cache Config page.  On this page you can clear the realm "
 "cache, the user cache or cache of external public keys."
 msgstr ""
+"レルムまたはユーザー・キャッシュをクリアするには、{project_name}の管理コンソール・レルム設定->キャッシュ設定ページへ移動します。このページでは、レルム・キャッシュ、ユーザー・キャッシュ、外部パブリック鍵キャッシュをクリアすることができます。"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/clear.adoc:7
 msgid "The cache will be cleared for all realms!"
-msgstr ""
+msgstr "レルム用のキャッシュはすべてクリアされます！"

--- a/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_installation/topics/cache/clear.adoc:2
 #, no-wrap
 msgid "Clearing Caches at Runtime"
-msgstr "実行時でのキャッシュのクリア"
+msgstr "実行時のキャッシュクリア"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/clear.adoc:6
@@ -28,9 +28,10 @@ msgid ""
 "Realm Settings->Cache Config page.  On this page you can clear the realm "
 "cache, the user cache or cache of external public keys."
 msgstr ""
-"レルムまたはユーザー・キャッシュをクリアするには、{project_name}の管理コンソール・レルム設定->キャッシュ設定ページへ移動します。このページでは、レルム・キャッシュ、ユーザー・キャッシュ、外部パブリック鍵キャッシュをクリアすることができます。"
+"レルムまたはユーザー・キャッシュをクリアするには、{project_name}の管理コンソールのRealm "
+"Settings->Cache設定ページへ移動します。このページでは、レルム・キャッシュ、ユーザー・キャッシュ、外部の公開鍵キャッシュをクリアすることができます。"
 
 #. type: Plain text
 #: source/server_installation/topics/cache/clear.adoc:7
 msgid "The cache will be cleared for all realms!"
-msgstr "レルム用のキャッシュはすべてクリアされます！"
+msgstr "すべてのレルムのキャッシュがクリアされます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__clear
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__cache__clear/ja_JP/index.html
