### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/overview.adoc:3
 #, no-wrap
 msgid "Brokering Overview"
-msgstr ""
+msgstr "ブローキングの概要"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:7
@@ -29,44 +29,48 @@ msgid ""
 "Instead, they are presented with a list of identity providers from which "
 "they can authenticate."
 msgstr ""
+"{project_name} "
+"をアイデンティティ・ブローカーとして使用する場合、ユーザーは特定のレルムで認証するためにクレデンシャルを提供する必要はありません。 "
+"代わりに、認証できるアイデンティティ・プロバイダーのリストが提示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:9
 msgid ""
 "You can also configure a default broker. In this case the user will not be "
 "given a choice, but instead be redirected directly to the parent broker."
-msgstr ""
+msgstr "また、デフォルトのブローカーを設定することもできます。 この場合、ユーザーには選択肢が与えられず、直接親ブローカーにリダイレクトされます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:11
 msgid ""
 "The following diagram demonstrates the steps involved when using "
 "{project_name} to broker an external identity provider:"
-msgstr ""
+msgstr "次の図は、 {project_name} を使用して外部アイデンティティ・プロバイダーを仲介するときに、必要な手順を示しています:"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/overview.adoc:12
 #, no-wrap
 msgid "Identity Broker Flow"
-msgstr ""
+msgstr "アイデンティティ・ブローカーのフロー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:14
 msgid "image:images/identity_broker_flow.png[]"
-msgstr ""
+msgstr "image:images/identity_broker_flow.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:16
 msgid ""
 "User is not authenticated and requests a protected resource in a client "
 "application."
-msgstr ""
+msgstr "ユーザーは認証されず、クライアント・アプリケーションの保護されたリソースを要求します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:17
 msgid ""
-"The client applications redirects the user to {project_name} to authenticate."
-msgstr ""
+"The client applications redirects the user to {project_name} to "
+"authenticate."
+msgstr "クライアント・アプリケーションは、ユーザーを {project_name} にリダイレクトして認証します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:18
@@ -74,13 +78,14 @@ msgid ""
 "At this point the user is presented with the login page where there is a "
 "list of identity providers supported by a realm."
 msgstr ""
+"この時点で、ユーザーにはログイン・ページが表示されます。ログイン・ページには、レルムがサポートするアイデンティティ・プロバイダーのリストがあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:19
 msgid ""
 "User selects one of the identity providers by clicking on its respective "
 "button or link."
-msgstr ""
+msgstr "ユーザーは、それぞれのボタンまたはリンクをクリックしてアイデンティティ・プロバイダーの1つを選択します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:22
@@ -91,13 +96,15 @@ msgid ""
 "configuration options for the identity provider were previously set by the "
 "administrator in the Admin Console."
 msgstr ""
+"{project_name} "
+"は、ターゲットのアイデンティティ・プロバイダーに認証を要求する認証要求を発行し、ユーザーはアイデンティティ・プロバイダーのログイン・ページにリダイレクトされます。アイデンティティ・プロバイダーの接続プロパティとその他の設定オプションは、管理者が管理コンソールで以前に設定したものです。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:23
 msgid ""
 "User provides his credentials or consent in order to authenticate in the "
 "identity provider."
-msgstr ""
+msgstr "ユーザーは、アイデンティティ・プロバイダーで認証するためにはクレデンシャルまたは同意を提供します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:26
@@ -108,6 +115,9 @@ msgid ""
 "to trust the authentication performed by the identity provider and retrieve "
 "information about the user."
 msgstr ""
+"アイデンティティ・プロバイダーによる認証が成功すると、ユーザは認証レスポンスとともに {project_name} にリダイレクトされます。 "
+"通常、このレスポンスには、アイデンティティ・プロバイダーによって実行された認証を信頼し、そのユーザーに関する情報を取得するために、 "
+"{project_name} によって使用されるセキュリティ・トークンが含まれています。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:33
@@ -118,28 +128,39 @@ msgid ""
 "may ask the identity provider for information about the user if that info "
 "doesn't already exist in the token.  This is what we call _identity "
 "federation_.  If the user already exists {project_name} may ask him to link "
-"the identity returned from the identity provider with his existing account.  "
-"We call this process _account linking_.  What exactly is done is "
-"configurable and can be specified by setup of <<_identity_broker_first_login,"
-"First Login Flow>> . At the end of this step, {project_name} authenticates "
-"the user and issues its own token in order to access the requested resource "
-"in the service provider."
+"the identity returned from the identity provider with his existing account."
+"  We call this process _account linking_.  What exactly is done is "
+"configurable and can be specified by setup of "
+"<<_identity_broker_first_login,First Login Flow>> . At the end of this step,"
+" {project_name} authenticates the user and issues its own token in order to "
+"access the requested resource in the service provider."
 msgstr ""
+" {project_name} "
+"は、アイデンティティ・プロバイダーからのレスポンスが有効かどうかをチェックします。有効な場合は、新しいユーザーをインポートして作成するか、ユーザーが既に存在する場合はスキップします。"
+" 新規ユーザーの場合、 {project_name} "
+"は、その情報がトークンにまだ存在していない場合、ユーザーに関する情報をアイデンティティ・プロバイダーに問い合わせることがあります。これが "
+"_identity federation_ と呼ばれるものです。ユーザーが既に存在する場合、 {project_name} "
+"はアイデンティティ・プロバイダーから返されたアイデンティティを既存のアカウントにリンクするように要求することがあります。このプロセスを _account"
+" linking_ と呼びます。正確に行われることは設定可能で、 <<_identity_broker_first_login,First Login "
+"Flow>> の設定で指定できます。 このステップの最後に、 {project_name} "
+"がユーザーを認証し、サービス・プロバイダーの要求されたリソースにアクセスするために独自のトークンを発行します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:34
 msgid ""
-"Once the user is locally authenticated, {project_name} redirects the user to "
-"the service provider by sending the token previously issued during the local "
-"authentication."
+"Once the user is locally authenticated, {project_name} redirects the user to"
+" the service provider by sending the token previously issued during the "
+"local authentication."
 msgstr ""
+"ユーザーがローカルで認証されると、 {project_name} "
+"は、ローカル認証時に以前に発行されたトークンを送信することによって、ユーザーをサービス・プロバイダーにリダイレクトします。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:35
 msgid ""
 "The service provider receives the token from {project_name} and allows "
 "access to the protected resource."
-msgstr ""
+msgstr "サービス・プロバイダーは {project_name} からトークンを受け取り、保護されたリソースへのアクセスを許可します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:39
@@ -150,6 +171,9 @@ msgid ""
 "force the user to provide additional information before federating his "
 "identity."
 msgstr ""
+"このフローにはいくつかのバリエーションがあり、後で説明します。 "
+"例えば、アイデンティティ・プロバイダーのリストを提示する代わりに、クライアント・アプリケーションは特定のプロバイダーを要求することができます。 または、"
+" {project_name} に自分のアイデンティティを統合する前に追加の情報をユーザーに強制的に伝えるように指示できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:43
@@ -159,6 +183,9 @@ msgid ""
 "      At this moment, all the identity providers supported by {project_name} use a flow just like described above.\n"
 "      However, despite the protocol in use, user experience should be pretty much the same.\n"
 msgstr ""
+"異なるプロトコルは、異なる認証フローを必要とすることがある。\n"
+"      現在のところ、 {project_name} でサポートされているすべてのアイデンティティ・プロバイダーは、前述のようなフローを使用します。\n"
+"      しかし、使用するプロトコルにかかわらず、ユーザー・エクスペリエンスはほぼ同じでなければなりません。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:47
@@ -170,3 +197,7 @@ msgid ""
 "Connect, OAuth, etc) was used or how the user's identity was validated.  "
 "They only need to know about {project_name}."
 msgstr ""
+"気づいたかもしれませんが、認証プロセスの終わりに {project_name} "
+"は常に独自のトークンをクライアント・アプリケーションに発行します。これは、クライアント・アプリケーションが外部アイデンティティ・プロバイダーと完全に分離されていることを意味します。どのプロトコル（SAML、OpenID"
+" Connect、OAuthなど）が使用されたか、またはユーザーの身元がどのように検証されたかを知る必要はありません。 それらは "
+"{project_name} についてだけ知る必要があります。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/overview.adoc:3
 #, no-wrap
 msgid "Brokering Overview"
-msgstr "ブローキングの概要"
+msgstr "ブローカリングの概要"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:7
@@ -29,29 +29,27 @@ msgid ""
 "Instead, they are presented with a list of identity providers from which "
 "they can authenticate."
 msgstr ""
-"{project_name} "
-"をアイデンティティ・ブローカーとして使用する場合、ユーザーは特定のレルムで認証するためにクレデンシャルを提供する必要はありません。 "
-"代わりに、認証できるアイデンティティ・プロバイダーのリストが提示されます。"
+"{project_name}をアイデンティティー・ブローカーとして使用する場合、ユーザーは特定のレルムで認証するためにクレデンシャルを提供する必要はありません。代わりに、認証可能なアイデンティティー・プロバイダーのリストが提示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:9
 msgid ""
 "You can also configure a default broker. In this case the user will not be "
 "given a choice, but instead be redirected directly to the parent broker."
-msgstr "また、デフォルトのブローカーを設定することもできます。 この場合、ユーザーには選択肢が与えられず、直接親ブローカーにリダイレクトされます。"
+msgstr "また、デフォルトのブローカーを設定することもできます。この場合、ユーザーには選択肢が与えられず、親のブローカーに直接リダイレクトされます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:11
 msgid ""
 "The following diagram demonstrates the steps involved when using "
 "{project_name} to broker an external identity provider:"
-msgstr "次の図は、 {project_name} を使用して外部アイデンティティ・プロバイダーを仲介するときに、必要な手順を示しています:"
+msgstr "次の図は、{project_name}を使用して外部アイデンティティー・プロバイダーを仲介するときに、必要な手順を示しています。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/overview.adoc:12
 #, no-wrap
 msgid "Identity Broker Flow"
-msgstr "アイデンティティ・ブローカーのフロー"
+msgstr "アイデンティティー・ブローカーのフロー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:14
@@ -63,14 +61,14 @@ msgstr "image:images/identity_broker_flow.png[]"
 msgid ""
 "User is not authenticated and requests a protected resource in a client "
 "application."
-msgstr "ユーザーは認証されず、クライアント・アプリケーションの保護されたリソースを要求します。"
+msgstr "ユーザーは認証しておらず、クライアント・アプリケーションの保護されたリソースを要求します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:17
 msgid ""
 "The client applications redirects the user to {project_name} to "
 "authenticate."
-msgstr "クライアント・アプリケーションは、ユーザーを {project_name} にリダイレクトして認証します。"
+msgstr "クライアント・アプリケーションは、ユーザーを認証するために{project_name}にリダイレクトさせます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:18
@@ -78,14 +76,14 @@ msgid ""
 "At this point the user is presented with the login page where there is a "
 "list of identity providers supported by a realm."
 msgstr ""
-"この時点で、ユーザーにはログイン・ページが表示されます。ログイン・ページには、レルムがサポートするアイデンティティ・プロバイダーのリストがあります。"
+"この時点で、ユーザーにはログイン・ページが表示されます。ログイン・ページには、レルムがサポートするアイデンティティー・プロバイダーのリストがあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:19
 msgid ""
 "User selects one of the identity providers by clicking on its respective "
 "button or link."
-msgstr "ユーザーは、それぞれのボタンまたはリンクをクリックしてアイデンティティ・プロバイダーの1つを選択します。"
+msgstr "ユーザーは、各ボタンまたはリンクをクリックしてアイデンティティー・プロバイダーの1つを選択します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:22
@@ -96,15 +94,14 @@ msgid ""
 "configuration options for the identity provider were previously set by the "
 "administrator in the Admin Console."
 msgstr ""
-"{project_name} "
-"は、ターゲットのアイデンティティ・プロバイダーに認証を要求する認証要求を発行し、ユーザーはアイデンティティ・プロバイダーのログイン・ページにリダイレクトされます。アイデンティティ・プロバイダーの接続プロパティとその他の設定オプションは、管理者が管理コンソールで以前に設定したものです。"
+"{project_name}は、ターゲットのアイデンティティー・プロバイダーに認証を要求する認証リクエストを発行し、ユーザーはアイデンティティー・プロバイダーのログイン・ページにリダイレクトされます。アイデンティティー・プロバイダーの接続プロパティとその他の設定オプションは、管理者が管理コンソールで前もって設定したものになります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:23
 msgid ""
 "User provides his credentials or consent in order to authenticate in the "
 "identity provider."
-msgstr "ユーザーは、アイデンティティ・プロバイダーで認証するためにはクレデンシャルまたは同意を提供します。"
+msgstr "ユーザーは、アイデンティティー・プロバイダーで認証するためにクレデンシャルまたは同意を提供します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:26
@@ -115,9 +112,7 @@ msgid ""
 "to trust the authentication performed by the identity provider and retrieve "
 "information about the user."
 msgstr ""
-"アイデンティティ・プロバイダーによる認証が成功すると、ユーザは認証レスポンスとともに {project_name} にリダイレクトされます。 "
-"通常、このレスポンスには、アイデンティティ・プロバイダーによって実行された認証を信頼し、そのユーザーに関する情報を取得するために、 "
-"{project_name} によって使用されるセキュリティ・トークンが含まれています。"
+"アイデンティティー・プロバイダーによる認証が成功すると、ユーザは認証レスポンスとともに{project_name}にリダイレクトされます。通常、このレスポンスには、{project_name}によって使用されるセキュリティ・トークンが含まれています。セキュリティ・トークンは、アイデンティティー・プロバイダーによって実行された認証を信頼し、そのユーザーに関する情報を取得するために使用されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:33
@@ -135,15 +130,15 @@ msgid ""
 " {project_name} authenticates the user and issues its own token in order to "
 "access the requested resource in the service provider."
 msgstr ""
-" {project_name} "
-"は、アイデンティティ・プロバイダーからのレスポンスが有効かどうかをチェックします。有効な場合は、新しいユーザーをインポートして作成するか、ユーザーが既に存在する場合はスキップします。"
-" 新規ユーザーの場合、 {project_name} "
-"は、その情報がトークンにまだ存在していない場合、ユーザーに関する情報をアイデンティティ・プロバイダーに問い合わせることがあります。これが "
-"_identity federation_ と呼ばれるものです。ユーザーが既に存在する場合、 {project_name} "
-"はアイデンティティ・プロバイダーから返されたアイデンティティを既存のアカウントにリンクするように要求することがあります。このプロセスを _account"
-" linking_ と呼びます。正確に行われることは設定可能で、 <<_identity_broker_first_login,First Login "
-"Flow>> の設定で指定できます。 このステップの最後に、 {project_name} "
-"がユーザーを認証し、サービス・プロバイダーの要求されたリソースにアクセスするために独自のトークンを発行します。"
+" "
+"{project_name}は、アイデンティティー・プロバイダーからのレスポンスが有効かどうかをチェックします。有効な場合は、新しいユーザーをインポートして作成するか、ユーザーがすでに存在する場合はスキップします。"
+" "
+"新規ユーザーの場合、{project_name}は、ユーザーに関する情報がトークンにまだ存在していなければアイデンティティー・プロバイダーに問い合わせることがあります。これが"
+" _アイデンティティー・フェデレーション_ "
+"と呼ばれるものです。ユーザーがすでに存在する場合、{project_name}はアイデンティティー・プロバイダーから返されたアイデンティティーを既存のアカウントにリンクするように要求することがあります。このプロセスを"
+" _アカウント・リンキング_ と呼びます。正確に行われることは設定可能で、<<_identity_broker_first_login,First "
+"Login "
+"Flow>>の設定で指定できます。このステップの最後で、{project_name}がユーザーを認証し、サービス・プロバイダーの要求されたリソースにアクセスするために独自のトークンを発行します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:34
@@ -152,15 +147,14 @@ msgid ""
 " the service provider by sending the token previously issued during the "
 "local authentication."
 msgstr ""
-"ユーザーがローカルで認証されると、 {project_name} "
-"は、ローカル認証時に以前に発行されたトークンを送信することによって、ユーザーをサービス・プロバイダーにリダイレクトします。"
+"ユーザーがローカルで認証されると、{project_name}は、ローカル認証時に先に発行されたトークンを送信してユーザーをサービス・プロバイダーにリダイレクトします。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:35
 msgid ""
 "The service provider receives the token from {project_name} and allows "
 "access to the protected resource."
-msgstr "サービス・プロバイダーは {project_name} からトークンを受け取り、保護されたリソースへのアクセスを許可します。"
+msgstr "サービス・プロバイダーは{project_name}からトークンを受け取り、保護されたリソースへのアクセスを許可します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:39
@@ -171,9 +165,7 @@ msgid ""
 "force the user to provide additional information before federating his "
 "identity."
 msgstr ""
-"このフローにはいくつかのバリエーションがあり、後で説明します。 "
-"例えば、アイデンティティ・プロバイダーのリストを提示する代わりに、クライアント・アプリケーションは特定のプロバイダーを要求することができます。 または、"
-" {project_name} に自分のアイデンティティを統合する前に追加の情報をユーザーに強制的に伝えるように指示できます。"
+"このフローにはいくつかのバリエーションがありますので、後ほど説明します。例えば、アイデンティティー・プロバイダーのリストを提示する代わりに、クライアント・アプリケーションは特定のプロバイダーを要求することができます。または、ユーザーが自分のアイデンティティーを統合する前に、ユーザーに追加の情報提供を強制させるように{project_name}に指示できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:43
@@ -183,9 +175,7 @@ msgid ""
 "      At this moment, all the identity providers supported by {project_name} use a flow just like described above.\n"
 "      However, despite the protocol in use, user experience should be pretty much the same.\n"
 msgstr ""
-"異なるプロトコルは、異なる認証フローを必要とすることがある。\n"
-"      現在のところ、 {project_name} でサポートされているすべてのアイデンティティ・プロバイダーは、前述のようなフローを使用します。\n"
-"      しかし、使用するプロトコルにかかわらず、ユーザー・エクスペリエンスはほぼ同じでなければなりません。\n"
+"異なるプロトコルは、異なる認証フローを必要とすることがあります。現在のところ、{project_name}でサポートされているすべてのアイデンティティー・プロバイダーは、前述のようなフローを使用します。しかし、使用するプロトコルにかかわらず、ユーザー・エクスペリエンスはほぼ同じでなければなりません。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/overview.adoc:47
@@ -197,7 +187,6 @@ msgid ""
 "Connect, OAuth, etc) was used or how the user's identity was validated.  "
 "They only need to know about {project_name}."
 msgstr ""
-"気づいたかもしれませんが、認証プロセスの終わりに {project_name} "
-"は常に独自のトークンをクライアント・アプリケーションに発行します。これは、クライアント・アプリケーションが外部アイデンティティ・プロバイダーと完全に分離されていることを意味します。どのプロトコル（SAML、OpenID"
-" Connect、OAuthなど）が使用されたか、またはユーザーの身元がどのように検証されたかを知る必要はありません。 それらは "
-"{project_name} についてだけ知る必要があります。"
+"気づいたかもしれませんが、認証プロセスの終わりに{project_name}は常に独自のトークンをクライアント・アプリケーションに発行します。これは、クライアント・アプリケーションが外部アイデンティティー・プロバイダーと完全に分離されていることを意味します。クライアント・アプリケーションは、どのプロトコル（例：SAML、OpenID"
+" "
+"Connect、OAuthなど）が使用されたか、またはユーザーのアイデンティティーがどのように検証されたかを知る必要はなく、{project_name}について知る必要があるだけです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__overview/ja_JP/index.html
