### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__manage."
-"ja_JP.po\n"
 
 #. type: Block title
 #: source/getting_started/topics/first-boot/boot.adoc:11
@@ -25,7 +26,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -41,7 +42,7 @@ msgstr "Linux/Unix"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
@@ -70,17 +71,13 @@ msgstr "> ...\\bin\\jboss-cli.bat\n"
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:24
 #: source/server_installation/topics/manage.adoc:28
-#, fuzzy
 msgid "This will bring you to a prompt like this:"
-msgstr ""
-"#-#-#-#-#  manage.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"これにより、以下のようなプロンプトが表示されます。\n"
-"#-#-#-#-#  start-cli.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"これにより、以下のようなプロンプトが表示されます。"
+msgstr "これを実行すると、以下のようにプロンプトが表示されます。"
 
-#. type: Block title
+#. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:25
 #: source/server_installation/topics/manage.adoc:29
+#: source/server_admin/topics/identity-broker/oidc.adoc:50
 #, no-wrap
 msgid "Prompt"
 msgstr "プロンプト"
@@ -102,36 +99,23 @@ msgstr "接続"
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:46
 #: source/server_installation/topics/manage.adoc:49
-#, fuzzy
 msgid ""
 "You may be thinking to yourself, \"I didn't enter in any username or "
 "password!\".  If you run `jboss-cli` on the same machine as your running "
-"standalone server or domain controller and your account has appropriate file "
-"permissions, you do not have to setup or enter in a admin username and "
-"password.  See the link:{appserver_admindoc_link}[_{appserver_admindoc_name}"
-"_] for more details on how to make things more secure if you are "
-"uncomfortable with that setup."
+"standalone server or domain controller and your account has appropriate file"
+" permissions, you do not have to setup or enter in a admin username and "
+"password.  See the "
+"link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more details"
+" on how to make things more secure if you are uncomfortable with that setup."
 msgstr ""
-"#-#-#-#-#  manage.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"ユーザー名もパスワードも入力していない！と思っているかもしれませんが、 "
-"`jboss-cli` を実行中のスタンドアロン・サーバーまたはドメイン・コントローラー"
-"と同じマシンで実行し、アカウントに適切なファイルの許可がある場合は、管理者の"
-"ユーザー名とパスワードを設定または入力する必要はありません。この設定では心配"
-"でよりセキュアにしたい場合、詳しくはlink:{appserver_admindoc_link}"
-"[_{appserver_admindoc_name}_]をご覧ください。\n"
-"#-#-#-#-#  start-cli.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"ユーザー名もパスワードも入力していない！と思っているかもしれませんが、 "
-"`jboss-cli` を実行中のスタンドアロン・サーバーまたはドメイン・コントローラー"
-"と同じマシンで実行し、アカウントに適切なファイルの許可がある場合は、管理者の"
-"ユーザー名とパスワードを設定または入力する必要はありません。この設定では心配"
-"でよりセキュアにしたい場合、詳しくはlink:{appserver_admindoc_link}"
-"[_{appserver_admindoc_name}_]をご覧ください。"
+"ここでユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
+"を実行中のスタンドアロン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
 
 #. type: Title ==
 #: source/server_installation/topics/manage.adoc:3
 #, no-wrap
 msgid "Manage Configuration at Runtime"
-msgstr ""
+msgstr "実行時の構成管理"
 
 #. type: Plain text
 #: source/server_installation/topics/manage.adoc:9
@@ -140,16 +124,19 @@ msgid ""
 "application server configuration changes to your deployment.  You'll be "
 "shown how to edit the _standalone.xml_ or _domain.xml_ directly.  This must "
 "be done when the server (or servers) are offline.  Additionally, you may be "
-"shown how to apply config changes on a running server using the app server's "
-"command line interface ({appserver_name} CLI).  This chapter discusses how "
+"shown how to apply config changes on a running server using the app server's"
+" command line interface ({appserver_name} CLI).  This chapter discusses how "
 "you will do this."
 msgstr ""
+"次の章では、アプリケーション・サーバーの構成変更をデプロイに適用させるための2つのオプションが提供されます。 _standalone.xml_ または "
+"_domain.xml_ "
+"を直接編集する方法を示します。これは、サーバー（または複数のサーバー）のオフライン時に行われる必要があります。また、アプリケーション・サーバーのコマンドラインのインターフェイス（{appserver_name}CLI）を使用してサーバーを実行する際に構成を変更する方法も示します。この章では、この方法についてご説明します。"
 
 #. type: Plain text
 #: source/server_installation/topics/manage.adoc:14
 msgid ""
 "To start the {appserver_name} CLI, you need to run the `jboss-cli` script."
-msgstr ""
+msgstr "{appserver_name} CLIを開始するには、 ``jboss-cli` スクリプトを実行する必要があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/manage.adoc:38
@@ -159,6 +146,8 @@ msgid ""
 "booted up before you can execute CLI commands.  To connect to a running "
 "server simply execute the `connect` command."
 msgstr ""
+"スタンドアロン・サーバーまたはドメイン・コントローラーを起動せずに実行できるコマンドもありますが、通常はこれらのサービスを起動してからCLIコマンドを実行する必要があります。実行サーバーに接続するには"
+" `connect` を実行するだけです。"
 
 #. type: delimited block -
 #: source/server_installation/topics/manage.adoc:45
@@ -168,3 +157,6 @@ msgid ""
 "connect\n"
 "[domain@localhost:9990 /]\n"
 msgstr ""
+"[disconnected /] connect\n"
+"connect\n"
+"[domain@localhost:9990 /]\n"

--- a/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -128,9 +128,10 @@ msgid ""
 " command line interface ({appserver_name} CLI).  This chapter discusses how "
 "you will do this."
 msgstr ""
-"次の章では、アプリケーション・サーバーの構成変更をデプロイに適用させるための2つのオプションが提供されます。 _standalone.xml_ または "
-"_domain.xml_ "
-"を直接編集する方法を示します。これは、サーバー（または複数のサーバー）のオフライン時に行われる必要があります。また、アプリケーション・サーバーのコマンドラインのインターフェイス（{appserver_name}CLI）を使用してサーバーを実行する際に構成を変更する方法も示します。この章では、この方法についてご説明します。"
+"次の章では、アプリケーション・サーバーの構成変更をデプロイメントに適用させるための2つのオプションをご説明します。 _standalone.xml_ "
+"または _domain.xml_ "
+"を直接編集する方法を示します。これは、サーバー（または複数のサーバー）のオフライン時に行われる必要があります。また、アプリケーション・サーバーのコマンドラインのインターフェイス（{appserver_name}"
+" CLI）を使用して、稼働中のサーバーに対して構成変更を適用する方法も示します。この章では、この方法についてご説明します。"
 
 #. type: Plain text
 #: source/server_installation/topics/manage.adoc:14
@@ -146,7 +147,7 @@ msgid ""
 "booted up before you can execute CLI commands.  To connect to a running "
 "server simply execute the `connect` command."
 msgstr ""
-"スタンドアロン・サーバーまたはドメイン・コントローラーを起動せずに実行できるコマンドもありますが、通常はこれらのサービスを起動してからCLIコマンドを実行する必要があります。実行サーバーに接続するには"
+"スタンドアロン・サーバーまたはドメイン・コントローラーが稼働中でなくても実行できるコマンドもありますが、通常はこれらのサービスを起動してからCLIコマンドを実行する必要があります。稼働中のサーバーに接続するには"
 " `connect` を実行するだけです。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__manage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__manage/ja_JP/index.html
