### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -15,11 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title =====
-#, no-wrap
-msgid "Adapter Installation"
-msgstr "アダプターのインストール"
-
 #. type: Title ====
 #, no-wrap
 msgid "CLI / Desktop Applications"
@@ -49,7 +44,7 @@ msgid ""
 "Tip: Google provides some more information about this approach on at "
 "https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]."
 msgstr ""
-"Tip：Googleではhttps://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]から、このアプローチに関する情報を提供しています。"
+"Tip：Googleはhttps://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]で、このアプローチに関する情報を提供しています。"
 
 #. type: Title =====
 #, no-wrap
@@ -83,8 +78,9 @@ msgid ""
 "flow.  Once the code to token exchange is completed the `ServerSocket` is "
 "shutdown."
 msgstr ""
-"ログイン成功後、 `KeycloakInstalled` は受信したHTTPリクエストから認可コードを受け取り、認可コード・フローを実行します。 "
-"トークンからコードへの交換が完了すると、 `ServerSocket` がシャットダウンされます。"
+"ログイン成功後、 `KeycloakInstalled` "
+"は受信したHTTPリクエストから認可コードを受け取り、認可コード・フローを実行します。トークンからコードへの交換が完了すると、 "
+"`ServerSocket` はシャットダウンされます。"
 
 #. type: Plain text
 msgid ""
@@ -99,13 +95,18 @@ msgid ""
 "The client eventually receives the tokens (access_token, refresh_token, "
 "id_token) which can then be used to call backend services."
 msgstr ""
-"クライアントは、最終的にバックエンド・サービスを呼び出すために使用できるトークン(access_token、refresh_token、id_token)を受け取ります。"
+"クライアントは、最終的にバックエンド・サービスを呼び出すために使用できるトークン（access_token、refresh_token、id_token）を受け取ります。"
 
 #. type: Plain text
 msgid ""
 "The `KeycloakInstalled` adapter provides support for renewal of stale "
 "tokens."
 msgstr "`KeycloakInstalled` アダプターは失効したトークンの更新をサポートします。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Adapter Installation"
+msgstr "アダプターのインストール"
 
 #. type: delimited block -
 #, no-wrap
@@ -133,8 +134,8 @@ msgid ""
 "with `Standard Flow Enabled` and pass:[http://localhost:*] as an allowed "
 "`Valid Redirect URI`."
 msgstr ""
-"アプリケーションは、 `Standard Flow Enabled` を持つ `public` なOpenID "
-"Connectクライアントとして設定され、許可された `Valid Redirect URI` "
+"アプリケーションは、 `public` なOpenID Connectクライアントが `Standard Flow Enabled` "
+"として設定され、許可される `Valid Redirect URI` "
 "としてpass:[http://localhost:*]が設定される必要があります。"
 
 #. type: Title ====
@@ -150,14 +151,14 @@ msgid ""
 "`KeycloakInstalled` constructor."
 msgstr ""
 "`KeycloakInstalled` アダプターはクラスパス上の `META-INF/keycloak.json` "
-"から設定を読み込みます。カスタム設定は、 `KeycloakInstalled` コンストラクタを介して、 ` InputStream` または "
+"から設定を読み込みます。カスタム設定は、 `KeycloakInstalled` コンストラクタを介して、 `InputStream` または "
 "`KeycloakDeployment` で提供することができます。"
 
 #. type: Plain text
 msgid ""
 "In the example below, the client configuration for `desktop-app` uses the "
 "following `keycloak.json`:"
-msgstr "以下の例では、 `desktop-app` のクライアント設定は `keycloak.json` を使います："
+msgstr "以下の例では、 `desktop-app` のクライアント設定は `keycloak.json` を使います。"
 
 #. type: delimited block -
 #, no-wrap
@@ -184,7 +185,7 @@ msgstr ""
 msgid ""
 "the following sketch demonstrates working with the `KeycloakInstalled` "
 "adapter:"
-msgstr "次のスケッチは、 `KeycloakInstalled` アダプターとの動作を示しています:"
+msgstr "次のスケッチは、 `KeycloakInstalled` アダプターとの動作を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -250,7 +251,7 @@ msgstr "例"
 #. type: Plain text
 msgid ""
 "The following provides an example for the configuration mentioned above."
-msgstr "以下に、上記の設定の例を示します。"
+msgstr "以下に、上記の設定例を示します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -1,0 +1,422 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =====
+#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
+#: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
+#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
+#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
+#, no-wrap
+msgid "Adapter Installation"
+msgstr "アダプターのインストール"
+
+#. type: Title ====
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:2
+#, no-wrap
+msgid "CLI / Desktop Applications"
+msgstr "CLI / デスクトップ・アプリケーション"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:7
+msgid ""
+"{project_name} supports securing desktop (e.g. Swing, JavaFX) or CLI "
+"applications via the `KeycloakInstalled` adapter by performing the "
+"authentication step via the system browser."
+msgstr ""
+"{project_name} は、システム・ブラウザを介して認証ステップを実行することによって、 `KeycloakInstalled` "
+"アダプタを介してデスクトップ(例えば、Swing、JavaFX)またはCLIアプリケーションのセキュリティをサポートします。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:12
+msgid ""
+"The `KeycloakInstalled` adapter supports a `desktop` and a `manual` variant."
+" The desktop variant uses the system browser to gather the user credentials."
+" The manual variant reads the user credentials from `STDIN`."
+msgstr ""
+"`KeycloakInstalled` アダプターは、 `desktop` と `manual` のバリアントをサポートしています。 "
+"デスクトップ・バリアントは、システム・クレデンシャルを収集するためにシステム・ブラウザを使用します。手動バリアントは、ユーザー・クレデンシャルを "
+"`STDIN` から読み込みます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:15
+msgid ""
+"Tip: Google provides some more information about this approach on at "
+"https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]."
+msgstr ""
+"Tip：Googleでは "
+"https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]"
+" から、このアプローチに関する情報を提供しています。"
+
+#. type: Title =====
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:16
+#, no-wrap
+msgid "How it works"
+msgstr "どのように動くか"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:21
+msgid ""
+"To authenticate a user with the `desktop` variant the `KeycloakInstalled` "
+"adapter opens a desktop browser window where a user uses the regular "
+"{project_name} login pages to login when the `loginDesktop()` method is "
+"called on the `KeycloakInstalled` object."
+msgstr ""
+"`desktop` バリアントでユーザーを認証するために、`KeycloakInstalled` アダプターは 、`KeycloakInstalled`"
+" オブジェクトの `loginDesktop()` メソッドが呼び出されたとき、ログインするためにユーザーが通常の {project_name} "
+"ログイン・ページを使用しているブラウザのウィンドウを開きます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:25
+msgid ""
+"The login page URL is opened with redirect parameter that points to a local "
+"`ServerSocket` listening on a free ephemeral port on `localhost` which is "
+"started by the adapter."
+msgstr ""
+"ログイン・ページのURLは、アダプターによって起動される `localhost` の空きエフェメラル・ポートをリッスンするローカル "
+"`ServerSocket` を指すリダイレクト・パラメーターで開かれます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:29
+msgid ""
+"After a succesful login the `KeycloakInstalled` receives the authorization "
+"code from the incoming HTTP request and performs the authorization code "
+"flow.  Once the code to token exchange is completed the `ServerSocket` is "
+"shutdown."
+msgstr ""
+"ログイン成功後、 `KeycloakInstalled` は受信したHTTPリクエストから認可コードを受け取り、認可コード・フローを実行します。 "
+"トークンからコードへの交換が完了すると、 `ServerSocket` がシャットダウンされます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:33
+msgid ""
+"If the user already has an active {project_name} session then the login form"
+" is not shown but the code to token exchange is continued, which enables a "
+"smooth Web based SSO experience."
+msgstr ""
+"ユーザーが既に {project_name} "
+"のアクティブなセッションを持っている場合、ログイン・フォームは表示されませんが、コードからトークンへの交換は継続され、スムーズなWebベースのSSO体験が可能になります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:36
+msgid ""
+"The client eventually receives the tokens (access_token, refresh_token, "
+"id_token) which can then be used to call backend services."
+msgstr ""
+"クライアントは、最終的にバックエンド・サービスを呼び出すために使用できるトークン(access_token、refresh_token、id_token)を受け取ります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:38
+msgid ""
+"The `KeycloakInstalled` adapter provides support for reneval of stale "
+"tokens."
+msgstr "`KeycloakInstalled` アダプターは失効したトークンの更新をサポートします。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:51
+#, no-wrap
+msgid ""
+"<dependency>\n"
+"\t<groupId>org.keycloak</groupId>\n"
+"\t<artifactId>keycloak-installed-adapter</artifactId>\n"
+"\t<version>{project_versionMvn}</version>\n"
+"</dependency>\n"
+msgstr ""
+"<dependency>\n"
+"\t<groupId>org.keycloak</groupId>\n"
+"\t<artifactId>keycloak-installed-adapter</artifactId>\n"
+"\t<version>{project_versionMvn}</version>\n"
+"</dependency>\n"
+
+#. type: Title =====
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:55
+#, no-wrap
+msgid "Client Configuration"
+msgstr "クライアントの設定"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:59
+msgid ""
+"The application needs to be configured as a `public` openid connect client "
+"with `Standard Flow Enabled` and pass:[http://localhost:*] as an allowed "
+"`Valid Redirect URI`."
+msgstr ""
+"アプリケーションは、 `Standard Flow Enabled` を持つ` public` なOpenid "
+"Connectクライアントとして設定され、許可された `Valid Redirect URI` として "
+"pass:[http://localhost:*] が設定される必要があります。"
+
+#. type: Title ====
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:60
+#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:45
+#, no-wrap
+msgid "Usage"
+msgstr "使い方"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:66
+msgid ""
+"The `KeycloakInstalled` adapter reads it's configuration from `META-"
+"INF/keycloak.json` on the classpath. Custom configurations can be supplied "
+"with an `InputStream` or a `KeycloakDeployment` through the "
+"`KeycloakInstalled` constructor."
+msgstr ""
+"`KeycloakInstalled` アダプターはクラスパス上の `META-INF /keycloak.json` "
+"から設定を読み込みます。カスタム設定は、 `KeycloakInstalled` コンストラクタを介して、 ` InputStream` または "
+"`KeycloakDeployment` で提供することができます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:69
+msgid ""
+"In the example below, the client configuration for `desktop-app` uses the "
+"following `keycloak.json`:"
+msgstr "以下の例では、 `desktop-app` のクライアント設定は` keycloak.json` を使います："
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:81
+#, no-wrap
+msgid ""
+"{\n"
+"  \"realm\": \"desktop-app-auth\",\n"
+"  \"auth-server-url\": \"http://localhost:8081/auth\",\n"
+"  \"ssl-required\": \"external\",\n"
+"  \"resource\": \"desktop-app\",\n"
+"  \"public-client\": true,\n"
+"  \"use-resource-role-mappings\": true\n"
+"}\n"
+msgstr ""
+"{\n"
+"  \"realm\": \"desktop-app-auth\",\n"
+"  \"auth-server-url\": \"http://localhost:8081/auth\",\n"
+"  \"ssl-required\": \"external\",\n"
+"  \"resource\": \"desktop-app\",\n"
+"  \"public-client\": true,\n"
+"  \"use-resource-role-mappings\": true\n"
+"}\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:85
+msgid ""
+"the following sketch demonstrates working with the `KeycloakInstalled` "
+"adapter:"
+msgstr "次のスケッチは、 `KeycloakInstalled` アダプターとの動作を示しています:"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:90
+#, no-wrap
+msgid ""
+"// reads the configuration from classpath: META-INF/keycloak.json\n"
+"KeycloakInstalled keycloak = new KeycloakInstalled();\n"
+msgstr ""
+"// reads the configuration from classpath: META-INF/keycloak.json\n"
+"KeycloakInstalled keycloak = new KeycloakInstalled();\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:93
+#, no-wrap
+msgid ""
+"// opens desktop browser\n"
+"keycloak.loginDesktop();\n"
+msgstr ""
+"// opens desktop browser\n"
+"keycloak.loginDesktop();\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:96
+#, no-wrap
+msgid ""
+"AccessToken token = keycloak.getToken();\n"
+"// use token to send backend request\n"
+msgstr ""
+"AccessToken token = keycloak.getToken();\n"
+"// use token to send backend request\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:100
+#, no-wrap
+msgid ""
+"// ensure token is valid for at least 30 seconds\n"
+"long minValidity = 30L;\n"
+"String tokenString = keycloak.getTokenString(minValidity, TimeUnit.SECONDS);\n"
+msgstr ""
+"// ensure token is valid for at least 30 seconds\n"
+"long minValidity = 30L;\n"
+"String tokenString = keycloak.getTokenString(minValidity, TimeUnit.SECONDS);\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:104
+#, no-wrap
+msgid ""
+" // when you want to logout the user.\n"
+"keycloak.logout();\n"
+msgstr ""
+" // when you want to logout the user.\n"
+"keycloak.logout();\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:109
+msgid ""
+"The `KeycloakInstalled` class supports customization of the http responses "
+"returned by login / logout requests via the `loginResponseWriter` and "
+"`logoutResponseWriter` attributes."
+msgstr ""
+"`KeycloakInstalled` クラスは `loginResponseWriter` 属性と `logoutResponseWriter` "
+"属性を介したログイン/ログアウト・リクエストによって、返されたHTTPレスポンスのカスタマイズをサポートしています。"
+
+#. type: Title =====
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:110
+#, no-wrap
+msgid "Example"
+msgstr "例"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:113
+msgid ""
+"The following provides an example for the configuration mentioned above."
+msgstr "以下に、上記の設定の例を示します。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:119
+#, no-wrap
+msgid ""
+"import java.util.Locale;\n"
+"import java.util.concurrent.Executors;\n"
+"import java.util.concurrent.TimeUnit;\n"
+msgstr ""
+"import java.util.Locale;\n"
+"import java.util.concurrent.Executors;\n"
+"import java.util.concurrent.TimeUnit;\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:122
+#, no-wrap
+msgid ""
+"import org.keycloak.adapters.installed.KeycloakInstalled;\n"
+"import org.keycloak.representations.AccessToken;\n"
+msgstr ""
+"import org.keycloak.adapters.installed.KeycloakInstalled;\n"
+"import org.keycloak.representations.AccessToken;\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:124
+#, no-wrap
+msgid "public class DesktopApp {\n"
+msgstr "public class DesktopApp {\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:126
+#, no-wrap
+msgid "\tpublic static void main(String[] args) throws Exception {\n"
+msgstr "\tpublic static void main(String[] args) throws Exception {\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:130
+#, no-wrap
+msgid ""
+"\t\tKeycloakInstalled keycloak = new KeycloakInstalled();\n"
+"\t\tkeycloak.setLocale(Locale.ENGLISH);\n"
+"\t\tkeycloak.loginDesktop();\n"
+msgstr ""
+"\t\tKeycloakInstalled keycloak = new KeycloakInstalled();\n"
+"\t\tkeycloak.setLocale(Locale.ENGLISH);\n"
+"\t\tkeycloak.loginDesktop();\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:133
+#, no-wrap
+msgid ""
+"\t\tAccessToken token = keycloak.getToken();\n"
+"\t\tExecutors.newSingleThreadExecutor().submit(() -> {\n"
+msgstr ""
+"\t\tAccessToken token = keycloak.getToken();\n"
+"\t\tExecutors.newSingleThreadExecutor().submit(() -> {\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:142
+#, no-wrap
+msgid ""
+"\t\t\tSystem.out.println(\"Logged in...\");\n"
+"\t\t\tSystem.out.println(\"Token: \" + token.getSubject());\n"
+"\t\t\tSystem.out.println(\"Username: \" + token.getPreferredUsername());\n"
+"\t\t\ttry {\n"
+"\t\t\t\tSystem.out.println(\"AccessToken: \" + keycloak.getTokenString());\n"
+"\t\t\t} catch (Exception ex) {\n"
+"\t\t\t\tex.printStackTrace();\n"
+"\t\t\t}\n"
+msgstr ""
+"\t\t\tSystem.out.println(\"Logged in...\");\n"
+"\t\t\tSystem.out.println(\"Token: \" + token.getSubject());\n"
+"\t\t\tSystem.out.println(\"Username: \" + token.getPreferredUsername());\n"
+"\t\t\ttry {\n"
+"\t\t\t\tSystem.out.println(\"AccessToken: \" + keycloak.getTokenString());\n"
+"\t\t\t} catch (Exception ex) {\n"
+"\t\t\t\tex.printStackTrace();\n"
+"\t\t\t}\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:150
+#, no-wrap
+msgid ""
+"\t\t\tint timeoutSeconds = 20;\n"
+"\t\t\tSystem.out.printf(\"Logging out in...%d Seconds%n\", timeoutSeconds);\n"
+"\t\t\ttry {\n"
+"\t\t\t\tTimeUnit.SECONDS.sleep(timeoutSeconds);\n"
+"\t\t\t} catch (Exception e) {\n"
+"\t\t\t\te.printStackTrace();\n"
+"\t\t\t}\n"
+msgstr ""
+"\t\t\tint timeoutSeconds = 20;\n"
+"\t\t\tSystem.out.printf(\"Logging out in...%d Seconds%n\", timeoutSeconds);\n"
+"\t\t\ttry {\n"
+"\t\t\t\tTimeUnit.SECONDS.sleep(timeoutSeconds);\n"
+"\t\t\t} catch (Exception e) {\n"
+"\t\t\t\te.printStackTrace();\n"
+"\t\t\t}\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:156
+#, no-wrap
+msgid ""
+"\t\t\ttry {\n"
+"\t\t\t\tkeycloak.logout();\n"
+"\t\t\t} catch (Exception e) {\n"
+"\t\t\t\te.printStackTrace();\n"
+"\t\t\t}\n"
+msgstr ""
+"\t\t\ttry {\n"
+"\t\t\t\tkeycloak.logout();\n"
+"\t\t\t} catch (Exception e) {\n"
+"\t\t\t\te.printStackTrace();\n"
+"\t\t\t}\n"
+
+#. type: delimited block -
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:162
+#, no-wrap
+msgid ""
+"\t\t\tSystem.out.println(\"Exiting...\");\n"
+"\t\t\tSystem.exit(0);\n"
+"\t\t});\n"
+"\t}\n"
+"}\n"
+msgstr ""
+"\t\t\tSystem.out.println(\"Exiting...\");\n"
+"\t\t\tSystem.exit(0);\n"
+"\t\t});\n"
+"\t}\n"
+"}\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,63 +16,47 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
-#: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
 msgstr "アダプターのインストール"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:2
 #, no-wrap
 msgid "CLI / Desktop Applications"
 msgstr "CLI / デスクトップ・アプリケーション"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:7
 msgid ""
 "{project_name} supports securing desktop (e.g. Swing, JavaFX) or CLI "
 "applications via the `KeycloakInstalled` adapter by performing the "
 "authentication step via the system browser."
 msgstr ""
-"{project_name} は、システム・ブラウザを介して認証ステップを実行することによって、 `KeycloakInstalled` "
-"アダプタを介してデスクトップ(例えば、Swing、JavaFX)またはCLIアプリケーションのセキュリティをサポートします。"
+"{project_name}は、システム・ブラウザーを介して認証ステップを実行することによって、 `KeycloakInstalled` "
+"アダプターを介してデスクトップ（例えば、Swing、JavaFX）またはCLIアプリケーションのセキュリティ保護をサポートします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:12
 msgid ""
 "The `KeycloakInstalled` adapter supports a `desktop` and a `manual` variant."
 " The desktop variant uses the system browser to gather the user credentials."
 " The manual variant reads the user credentials from `STDIN`."
 msgstr ""
-"`KeycloakInstalled` アダプターは、 `desktop` と `manual` のバリアントをサポートしています。 "
-"デスクトップ・バリアントは、システム・クレデンシャルを収集するためにシステム・ブラウザを使用します。手動バリアントは、ユーザー・クレデンシャルを "
-"`STDIN` から読み込みます。"
+"`KeycloakInstalled` アダプターは、 `desktop` と `manual` "
+"のバリアントをサポートしています。デスクトップ・バリアントは、システム・クレデンシャルを収集するためにシステム・ブラウザーを使用します。手動バリアントは、ユーザー・クレデンシャルを"
+" `STDIN` から読み込みます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:15
 msgid ""
 "Tip: Google provides some more information about this approach on at "
 "https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]."
 msgstr ""
-"Tip：Googleでは "
-"https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]"
-" から、このアプローチに関する情報を提供しています。"
+"Tip：Googleではhttps://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]から、このアプローチに関する情報を提供しています。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:16
 #, no-wrap
 msgid "How it works"
 msgstr "どのように動くか"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:21
 msgid ""
 "To authenticate a user with the `desktop` variant the `KeycloakInstalled` "
 "adapter opens a desktop browser window where a user uses the regular "
@@ -80,21 +64,19 @@ msgid ""
 "called on the `KeycloakInstalled` object."
 msgstr ""
 "`desktop` バリアントでユーザーを認証するために、`KeycloakInstalled` アダプターは 、`KeycloakInstalled`"
-" オブジェクトの `loginDesktop()` メソッドが呼び出されたとき、ログインするためにユーザーが通常の {project_name} "
-"ログイン・ページを使用しているブラウザのウィンドウを開きます。"
+" オブジェクトの `loginDesktop()` "
+"メソッドが呼び出されたとき、ログインするためにユーザーが通常の{project_name}ログイン・ページを使用しているブラウザーのウィンドウを開きます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:25
 msgid ""
 "The login page URL is opened with redirect parameter that points to a local "
 "`ServerSocket` listening on a free ephemeral port on `localhost` which is "
 "started by the adapter."
 msgstr ""
 "ログイン・ページのURLは、アダプターによって起動される `localhost` の空きエフェメラル・ポートをリッスンするローカル "
-"`ServerSocket` を指すリダイレクト・パラメーターで開かれます。"
+"`ServerSocket` を指すリダイレクト・パラメーターでオープンされます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:29
 msgid ""
 "After a succesful login the `KeycloakInstalled` receives the authorization "
 "code from the incoming HTTP request and performs the authorization code "
@@ -105,17 +87,14 @@ msgstr ""
 "トークンからコードへの交換が完了すると、 `ServerSocket` がシャットダウンされます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:33
 msgid ""
 "If the user already has an active {project_name} session then the login form"
 " is not shown but the code to token exchange is continued, which enables a "
 "smooth Web based SSO experience."
 msgstr ""
-"ユーザーが既に {project_name} "
-"のアクティブなセッションを持っている場合、ログイン・フォームは表示されませんが、コードからトークンへの交換は継続され、スムーズなWebベースのSSO体験が可能になります。"
+"ユーザーが既に{project_name}のアクティブなセッションを持っている場合、ログイン・フォームは表示されませんが、コードからトークンへの交換は継続され、スムーズなWebベースのSSO体験が可能になります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:36
 msgid ""
 "The client eventually receives the tokens (access_token, refresh_token, "
 "id_token) which can then be used to call backend services."
@@ -123,14 +102,12 @@ msgstr ""
 "クライアントは、最終的にバックエンド・サービスを呼び出すために使用できるトークン(access_token、refresh_token、id_token)を受け取ります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:38
 msgid ""
-"The `KeycloakInstalled` adapter provides support for reneval of stale "
+"The `KeycloakInstalled` adapter provides support for renewal of stale "
 "tokens."
 msgstr "`KeycloakInstalled` アダプターは失効したトークンの更新をサポートします。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:51
 #, no-wrap
 msgid ""
 "<dependency>\n"
@@ -146,50 +123,43 @@ msgstr ""
 "</dependency>\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:55
 #, no-wrap
 msgid "Client Configuration"
 msgstr "クライアントの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:59
 msgid ""
-"The application needs to be configured as a `public` openid connect client "
+"The application needs to be configured as a `public` OpenID Connect client "
 "with `Standard Flow Enabled` and pass:[http://localhost:*] as an allowed "
 "`Valid Redirect URI`."
 msgstr ""
-"アプリケーションは、 `Standard Flow Enabled` を持つ` public` なOpenid "
-"Connectクライアントとして設定され、許可された `Valid Redirect URI` として "
-"pass:[http://localhost:*] が設定される必要があります。"
+"アプリケーションは、 `Standard Flow Enabled` を持つ `public` なOpenID "
+"Connectクライアントとして設定され、許可された `Valid Redirect URI` "
+"としてpass:[http://localhost:*]が設定される必要があります。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:60
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:45
 #, no-wrap
 msgid "Usage"
 msgstr "使い方"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:66
 msgid ""
 "The `KeycloakInstalled` adapter reads it's configuration from `META-"
 "INF/keycloak.json` on the classpath. Custom configurations can be supplied "
 "with an `InputStream` or a `KeycloakDeployment` through the "
 "`KeycloakInstalled` constructor."
 msgstr ""
-"`KeycloakInstalled` アダプターはクラスパス上の `META-INF /keycloak.json` "
+"`KeycloakInstalled` アダプターはクラスパス上の `META-INF/keycloak.json` "
 "から設定を読み込みます。カスタム設定は、 `KeycloakInstalled` コンストラクタを介して、 ` InputStream` または "
 "`KeycloakDeployment` で提供することができます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:69
 msgid ""
 "In the example below, the client configuration for `desktop-app` uses the "
 "following `keycloak.json`:"
-msgstr "以下の例では、 `desktop-app` のクライアント設定は` keycloak.json` を使います："
+msgstr "以下の例では、 `desktop-app` のクライアント設定は `keycloak.json` を使います："
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:81
 #, no-wrap
 msgid ""
 "{\n"
@@ -211,14 +181,12 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:85
 msgid ""
 "the following sketch demonstrates working with the `KeycloakInstalled` "
 "adapter:"
 msgstr "次のスケッチは、 `KeycloakInstalled` アダプターとの動作を示しています:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:90
 #, no-wrap
 msgid ""
 "// reads the configuration from classpath: META-INF/keycloak.json\n"
@@ -228,7 +196,6 @@ msgstr ""
 "KeycloakInstalled keycloak = new KeycloakInstalled();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:93
 #, no-wrap
 msgid ""
 "// opens desktop browser\n"
@@ -238,7 +205,6 @@ msgstr ""
 "keycloak.loginDesktop();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:96
 #, no-wrap
 msgid ""
 "AccessToken token = keycloak.getToken();\n"
@@ -248,7 +214,6 @@ msgstr ""
 "// use token to send backend request\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:100
 #, no-wrap
 msgid ""
 "// ensure token is valid for at least 30 seconds\n"
@@ -260,7 +225,6 @@ msgstr ""
 "String tokenString = keycloak.getTokenString(minValidity, TimeUnit.SECONDS);\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:104
 #, no-wrap
 msgid ""
 " // when you want to logout the user.\n"
@@ -270,7 +234,6 @@ msgstr ""
 "keycloak.logout();\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:109
 msgid ""
 "The `KeycloakInstalled` class supports customization of the http responses "
 "returned by login / logout requests via the `loginResponseWriter` and "
@@ -280,19 +243,16 @@ msgstr ""
 "属性を介したログイン/ログアウト・リクエストによって、返されたHTTPレスポンスのカスタマイズをサポートしています。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:110
 #, no-wrap
 msgid "Example"
 msgstr "例"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:113
 msgid ""
 "The following provides an example for the configuration mentioned above."
 msgstr "以下に、上記の設定の例を示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:119
 #, no-wrap
 msgid ""
 "import java.util.Locale;\n"
@@ -304,7 +264,6 @@ msgstr ""
 "import java.util.concurrent.TimeUnit;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:122
 #, no-wrap
 msgid ""
 "import org.keycloak.adapters.installed.KeycloakInstalled;\n"
@@ -314,19 +273,16 @@ msgstr ""
 "import org.keycloak.representations.AccessToken;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:124
 #, no-wrap
 msgid "public class DesktopApp {\n"
 msgstr "public class DesktopApp {\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:126
 #, no-wrap
 msgid "\tpublic static void main(String[] args) throws Exception {\n"
 msgstr "\tpublic static void main(String[] args) throws Exception {\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:130
 #, no-wrap
 msgid ""
 "\t\tKeycloakInstalled keycloak = new KeycloakInstalled();\n"
@@ -338,7 +294,6 @@ msgstr ""
 "\t\tkeycloak.loginDesktop();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:133
 #, no-wrap
 msgid ""
 "\t\tAccessToken token = keycloak.getToken();\n"
@@ -348,7 +303,6 @@ msgstr ""
 "\t\tExecutors.newSingleThreadExecutor().submit(() -> {\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:142
 #, no-wrap
 msgid ""
 "\t\t\tSystem.out.println(\"Logged in...\");\n"
@@ -370,7 +324,6 @@ msgstr ""
 "\t\t\t}\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:150
 #, no-wrap
 msgid ""
 "\t\t\tint timeoutSeconds = 20;\n"
@@ -390,7 +343,6 @@ msgstr ""
 "\t\t\t}\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:156
 #, no-wrap
 msgid ""
 "\t\t\ttry {\n"
@@ -406,7 +358,6 @@ msgstr ""
 "\t\t\t}\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:162
 #, no-wrap
 msgid ""
 "\t\t\tSystem.out.println(\"Exiting...\");\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__installed-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__installed-adapter/ja_JP/index.html
