### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -21,7 +21,7 @@ msgstr ""
 #: source/topics/templates/document-attributes-product.adoc:32
 #, no-wrap
 msgid "Profiles"
-msgstr "プロフィール"
+msgstr "プロファイル"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:8
@@ -30,7 +30,7 @@ msgid ""
 "by default, including features that are considered less mature. It is "
 "however possible to disable individual features."
 msgstr ""
-"{project_name}には、成熟度が低い機能を含め、デフォルトですべての機能を有効にする単一のプロファイル、コミュニティがあります。ただし、これによって個別機能が無効になる可能性があります。"
+"{project_name}には、成熟度が低いと考えられる機能を含め、デフォルトですべての機能を有効にするcommunityプロファイルがあります。ただし、個々の機能を無効にすることは可能です。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:10
@@ -51,7 +51,7 @@ msgstr "3*"
 #: source/server_admin/topics/clients/client-saml.adoc:38
 #, no-wrap
 msgid "Name"
-msgstr "Name"
+msgstr "名前"
 
 #. type: Labeled list
 #: source/server_installation/topics/profiles.adoc:15
@@ -59,13 +59,13 @@ msgstr "Name"
 #: source/server_admin/topics/clients/client-saml.adoc:43
 #, no-wrap
 msgid "Description"
-msgstr "Description"
+msgstr "説明"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:16
 #: source/server_installation/topics/profiles.adoc:63
 msgid "Enabled by default"
-msgstr "Enabled by default"
+msgstr "デフォルトで有効"
 
 #. type: Labeled list
 #: source/server_installation/topics/profiles.adoc:18
@@ -102,7 +102,7 @@ msgstr "docker"
 #: source/server_installation/topics/profiles.adoc:23
 #: source/server_installation/topics/profiles.adoc:70
 msgid "Docker Registry protocol"
-msgstr "Dockerレジストリのプロトコル"
+msgstr "Dockerレジストリーのプロトコル"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:24
@@ -123,7 +123,7 @@ msgstr "impersonation"
 #: source/server_installation/topics/profiles.adoc:27
 #: source/server_installation/topics/profiles.adoc:74
 msgid "Ability for admins to impersonate users"
-msgstr "管理者がユーザーを偽装する機能"
+msgstr "管理者がユーザーに成り代わる機能"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:30
@@ -145,12 +145,12 @@ msgid ""
 "the features you can either switch to the preview profile or enable "
 "individual features."
 msgstr ""
-"{project_name}には、プロダクト、プレビューおよび2つのプロファイルがあります。プロダクト・プロファイルはデフォルトで有効になっていて、テクニカルなプレビュー機能を無効にします。この機能を有効にするには、プレビュー・プロファイルに切り替えるか、個別機能を有効にします。"
+"{project_name}には、productとpreviewの2プロファイルがあります。productプロファイルはデフォルトで有効になっていて、テクニカル・プレビュー機能を無効にします。この機能を有効にするには、previewプロファイルに切り替えるか、個別機能を有効にします。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:41
 msgid "To enable the preview profile start the server with:"
-msgstr "プレビュー・プロファイルを有効にするには、以下を使用してサーバーを起動します。"
+msgstr "previewプロファイルを有効にするには、以下のようにサーバーを起動します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:45
@@ -179,7 +179,7 @@ msgstr "profile=preview\n"
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:83
 msgid "To enable a specific feature start the server with:"
-msgstr "特定の機能を有効にするには、以下を使用してサーバーを起動します。"
+msgstr "特定の機能を有効にするには、以下のようにサーバーを起動します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:87
@@ -201,7 +201,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:92
 msgid "To disable a specific feature start the server with:"
-msgstr "特定の機能を無効にするには、以下を使用してサーバーを起動します。"
+msgstr "特定の機能を無効にするには、以下のようにサーバーを起動します。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:99
@@ -209,15 +209,15 @@ msgid ""
 "For example to disable Impersonation use "
 "`-Dkeycloak.profile.feature.impersonation=disabled`."
 msgstr ""
-"サンプルとして、Impersonationを無効にするには "
-"`-Dkeycloak.profile.feature.impersonation=disabled` を使用します。"
+"サンプルとして、代理ログイン機能を無効にするには `-Dkeycloak.profile.feature.impersonation=disabled`"
+" を使用します。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:101
 #: source/server_installation/topics/profiles.adoc:118
 msgid ""
 "You can set this permanently in the `profile.properties` file by adding:"
-msgstr "以下を追加することにより、 `profile.properties` ファイルにこれを永続的に設定することができます。"
+msgstr "`profile.properties` ファイルに以下を追加することにより、永続的に設定することができます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:105
@@ -230,7 +230,7 @@ msgstr "feature.impersonation=disabled\n"
 msgid ""
 "To enable a specific feature without enabling the full preview profile you "
 "can start the server with:"
-msgstr "全プレビュー・プロファイルを有効にするのではなく、特定の機能のみ有効にするには、以下を使用してサーバーを起動します。"
+msgstr "previewプロファイルを有効にするのではなく、特定の機能のみ有効にするには、以下のようにサーバーを起動します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:113

--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -1,125 +1,156 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__profiles."
-"ja_JP.po\n"
 
 #. type: Attribute :installguide_profile_name:
 #: source/server_installation/topics/profiles.adoc:3
 #: source/topics/templates/document-attributes-community.adoc:32
 #: source/topics/templates/document-attributes-product.adoc:32
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Profiles"
-msgstr ""
-"#-#-#-#-#  document-attributes-product.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"プロフィール\n"
-"#-#-#-#-#  document-attributes-community.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"プロフィール\n"
-"#-#-#-#-#  profiles.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"プロファイル"
+msgstr "プロフィール"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:8
-#, fuzzy, no-wrap
-#| msgid "{project_name} has a single profile, community, that enables most features by default, including features that are considered less mature. It is however possible to disable individual features."
 msgid ""
-"ifeval::[{project_community}==true]\n"
-"{project_name} has a single profile, community, that enables most features by default, including features that\n"
-"are considered less mature. It is however possible to disable individual features.\n"
-msgstr "{project_name}は、成熟度が低い機能を含め、デフォルトですべての機能を有効にする単一のプロファイル、コミュニティを持っています。ただし、それらの機能を個別に無効にすることができます。"
+"{project_name} has a single profile, community, that enables most features "
+"by default, including features that are considered less mature. It is "
+"however possible to disable individual features."
+msgstr ""
+"{project_name}には、成熟度が低い機能を含め、デフォルトですべての機能を有効にする単一のプロファイル、コミュニティがあります。ただし、これによって個別機能が無効になる可能性があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:10
 #: source/server_installation/topics/profiles.adoc:57
-#, fuzzy, no-wrap
-#| msgid "The features that can be enabled and disabled are:"
-msgid "The features that can be enabled and disabled are:\n"
-msgstr "有効または無効にできる機能は、以下のとおりです。"
+msgid "The features that can be enabled and disabled are:"
+msgstr "有効および無効にできる機能は、以下のとおりです。"
+
+#. type: Named 'cols' AttributeList argument for style 'cols'
+#: source/server_installation/topics/profiles.adoc:11
+#: source/server_installation/topics/profiles.adoc:58
+#, no-wrap
+msgid "3*"
+msgstr "3*"
+
+#. type: Labeled list
+#: source/server_installation/topics/profiles.adoc:14
+#: source/server_installation/topics/profiles.adoc:61
+#: source/server_admin/topics/clients/client-saml.adoc:38
+#, no-wrap
+msgid "Name"
+msgstr "Name"
+
+#. type: Labeled list
+#: source/server_installation/topics/profiles.adoc:15
+#: source/server_installation/topics/profiles.adoc:62
+#: source/server_admin/topics/clients/client-saml.adoc:43
+#, no-wrap
+msgid "Description"
+msgstr "Description"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:16
 #: source/server_installation/topics/profiles.adoc:63
-#, fuzzy, no-wrap
-#| msgid "|=== |Name |Description |Enabled by default"
-msgid ""
-"[cols=\"3*\", options=\"header\"]\n"
-"|===\n"
-"|Name\n"
-"|Description\n"
-"|Enabled by default\n"
-msgstr "|=== |名前|説明 |デフォルトで有効"
+msgid "Enabled by default"
+msgstr "Enabled by default"
+
+#. type: Labeled list
+#: source/server_installation/topics/profiles.adoc:18
+#: source/server_installation/topics/profiles.adoc:65
+#: source/server_admin/topics/overview/concepts.adoc:12
+#, no-wrap
+msgid "authorization"
+msgstr "authorization"
+
+#. type: Title =
+#: source/server_installation/topics/profiles.adoc:19
+#: source/server_installation/topics/profiles.adoc:66
+#: source/authorization_services/topics/auth-services-architecture.adoc:84
+#: source/authorization_services/topics/service-overview.adoc:2
+#, no-wrap
+msgid "Authorization Services"
+msgstr "認可サービス"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:20
-#, fuzzy, no-wrap
-#| msgid "|authorization |Authorization Services |Yes"
-msgid ""
-"|authorization\n"
-"|Authorization Services\n"
-"|Yes\n"
-msgstr "|認可|認可サービス|Yes"
+#: source/server_installation/topics/profiles.adoc:28
+#: source/server_installation/topics/profiles.adoc:32
+#: source/server_installation/topics/profiles.adoc:75
+msgid "Yes"
+msgstr "Yes"
+
+#. type: Plain text
+#: source/server_installation/topics/profiles.adoc:22
+#: source/server_installation/topics/profiles.adoc:69
+msgid "docker"
+msgstr "docker"
+
+#. type: Plain text
+#: source/server_installation/topics/profiles.adoc:23
+#: source/server_installation/topics/profiles.adoc:70
+msgid "Docker Registry protocol"
+msgstr "Dockerレジストリのプロトコル"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:24
+#: source/server_installation/topics/profiles.adoc:67
 #: source/server_installation/topics/profiles.adoc:71
-#, fuzzy, no-wrap
-#| msgid "|docker |Docker Registry protocol |No"
-msgid ""
-"|docker\n"
-"|Docker Registry protocol\n"
-"|No\n"
-msgstr "|docker |Dockerレジストリプロトコル|No"
+#: source/server_installation/topics/profiles.adoc:79
+msgid "No"
+msgstr "No"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:28
-#: source/server_installation/topics/profiles.adoc:75
-#, fuzzy, no-wrap
-#| msgid "|impersonation |Ability for admins to impersonate users |Yes"
-msgid ""
-"|impersonation\n"
-"|Ability for admins to impersonate users\n"
-"|Yes\n"
-msgstr "|成り代わり機能|管理者がユーザーに成り変わる機能|Yes"
+#: source/server_installation/topics/profiles.adoc:26
+#: source/server_installation/topics/profiles.adoc:73
+#: source/server_admin/topics/admin-console-permissions/per-realm.adoc:23
+msgid "impersonation"
+msgstr "impersonation"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:34
-#, fuzzy, no-wrap
-#| msgid "|script |Write custom authenticators using JavaScript |Yes |==="
-msgid ""
-"|script\n"
-"|Write custom authenticators using JavaScript\n"
-"|Yes\n"
-"|===\n"
-"endif::[]\n"
-msgstr "|スクリプト|JavaScriptを使用してカスタム認証コードを記述|Yes |==="
+#: source/server_installation/topics/profiles.adoc:27
+#: source/server_installation/topics/profiles.adoc:74
+msgid "Ability for admins to impersonate users"
+msgstr "管理者がユーザーを偽装する機能"
+
+#. type: Plain text
+#: source/server_installation/topics/profiles.adoc:30
+#: source/server_installation/topics/profiles.adoc:77
+msgid "script"
+msgstr "script"
+
+#. type: Plain text
+#: source/server_installation/topics/profiles.adoc:31
+#: source/server_installation/topics/profiles.adoc:78
+msgid "Write custom authenticators using JavaScript"
+msgstr "Javaスクリプトを使用したカスタム認証の記述"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:39
-#, fuzzy, no-wrap
-#| msgid "{project_name} has two profiles, product and preview. The product profile is enabled by default, which disables some tech preview features. To enable the features you can either switch to the preview profile or enable individual features."
 msgid ""
-"ifeval::[{project_product}==true]\n"
-"{project_name} has two profiles, product and preview. The product profile is enabled by default, which disables\n"
-"some tech preview features. To enable the features you can either switch to the preview profile or enable individual\n"
-"features.\n"
-msgstr "{project_name}には、2つのプロファイルと、プロダクト、プレビューがあります。プロダクト・プロフィールは、デフォルトで有効になっており、いくつかの技術のプレビュー機能を無効にします。これらのプレビュー機能を有効にするには、プレビュー・プロフィールに切り替える、または個別の機能を有効にします。"
+"{project_name} has two profiles, product and preview. The product profile is"
+" enabled by default, which disables some tech preview features. To enable "
+"the features you can either switch to the preview profile or enable "
+"individual features."
+msgstr ""
+"{project_name}には、プロダクト、プレビューおよび2つのプロファイルがあります。プロダクト・プロファイルはデフォルトで有効になっていて、テクニカルなプレビュー機能を無効にします。この機能を有効にするには、プレビュー・プロファイルに切り替えるか、個別機能を有効にします。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:41
-#, fuzzy, no-wrap
-#| msgid "To enable the preview profile start the server with:"
-msgid "To enable the preview profile start the server with:\n"
-msgstr "プレビュー・プロファイルを有効にするには、以下のとおりサーバーを起動します。"
+msgid "To enable the preview profile start the server with:"
+msgstr "プレビュー・プロファイルを有効にするには、以下を使用してサーバーを起動します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:45
@@ -129,13 +160,15 @@ msgstr "bin/standalone.sh|bat -Dkeycloak.profile=preview\n"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:50
-#, fuzzy, no-wrap
-#| msgid "You can set this permanently by creating the file `standalone/configuration/profile.properties` (or `domain/servers/server-one/configuration/profile.properties` for `server-one` in domain mode). Add the following to the file:"
 msgid ""
-"You can set this permanently by creating the file `standalone/configuration/profile.properties`\n"
-"(or `domain/servers/server-one/configuration/profile.properties` for `server-one` in domain mode). Add the following to\n"
-"the file:\n"
-msgstr "これを永続的に設定するには、ドメインモードで `server-one` に `standalone/configuration/profile.properties` または `domain/servers/server-one/configuration/profile.properties` のファイルを作成します。このファイルに以下を追加します。"
+"You can set this permanently by creating the file "
+"`standalone/configuration/profile.properties` (or `domain/servers/server-"
+"one/configuration/profile.properties` for `server-one` in domain mode). Add "
+"the following to the file:"
+msgstr ""
+"`standalone/configuration/profile.properties` （またはドメイン・モード内の `server-one` 用の"
+" `domain/servers/server-one/configuration/profile.properties` "
+"）ファイルを作成することにより、これを永続的に設定することができます。以下をファイルに追加します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:54
@@ -144,69 +177,47 @@ msgid "profile=preview\n"
 msgstr "profile=preview\n"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:67
-#, fuzzy, no-wrap
-#| msgid "|authorization |Authorization Services |No"
-msgid ""
-"|authorization\n"
-"|Authorization Services\n"
-"|No\n"
-msgstr "|認可|認可サービス|No"
-
-#. type: Plain text
-#: source/server_installation/topics/profiles.adoc:81
-#, fuzzy, no-wrap
-#| msgid "|script |Write custom authenticators using JavaScript |No |==="
-msgid ""
-"|script\n"
-"|Write custom authenticators using JavaScript\n"
-"|No\n"
-"|===\n"
-"endif::[]\n"
-msgstr "|スクリプト|JavaScriptを使用してカスタム認証コードを記述|No |==="
-
-#. type: Plain text
 #: source/server_installation/topics/profiles.adoc:83
-#, fuzzy, no-wrap
-#| msgid "To enable a specific feature start the server with:"
-msgid "To enable a specific feature start the server with:\n"
-msgstr "特定の機能を有効にするには、以下のとおりサーバーを起動します。"
+msgid "To enable a specific feature start the server with:"
+msgstr "特定の機能を有効にするには、以下を使用してサーバーを起動します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:87
 #: source/server_installation/topics/profiles.adoc:96
 #, no-wrap
-msgid "bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
-msgstr "bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
+msgid ""
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
+msgstr ""
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:90
-#, fuzzy, no-wrap
-#| msgid "For example to enable Docker use `-Dkeycloak.profile.feature.docker=enabled`."
-msgid "For example to enable Docker use `-Dkeycloak.profile.feature.docker=enabled`.\n"
-msgstr "サンプルとして、Dockerを有効にする場合は `-Dkeycloak.profile.feature.docker=enabled` を使用します。"
+msgid ""
+"For example to enable Docker use "
+"`-Dkeycloak.profile.feature.docker=enabled`."
+msgstr ""
+"サンプルとして、Dockerを有効にするには `-Dkeycloak.profile.feature.docker=enabled` を使用します。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:92
-#, fuzzy, no-wrap
-#| msgid "To disable a specific feature start the server with:"
-msgid "To disable a specific feature start the server with:\n"
-msgstr "特定の機能を無効にするには、以下のとおりサーバーを起動します。"
+msgid "To disable a specific feature start the server with:"
+msgstr "特定の機能を無効にするには、以下を使用してサーバーを起動します。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:99
-#, fuzzy, no-wrap
-#| msgid "For example to disable Impersonation use `-Dkeycloak.profile.feature.impersonation=disabled`."
-msgid "For example to disable Impersonation use `-Dkeycloak.profile.feature.impersonation=disabled`.\n"
-msgstr "サンプルとして、成り代わり機能を無効にする場合は `-Dkeycloak.profile.feature.impersonation=disabled` を使用します。"
+msgid ""
+"For example to disable Impersonation use "
+"`-Dkeycloak.profile.feature.impersonation=disabled`."
+msgstr ""
+"サンプルとして、Impersonationを無効にするには "
+"`-Dkeycloak.profile.feature.impersonation=disabled` を使用します。"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:101
 #: source/server_installation/topics/profiles.adoc:118
-#, fuzzy, no-wrap
-#| msgid "You can set this permanently in the `profile.properties` file by adding:"
-msgid "You can set this permanently in the `profile.properties` file by adding:\n"
-msgstr "これを永続的に設定するには、 `profile.properties` ファイルに以下を追加します。"
+msgid ""
+"You can set this permanently in the `profile.properties` file by adding:"
+msgstr "以下を追加することにより、 `profile.properties` ファイルにこれを永続的に設定することができます。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:105
@@ -216,34 +227,30 @@ msgstr "feature.impersonation=disabled\n"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:109
-#, fuzzy, no-wrap
-#| msgid "To enable a specific feature without enabling the full preview profile you can start the server with:"
 msgid ""
-"ifeval::[{project_product}==true]\n"
-"To enable a specific feature without enabling the full preview profile you can start the server with:\n"
-msgstr "フルプレビュー・プロファイルを有効にせず特定の機能を有効にするには、以下のとおりサーバーを起動します。"
+"To enable a specific feature without enabling the full preview profile you "
+"can start the server with:"
+msgstr "全プレビュー・プロファイルを有効にするのではなく、特定の機能のみ有効にするには、以下を使用してサーバーを起動します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:113
 #, no-wrap
-msgid "bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
-msgstr "bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
+msgid ""
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
+msgstr ""
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
 
 #. type: Plain text
 #: source/server_installation/topics/profiles.adoc:116
-#, fuzzy, no-wrap
-#| msgid "For example to enable Authorization Services use `-Dkeycloak.profile.feature.authorization=enabled`."
-msgid "For example to enable Authorization Services use `-Dkeycloak.profile.feature.authorization=enabled`.\n"
-msgstr "サンプルとして、認可サービスを有効にする場合は `-Dkeycloak.profile.feature.authorization=enabled` を使用します。"
+msgid ""
+"For example to enable Authorization Services use "
+"`-Dkeycloak.profile.feature.authorization=enabled`."
+msgstr ""
+"サンプルとして、認可サービスを有効にするには、 `-Dkeycloak.profile.feature.authorization=enabled` "
+"を使用します。"
 
 #. type: delimited block -
 #: source/server_installation/topics/profiles.adoc:122
 #, no-wrap
 msgid "feature.authorization=enabled\n"
 msgstr "feature.authorization=enabled\n"
-
-#. type: Plain text
-#: source/server_installation/topics/profiles.adoc:123
-#, no-wrap
-msgid "endif::[]\n"
-msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__profiles/ja_JP/index.html
