### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
@@ -2,34 +2,36 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_admin/topics/identity-broker.adoc:2
 #, no-wrap
 msgid "Identity Brokering"
-msgstr ""
+msgstr "アイデンティティ・ブローキング"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:7
 msgid ""
-"An Identity Broker is an intermediary service that connects multiple service "
-"providers with different identity providers.  As an intermediary service, "
-"the identity broker is responsible for creating a trust relationship with an "
-"external identity provider in order to use its identities to access internal "
-"services exposed by service providers."
+"An Identity Broker is an intermediary service that connects multiple service"
+" providers with different identity providers.  As an intermediary service, "
+"the identity broker is responsible for creating a trust relationship with an"
+" external identity provider in order to use its identities to access "
+"internal services exposed by service providers."
 msgstr ""
+"アイデンティティ・ブローカーは、複数のサービス・プロバイダーを異なるアイデンティティ・プロバイダーに接続する仲介サービスです。 "
+"仲介サービスとして、アイデンティティ・ブローカーは、サービス・プロバイダーによって公開される内部サービスにアクセスするためにアイデンティティを使用するため、外部アイデンティティ・プロバイダーとの信頼関係を作成する責任があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:11
@@ -40,68 +42,75 @@ msgid ""
 "different identity providers or even created based on the identity "
 "information obtained from them."
 msgstr ""
+"ユーザーの観点から、アイデンティティ・ブローカーは、異なるセキュリティー・ドメインまたはレルム間のアイデンティティを管理するための、ユーザー中心かつ一元的な方法を提供します。"
+" "
+"既存のアカウントは、異なるアイデンティティ・プロバイダーの1つ以上のアイデンティティとリンクすることも、それらから取得したアイデンティティ情報に基づいて作成することもできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:15
 msgid ""
-"An identity provider is usually based on a specific protocol that is used to "
-"authenticate and communicate authentication and authorization information to "
-"their users.  It can be a social provider such as Facebook, Google or "
+"An identity provider is usually based on a specific protocol that is used to"
+" authenticate and communicate authentication and authorization information "
+"to their users.  It can be a social provider such as Facebook, Google or "
 "Twitter.  It can be a business partner whose users need to access your "
 "services. Or it an be a cloud-based identity service that you want to "
 "integrate with."
 msgstr ""
+"アイデンティティ・プロバイダーは、通常、認証し、認証および認可の情報をユーザーに伝えるために使用される特定のプロトコルに基づいて実装されています。 "
+"アイデンティティ・プロバイダーは、Facebook、Google、Twitterなどのソーシャル・プロバイダーになることや、 "
+"ユーザーがサービスにアクセスする必要のあるビジネスパートナーになることができます。 "
+"または、統合したいクラウド・ベースのアイデンティティ・サービスになることもできます。 "
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:17
 msgid "Usually, identity providers are based on the following protocols:"
-msgstr ""
+msgstr "通常、アイデンティティ・プロバイダーは次のプロトコルに基づいて実装されています。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:19
 #, no-wrap
 msgid "`SAML v2.0`            \n"
-msgstr ""
+msgstr "`SAML v2.0`            \n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:20
 #, no-wrap
 msgid "`OpenID Connect v1.0`            \n"
-msgstr ""
+msgstr "`OpenID Connect v1.0`            \n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:21
 #, no-wrap
 msgid "`OAuth v2.0`            \n"
-msgstr ""
+msgstr "`OAuth v2.0`            \n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:23
 msgid ""
-"In the next sections we'll see how to configure and use {project_name} as an "
-"identity broker, covering some important aspects such as:"
-msgstr ""
+"In the next sections we'll see how to configure and use {project_name} as an"
+" identity broker, covering some important aspects such as:"
+msgstr "次のセクションでは、{project_name} をアイデンティティ・ブローカーとして設定および使用する方法を説明します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:25
 #, no-wrap
 msgid "`Social Authentication`            \n"
-msgstr ""
+msgstr "`Social Authentication`            \n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:26
 #, no-wrap
 msgid "`OpenID Connect v1.0 Brokering`            \n"
-msgstr ""
+msgstr "`OpenID Connect v1.0 Brokering`            \n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:27
 #, no-wrap
 msgid "`SAML v2.0 Brokering`            \n"
-msgstr ""
+msgstr "`SAML v2.0 Brokering`            \n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:28
 #, no-wrap
 msgid "`Identity Federation`            \n"
-msgstr ""
+msgstr "`Identity Federation`            \n"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker.adoc:2
 #, no-wrap
 msgid "Identity Brokering"
-msgstr "アイデンティティ・ブローキング"
+msgstr "アイデンティティー・ブローカリング"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:7
@@ -30,8 +30,7 @@ msgid ""
 " external identity provider in order to use its identities to access "
 "internal services exposed by service providers."
 msgstr ""
-"アイデンティティ・ブローカーは、複数のサービス・プロバイダーを異なるアイデンティティ・プロバイダーに接続する仲介サービスです。 "
-"仲介サービスとして、アイデンティティ・ブローカーは、サービス・プロバイダーによって公開される内部サービスにアクセスするためにアイデンティティを使用するため、外部アイデンティティ・プロバイダーとの信頼関係を作成する責任があります。"
+"アイデンティティー・ブローカーは、複数のサービス・プロバイダーを異なるアイデンティティー・プロバイダーに接続する仲介サービスです。仲介サービスとして、アイデンティティー・ブローカーは、サービス・プロバイダーによって公開される内部サービスへのアクセスでアイデンティティーを使用するために、外部アイデンティティー・プロバイダーとの信頼関係を作成する責任があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:11
@@ -42,9 +41,7 @@ msgid ""
 "different identity providers or even created based on the identity "
 "information obtained from them."
 msgstr ""
-"ユーザーの観点から、アイデンティティ・ブローカーは、異なるセキュリティー・ドメインまたはレルム間のアイデンティティを管理するための、ユーザー中心かつ一元的な方法を提供します。"
-" "
-"既存のアカウントは、異なるアイデンティティ・プロバイダーの1つ以上のアイデンティティとリンクすることも、それらから取得したアイデンティティ情報に基づいて作成することもできます。"
+"ユーザーの観点から、アイデンティティー・ブローカーは、異なるセキュリティ・ドメインまたはレルム間のアイデンティティーを管理するための、ユーザー中心かつ一元的な方法を提供します。既存のアカウントは、異なるアイデンティティー・プロバイダーの1つ以上のアイデンティティーとリンクすることも、それらから取得したアイデンティティー情報に基づいて作成することもできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:15
@@ -56,15 +53,13 @@ msgid ""
 "services. Or it an be a cloud-based identity service that you want to "
 "integrate with."
 msgstr ""
-"アイデンティティ・プロバイダーは、通常、認証し、認証および認可の情報をユーザーに伝えるために使用される特定のプロトコルに基づいて実装されています。 "
-"アイデンティティ・プロバイダーは、Facebook、Google、Twitterなどのソーシャル・プロバイダーになることや、 "
-"ユーザーがサービスにアクセスする必要のあるビジネスパートナーになることができます。 "
-"または、統合したいクラウド・ベースのアイデンティティ・サービスになることもできます。 "
+"アイデンティティー・プロバイダーは、通常、認証し、認証および認可の情報をユーザーに伝えるために使用される特定のプロトコルに基づいて実装されています。Facebook、Google、Twitterなどのソーシャル・プロバイダーや、サービスにアクセスする必要のあるユーザをかかえるビジネスパートナーがアイデンティティー・プロバイダーになることができます。または、統合したいクラウドベースのアイデンティティー・サービスがなることもできます。"
+" "
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:17
 msgid "Usually, identity providers are based on the following protocols:"
-msgstr "通常、アイデンティティ・プロバイダーは次のプロトコルに基づいて実装されています。"
+msgstr "通常、アイデンティティー・プロバイダーは次のプロトコルに基づいて実装されています。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:19
@@ -89,7 +84,8 @@ msgstr "`OAuth v2.0`            \n"
 msgid ""
 "In the next sections we'll see how to configure and use {project_name} as an"
 " identity broker, covering some important aspects such as:"
-msgstr "次のセクションでは、{project_name} をアイデンティティ・ブローカーとして設定および使用する方法を説明します。"
+msgstr ""
+"次のセクションでは、{project_name}をアイデンティティー・ブローカーとして設定および使用する方法を説明します。以下のいくつかの重要な側面について説明します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker.adoc:25


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker/ja_JP/index.html
