### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/default-provider.adoc:3
 #, no-wrap
 msgid "Default Identity Provider"
-msgstr ""
+msgstr "デフォルトのアイデンティティ・プロバイダー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/default-provider.adoc:6
@@ -30,13 +30,17 @@ msgid ""
 "authenticator. Set `Default Identity Provider` to the alias of the identity "
 "provider you want to automatically redirect users to."
 msgstr ""
+"ログイン・フォームを表示する代わりに、アイデンティティ・プロバイダーに自動的にリダイレクトすることが可能です。 これを有効にするには "
+"`Authentication` に行き、 `Browser` フローを選択してください。次に、 `Identity Provider "
+"Redirector` オーセンティケータの設定をクリックします。 `Default Identity Provider` "
+"を自動的にユーザーをリダイレクトするアイデンティティ・プロバイダーのエイリアスに設定します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/default-provider.adoc:8
 msgid ""
-"If the configured default identity provider is not found the login form will "
-"be displayed instead."
-msgstr ""
+"If the configured default identity provider is not found the login form will"
+" be displayed instead."
+msgstr "設定されたデフォルトのアイデンティティ・プロバイダーが見つからない場合は、代わりにログイン・フォームが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/default-provider.adoc:9
@@ -45,3 +49,6 @@ msgid ""
 "query parameter. See <<_client_suggested_idp, client suggested identity "
 "provider>> section for more details."
 msgstr ""
+"このオーセンティケータは、 `kc_idp_hint` クエリー・パラメーターを扱う責任も持っています。詳細については、 "
+"<<_client_suggested_idp, client suggested identity provider>> "
+"のセクションを参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/default-provider.adoc:3
 #, no-wrap
 msgid "Default Identity Provider"
-msgstr "デフォルトのアイデンティティ・プロバイダー"
+msgstr "デフォルトのアイデンティティー・プロバイダー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/default-provider.adoc:6
@@ -30,17 +30,17 @@ msgid ""
 "authenticator. Set `Default Identity Provider` to the alias of the identity "
 "provider you want to automatically redirect users to."
 msgstr ""
-"ログイン・フォームを表示する代わりに、アイデンティティ・プロバイダーに自動的にリダイレクトすることが可能です。 これを有効にするには "
+"ログイン・フォームを表示する代わりに、アイデンティティー・プロバイダーに自動的にリダイレクトすることが可能です。これを有効にするには "
 "`Authentication` に行き、 `Browser` フローを選択してください。次に、 `Identity Provider "
-"Redirector` オーセンティケータの設定をクリックします。 `Default Identity Provider` "
-"を自動的にユーザーをリダイレクトするアイデンティティ・プロバイダーのエイリアスに設定します。"
+"Redirector` オーセンティケーターの設定をクリックします。 `Default Identity Provider` "
+"を、自動的にユーザーをリダイレクトするアイデンティティー・プロバイダーのエイリアスに設定します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/default-provider.adoc:8
 msgid ""
 "If the configured default identity provider is not found the login form will"
 " be displayed instead."
-msgstr "設定されたデフォルトのアイデンティティ・プロバイダーが見つからない場合は、代わりにログイン・フォームが表示されます。"
+msgstr "設定されたデフォルトのアイデンティティー・プロバイダーが見つからない場合は、代わりにログイン・フォームが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/default-provider.adoc:9
@@ -49,6 +49,6 @@ msgid ""
 "query parameter. See <<_client_suggested_idp, client suggested identity "
 "provider>> section for more details."
 msgstr ""
-"このオーセンティケータは、 `kc_idp_hint` クエリー・パラメーターを扱う責任も持っています。詳細については、 "
-"<<_client_suggested_idp, client suggested identity provider>> "
-"のセクションを参照してください。"
+"このオーセンティケーターは、 `kc_idp_hint` "
+"クエリー・パラメーターを扱う責任も持っています。詳細については、<<_client_suggested_idp, "
+"クライアント提案のアイデンティティー・プロバイダー>>のセクションを参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__default-provider
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__default-provider/ja_JP/index.html
