### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social-login.adoc:2
 #, no-wrap
 msgid "Social Identity Providers"
-msgstr "ソーシャル・アイデンティティ・プロバイダー"
+msgstr "ソーシャル・アイデンティティー・プロバイダー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social-login.adoc:8
@@ -32,6 +32,4 @@ msgid ""
 " support for the most common social networks out there, such as Google, "
 "Facebook, Twitter, Github, LinkedIn, Microsoft and StackOverflow."
 msgstr ""
-"インターネットに接続するアプリケーションでは、ユーザーがアクセスするためにサイトに登録する必要があります。さらに別のユーザー名とパスワードの組み合わせを覚えておく必要があります。ソーシャル・アイデンティティ・プロバイダーを使用すると、ある程度信頼性があり、評判が高いエンティティに認証を委任することができます。"
-" {project_name} "
-"は、Google、Facebook、Twitter、Github、LinkedIn、Microsoft、StackOverflowなど、最も一般的なソーシャル・ネットワークのサポートを内蔵しています。"
+"インターネット上のアプリケーションでは、ユーザーはアクセスするためにサイトに登録する必要があります。さらに別のユーザー名とパスワードの組み合わせを覚えておく必要があります。ソーシャル・アイデンティティー・プロバイダーを使用すると、ユーザーはすでにアカウントを持っている可能性のある、ある程度信頼性があり評判のよい事業者に認証を委譲することができます。{project_name}は、Google、Facebook、Twitter、Github、LinkedIn、Microsoft、StackOverflowなど、最も一般的なソーシャル・ネットワークのビルトイン・サポートを提供しています。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
@@ -2,33 +2,36 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/social-login.adoc:2
 #, no-wrap
 msgid "Social Identity Providers"
-msgstr ""
+msgstr "ソーシャル・アイデンティティ・プロバイダー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social-login.adoc:8
 msgid ""
 "For Internet facing applications, it is quite burdensome for users to have "
-"to register at your site to obtain access.  It requires them to remember yet "
-"another username and password combination.  Social identity providers allow "
-"you to delegate authentication to a semi-trusted and respected entity where "
-"the user probably already has an account.  {project_name} provides built-in "
-"support for the most common social networks out there, such as Google, "
+"to register at your site to obtain access.  It requires them to remember yet"
+" another username and password combination.  Social identity providers allow"
+" you to delegate authentication to a semi-trusted and respected entity where"
+" the user probably already has an account.  {project_name} provides built-in"
+" support for the most common social networks out there, such as Google, "
 "Facebook, Twitter, Github, LinkedIn, Microsoft and StackOverflow."
 msgstr ""
+"インターネットに接続するアプリケーションでは、ユーザーがアクセスするためにサイトに登録する必要があります。さらに別のユーザー名とパスワードの組み合わせを覚えておく必要があります。ソーシャル・アイデンティティ・プロバイダーを使用すると、ある程度信頼性があり、評判が高いエンティティに認証を委任することができます。"
+" {project_name} "
+"は、Google、Facebook、Twitter、Github、LinkedIn、Microsoft、StackOverflowなど、最も一般的なソーシャル・ネットワークのサポートを内蔵しています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social-login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__social-login/ja_JP/index.html
