### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -30,7 +29,7 @@ msgstr "Wildfly 11"
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:63
 #, no-wrap
 msgid "Any other server but Wildfly 11"
-msgstr ""
+msgstr "Wildfly 11以外の他のサーバー"
 
 #. type: Title =====
 #: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
@@ -38,22 +37,23 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
 #: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
 #: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
-msgstr ""
+msgstr "アダプターのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:6
 msgid ""
 "Each adapter is a separate download on the {project_name} download site."
-msgstr ""
+msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードされます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:9
 msgid "Install on Wildfly 9 or 10, 11 or JBoss EAP 7:"
-msgstr ""
+msgstr "Wildfly 9、10、11、またはJBoss EAP 7へのインストール"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:15
@@ -69,7 +69,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:21
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:31
 msgid "Install on JBoss EAP 6.x:"
-msgstr ""
+msgstr "JBoss EAP 6.xへのインストール"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:26
@@ -94,7 +94,7 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:39
 msgid "Install on JBoss EAP 7.x:"
-msgstr ""
+msgstr "JBoss EAP 7.xへのインストール"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:44
@@ -112,6 +112,8 @@ msgid ""
 "These zip files create new JBoss Modules specific to the Wildfly/JBoss EAP "
 "SAML Adapter within your Wildfly or JBoss EAP distro."
 msgstr ""
+"これらのzipファイルは、WildflyまたはJBoss EAPディストリビューション内のWildfly/JBoss EAP "
+"SAMLアダプターに固有の新しいJBossモジュールを作成します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:51
@@ -120,13 +122,15 @@ msgid ""
 "Subsystem within your app server's server configuration: `domain.xml` or "
 "`standalone.xml`."
 msgstr ""
+"モジュールを追加したら、アプリケーション・サーバーのサーバー設定`domain.xml`または`standalone.xml`内にある{project_name}"
+" SAMLサブシステムを有効にする必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:54
 msgid ""
 "There is a CLI script that will help you modify your server configuration.  "
 "Start the server and run the script from the server's bin directory:"
-msgstr ""
+msgstr "サーバー設定の変更に役立つCLIスクリプトがあります。 サーバーを起動し、サーバーの`bin`ディレクトリからスクリプトを実行します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:60
@@ -137,29 +141,29 @@ msgstr ""
 "$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:71
+#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:69
 #, no-wrap
 msgid ""
 "$ cd $JBOSS_HOME/bin\n"
 "$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
-"----        \n"
-"The script will add the extension, subsystem, and optional security-domain as described below. \n"
 msgstr ""
+"$ cd $JBOSS_HOME/bin\n"
+"$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:71
+msgid ""
+"The script will add the extension, subsystem, and optional security-domain "
+"as described below."
+msgstr "スクリプトは、以下に説明するように、extension、subsystem、optionalのセキュリティ・ドメインを追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:73
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:35
-#: source/server_development/topics/providers.adoc:228
-#, no-wrap
-msgid "[source,xml]\n"
-msgstr "[source,xml]\n"
-
-#. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:75
-msgid "<server xmlns=\"urn:jboss:domain:1.4\">"
-msgstr "<server xmlns=\"urn:jboss:domain:1.4\">"
+#, no-wrap
+msgid "<server xmlns=\"urn:jboss:domain:1.4\">\n"
+msgstr "<server xmlns=\"urn:jboss:domain:1.4\">\n"
 
-#. type: Plain text
+#. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:80
 #, no-wrap
 msgid ""
@@ -173,30 +177,30 @@ msgstr ""
 "          ...\n"
 "    </extensions>\n"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:86
+#. type: delimited block -
+#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:85
 #, no-wrap
 msgid ""
 "    <profile>\n"
 "        <subsystem xmlns=\"urn:jboss:domain:keycloak-saml:1.1\"/>\n"
 "         ...\n"
 "    </profile>\n"
-"----    \n"
 msgstr ""
 "    <profile>\n"
 "        <subsystem xmlns=\"urn:jboss:domain:keycloak-saml:1.1\"/>\n"
 "         ...\n"
 "    </profile>\n"
-"----    \n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:90
 msgid ""
-"The `keycloak` security domain should be used with EJBs and other components "
-"when you need the security context created in the secured web tier to be "
+"The `keycloak` security domain should be used with EJBs and other components"
+" when you need the security context created in the secured web tier to be "
 "propagated to the EJBs (other EE component) you are invoking.  Otherwise "
 "this configuration is optional."
 msgstr ""
+"セキュリティ保護されたWeb層で作成されたセキュリティ・コンテキストを呼び出すEJB（他のEEコンポーネント）に伝播する必要がある場合は、 "
+"`keycloak`セキュリティ・ドメインをEJBなどのコンポーネントとともに使用する必要があります。 それ以外の場合、この設定はオプションです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:105
@@ -229,10 +233,12 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:109
 msgid ""
-"For example, if you have a JAX-RS service that is an EJB within your WEB-INF/"
-"classes directory, you'll want to annotate it with the `@SecurityDomain` "
-"annotation as follows:"
+"For example, if you have a JAX-RS service that is an EJB within your WEB-"
+"INF/classes directory, you'll want to annotate it with the `@SecurityDomain`"
+" annotation as follows:"
 msgstr ""
+"たとえば、`WEB-INF/classes`ディレクトリ内のEJBであるJAX-"
+"RSサービスを使用している場合は、次のように`@SecurityDomain`アノテーションを付けます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:115
@@ -319,3 +325,5 @@ msgid ""
 "specify the `@SecurityDomain` annotation when you want to propagate a "
 "keycloak security context to the EJB tier."
 msgstr ""
+"`keycloak`セキュリティ・コンテキストをEJB層に伝播するときに、 "
+"`@SecurityDomain`アノテーションを指定する必要がないように、今後の統合を改善したいと考えています。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -48,12 +48,12 @@ msgstr "アダプターのインストール"
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:6
 msgid ""
 "Each adapter is a separate download on the {project_name} download site."
-msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードされます。"
+msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:9
 msgid "Install on Wildfly 9 or 10, 11 or JBoss EAP 7:"
-msgstr "Wildfly 9、10、11、またはJBoss EAP 7へのインストール"
+msgstr "Wildfly 9、10、11、またはJBoss EAP 7へのインストールは次のとおりです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:15
@@ -69,7 +69,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:21
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:31
 msgid "Install on JBoss EAP 6.x:"
-msgstr "JBoss EAP 6.xへのインストール"
+msgstr "JBoss EAP 6.xへのインストールは次のとおりです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:26
@@ -94,7 +94,7 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:39
 msgid "Install on JBoss EAP 7.x:"
-msgstr "JBoss EAP 7.xへのインストール"
+msgstr "JBoss EAP 7.xへのインストールは次のとおりです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:44
@@ -112,7 +112,7 @@ msgid ""
 "These zip files create new JBoss Modules specific to the Wildfly/JBoss EAP "
 "SAML Adapter within your Wildfly or JBoss EAP distro."
 msgstr ""
-"これらのzipファイルは、WildflyまたはJBoss EAPディストリビューション内のWildfly/JBoss EAP "
+"これらのzipファイルは、WildflyまたはJBoss EAP用の配布物内のWildfly/JBoss EAP "
 "SAMLアダプターに固有の新しいJBossモジュールを作成します。"
 
 #. type: Plain text
@@ -122,15 +122,15 @@ msgid ""
 "Subsystem within your app server's server configuration: `domain.xml` or "
 "`standalone.xml`."
 msgstr ""
-"モジュールを追加したら、アプリケーション・サーバーのサーバー設定`domain.xml`または`standalone.xml`内にある{project_name}"
-" SAMLサブシステムを有効にする必要があります。"
+"モジュールを追加したら、アプリケーション・サーバーのサーバー設定 `domain.xml` または `standalone.xml` "
+"内にある{project_name} SAMLサブシステムを有効にする必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:54
 msgid ""
 "There is a CLI script that will help you modify your server configuration.  "
 "Start the server and run the script from the server's bin directory:"
-msgstr "サーバー設定の変更に役立つCLIスクリプトがあります。 サーバーを起動し、サーバーの`bin`ディレクトリからスクリプトを実行します。"
+msgstr "サーバー設定の変更に役立つCLIスクリプトがあります。サーバーを起動し、サーバーの `bin` ディレクトリからスクリプトを実行します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:60
@@ -155,7 +155,7 @@ msgstr ""
 msgid ""
 "The script will add the extension, subsystem, and optional security-domain "
 "as described below."
-msgstr "スクリプトは、以下に説明するように、extension、subsystem、optionalのセキュリティ・ドメインを追加します。"
+msgstr "スクリプトは、以下に説明するように、extension、subsystem、オプションでsecurity-domainを追加します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:75
@@ -200,7 +200,7 @@ msgid ""
 "this configuration is optional."
 msgstr ""
 "セキュリティ保護されたWeb層で作成されたセキュリティ・コンテキストを呼び出すEJB（他のEEコンポーネント）に伝播する必要がある場合は、 "
-"`keycloak`セキュリティ・ドメインをEJBなどのコンポーネントとともに使用する必要があります。 それ以外の場合、この設定はオプションです。"
+"`keycloak` セキュリティ・ドメインをEJBなどのコンポーネントとともに使用する必要があります。それ以外の場合、この設定はオプションです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:105
@@ -237,8 +237,8 @@ msgid ""
 "INF/classes directory, you'll want to annotate it with the `@SecurityDomain`"
 " annotation as follows:"
 msgstr ""
-"たとえば、`WEB-INF/classes`ディレクトリ内のEJBであるJAX-"
-"RSサービスを使用している場合は、次のように`@SecurityDomain`アノテーションを付けます。"
+"たとえば、 `WEB-INF/classes` ディレクトリ内のEJBであるJAX-RSサービスを使用している場合は、次のように "
+"`@SecurityDomain` アノテーションを付けます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:115
@@ -325,5 +325,5 @@ msgid ""
 "specify the `@SecurityDomain` annotation when you want to propagate a "
 "keycloak security context to the EJB tier."
 msgstr ""
-"`keycloak`セキュリティ・コンテキストをEJB層に伝播するときに、 "
-"`@SecurityDomain`アノテーションを指定する必要がないように、今後の統合を改善したいと考えています。"
+"`keycloak` セキュリティ・コンテキストをEJB層に伝播するときに、 `@SecurityDomain` "
+"アノテーションを指定する必要がないように、今後の統合を改善したいと考えています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation/ja_JP/index.html
