### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -91,7 +91,7 @@ msgid ""
 "applications `WEB-INF/keycloak.json` and add:"
 msgstr ""
 "セキュリティ・コンテキストを保存するためにCookieストアを使用するには、アプリケーションの `WEB-INF/keycloak.json` "
-"を編集して次の行を追加します:"
+"を編集して次の行を追加します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -122,10 +122,10 @@ msgid ""
 "store. Hence it's recommended to use a short value for the access token "
 "timeout (for example 1 minute)."
 msgstr ""
-"もう一つの小さな制限は、シングル・サイン・アウトのサポートが限られていることです。 アダプターが `KEYCLOAK_ADAPTER_STATE` "
-"クッキーを削除するので、アプリケーション自体からサーブレット・ログアウト( `HttpServletRequest.logout` "
-")を開始すると、問題なく動作します。 "
-"ただし、別のアプリケーションからの初期化されたバックチャネル・ログアウトは、{project_name}によってCookieストアを使用するアプリケーションに伝播されません。したがって、アクセス・トークンのタイムアウトに短い値(例えば1分)を使用することをお勧めします。"
+"もう一つの小さな制限は、シングル・サイン・アウトのサポートが限られていることです。アダプターが `KEYCLOAK_ADAPTER_STATE` "
+"クッキーを削除するので、アプリケーション自体からサーブレット・ログアウト（ `HttpServletRequest.logout` "
+"）を開始すると、問題なく動作します。 "
+"ただし、別のアプリケーションからの初期化されたバックチャネル・ログアウトは、{project_name}によってCookieストアを使用するアプリケーションに伝播されません。したがって、アクセス・トークンのタイムアウトに短い値（例えば1分）を使用することをお勧めします。"
 
 #. type: Title =====
 #, no-wrap
@@ -138,7 +138,7 @@ msgid ""
 "on the same domain (through a reverse proxy or load balancer) it can be "
 "convenient to use relative URI options in your client configuration."
 msgstr ""
-"{project_name}とアプリケーションが同じドメイン(リバース・プロキシーまたはロード・バランサーを介して)でホストされている配備のシナリオでは、クライアント設定で相対URIオプションを使用すると便利です。"
+"{project_name}とアプリケーションが同じドメイン（リバースプロキシーまたはロードバランサーを介して）でホストされているデプロイメントのシナリオでは、クライアント設定で相対URIオプションを使用すると便利です。"
 
 #. type: Plain text
 msgid ""
@@ -168,7 +168,7 @@ msgid ""
 "backend requests to the application for various tasks, like logout users or "
 "push revocation policies."
 msgstr ""
-"特定のクライアント用の管理者URLは、{project_name}管理コンソールで設定できます。これは、{project_name}サーバーによって、ログアウト・ユーザーやプッシュ取消しポリシーなどの様々なタスクのバックエンド・リクエストをアプリケーションに送信するために使用されます。"
+"特定のクライアント用の管理者URLは、{project_name}管理コンソールで設定できます。これは、{project_name}サーバーによって、ユーザーのログアウトや取消しポリシーのプッシュなどの様々なタスクのバックエンド・リクエストをアプリケーションに送信するために使用されます。"
 
 #. type: Plain text
 msgid "For example the way backchannel logout works is:"
@@ -219,7 +219,7 @@ msgid ""
 " one of them.  For example to push a new not before policy to the "
 "application or to logout all users from the application."
 msgstr ""
-"前のセクションでは、{project_name}が特定のHTTPセッションに関連付けられたノードにログアウト・リクエストを送信する方法について説明しました。しかし、管理者のタスクを、登録されている全てのクラスター・ノードに伝播させたい場合があります。例えば、新しいnot"
+"前のセクションでは、{project_name}が特定のHTTPセッションに関連付けられたノードにログアウト・リクエストを送信する方法について説明しました。しかし、管理者が管理タスクを登録されている全てのクラスター・ノードに伝播させたい場合があります。例えば、新しいnot"
 " beforeポリシーをアプリケーションにプッシュする、またはアプリケーションからすべてのユーザーをログアウトするなどです。"
 
 #. type: Plain text
@@ -228,7 +228,7 @@ msgid ""
 "nodes, so it can send the event to all of them.  To achieve this, we support"
 " auto-discovery mechanism:"
 msgstr ""
-"この場合、{project_name}はすべてのアプリケーション・クラスター・ノードを認識する必要があるため、全てのノードにイベントを送信できます。これを達成するために、私たちはオート・ディスカバリーのメカニズムをサポートしています。"
+"この場合、{project_name}はすべてのアプリケーション・クラスター・ノードを認識する必要があります。これにより、全てのノードにイベントを送信できます。これを達成するために、私たちはオート・ディスカバリーのメカニズムをサポートしています。"
 
 #. type: Plain text
 msgid ""
@@ -297,8 +297,9 @@ msgid ""
 "remove stale application nodes in the event your not using the automatic "
 "unregistration feature."
 msgstr ""
-"{project_name}管理コンソールでは、最大ノード再登録タイムアウトを指定できます(アダプター設定から_register-node-"
-"period_より大きい値にする必要があります)。管理コンソールから、クラスター・ノードを手動で追加したり、削除することもできます。自動登録機能を使用したくない場合や、自動登録解除機能を使用しない場合、失効したアプリケーション・ノードを削除する場合に便利です"
+"{project_name}管理コンソールでは、最大ノード再登録タイムアウトを指定できます（アダプター設定から _register-node-"
+"period_ "
+"より大きい値にする必要があります）。管理コンソールから、クラスター・ノードを手動で追加したり、削除することもできます。自動登録機能を使用したくない場合や、自動登録解除機能を使用しない場合、失効したアプリケーション・ノードを削除する場合に便利です"
 " 。"
 
 #. type: Title =====
@@ -313,9 +314,7 @@ msgid ""
 "token on every request. This may have a performance impact as your "
 "application will send more requests to the {project_name} server."
 msgstr ""
-"デフォルトでは、アプリケーション・アダプターは期限切れになったときにのみ、アクセス・トークンを更新します。 "
-"ただし、リクエストごとにトークンをリフレッシュするようにアダプターを設定することもできます。 "
-"これは、アプリケーションが{project_name}サーバーにさらに多くのリクエストを送信するため、パフォーマンスに影響を与える可能性があります。"
+"デフォルトでは、アプリケーション・アダプターは期限切れになったときにのみ、アクセス・トークンを更新します。ただし、リクエストごとにトークンをリフレッシュするようにアダプターを設定することもできます。これは、アプリケーションが{project_name}サーバーにさらに多くのリクエストを送信するため、パフォーマンスに影響を与える可能性があります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -330,4 +329,4 @@ msgid ""
 "    minutes of the logout.\n"
 msgstr ""
 "これはパフォーマンスに重大な影響を与える可能性があります。ログアウトとnot "
-"beforeポリシーを伝播するために、バックチャネル・メッセージに頼ることができない場合にのみ、この機能を有効にしてください。考慮すべきもう一つは、デフォルトではアクセス・トークンの有効期限が短く、ログアウトが伝播されなくてもログアウトから数分以内にトークンが期限切れになることです。\n"
+"beforeポリシーを伝播するために、バックチャネル・メッセージに頼ることができない場合にのみ、この機能を有効にしてください。考慮すべきこととして、デフォルトではアクセス・トークンの有効期限が短く、ログアウトが伝播されなくてもログアウトから数分以内にトークンが期限切れになります。\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -2,33 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:99
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:109
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:39
-#: source/server_development/topics/providers.adoc:202
-msgid "[source]"
-msgstr "[source]"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:2
 #, no-wrap
 msgid "Application Clustering"
-msgstr ""
+msgstr "アプリケーション・クラスタ リング"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:6
@@ -36,71 +27,75 @@ msgid ""
 "This chapter is related to supporting clustered applications deployed to "
 "JBoss EAP, WildFly and JBoss AS."
 msgstr ""
+"この章では、JBoss EAP、WildFly、JBoss ASにデプロイされたクラスター化されたアプリケーションのサポートについて解説します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:9
 msgid ""
 "This chapter is related to supporting clustered applications deployed to "
 "JBoss EAP."
-msgstr ""
+msgstr "この章では、JBoss EAPにデプロイされたクラスタ化されたアプリケーションのサポートについて解説します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:12
 msgid ""
 "There are a few options available depending on whether your application is:"
-msgstr ""
+msgstr "アプリケーションが次のような場合には、いくつかのオプションがあります:"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:14
 msgid "Stateless or stateful"
-msgstr ""
+msgstr "ステートレスまたはステートフル"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:15
 msgid "Distributable (replicated http session) or non-distributable"
-msgstr ""
+msgstr "配信可能(レプリケーションされたHTTPセッション)または配信不可能"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:16
 msgid "Relying on sticky sessions provided by load balancer"
-msgstr ""
+msgstr "ロード・バランサーによって提供されるスティッキー・セッションに依存する"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:17
 msgid "Hosted on same domain as {project_name}"
-msgstr ""
+msgstr "{project_name}と同じドメインでホストされている"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:20
 msgid ""
-"Dealing with clustering is not quite as simple as for a regular application. "
-"Mainly due to the fact that both the browser and the server-side application "
-"sends requests to {project_name}, so it's not as simple as enabling sticky "
-"sessions on your load balancer."
+"Dealing with clustering is not quite as simple as for a regular application."
+" Mainly due to the fact that both the browser and the server-side "
+"application sends requests to {project_name}, so it's not as simple as "
+"enabling sticky sessions on your load balancer."
 msgstr ""
+"クラスタリングを扱うことは、通常のアプリケーションの場合ほど簡単ではありません。ブラウザーとサーバー・サイド・アプリケーションの両方が{project_name}にリクエストを送信することになるため、ロードバランサーでスティッキー・セッションを有効にするほど簡単ではありません。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:21
 #, no-wrap
 msgid "Stateless token store"
-msgstr ""
+msgstr "ステートレス・トークン・ストア"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:25
 msgid ""
 "By default, the web application secured by {project_name} uses the HTTP "
-"session to store security context. This means that you either have to enable "
-"sticky sessions or replicate the HTTP session."
+"session to store security context. This means that you either have to enable"
+" sticky sessions or replicate the HTTP session."
 msgstr ""
+"デフォルトでは、{project_name}によって保護されたWebアプリケーションは、HTTPセッションを使用してセキュリティ・コンテキストを格納します。つまり、スティッキー・セッションを有効にするか、HTTPセッションをレプリケーションする必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:28
 msgid ""
 "As an alternative to storing the security context in the HTTP session the "
 "adapter can be configured to store this in a cookie instead. This is useful "
-"if you want to make your application stateless or if you don't want to store "
-"the security context in the HTTP session."
+"if you want to make your application stateless or if you don't want to store"
+" the security context in the HTTP session."
 msgstr ""
+"HTTPセッションにセキュリティ・コンテキストを保存する代わりに、これをCookieに保存するようにアダプターを設定することもできます。これは、アプリケーションをステートレスにする場合や、セキュリティ・コンテキストをHTTPセッションに保存したくない場合に便利です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:30
@@ -108,72 +103,85 @@ msgid ""
 "To use the cookie store for saving the security context, edit your "
 "applications `WEB-INF/keycloak.json` and add:"
 msgstr ""
+"セキュリティ・コンテキストを保存するためにCookieストアを使用するには、アプリケーションの`WEB-"
+"INF/keycloak.json`を編集して次の行を追加します:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:34
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:33
 #, no-wrap
-msgid ""
-"\"token-store\": \"cookie\"\n"
-"----        \n"
-msgstr ""
+msgid "\"token-store\": \"cookie\"\n"
+msgstr "\"token-store\": \"cookie\"\n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:36
-#, no-wrap
-msgid "NOTE: The default value for `token-store` is `session`, which stores the security context in the HTTP session.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:38
-#, no-wrap
-msgid "One limitation of using the cookie store is that the whole security context is passed in the cookie for every HTTP request. This may impact performance.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:42
-#, no-wrap
 msgid ""
-"Another small limitation is limited support for Single-Sign Out. It works without issues if you init servlet logout (HttpServletRequest.logout) from the\n"
-"application itself as the adapter will delete the KEYCLOAK_ADAPTER_STATE cookie. However, back-channel logout initialized from a different application isn't\n"
-"propagated by {project_name} to applications using cookie store. Hence it's recommended to use a short value for the access token timeout (for example 1 minute).\n"
+"The default value for `token-store` is `session`, which stores the security "
+"context in the HTTP session."
 msgstr ""
+"`token-store`のデフォルト値は`session`です。これにより、セキュリティ・コンテキストがHTTPセッションに保存されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:38
+msgid ""
+"One limitation of using the cookie store is that the whole security context "
+"is passed in the cookie for every HTTP request. This may impact performance."
+msgstr ""
+"Cookieストアを使用する際の制限の1つは、すべてのHTTPリクエストに対して、セキュリティ・コンテキスト全体がCookieに渡されることです。これはパフォーマンスに影響する可能性があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:42
+msgid ""
+"Another small limitation is limited support for Single-Sign Out. It works "
+"without issues if you init servlet logout (HttpServletRequest.logout) from "
+"the application itself as the adapter will delete the KEYCLOAK_ADAPTER_STATE"
+" cookie. However, back-channel logout initialized from a different "
+"application isn't propagated by {project_name} to applications using cookie "
+"store. Hence it's recommended to use a short value for the access token "
+"timeout (for example 1 minute)."
+msgstr ""
+"もう一つの小さな制限は、シングル・サイン・アウトのサポートが限られていることです。 "
+"アダプターが`KEYCLOAK_ADAPTER_STATE`クッキーを削除するので、アプリケーション自体からサーブレット・ログアウト(`HttpServletRequest.logout`)を開始すると、問題なく動作します。"
+" "
+"ただし、別のアプリケーションからの初期化されたバックチャネル・ログアウトは、{project_name}によってCookieストアを使用するアプリケーションに伝播されません。したがって、アクセス・トークンのタイムアウトに短い値(例えば1分)を使用することをお勧めします。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:43
 #, no-wrap
 msgid "Relative URI optimization"
-msgstr ""
+msgstr "相対URIの最適化"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:47
 msgid ""
 "In deployment scenarios where {project_name} and the application is hosted "
 "on the same domain (through a reverse proxy or load balancer) it can be "
 "convenient to use relative URI options in your client configuration."
 msgstr ""
+"{project_name}とアプリケーションが同じドメイン(リバース・プロキシーまたはロード・バランサーを介して)でホストされている配備のシナリオでは、クライアント設定で相対URIオプションを使用すると便利です。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:49
 msgid ""
 "With relative URIs the URI is resolved as relative to the URL of the URL "
 "used to access {project_name}."
-msgstr ""
+msgstr "相対URIの場合、URIは{project_name}にアクセスするために使用されるURLに関連して解決されます。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:52
 msgid ""
 "For example if the URL to your application is `$$https://acme.org/myapp$$` "
 "and the URL to {project_name} is `$$https://acme.org/auth$$`, then you can "
 "use the redirect-uri `/myapp` instead of `$$https://acme.org/myapp$$`."
 msgstr ""
+"例えば、アプリケーションへのURLが`$$https://acme.org/myapp$$`で、{project_name}へのURLが`$$https://acme.org/auth$$`である場合、`$$https://acme.org/myapp$$`の代わりにリダイレクトURIの`/myapp`を使うことができます。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:53
 #, no-wrap
 msgid "Admin URL configuration"
-msgstr ""
+msgstr "管理者URLの設定"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:57
 msgid ""
 "Admin URL for a particular client can be configured in the {project_name} "
@@ -181,128 +189,166 @@ msgid ""
 "backend requests to the application for various tasks, like logout users or "
 "push revocation policies."
 msgstr ""
+"特定のクライアント用の管理者URLは、{project_name}管理コンソールで設定できます。これは、{project_name}サーバーによって、ログアウト・ユーザーやプッシュ取消しポリシーなどの様々なタスクのバックエンド・リクエストをアプリケーションに送信するために使用されます。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:59
 msgid "For example the way backchannel logout works is:"
-msgstr ""
+msgstr "例えば、バックチャネル・ログアウトの仕組みは次の通りです。"
 
-#. type: delimited block -
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:61
+msgid "User sends logout request from one application"
+msgstr "ユーザーが1つのアプリケーションからログアウト・リクエストを送信します"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:62
+msgid "The application sends logout request to {project_name}"
+msgstr "アプリケーションは{project_name}にログアウト・リクエストを送信します"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:63
+msgid "The {project_name} server invalidates the user session"
+msgstr "{project_name}サーバーはユーザー・セッションを無効にします"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:64
+msgid ""
+"The {project_name} server then sends a backchannel request to application "
+"with an admin url that are associated with the session"
+msgstr "{project_name}サーバーは、セッションに関連付けられた管理者URLでバックチャネル・リクエストをアプリケーションに送信します"
+
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:65
 msgid ""
-". User sends logout request from one application . The application sends "
-"logout request to {project_name} . The {project_name} server invalidates the "
-"user session . The {project_name} server then sends a backchannel request to "
-"application with an admin url that are associated with the session . When an "
-"application receives the logout request it invalidates the corresponding "
-"HTTP session"
-msgstr ""
+"When an application receives the logout request it invalidates the "
+"corresponding HTTP session"
+msgstr "アプリケーションがログアウト・リクエストを受信すると、対応するHTTPセッションが無効になります"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:67
 msgid ""
-"If admin URL contains `${application.session.host}` it will be replaced with "
-"the URL to the node associated with the HTTP session."
+"If admin URL contains `${application.session.host}` it will be replaced with"
+" the URL to the node associated with the HTTP session."
 msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:69
-msgid "[[_registration_app_nodes]]"
-msgstr ""
+"管理者URLに`$ "
+"{application.session.host}`が含まれていると、HTTPセッションに関連付けられたノードのURLに置き換えられます。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:69
 #, no-wrap
 msgid "Registration of application nodes"
-msgstr ""
+msgstr "アプリケーション・ノードの登録"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:74
 msgid ""
-"The previous section describes how {project_name} can send logout request to "
-"node associated with a specific HTTP session.  However, in some cases admin "
-"may want to propagate admin tasks to all registered cluster nodes, not just "
-"one of them.  For example to push a new not before policy to the application "
-"or to logout all users from the application."
+"The previous section describes how {project_name} can send logout request to"
+" node associated with a specific HTTP session.  However, in some cases admin"
+" may want to propagate admin tasks to all registered cluster nodes, not just"
+" one of them.  For example to push a new not before policy to the "
+"application or to logout all users from the application."
 msgstr ""
+"前のセクションでは、{project_name}が特定のHTTPセッションに関連付けられたノードにログアウト・リクエストを送信する方法について説明しました。しかし、管理者のタスクを、登録されている全てのクラスター・ノードに伝播させたい場合があります。例えば、新しいnot"
+" beforeポリシーをアプリケーションにプッシュする、またはアプリケーションからすべてのユーザーをログアウトするなどです。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:77
 msgid ""
 "In this case {project_name} needs to be aware of all application cluster "
-"nodes, so it can send the event to all of them.  To achieve this, we support "
-"auto-discovery mechanism:"
+"nodes, so it can send the event to all of them.  To achieve this, we support"
+" auto-discovery mechanism:"
 msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:83
-#, no-wrap
-msgid ""
-". When a new application node joins the cluster, it sends a registration request to the {project_name} server\n"
-". The request may be re-sent to {project_name} in configured periodic intervals\n"
-". If the {project_name} server doesn't receive a re-registration request within a specified timeout then it automatically unregisters the specific node\n"
-". The node is also unregistered in {project_name} when it sends an unregistration request, which is usually during node shutdown or application undeployment.\n"
-"  This may not work properly for forced shutdown when undeployment listeners are not invoked, which results in the need for automatic unregistration\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:85
-#, no-wrap
-msgid "Sending startup registrations and periodic re-registration is disabled by default as it's only required for some clustered applications.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:87
-#, no-wrap
-msgid "To enable the feature edit the `WEB-INF/keycloak.json` file for your application and add:\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:89
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:31
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:56
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:66
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:23
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:23
-#: source/server_development/topics/auth-spi.adoc:148
-#: source/server_development/topics/preface.adoc:16
-#, no-wrap
-msgid "[source]\n"
-msgstr ""
+"この場合、{project_name}はすべてのアプリケーション・クラスター・ノードを認識する必要があるため、全てのノードにイベントを送信できます。これを達成するために、私たちはオート・ディスカバリーのメカニズムをサポートしています。"
 
 #. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:79
+msgid ""
+"When a new application node joins the cluster, it sends a registration "
+"request to the {project_name} server"
+msgstr "新しいアプリケーション・ノードがクラスタに参加すると、{project_name}サーバーに登録リクエストを送信します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:80
+msgid ""
+"The request may be re-sent to {project_name} in configured periodic "
+"intervals"
+msgstr "定期的に設定された間隔で、設定が{project_name}に送信されます"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:81
+msgid ""
+"If the {project_name} server doesn't receive a re-registration request "
+"within a specified timeout then it automatically unregisters the specific "
+"node"
+msgstr ""
+"{project_name}サーバーが指定されたタイムアウト時間内に再登録リクエストを受信しなかった場合、{project_name}サーバーは自動的に特定のノードの登録を解除します"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:83
+msgid ""
+"The node is also unregistered in {project_name} when it sends an "
+"unregistration request, which is usually during node shutdown or application"
+" undeployment.  This may not work properly for forced shutdown when "
+"undeployment listeners are not invoked, which results in the need for "
+"automatic unregistration"
+msgstr ""
+"また、登録解除リクエストを送信するときに、ノードは{project_name}で登録抹消されます。これは、通常、ノードのシャットダウンまたはアプリケーションのアンデプロイメント中です。アンデプロイメント・リスナーが呼び出されない場合、強制シャットダウンで正しく動作しないことがあります。その結果、自動登録解除が必要になります"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:85
+msgid ""
+"Sending startup registrations and periodic re-registration is disabled by "
+"default as it's only required for some clustered applications."
+msgstr "スタートアップ登録の送信と定期的な再登録は、クラスター化された一部のアプリケーションでのみ必要なので、デフォルトでは無効になっています。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:87
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:107
+msgid ""
+"To enable the feature edit the `WEB-INF/keycloak.json` file for your "
+"application and add:"
+msgstr "この機能を有効にするには、アプリケーションの`WEB-INF/keycloak.json`ファイルを編集し、次の行を追加します。"
+
+#. type: delimited block -
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:92
-msgid "\"register-node-at-startup\": true, \"register-node-period\": 600,"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:95
-#, no-wrap
-msgid "This means the adapter will send the registration request on startup and re-register every 10 minutes.\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:99
 #, no-wrap
 msgid ""
-"In the {project_name} Administration Console you can specify the maximum node re-registration timeout (should be larger than _register-node-period_ from\n"
-"the adapter configuration). You can also manually add and remove cluster nodes in through the Adminstration Console, which is useful if you don't want to rely\n"
-"on the automatic registration feature or if you want to remove stale application nodes in the event your not using the automatic unregistration feature.\n"
+"\"register-node-at-startup\": true,\n"
+"\"register-node-period\": 600,\n"
 msgstr ""
+"\"register-node-at-startup\": true,\n"
+"\"register-node-period\": 600,\n"
 
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:101
-#, no-wrap
-msgid "[[_refresh_token_each_req]]\n"
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:95
+msgid ""
+"This means the adapter will send the registration request on startup and re-"
+"register every 10 minutes."
+msgstr "これは、アダプターが起動時に登録リクエストを送信し、10分ごとに再登録することを意味します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:99
+msgid ""
+"In the {project_name} Administration Console you can specify the maximum "
+"node re-registration timeout (should be larger than _register-node-period_ "
+"from the adapter configuration). You can also manually add and remove "
+"cluster nodes in through the Adminstration Console, which is useful if you "
+"don't want to rely on the automatic registration feature or if you want to "
+"remove stale application nodes in the event your not using the automatic "
+"unregistration feature."
 msgstr ""
+"{project_name}管理コンソールでは、最大ノード再登録タイムアウトを指定できます(アダプター設定から_register-node-"
+"period_より大きい値にする必要があります)。管理コンソールから、クラスター・ノードを手動で追加したり、削除することもできます。自動登録機能を使用したくない場合や、自動登録解除機能を使用しない場合、失効したアプリケーション・ノードを削除する場合に便利です"
+" 。"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:101
 #, no-wrap
 msgid "Refresh token in each request"
-msgstr ""
+msgstr "各リクエストのトークンをリフレッシュします"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:105
 msgid ""
 "By default the application adapter will only refresh the access token when "
@@ -310,21 +356,15 @@ msgid ""
 "token on every request. This may have a performance impact as your "
 "application will send more requests to the {project_name} server."
 msgstr ""
+"デフォルトでは、アプリケーション・アダプターは期限切れになったときにのみ、アクセス・トークンを更新します。 "
+"ただし、リクエストごとにトークンをリフレッシュするようにアダプターを設定することもできます。 "
+"これは、アプリケーションが{project_name}サーバーにさらに多くのリクエストを送信するため、パフォーマンスに影響を与える可能性があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:107
-msgid ""
-"To enable the feature edit the `WEB-INF/keycloak.json` file for your "
-"application and add:"
-msgstr ""
-
-#. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:112
+#: source/securing_apps/topics/oidc/java/application-clustering.adoc:111
 #, no-wrap
-msgid ""
-"\"always-refresh-token\": true\n"
-"----        \n"
-msgstr ""
+msgid "\"always-refresh-token\": true\n"
+msgstr "\"always-refresh-token\": true\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/application-clustering.adoc:115
@@ -334,3 +374,5 @@ msgid ""
 "    policies. Another thing to consider is that by default access tokens has a short expiration so even if logout is not propagated the token will expire within\n"
 "    minutes of the logout.\n"
 msgstr ""
+"これはパフォーマンスに重大な影響を与える可能性があります。ログアウトとnot "
+"beforeポリシーを伝播するために、バックチャネル・メッセージに頼ることができない場合にのみ、この機能を有効にしてください。考慮すべきもう一つは、デフォルトではアクセス・トークンの有効期限が短く、ログアウトが伝播されなくてもログアウトから数分以内にトークンが期限切れになることです。\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:2
 #, no-wrap
 msgid "Application Clustering"
-msgstr "アプリケーション・クラスタ リング"
+msgstr "アプリケーション・クラスタリング"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:6
 msgid ""
 "This chapter is related to supporting clustered applications deployed to "
 "JBoss EAP, WildFly and JBoss AS."
@@ -30,65 +28,55 @@ msgstr ""
 "この章では、JBoss EAP、WildFly、JBoss ASにデプロイされたクラスター化されたアプリケーションのサポートについて解説します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:9
 msgid ""
 "This chapter is related to supporting clustered applications deployed to "
 "JBoss EAP."
-msgstr "この章では、JBoss EAPにデプロイされたクラスタ化されたアプリケーションのサポートについて解説します。"
+msgstr "この章では、JBoss EAPにデプロイされたクラスター化されたアプリケーションのサポートについて解説します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:12
 msgid ""
 "There are a few options available depending on whether your application is:"
-msgstr "アプリケーションが次のような場合には、いくつかのオプションがあります:"
+msgstr "アプリケーションが次のような場合には、いくつかのオプションがあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:14
 msgid "Stateless or stateful"
 msgstr "ステートレスまたはステートフル"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:15
 msgid "Distributable (replicated http session) or non-distributable"
-msgstr "配信可能(レプリケーションされたHTTPセッション)または配信不可能"
+msgstr "分散可能（HTTPセッション・レプリケーション）または分散不可能"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:16
 msgid "Relying on sticky sessions provided by load balancer"
-msgstr "ロード・バランサーによって提供されるスティッキー・セッションに依存する"
+msgstr "ロードバランサーによって提供されるスティッキー・セッションに依存"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:17
 msgid "Hosted on same domain as {project_name}"
 msgstr "{project_name}と同じドメインでホストされている"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:20
 msgid ""
 "Dealing with clustering is not quite as simple as for a regular application."
 " Mainly due to the fact that both the browser and the server-side "
 "application sends requests to {project_name}, so it's not as simple as "
 "enabling sticky sessions on your load balancer."
 msgstr ""
-"クラスタリングを扱うことは、通常のアプリケーションの場合ほど簡単ではありません。ブラウザーとサーバー・サイド・アプリケーションの両方が{project_name}にリクエストを送信することになるため、ロードバランサーでスティッキー・セッションを有効にするほど簡単ではありません。"
+"クラスタリングを扱うことは、通常のアプリケーションほど簡単ではありません。ブラウザーとサーバー・サイド・アプリケーションの両方が{project_name}にリクエストを送信することになるため、ロードバランサーでスティッキー・セッションを有効にするほど簡単ではありません。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:21
 #, no-wrap
 msgid "Stateless token store"
 msgstr "ステートレス・トークン・ストア"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:25
 msgid ""
 "By default, the web application secured by {project_name} uses the HTTP "
 "session to store security context. This means that you either have to enable"
 " sticky sessions or replicate the HTTP session."
 msgstr ""
-"デフォルトでは、{project_name}によって保護されたWebアプリケーションは、HTTPセッションを使用してセキュリティ・コンテキストを格納します。つまり、スティッキー・セッションを有効にするか、HTTPセッションをレプリケーションする必要があります。"
+"デフォルトでは、{project_name}によって保護されたWebアプリケーションは、HTTPセッションを使用してセキュリティ・コンテキストを保存します。つまり、スティッキー・セッションを有効にするか、HTTPセッションをレプリケーションする必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:28
 msgid ""
 "As an alternative to storing the security context in the HTTP session the "
 "adapter can be configured to store this in a cookie instead. This is useful "
@@ -98,30 +86,26 @@ msgstr ""
 "HTTPセッションにセキュリティ・コンテキストを保存する代わりに、これをCookieに保存するようにアダプターを設定することもできます。これは、アプリケーションをステートレスにする場合や、セキュリティ・コンテキストをHTTPセッションに保存したくない場合に便利です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:30
 msgid ""
 "To use the cookie store for saving the security context, edit your "
 "applications `WEB-INF/keycloak.json` and add:"
 msgstr ""
-"セキュリティ・コンテキストを保存するためにCookieストアを使用するには、アプリケーションの`WEB-"
-"INF/keycloak.json`を編集して次の行を追加します:"
+"セキュリティ・コンテキストを保存するためにCookieストアを使用するには、アプリケーションの `WEB-INF/keycloak.json` "
+"を編集して次の行を追加します:"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:33
 #, no-wrap
 msgid "\"token-store\": \"cookie\"\n"
 msgstr "\"token-store\": \"cookie\"\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:36
 msgid ""
 "The default value for `token-store` is `session`, which stores the security "
 "context in the HTTP session."
 msgstr ""
-"`token-store`のデフォルト値は`session`です。これにより、セキュリティ・コンテキストがHTTPセッションに保存されます。"
+"`token-store` のデフォルト値は `session` です。これにより、セキュリティ・コンテキストがHTTPセッションに保存されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:38
 msgid ""
 "One limitation of using the cookie store is that the whole security context "
 "is passed in the cookie for every HTTP request. This may impact performance."
@@ -129,7 +113,6 @@ msgstr ""
 "Cookieストアを使用する際の制限の1つは、すべてのHTTPリクエストに対して、セキュリティ・コンテキスト全体がCookieに渡されることです。これはパフォーマンスに影響する可能性があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:42
 msgid ""
 "Another small limitation is limited support for Single-Sign Out. It works "
 "without issues if you init servlet logout (HttpServletRequest.logout) from "
@@ -139,19 +122,17 @@ msgid ""
 "store. Hence it's recommended to use a short value for the access token "
 "timeout (for example 1 minute)."
 msgstr ""
-"もう一つの小さな制限は、シングル・サイン・アウトのサポートが限られていることです。 "
-"アダプターが`KEYCLOAK_ADAPTER_STATE`クッキーを削除するので、アプリケーション自体からサーブレット・ログアウト(`HttpServletRequest.logout`)を開始すると、問題なく動作します。"
-" "
+"もう一つの小さな制限は、シングル・サイン・アウトのサポートが限られていることです。 アダプターが `KEYCLOAK_ADAPTER_STATE` "
+"クッキーを削除するので、アプリケーション自体からサーブレット・ログアウト( `HttpServletRequest.logout` "
+")を開始すると、問題なく動作します。 "
 "ただし、別のアプリケーションからの初期化されたバックチャネル・ログアウトは、{project_name}によってCookieストアを使用するアプリケーションに伝播されません。したがって、アクセス・トークンのタイムアウトに短い値(例えば1分)を使用することをお勧めします。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:43
 #, no-wrap
 msgid "Relative URI optimization"
 msgstr "相対URIの最適化"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:47
 msgid ""
 "In deployment scenarios where {project_name} and the application is hosted "
 "on the same domain (through a reverse proxy or load balancer) it can be "
@@ -160,29 +141,27 @@ msgstr ""
 "{project_name}とアプリケーションが同じドメイン(リバース・プロキシーまたはロード・バランサーを介して)でホストされている配備のシナリオでは、クライアント設定で相対URIオプションを使用すると便利です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:49
 msgid ""
-"With relative URIs the URI is resolved as relative to the URL of the URL "
-"used to access {project_name}."
+"With relative URIs the URI is resolved as relative to the URL used to access"
+" {project_name}."
 msgstr "相対URIの場合、URIは{project_name}にアクセスするために使用されるURLに関連して解決されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:52
 msgid ""
 "For example if the URL to your application is `$$https://acme.org/myapp$$` "
 "and the URL to {project_name} is `$$https://acme.org/auth$$`, then you can "
 "use the redirect-uri `/myapp` instead of `$$https://acme.org/myapp$$`."
 msgstr ""
-"例えば、アプリケーションへのURLが`$$https://acme.org/myapp$$`で、{project_name}へのURLが`$$https://acme.org/auth$$`である場合、`$$https://acme.org/myapp$$`の代わりにリダイレクトURIの`/myapp`を使うことができます。"
+"例えば、アプリケーションへのURLが `$$https://acme.org/myapp$$` で、{project_name}へのURLが "
+"`$$https://acme.org/auth$$` である場合、 `$$https://acme.org/myapp$$` "
+"の代わりにリダイレクトURIの `/myapp` を使うことができます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:53
 #, no-wrap
 msgid "Admin URL configuration"
 msgstr "管理者URLの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:57
 msgid ""
 "Admin URL for a particular client can be configured in the {project_name} "
 "Administration Console.  It's used by the {project_name} server to send "
@@ -192,56 +171,47 @@ msgstr ""
 "特定のクライアント用の管理者URLは、{project_name}管理コンソールで設定できます。これは、{project_name}サーバーによって、ログアウト・ユーザーやプッシュ取消しポリシーなどの様々なタスクのバックエンド・リクエストをアプリケーションに送信するために使用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:59
 msgid "For example the way backchannel logout works is:"
 msgstr "例えば、バックチャネル・ログアウトの仕組みは次の通りです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:61
 msgid "User sends logout request from one application"
 msgstr "ユーザーが1つのアプリケーションからログアウト・リクエストを送信します"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:62
 msgid "The application sends logout request to {project_name}"
 msgstr "アプリケーションは{project_name}にログアウト・リクエストを送信します"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:63
 msgid "The {project_name} server invalidates the user session"
 msgstr "{project_name}サーバーはユーザー・セッションを無効にします"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:64
 msgid ""
 "The {project_name} server then sends a backchannel request to application "
 "with an admin url that are associated with the session"
 msgstr "{project_name}サーバーは、セッションに関連付けられた管理者URLでバックチャネル・リクエストをアプリケーションに送信します"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:65
 msgid ""
 "When an application receives the logout request it invalidates the "
 "corresponding HTTP session"
 msgstr "アプリケーションがログアウト・リクエストを受信すると、対応するHTTPセッションが無効になります"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:67
 msgid ""
 "If admin URL contains `${application.session.host}` it will be replaced with"
 " the URL to the node associated with the HTTP session."
 msgstr ""
-"管理者URLに`$ "
-"{application.session.host}`が含まれていると、HTTPセッションに関連付けられたノードのURLに置き換えられます。"
+"管理者URLに `${application.session.host}` "
+"が含まれていると、HTTPセッションに関連付けられたノードのURLに置き換えられます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:69
 #, no-wrap
 msgid "Registration of application nodes"
 msgstr "アプリケーション・ノードの登録"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:74
 msgid ""
 "The previous section describes how {project_name} can send logout request to"
 " node associated with a specific HTTP session.  However, in some cases admin"
@@ -253,7 +223,6 @@ msgstr ""
 " beforeポリシーをアプリケーションにプッシュする、またはアプリケーションからすべてのユーザーをログアウトするなどです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:77
 msgid ""
 "In this case {project_name} needs to be aware of all application cluster "
 "nodes, so it can send the event to all of them.  To achieve this, we support"
@@ -262,21 +231,18 @@ msgstr ""
 "この場合、{project_name}はすべてのアプリケーション・クラスター・ノードを認識する必要があるため、全てのノードにイベントを送信できます。これを達成するために、私たちはオート・ディスカバリーのメカニズムをサポートしています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:79
 msgid ""
 "When a new application node joins the cluster, it sends a registration "
 "request to the {project_name} server"
-msgstr "新しいアプリケーション・ノードがクラスタに参加すると、{project_name}サーバーに登録リクエストを送信します。"
+msgstr "新しいアプリケーション・ノードがクラスターに参加すると、{project_name}サーバーに登録リクエストを送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:80
 msgid ""
 "The request may be re-sent to {project_name} in configured periodic "
 "intervals"
 msgstr "定期的に設定された間隔で、設定が{project_name}に送信されます"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:81
 msgid ""
 "If the {project_name} server doesn't receive a re-registration request "
 "within a specified timeout then it automatically unregisters the specific "
@@ -285,7 +251,6 @@ msgstr ""
 "{project_name}サーバーが指定されたタイムアウト時間内に再登録リクエストを受信しなかった場合、{project_name}サーバーは自動的に特定のノードの登録を解除します"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:83
 msgid ""
 "The node is also unregistered in {project_name} when it sends an "
 "unregistration request, which is usually during node shutdown or application"
@@ -296,22 +261,18 @@ msgstr ""
 "また、登録解除リクエストを送信するときに、ノードは{project_name}で登録抹消されます。これは、通常、ノードのシャットダウンまたはアプリケーションのアンデプロイメント中です。アンデプロイメント・リスナーが呼び出されない場合、強制シャットダウンで正しく動作しないことがあります。その結果、自動登録解除が必要になります"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:85
 msgid ""
 "Sending startup registrations and periodic re-registration is disabled by "
 "default as it's only required for some clustered applications."
 msgstr "スタートアップ登録の送信と定期的な再登録は、クラスター化された一部のアプリケーションでのみ必要なので、デフォルトでは無効になっています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:87
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:107
 msgid ""
 "To enable the feature edit the `WEB-INF/keycloak.json` file for your "
 "application and add:"
-msgstr "この機能を有効にするには、アプリケーションの`WEB-INF/keycloak.json`ファイルを編集し、次の行を追加します。"
+msgstr "この機能を有効にするには、アプリケーションの `WEB-INF/keycloak.json` ファイルを編集し、次の行を追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:92
 #, no-wrap
 msgid ""
 "\"register-node-at-startup\": true,\n"
@@ -321,14 +282,12 @@ msgstr ""
 "\"register-node-period\": 600,\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:95
 msgid ""
 "This means the adapter will send the registration request on startup and re-"
 "register every 10 minutes."
 msgstr "これは、アダプターが起動時に登録リクエストを送信し、10分ごとに再登録することを意味します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:99
 msgid ""
 "In the {project_name} Administration Console you can specify the maximum "
 "node re-registration timeout (should be larger than _register-node-period_ "
@@ -343,13 +302,11 @@ msgstr ""
 " 。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:101
 #, no-wrap
 msgid "Refresh token in each request"
 msgstr "各リクエストのトークンをリフレッシュします"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:105
 msgid ""
 "By default the application adapter will only refresh the access token when "
 "it's expired. However, you can also configure the adapter to refresh the "
@@ -361,13 +318,11 @@ msgstr ""
 "これは、アプリケーションが{project_name}サーバーにさらに多くのリクエストを送信するため、パフォーマンスに影響を与える可能性があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:111
 #, no-wrap
 msgid "\"always-refresh-token\": true\n"
 msgstr "\"always-refresh-token\": true\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:115
 #, no-wrap
 msgid ""
 "This may have a significant impact on performance. Only enable this feature if you can't rely on backchannel messages to propagate logout and not before\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__application-clustering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__application-clustering/ja_JP/index.html
