### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/keycloak/upgrading.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/keycloak/upgrading.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/keycloak/upgrading.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
@@ -20,11 +20,11 @@ msgstr ""
 #: source/upgrading/topics/rhsso/upgrading.adoc:3
 #, no-wrap
 msgid "Upgrading {project_name} Server"
-msgstr ""
+msgstr "{project_name}サーバーのアップグレード"
 
 #. type: Title ==
 #: source/upgrading/topics/keycloak/upgrading.adoc:14
 #: source/upgrading/topics/rhsso/upgrading.adoc:29
 #, no-wrap
 msgid "Upgrading {project_name} Adapters"
-msgstr ""
+msgstr "{project_name}アダプターのアップグレード"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/keycloak/upgrading.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__keycloak__upgrading
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-upgrading__topics__keycloak__upgrading/ja_JP/index.html
