### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
@@ -604,9 +604,7 @@ msgstr "keycloak-access-token"
 msgid ""
 "e.g.\n"
 "MYAPP_ACCESS_TOKEN             \n"
-msgstr ""
-"例：\n"
-"MYAPP_ACCESS_TOKEN\n"
+msgstr "例：MYAPP_ACCESS_TOKEN\n"
 
 #. type: Title ===
 #: source/server_installation/topics/proxy.adoc:212


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__proxy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__proxy/ja_JP/index.html
