### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -90,7 +90,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr "Add Identity Provider"
+msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:19

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -28,13 +28,13 @@ msgstr "Enabled"
 #: source/server_admin/topics/identity-broker/oidc.adoc:19
 #: source/server_admin/topics/identity-broker/saml.adoc:18
 msgid "Configuration|Description"
-msgstr "Configuration|Description"
+msgstr "設定|説明"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/configuration.adoc:3
 #, no-wrap
 msgid "General Configuration"
-msgstr "一般的な設定"
+msgstr "共通設定"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:8
@@ -45,20 +45,20 @@ msgid ""
 "can use any of the registered identity providers when signing in to an "
 "application."
 msgstr ""
-"アイデンティティ・ブローカーの設定は、すべてアイデンティティ・プロバイダーに基づいています。アイデンティティ・プロバイダーは各レルムに対して作成され、デフォルトでは単一アプリケーションごとに有効化されています。つまり、レルムのユーザーは、アプリケーションにサインインするときに、登録されているアイデンティティ・プロバイダーのいずれかを使用できます。"
+"アイデンティティー・ブローカーの設定は、すべてアイデンティティー・プロバイダーに基づいています。アイデンティティー・プロバイダーは各レルムに対して作成され、デフォルトでは単一アプリケーションごとに有効化されます。つまり、レルムのユーザーは、アプリケーションにサインインするときに、登録されているアイデンティティー・プロバイダーのいずれかを使用することができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:10
 msgid ""
 "In order to create an identity provider click the `Identity Providers` left "
 "menu item."
-msgstr "アイデンティティ・プロバイダーを作成するには、左側の「アイデンティティ・プロバイダー」をクリックします。"
+msgstr "アイデンティティー・プロバイダーを作成するには、左側の `Identity Providers` をクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:11
 #, no-wrap
 msgid "Identity Providers"
-msgstr "アイデンティティ・プロバイダー"
+msgstr "Identity Providers"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:13
@@ -72,8 +72,8 @@ msgid ""
 "This will bring you to the configuration page for that identity provider "
 "type."
 msgstr ""
-"ドロップ・ダウン・リスト・ボックスで、追加するアイデンティティ・プロバイダを選択します。 "
-"これにより、そのアイデンティティ・プロバイダー・タイプの設定ページが表示されます。"
+"ドロップ・ダウン・リスト・ボックスで、追加するアイデンティティー・プロバイダを選択します。 "
+"これにより、そのアイデンティティー・プロバイダー・タイプの設定ページが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:17
@@ -90,7 +90,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr "アイデンティティ・プロバイダーの追加"
+msgstr "Add Identity Provider"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:19
@@ -104,8 +104,7 @@ msgid ""
 " configure an IDP, it will appear on the {project_name} login page as an "
 "option."
 msgstr ""
-"上記は、Googleのソーシャル・ログイン・プロバイダーを設定する例です。 IDPを設定すると、オプションとして {project_name} "
-"のログイン・ページにそれが表示されます。"
+"上記は、Googleのソーシャル・ログイン・プロバイダーを設定する例です。IDPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:23
@@ -133,9 +132,7 @@ msgid ""
 "Twitter, GitHub, LinkedIn, Microsoft, and StackOverflow are supported with "
 "more planned for the future."
 msgstr ""
-"ソーシャル・プロバイダーは、レルムでソーシャル認証を有効にすることができます。 {project_name} "
-"は、ユーザーがソーシャル・ネットワークで既存のアカウントを使用して、アプリケーションに簡単にログインできるようにします。 "
-"現在、Facebook、Google、Twitter、GitHub、LinkedIn、Microsoft、StackOverflowがサポートされており、将来的にはさらなる追加が計画されています。"
+"ソーシャル・プロバイダーは、レルムでソーシャル認証を有効にすることができます。{project_name}は、ユーザーがソーシャル・ネットワークの既存アカウントを使用して、アプリケーションに簡単にログインできるようにします。現在、Facebook、Google、Twitter、GitHub、LinkedIn、Microsoft、StackOverflowがサポートされており、将来的にはさらなる追加が計画されています。"
 
 #. type: Labeled list
 #: source/server_admin/topics/identity-broker/configuration.adoc:32
@@ -153,10 +150,9 @@ msgid ""
 "it easy to configure and broker any identity provider based on these open "
 "standards."
 msgstr ""
-"プロトコル・ベースのプロバイダーは、特定のプロトコルに依存してユーザーを認証および認可するものです。 "
-"特定のプロトコルに準拠しているすべてのアイデンティティ・プロバイダーに接続できます。  {project_name} はSAML v2.0とOpenID"
-" Connect v1.0プロトコルをサポートしています。 "
-"これにより、これらのオープンスタンダードに基づいて、任意のアイデンティティ・プロバイダーを簡単に設定および仲介できるようになります。"
+"プロトコル・ベースのプロバイダーは、特定のプロトコルに依存してユーザーを認証および認可するものです。特定のプロトコルに準拠しているすべてのアイデンティティー・プロバイダーに接続できます。{project_name}はSAML"
+" v2.0とOpenID Connect "
+"v1.0プロトコルをサポートしています。これにより、これらのオープンスタンダードに基づいた任意のアイデンティティー・プロバイダーを簡単に設定および仲介できるようになります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:40
@@ -166,8 +162,7 @@ msgid ""
 "provider you are creating, you'll see the following configuration options "
 "available:"
 msgstr ""
-"各タイプのアイデンティティ・プロバイダーには独自の設定オプションがありますが、すべて共通の設定を共有しています。 "
-"作成しているアイデンティティ・プロバイダに関係なく、次の設定オプションが使用できます。"
+"各タイプのアイデンティティー・プロバイダーには独自の設定オプションがありますが、すべて共通の設定を共有しています。作成しているアイデンティティー・プロバイダに関係なく、次の設定オプションが使用できます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:41
@@ -195,10 +190,10 @@ msgid ""
 " In this case, the alias is used to build the redirect URI.\n"
 " Every single identity provider must have an alias. Examples are facebook, google, idp.acme.com, etc.\n"
 msgstr ""
-"エイリアスは、アイデンティティ・プロバイダの一意の識別子です。 アイデンティティ・プロバイダーを内部的に参照するために使用されます。\n"
-"OpenID Connectなどの一部のプロトコルでは、アイデンティティ・プロバイダーと通信するために、リダイレクトURIまたはコールバックURLが必要です。\n"
+"エイリアスは、アイデンティティー・プロバイダの一意な識別子です。アイデンティティー・プロバイダーを内部的に参照するために使用されます。\n"
+"OpenID Connectなどの一部のプロトコルでは、アイデンティティー・プロバイダーと通信するために、リダイレクトURIまたはコールバックURLが必要です。\n"
 "この場合、エイリアスはリダイレクトURIを構築するために使用されます。\n"
-"すべての単一アイデンティティ・プロバイダーにエイリアスが必要です。 例としては、facebook、google、idp.acme.comなどです。\n"
+"すべてのアイデンティティー・プロバイダーにエイリアスが必要です。例としては、facebook、google、idp.acme.comなどです。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:54
@@ -217,9 +212,8 @@ msgid ""
 " the login page.  Clients can still request to use this provider by using "
 "the 'kc_idp_hint' parameter in the URL they use to request a login."
 msgstr ""
-"このスイッチがオンの場合、このプロバイダーはログイン・ページにログイン・オプションとして表示されません。 "
-"クライアントは、ログインを要求するために使用するURLの 'kc_idp_hint' "
-"パラメーターを使用して、このプロバイダーの使用を引き続き依頼できます。"
+"このスイッチがオンの場合、このプロバイダーはログイン・ページにログイン・オプションとして表示されません。クライアントは、ログインを要求するために使用するURLの"
+" 'kc_idp_hint' パラメーターを使用して、このプロバイダーの使用を引き続き依頼できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:59
@@ -233,8 +227,7 @@ msgid ""
 " not be shown as an option on the login page.  Existing accounts can still "
 "be linked with this provider though."
 msgstr ""
-"このスイッチをオンにすると、このプロバイダーをユーザーにログインすることができず、ログイン・ページにはオプションとして表示されません。 "
-"しかし、既存のアカウントはこのプロバイダーとリンクできます。"
+"このスイッチをオンにすると、このプロバイダーはユーザーのログインでは使用することができず、ログイン・ページにはオプションとして表示されません。しかし、既存のアカウントはこのプロバイダーとリンクできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:63
@@ -244,7 +237,7 @@ msgstr "Store Tokens"
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:64
 msgid "Whether or not to store the token received from the identity provider."
-msgstr "アイデンティティプロバイダから受け取ったトークンを保存するかどうか。"
+msgstr "アイデンティティー・プロバイダーから受け取ったトークンを保存するかどうか。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:66
@@ -258,8 +251,8 @@ msgid ""
 "Whether or not users are allowed to retrieve the stored identity provider token.  This also applies to the _broker_ client-level\n"
 " role _read token_\n"
 msgstr ""
-"ユーザーが格納されているアイデンティティ・プロバイダー・トークンを取得できるかどうか。  _broker_ クライアントレベルのロール _read "
-"token_ にも適用されます\n"
+"ユーザーは保存されたアイデンティティー・プロバイダー・トークンを取得できるかどうか。 _broker_ クライアント・レベルのロール _read "
+"token_ にも適用されます。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:70
@@ -273,8 +266,7 @@ msgid ""
 "If the identity provider supplies an email address this email address will be trusted.  If the realm required email validation,\n"
 " users that log in from this IDP will not have to go through the email verification process.\n"
 msgstr ""
-"アイデンティティ・プロバイダーが電子メール・アドレスを提供する場合、この電子メール・アドレスは信頼されます。 "
-"レルムに電子メールの検証が必要な場合、このIDPからログインしたユーザーは電子メールの確認プロセスを経る必要はありません。\n"
+"アイデンティティー・プロバイダーがメールアドレスを提供する場合、このメールアドレスは信頼されます。レルムに電子メールの検証が必要な場合、このIDPからログインしたユーザーは電子メールの検証プロセスを経る必要はありません。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:74
@@ -286,7 +278,7 @@ msgstr "GUI order"
 msgid ""
 "The order number that sorts how the available IDPs are listed on the "
 "{project_name} login page."
-msgstr "利用可能なIDPが {project_name} ログイン・ページにどのように表示されるかを並べ替えるオーダー番号。"
+msgstr "利用可能なIDPが{project_name}ログイン・ページにどのように表示されるかを並べ替えるオーダー番号。"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/configuration.adoc:77
@@ -301,7 +293,7 @@ msgstr "First Login Flow"
 msgid ""
 "This is the authentication flow that will be triggered for users that log into {project_name} through this IDP\n"
 " for the first time ever.\n"
-msgstr "このIDPを通じて、初めて {project_name} にログインするユーザーのために、トリガーされる認証フローです。\n"
+msgstr "このIDPを通じて、初めて{project_name}にログインするユーザーのためにトリガーされる認証フローです。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:81
@@ -313,4 +305,4 @@ msgstr "Post Login Flow"
 msgid ""
 "Authentication flow that is triggered after the user finishes logging in "
 "with the external identity provider."
-msgstr "ユーザーが外部IDプロバイダーへのログインを完了した後にトリガーされる認証フロー。"
+msgstr "ユーザーが外部アイデンティティー・プロバイダーへのログインを完了した後にトリガーされる認証フロー。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -2,60 +2,78 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#: source/server_admin/topics/clients/client-saml.adoc:46
+#: source/server_admin/topics/identity-broker/configuration.adoc:53
+#, no-wrap
+msgid "Enabled"
+msgstr "Enabled"
+
+#. type: Plain text
+#: source/server_admin/topics/sessions/timeouts.adoc:15
+#: source/server_admin/topics/identity-broker/configuration.adoc:45
+#: source/server_admin/topics/identity-broker/oidc.adoc:19
+#: source/server_admin/topics/identity-broker/saml.adoc:18
+msgid "Configuration|Description"
+msgstr "Configuration|Description"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/configuration.adoc:3
 #, no-wrap
 msgid "General Configuration"
-msgstr ""
+msgstr "一般的な設定"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:8
-#, no-wrap
 msgid ""
-"The identity broker configuration is all based on identity providers.\n"
-"Identity providers are created for each realm and by default they are enabled for every single application.\n"
-"That means that users from a realm can use any of the registered identity providers when signing in to an application.\n"
+"The identity broker configuration is all based on identity providers.  "
+"Identity providers are created for each realm and by default they are "
+"enabled for every single application.  That means that users from a realm "
+"can use any of the registered identity providers when signing in to an "
+"application."
 msgstr ""
+"アイデンティティ・ブローカーの設定は、すべてアイデンティティ・プロバイダーに基づいています。アイデンティティ・プロバイダーは各レルムに対して作成され、デフォルトでは単一アプリケーションごとに有効化されています。つまり、レルムのユーザーは、アプリケーションにサインインするときに、登録されているアイデンティティ・プロバイダーのいずれかを使用できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:10
-#, no-wrap
-msgid "In order to create an identity provider click the `Identity Providers` left menu item.\n"
-msgstr ""
+msgid ""
+"In order to create an identity provider click the `Identity Providers` left "
+"menu item."
+msgstr "アイデンティティ・プロバイダーを作成するには、左側の「アイデンティティ・プロバイダー」をクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:11
 #, no-wrap
 msgid "Identity Providers"
-msgstr ""
+msgstr "アイデンティティ・プロバイダー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:13
-#, fuzzy, no-wrap
-#| msgid "image:{project_images}/clients.png[]"
-msgid "image:{project_images}/identity-providers.png[]\n"
-msgstr "image:{project_images}/clients.png[]"
+msgid "image:{project_images}/identity-providers.png[]"
+msgstr "image:{project_images}/identity-providers.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:16
-#, no-wrap
 msgid ""
-"In the drop down list box, choose the identity provider you want to add.  This will bring you to the\n"
-"configuration page for that identity provider type.\n"
+"In the drop down list box, choose the identity provider you want to add.  "
+"This will bring you to the configuration page for that identity provider "
+"type."
 msgstr ""
+"ドロップ・ダウン・リスト・ボックスで、追加するアイデンティティ・プロバイダを選択します。 "
+"これにより、そのアイデンティティ・プロバイダー・タイプの設定ページが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:17
@@ -72,173 +90,227 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr ""
+msgstr "アイデンティティ・プロバイダーの追加"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:19
-#, fuzzy, no-wrap
-#| msgid "image:{project_images}/add-client.png[]"
-msgid "image:{project_images}/add-identity-provider.png[]\n"
-msgstr "image:{project_images}/add-client.png[]"
+msgid "image:{project_images}/add-identity-provider.png[]"
+msgstr "image:{project_images}/add-identity-provider.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:22
-#, no-wrap
 msgid ""
-"Above is an example of configuring a Google social login provider.  Once you configure an IDP, it will appear on the {project_name}\n"
-"login page as an option.\n"
+"Above is an example of configuring a Google social login provider.  Once you"
+" configure an IDP, it will appear on the {project_name} login page as an "
+"option."
 msgstr ""
+"上記は、Googleのソーシャル・ログイン・プロバイダーを設定する例です。 IDPを設定すると、オプションとして {project_name} "
+"のログイン・ページにそれが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:23
 #, no-wrap
 msgid "IDP login page"
-msgstr ""
+msgstr "IDPログイン・ページ"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:25
-#, fuzzy, no-wrap
-#| msgid "image:{project_images}/app-login-page.png[]"
-msgid "image:{project_images}/identity-provider-login-page.png[]\n"
-msgstr "image:{project_images}/app-login-page.png[]"
+msgid "image:{project_images}/identity-provider-login-page.png[]"
+msgstr "image:{project_images}/identity-provider-login-page.png[]"
 
 #. type: Labeled list
 #: source/server_admin/topics/identity-broker/configuration.adoc:27
 #, no-wrap
 msgid "Social"
-msgstr ""
+msgstr "ソーシャル"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:31
-#, no-wrap
 msgid ""
-"Social providers allow you to enable social authentication in your realm.\n"
-"{project_name} makes it easy to let users log in to your application using an existing account with a social network.\n"
-"Currently Facebook, Google, Twitter, GitHub, LinkedIn, Microsoft, and StackOverflow are supported with more planned for the future.\n"
+"Social providers allow you to enable social authentication in your realm.  "
+"{project_name} makes it easy to let users log in to your application using "
+"an existing account with a social network.  Currently Facebook, Google, "
+"Twitter, GitHub, LinkedIn, Microsoft, and StackOverflow are supported with "
+"more planned for the future."
 msgstr ""
+"ソーシャル・プロバイダーは、レルムでソーシャル認証を有効にすることができます。 {project_name} "
+"は、ユーザーがソーシャル・ネットワークで既存のアカウントを使用して、アプリケーションに簡単にログインできるようにします。 "
+"現在、Facebook、Google、Twitter、GitHub、LinkedIn、Microsoft、StackOverflowがサポートされており、将来的にはさらなる追加が計画されています。"
 
 #. type: Labeled list
 #: source/server_admin/topics/identity-broker/configuration.adoc:32
 #, no-wrap
 msgid "Protocol-based"
-msgstr ""
+msgstr "プロトコル・ ベース"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:37
-#, no-wrap
 msgid ""
-"Protocol-based providers are those that rely on a specific protocol in order to authenticate and authorize users.\n"
-"They allow you to connect to any identity provider compliant with a specific protocol.\n"
-"{project_name} provides support for SAML v2.0 and OpenID Connect v1.0 protocols.\n"
-"It makes it easy to configure and broker any identity provider based on these open standards.\n"
+"Protocol-based providers are those that rely on a specific protocol in order"
+" to authenticate and authorize users.  They allow you to connect to any "
+"identity provider compliant with a specific protocol.  {project_name} "
+"provides support for SAML v2.0 and OpenID Connect v1.0 protocols.  It makes "
+"it easy to configure and broker any identity provider based on these open "
+"standards."
 msgstr ""
+"プロトコル・ベースのプロバイダーは、特定のプロトコルに依存してユーザーを認証および認可するものです。 "
+"特定のプロトコルに準拠しているすべてのアイデンティティ・プロバイダーに接続できます。  {project_name} はSAML v2.0とOpenID"
+" Connect v1.0プロトコルをサポートしています。 "
+"これにより、これらのオープンスタンダードに基づいて、任意のアイデンティティ・プロバイダーを簡単に設定および仲介できるようになります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:40
-#, no-wrap
 msgid ""
-"Although each type of identity provider has its own configuration options, all of them share some very common configuration.\n"
-"Regardless the identity provider you are creating, you'll see the following configuration options available:\n"
+"Although each type of identity provider has its own configuration options, "
+"all of them share some very common configuration.  Regardless the identity "
+"provider you are creating, you'll see the following configuration options "
+"available:"
 msgstr ""
+"各タイプのアイデンティティ・プロバイダーには独自の設定オプションがありますが、すべて共通の設定を共有しています。 "
+"作成しているアイデンティティ・プロバイダに関係なく、次の設定オプションが使用できます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:41
 #, no-wrap
 msgid "Common Configuration"
-msgstr ""
+msgstr "共通の設定"
+
+#. type: Named 'cols' AttributeList argument for style 'cols'
+#: source/server_admin/topics/identity-broker/configuration.adoc:42
+#, no-wrap
+msgid "1,1"
+msgstr "1,1"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:45
-#, no-wrap
-msgid ""
-"[cols=\"1,1\", options=\"header\"]\n"
-"|===\n"
-"|Configuration|Description\n"
-msgstr ""
+#: source/server_admin/topics/identity-broker/configuration.adoc:47
+msgid "Alias"
+msgstr "Alias"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:51
 #, no-wrap
 msgid ""
-"|Alias\n"
-"|The alias is an unique identifier for an identity provider. It is used to reference an identity provider internally.\n"
+"The alias is an unique identifier for an identity provider. It is used to reference an identity provider internally.\n"
 " Some protocols such as OpenID Connect require a redirect URI or callback url in order to communicate with an identity provider.\n"
 " In this case, the alias is used to build the redirect URI.\n"
 " Every single identity provider must have an alias. Examples are facebook, google, idp.acme.com, etc.\n"
 msgstr ""
+"エイリアスは、アイデンティティ・プロバイダの一意の識別子です。 アイデンティティ・プロバイダーを内部的に参照するために使用されます。\n"
+"OpenID Connectなどの一部のプロトコルでは、アイデンティティ・プロバイダーと通信するために、リダイレクトURIまたはコールバックURLが必要です。\n"
+"この場合、エイリアスはリダイレクトURIを構築するために使用されます。\n"
+"すべての単一アイデンティティ・プロバイダーにエイリアスが必要です。 例としては、facebook、google、idp.acme.comなどです。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:54
-#, no-wrap
-msgid ""
-"|Enabled\n"
-"|Turn the provider on/off\n"
-msgstr ""
+msgid "Turn the provider on/off"
+msgstr "プロバイダーのオン/オフ"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:56
+msgid "Hide On Login Page"
+msgstr "Hide On Login Page"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:57
-#, no-wrap
 msgid ""
-"|Hide On Login Page\n"
-"|When this switch is on, this provider will not be shown as a login option on the login page.  Clients can still request to use this provider by using the 'kc_idp_hint' parameter in the URL they use to request a login.\n"
+"When this switch is on, this provider will not be shown as a login option on"
+" the login page.  Clients can still request to use this provider by using "
+"the 'kc_idp_hint' parameter in the URL they use to request a login."
 msgstr ""
+"このスイッチがオンの場合、このプロバイダーはログイン・ページにログイン・オプションとして表示されません。 "
+"クライアントは、ログインを要求するために使用するURLの 'kc_idp_hint' "
+"パラメーターを使用して、このプロバイダーの使用を引き続き依頼できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:59
+msgid "Link Only"
+msgstr "Link Only"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:60
-#, no-wrap
 msgid ""
-"|Link Only\n"
-"|When this switch is on, this provider cannot be used to login users and will not be shown as an option on the login page.  Existing accounts can still be linked with this provider though.\n"
+"When this switch is on, this provider cannot be used to login users and will"
+" not be shown as an option on the login page.  Existing accounts can still "
+"be linked with this provider though."
 msgstr ""
+"このスイッチをオンにすると、このプロバイダーをユーザーにログインすることができず、ログイン・ページにはオプションとして表示されません。 "
+"しかし、既存のアカウントはこのプロバイダーとリンクできます。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:63
+msgid "Store Tokens"
+msgstr "Store Tokens"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:64
-#, no-wrap
-msgid ""
-"|Store Tokens\n"
-"|Whether or not to store the token received from the identity provider.\n"
-msgstr ""
+msgid "Whether or not to store the token received from the identity provider."
+msgstr "アイデンティティプロバイダから受け取ったトークンを保存するかどうか。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:66
+msgid "Stored Tokens Readable"
+msgstr "Stored Tokens Readable"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:68
 #, no-wrap
 msgid ""
-"|Stored Tokens Readable\n"
-"|Whether or not users are allowed to retrieve the stored identity provider token.  This also applies to the _broker_ client-level\n"
+"Whether or not users are allowed to retrieve the stored identity provider token.  This also applies to the _broker_ client-level\n"
 " role _read token_\n"
 msgstr ""
+"ユーザーが格納されているアイデンティティ・プロバイダー・トークンを取得できるかどうか。  _broker_ クライアントレベルのロール _read "
+"token_ にも適用されます\n"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:70
+msgid "Trust email"
+msgstr "Trust email"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:72
 #, no-wrap
 msgid ""
-"|Trust email\n"
-"|If the identity provider supplies an email address this email address will be trusted.  If the realm required email validation,\n"
+"If the identity provider supplies an email address this email address will be trusted.  If the realm required email validation,\n"
 " users that log in from this IDP will not have to go through the email verification process.\n"
 msgstr ""
+"アイデンティティ・プロバイダーが電子メール・アドレスを提供する場合、この電子メール・アドレスは信頼されます。 "
+"レルムに電子メールの検証が必要な場合、このIDPからログインしたユーザーは電子メールの確認プロセスを経る必要はありません。\n"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:74
+msgid "GUI order"
+msgstr "GUI order"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:75
-#, no-wrap
 msgid ""
-"|GUI order\n"
-"|The order number that sorts how the available IDPs are listed on the {project_name} login page.\n"
-msgstr ""
+"The order number that sorts how the available IDPs are listed on the "
+"{project_name} login page."
+msgstr "利用可能なIDPが {project_name} ログイン・ページにどのように表示されるかを並べ替えるオーダー番号。"
+
+#. type: Title ===
+#: source/server_admin/topics/identity-broker/configuration.adoc:77
+#: source/server_admin/topics/identity-broker/first-login-flow.adoc:3
+#, no-wrap
+msgid "First Login Flow"
+msgstr "First Login Flow"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:79
 #, no-wrap
 msgid ""
-"|First Login Flow\n"
-"|This is the authentication flow that will be triggered for users that log into {project_name} through this IDP\n"
+"This is the authentication flow that will be triggered for users that log into {project_name} through this IDP\n"
 " for the first time ever.\n"
-msgstr ""
+msgstr "このIDPを通じて、初めて {project_name} にログインするユーザーのために、トリガーされる認証フローです。\n"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/configuration.adoc:81
+msgid "Post Login Flow"
+msgstr "Post Login Flow"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/configuration.adoc:82
-#, no-wrap
 msgid ""
-"|Post Login Flow\n"
-"|Authentication flow that is triggered after the user finishes logging in with the external identity provider.\n"
-"|===\n"
-msgstr ""
+"Authentication flow that is triggered after the user finishes logging in "
+"with the external identity provider."
+msgstr "ユーザーが外部IDプロバイダーへのログインを完了した後にトリガーされる認証フロー。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__configuration/ja_JP/index.html
