### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,8 +28,8 @@ msgid ""
 "inside https://developers.redhat.com/products/fuse/overview/[JBoss Fuse]."
 msgstr ""
 "現在、{project_name}は "
-"https://developers.redhat.com/products/fuse/overview/[JBoss Fuse] "
-"内で実行されているWebアプリケーションのセキュリティ保護をサポートしています。"
+"https://developers.redhat.com/products/fuse/overview/[JBoss "
+"Fuse]内で実行されているWebアプリケーションのセキュリティ保護をサポートしています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:10
@@ -38,9 +38,9 @@ msgid ""
 " with http://www.eclipse.org/jetty/[Jetty 9.2 server] under the covers and "
 "Jetty is used for running various kinds of web applications."
 msgstr ""
-"{fuseVersion}はhttp://www.eclipse.org/jetty/[Jetty 9.2 "
+"{fuseVersion}は http://www.eclipse.org/jetty/[Jetty 9.2 "
 "server]にバンドルされており、Jettyはさまざまな種類のWebアプリケーションの実行に使用されているため、<<_jetty9_adapter,Jetty"
-" 9 adapter>>を活用しています。"
+" 9アダプター>>を活用しています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:13
@@ -50,9 +50,8 @@ msgid ""
 "correctly. In particular, the http://hawt.io[Hawtio] integration will not "
 "work with earlier versions of Fuse."
 msgstr ""
-"サポートされているFuseのバージョンは{fuseVersion}のみです。 "
-"以前のバージョンのFuseを使用している場合、一部の機能が正しく動作しない可能性があります。 特に、http://hawt.io "
-"[Hawtio]との統合は、Fuseの以前のバージョンでは機能しません。"
+"サポートされているFuseのバージョンは{fuseVersion}のみです。以前のバージョンのFuseを使用している場合、一部の機能が正しく動作しない可能性があります。特に、"
+" http://hawt.io [Hawtio]との統合は、Fuseの以前のバージョンでは機能しません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:15
@@ -62,7 +61,7 @@ msgstr "Fuseに対して、以下の項目のセキュリティがサポート�
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:17
 msgid "Classic WAR applications deployed on Fuse with Pax Web War Extender"
-msgstr "Pax Web War Extenderを使用して、Fuseにデプロイされた従来のWARアプリケーション"
+msgstr "Pax Web War Extenderを使用して、FuseにデプロイされたクラシックWARアプリケーション"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:18
@@ -76,8 +75,8 @@ msgid ""
 "http://camel.apache.org/[Apache Camel] Jetty endpoints running with the "
 "http://camel.apache.org/jetty.html[Camel Jetty] component"
 msgstr ""
-"http://camel.apache.org/jetty.html[Camel "
-"Jetty]コンポーネントで動作するhttp://camel.apache.org/[Apache Camel] Jettyエンドポイント"
+"http://camel.apache.org/jetty.html[Camel Jetty]コンポーネントで動作する "
+"http://camel.apache.org/[Apache Camel] Jettyエンドポイント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:20
@@ -85,8 +84,8 @@ msgid ""
 "http://cxf.apache.org/[Apache CXF] endpoints running on their own separate "
 "http://cxf.apache.org/docs/jetty-configuration.html[Jetty engine]"
 msgstr ""
-"独自の分離されたhttp://cxf.apache.org/docs/jetty-"
-"configuration.html[Jettyエンジン]で動作するhttp://cxf.apache.org/[Apache CXF]エンドポイント"
+"独自の分離された http://cxf.apache.org/docs/jetty-configuration.html[Jettyエンジン]で動作する"
+" http://cxf.apache.org/[Apache CXF]エンドポイント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:21
@@ -94,7 +93,7 @@ msgid ""
 "http://cxf.apache.org/[Apache CXF] endpoints running on the default engine "
 "provided by the CXF servlet"
 msgstr ""
-"CXFサーブレットによって提供されるデフォルト・エンジンで実行されているhttp://cxf.apache.org/[Apache "
+"CXFサーブレットによって提供されるデフォルト・エンジンで実行されている http://cxf.apache.org/[Apache "
 "CXF]エンドポイント"
 
 #. type: Plain text
@@ -125,8 +124,8 @@ msgid ""
 msgstr ""
 "最初に{project_name} "
 "Karafの機能をインストールする必要があります。次に、保護するアプリケーションの種類に応じた手順を実行する必要があります。参照されているすべてのWebアプリケーションでは、{project_name}"
-" Jettyオーセンティケーターを、基盤となるJettyサーバーに注入する必要があります。 "
-"これを達成するための手順は、アプリケーションの種類によって異なります。詳細は以下のとおりです。"
+" "
+"Jettyオーセンティケーターを、基盤となるJettyサーバーに注入する必要があります。これを達成するための手順は、アプリケーションの種類によって異なります。詳細は以下のとおりです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:32
@@ -135,4 +134,5 @@ msgid ""
 "{project_name} examples in directory `fuse` . Most of the steps should be "
 "understandable from testing and understanding the demo."
 msgstr ""
-"始めるのに最適なのは、`fuse`ディレクトリ内の{project_name}のサンプルの一部としてバンドルされているFuseのデモを見ることです。ほとんどの手順はテストとデモから理解できるはずです。"
+"始めるのに最適なのは、 `fuse` "
+"ディレクトリ内の{project_name}のサンプルの一部としてバンドルされているFuseのデモを見ることです。ほとんどの手順はテストとデモから理解できるはずです。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:3
 #, no-wrap
 msgid "JBoss Fuse Adapter"
-msgstr ""
+msgstr "JBoss Fuseアダプター"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:6
@@ -27,14 +27,20 @@ msgid ""
 "Currently {project_name} supports securing your web applications running "
 "inside https://developers.redhat.com/products/fuse/overview/[JBoss Fuse]."
 msgstr ""
+"現在、{project_name}は "
+"https://developers.redhat.com/products/fuse/overview/[JBoss Fuse] "
+"内で実行されているWebアプリケーションのセキュリティ保護をサポートしています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:10
 msgid ""
-"It leverages <<_jetty9_adapter,Jetty 9 adapter>> as {fuseVersion} is bundled "
-"with http://www.eclipse.org/jetty/[Jetty 9.2 server] under the covers and "
+"It leverages <<_jetty9_adapter,Jetty 9 adapter>> as {fuseVersion} is bundled"
+" with http://www.eclipse.org/jetty/[Jetty 9.2 server] under the covers and "
 "Jetty is used for running various kinds of web applications."
 msgstr ""
+"{fuseVersion}はhttp://www.eclipse.org/jetty/[Jetty 9.2 "
+"server]にバンドルされており、Jettyはさまざまな種類のWebアプリケーションの実行に使用されているため、<<_jetty9_adapter,Jetty"
+" 9 adapter>>を活用しています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:13
@@ -44,25 +50,25 @@ msgid ""
 "correctly. In particular, the http://hawt.io[Hawtio] integration will not "
 "work with earlier versions of Fuse."
 msgstr ""
+"サポートされているFuseのバージョンは{fuseVersion}のみです。 "
+"以前のバージョンのFuseを使用している場合、一部の機能が正しく動作しない可能性があります。 特に、http://hawt.io "
+"[Hawtio]との統合は、Fuseの以前のバージョンでは機能しません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:15
 msgid "Security for the following items is supported for Fuse:"
-msgstr ""
+msgstr "Fuseに対して、以下の項目のセキュリティがサポートされています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:17
-msgid ""
-"Classic WAR applications deployed on Fuse with https://ops4j1.jira.com/wiki/"
-"display/ops4j/Pax+Web+Extender+-+War[Pax Web War Extender]"
-msgstr ""
+msgid "Classic WAR applications deployed on Fuse with Pax Web War Extender"
+msgstr "Pax Web War Extenderを使用して、Fuseにデプロイされた従来のWARアプリケーション"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:18
 msgid ""
-"Servlets deployed on Fuse as OSGI services with https://ops4j1.jira.com/wiki/"
-"display/ops4j/Pax+Web+Extender+-+Whiteboard[Pax Web Whiteboard Extender]"
-msgstr ""
+"Servlets deployed on Fuse as OSGI services with Pax Web Whiteboard Extender"
+msgstr "Pax Web Whiteboard Extenderを使用して、FuseにOSGIサービスとしてデプロイされたサーブレット"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:19
@@ -70,6 +76,8 @@ msgid ""
 "http://camel.apache.org/[Apache Camel] Jetty endpoints running with the "
 "http://camel.apache.org/jetty.html[Camel Jetty] component"
 msgstr ""
+"http://camel.apache.org/jetty.html[Camel "
+"Jetty]コンポーネントで動作するhttp://camel.apache.org/[Apache Camel] Jettyエンドポイント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:20
@@ -77,6 +85,8 @@ msgid ""
 "http://cxf.apache.org/[Apache CXF] endpoints running on their own separate "
 "http://cxf.apache.org/docs/jetty-configuration.html[Jetty engine]"
 msgstr ""
+"独自の分離されたhttp://cxf.apache.org/docs/jetty-"
+"configuration.html[Jettyエンジン]で動作するhttp://cxf.apache.org/[Apache CXF]エンドポイント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:21
@@ -84,22 +94,24 @@ msgid ""
 "http://cxf.apache.org/[Apache CXF] endpoints running on the default engine "
 "provided by the CXF servlet"
 msgstr ""
+"CXFサーブレットによって提供されるデフォルト・エンジンで実行されているhttp://cxf.apache.org/[Apache "
+"CXF]エンドポイント"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:22
 msgid "SSH and JMX admin access"
-msgstr ""
+msgstr "SSHおよびJMXの管理者アクセス"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:23
 msgid "http://hawt.io[Hawtio administration console]"
-msgstr ""
+msgstr "http://hawt.io[Hawtio administration console]"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:24
 #, no-wrap
 msgid "Securing Your Web Applications Inside Fuse"
-msgstr ""
+msgstr "Fuse内でWebアプリケーションを保護する"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:28
@@ -111,6 +123,10 @@ msgid ""
 "steps to achieve this depend on the application type. The details are "
 "described below."
 msgstr ""
+"最初に{project_name} "
+"Karafの機能をインストールする必要があります。次に、保護するアプリケーションの種類に応じた手順を実行する必要があります。参照されているすべてのWebアプリケーションでは、{project_name}"
+" Jettyオーセンティケーターを、基盤となるJettyサーバーに注入する必要があります。 "
+"これを達成するための手順は、アプリケーションの種類によって異なります。詳細は以下のとおりです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:32
@@ -119,3 +135,4 @@ msgid ""
 "{project_name} examples in directory `fuse` . Most of the steps should be "
 "understandable from testing and understanding the demo."
 msgstr ""
+"始めるのに最適なのは、`fuse`ディレクトリ内の{project_name}のサンプルの一部としてバンドルされているFuseのデモを見ることです。ほとんどの手順はテストとデモから理解できるはずです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__fuse-adapter/ja_JP/index.html
