### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -16,29 +16,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:28
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:142
 #, no-wrap
 msgid "connection-pool-size"
 msgstr "connection-pool-size"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:46
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:178
 #, no-wrap
 msgid "client-keystore"
 msgstr "client-keystore"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:50
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:183
 #, no-wrap
 msgid "client-keystore-password"
 msgstr "client-keystore-password"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:53
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:186
 msgid ""
 "Password for the client keystore.  This is _REQUIRED_ if `client-keystore` "
 "is set."
@@ -46,35 +38,28 @@ msgstr ""
 "クライアント・キーストア用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:54
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:187
 #, no-wrap
 msgid "client-key-password"
 msgstr "client-key-password"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:57
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:190
 msgid ""
 "Password for the client's key.  This is _REQUIRED_ if `client-keystore` is "
 "set."
 msgstr "クライアント・キー用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:3
 #, no-wrap
 msgid "Java Adapter Config"
 msgstr "Javaアダプターの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:7
 msgid ""
 "Each Java adapter supported by {project_name} can be configured by a simple "
 "JSON file.  This is what one might look like:"
 msgstr "{project_name}でサポートされている各Javaアダプターは、単純なJSONファイルで設定できます。これは、次のようになります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:27
 #, no-wrap
 msgid ""
 "{\n"
@@ -114,7 +99,6 @@ msgstr ""
 "   },\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:43
 #, no-wrap
 msgid ""
 "   \"connection-pool-size\" : 20,\n"
@@ -150,67 +134,59 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:47
 msgid ""
 "You can use `${...}` enclosure for system property replacement. For example "
 "`${jboss.server.config.dir}` would be replaced by `/path/to/{project_name}`."
 "  Replacement of environment variables is also supported via the `env` "
 "prefix, e.g. `${env.MY_ENVIRONMENT_VARIABLE}`."
 msgstr ""
-"`${...}`エンクロージャーを使用して、システム・プロパティの置換を行うことができます。たとえば`${jboss.server.config.dir}`は`/path/to/{project_name}`に置換できます。環境変数の置換では、`env`プレフィックスもサポートされています。たとえば、`${env.MY_ENVIRONMENT_VARIABLE}`。"
+"`${...}` エンクロージャーを使用して、システム・プロパティの置換を行うことができます。たとえば、 "
+"`${jboss.server.config.dir}` は `/path/to/{project_name}` に置換できます。環境変数の置換では、 "
+"`env` プレフィックスもサポートされています。たとえば、 `${env.MY_ENVIRONMENT_VARIABLE}` です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:50
 msgid ""
 "The initial config file can be obtained from the the admin console. This can"
 " be done by opening the admin console, select `Clients` from the menu and "
 "clicking on the corresponding client. Once the page for the client is opened"
 " click on the `Installation` tab and select `Keycloak OIDC JSON`."
 msgstr ""
-"初期設定ファイルは、管理コンソールから取得できます。これを行うには、管理コンソールを開き、メニューから`クライアント`を選択し、対応するクライアントをクリックします。クライアントのページが開かれたら、`インストール`タブをクリックし、`Keycloak"
-" OIDC JSON`を選択します。"
+"初期設定ファイルは、管理コンソールから取得できます。これを行うには、管理コンソールを開き、メニューから `Clients` "
+"を選択し、対応するクライアントをクリックします。クライアントのページが開かれたら、 `Installation` タブをクリックし、 `Keycloak"
+" OIDC JSON` を選択します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:52
-#: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:67
 msgid "Here is a description of each configuration option:"
 msgstr "各設定オプションの説明は次のとおりです。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:53
 #, no-wrap
 msgid "realm"
-msgstr "レルム"
+msgstr "realm"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:56
 msgid "Name of the realm.  This is _REQUIRED._"
-msgstr "レルムの名前。 これは_必須_です。"
+msgstr "レルムの名前。 これは _必須_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:57
-#: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:26
 #, no-wrap
 msgid "resource"
 msgstr "resource"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:60
 msgid ""
 "The client-id of the application. Each application has a client-id that is "
 "used to identify the application.  This is _REQUIRED._"
 msgstr ""
-"アプリケーションのクライアントID。 各アプリケーションには、アプリケーションを識別するために使用されるクライアントIDがあります。 "
-"これは_必須_です。"
+"アプリケーションのクライアントID。各アプリケーションには、アプリケーションを識別するために使用されるクライアントIDがあります。これは _必須_ "
+"です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:61
 #, no-wrap
 msgid "realm-public-key"
 msgstr "realm-public-key"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:66
 msgid ""
 "PEM format of the realm public key. You can obtain this from the "
 "administration console.  This is _OPTIONAL_ and it's not recommended to set "
@@ -220,179 +196,172 @@ msgid ""
 "new keys from {project_name}, so when {project_name} rotate it's keys, "
 "adapter will break."
 msgstr ""
-"レルム公開鍵のPEM形式。 "
-"これは管理コンソールから取得できます。これは_任意_であり、設定することはお勧めしません。これが設定されていない場合、アダプターは必要に応じて({project_name}の鍵をローテーションさせる場合など)、{project_name}からいつでもそれをダウンロードします。"
+"レルム公開鍵のPEM形式。これは管理コンソールから取得できます。これは _任意_ "
+"であり、設定することはお勧めしません。これが設定されていない場合、アダプターは必要に応じて（{project_name}の鍵をローテーションさせる場合など）、{project_name}からいつでもそれをダウンロードします。"
 " しかし、realm-public-"
 "keyが設定されている場合、アダプターは{project_name}から新しい鍵をダウンロードすることは無いので、{project_name}の鍵をローテーションするとアダプターが正常に動作しなくなります。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:67
 #, no-wrap
 msgid "auth-server-url"
 msgstr "auth-server-url"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:70
 msgid ""
 "The base URL of the {project_name} server. All other {project_name} pages "
 "and REST service endpoints are derived from this. It is usually of the form "
 "`$$https://host:port/auth$$`.  This is _REQUIRED._"
 msgstr ""
-"{project_name}サーバーのベースURL。 "
-"それ以外のすべての{project_name}ページとRESTサービスのエンドポイントは、これから派生しています。通常、 "
-"`$$https://host:port/auth$$`の形式です。 これは_必須_です。"
+"{project_name}サーバーのベースURL。それ以外のすべての{project_name}ページとRESTサービスのエンドポイントは、これから派生しています。通常、"
+" `$$https://host:port/auth$$` の形式です。これは _必須_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:71
 #, no-wrap
 msgid "ssl-required"
 msgstr "ssl-required"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:77
 msgid ""
 "Ensures that all communication to and from the {project_name} server is over"
 " HTTPS.  In production this should be set to `all`.  This is _OPTIONAL_.  "
 "The default value is _external_ meaning that HTTPS is required by default "
 "for external requests.  Valid values are 'all', 'external' and 'none'."
 msgstr ""
-"{project_name}サーバーとの間のすべての通信がHTTPS経由であることを保証します。プロダクション環境では、これを`all`に設定する必要があります。これは_任意_です。デフォルト値は_external_です。つまり、外部リクエストに対してデフォルトでHTTPSが必要です。有効な値は'all'、'external'、'none'です。"
+"{project_name}サーバーとの間のすべての通信がHTTPS経由であることを保証します。プロダクション環境では、これを `all` "
+"に設定する必要があります。これは _任意_ です。デフォルト値は _external_ "
+"です。つまり、外部リクエストに対してデフォルトでHTTPSが必要です。有効な値は `all` 、 `external` 、 `none` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:78
+#, no-wrap
+msgid "confidential-port"
+msgstr "confidential-port"
+
+#. type: Plain text
+msgid ""
+"The confidential port used by the {project_name} server for secure "
+"connections over SSL/TLS.  This is _OPTIONAL_.  The default value is _8443_."
+msgstr ""
+"SSL/TLS.を介した安全な接続のために、{project_name}サーバーが使用する機密ポート。これは _OPTIONAL_ です。デフォルト値は"
+" _8443_ です。"
+
+#. type: Labeled list
 #, no-wrap
 msgid "use-resource-role-mappings"
 msgstr "use-resource-role-mappings"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:82
 msgid ""
 "If set to true, the adapter will look inside the token for application level"
 " role mappings for the user. If false, it will look at the realm level for "
 "user role mappings.  This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
 "trueに設定すると、アダプターは、ユーザーのアプリケーション・レベルのロール・マッピングのトークンを調べます。falseの場合、ユーザー・ロール・マッピングのレルム・レベルが表示されます。"
-" これは_任意_です。デフォルト値は_false_です。 "
+" これは _任意_ です。デフォルト値は _false_ です。 "
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:83
 #, no-wrap
 msgid "public-client"
 msgstr "public-client"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:87
 msgid ""
 "If set to true, the adapter will not send credentials for the client to "
 "{project_name}.  This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
-"trueに設定すると、アダプターはクライアントのクレデンシャルを{project_name}に送信しません。これは_任意_です。デフォルト値は_false_です。"
+"trueに設定すると、アダプターはクライアントのクレデンシャルを{project_name}に送信しません。これは _任意_ です。デフォルト値は "
+"_false_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:88
 #, no-wrap
 msgid "enable-cors"
 msgstr "enable-cors"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:92
 msgid ""
 "This enables CORS support. It will handle CORS preflight requests. It will "
 "also look into the access token to determine valid origins.  This is "
 "_OPTIONAL_.  The default value is _false_."
 msgstr ""
 "これにより、CORSサポートが有効になります。 "
-"CORSプリフライト・リクエストを処理します。また、アクセス・トークンを調べて、有効な起点を特定します。これは_任意_です。デフォルト値は_false_です。"
+"CORSプリフライト・リクエストを処理します。また、アクセス・トークンを調べて、有効な起点を特定します。これは _任意_ です。デフォルト値は "
+"_false_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:93
 #, no-wrap
 msgid "cors-max-age"
 msgstr "cors-max-age"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:97
 msgid ""
 "If CORS is enabled, this sets the value of the `Access-Control-Max-Age` "
 "header.  This is _OPTIONAL_.  If not set, this header is not returned in "
 "CORS responses."
 msgstr ""
-"CORSが有効な場合、これは`Access-Control-Max-"
-"Age`ヘッダーの値を設定します。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
+"CORSが有効な場合、これは `Access-Control-Max-Age` ヘッダーの値を設定します。これは _任意_ "
+"です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:98
 #, no-wrap
 msgid "cors-allowed-methods"
 msgstr "cors-allowed-methods"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:103
 msgid ""
 "If CORS is enabled, this sets the value of the `Access-Control-Allow-"
 "Methods` header.  This should be a comma-separated string.  This is "
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
-"CORSが有効な場合、これは`Access-Control-Allow-Methods`ヘッダーの値を設定します。 "
+"CORSが有効な場合、これは `Access-Control-Allow-Methods` ヘッダーの値を設定します。 "
 "これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:104
 #, no-wrap
 msgid "cors-allowed-headers"
 msgstr "cors-allowed-headers"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:109
 msgid ""
 "If CORS is enabled, this sets the value of the `Access-Control-Allow-"
 "Headers` header.  This should be a comma-separated string.  This is "
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
-"CORSが有効な場合、これは`Access-Control-Allow-Headers`ヘッダーの値を設定します。 "
-"これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
+"CORSが有効な場合、これは `Access-Control-Allow-Headers` ヘッダーの値を設定します。 "
+"これはカンマ区切りの文字列でなければなりません。これは _任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:110
 #, no-wrap
 msgid "cors-exposed-headers"
 msgstr "cors-exposed-headers"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:115
 msgid ""
 "If CORS is enabled, this sets the value of the `Access-Control-Expose-"
 "Headers` header.  This should be a comma-separated string.  This is "
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
-"CORSが有効な場合、これは`Access-Control-Expose-Headers`ヘッダーの値を設定します。 "
+"CORSが有効な場合、これは `Access-Control-Expose-Headers` ヘッダーの値を設定します。 "
 "これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:116
 #, no-wrap
 msgid "bearer-only"
 msgstr "bearer-only"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:120
 msgid ""
 "This should be set to _true_ for services. If enabled the adapter will not "
 "attempt to authenticate users, but only verify bearer tokens.  This is "
 "_OPTIONAL_.  The default value is _false_."
 msgstr ""
-"これは、サービスに対して_true_に設定する必要があります。 "
-"有効にすると、アダプターはユーザーを認証しようとせず、ベアラー・トークンのみを検証します。これは_任意_です。デフォルト値は_false_です。"
+"これは、サービスに対して _true_ に設定する必要があります。 "
+"有効にすると、アダプターはユーザーを認証しようとせず、ベアラー・トークンのみを検証します。これは _任意_です。デフォルト値は _false_です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:121
 #, no-wrap
 msgid "autodetect-bearer-only"
 msgstr "autodetect-bearer-only"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:127
-#: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:58
 msgid ""
 "This should be set to __true__ if your application serves both a web "
 "application and web services (e.g. SOAP or REST).  It allows you to redirect"
@@ -409,47 +378,41 @@ msgstr ""
 "`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。 デフォルト値は _false_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:128
 #, no-wrap
 msgid "enable-basic-auth"
 msgstr "enable-basic-auth"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:132
 msgid ""
 "This tells the adapter to also support basic authentication. If this option "
 "is enabled, then _secret_ must also be provided.  This is _OPTIONAL_.  The "
 "default value is _false_."
 msgstr ""
-"これは、基本認証もサポートするようにアダプターに指示します。このオプションを有効にすると、_secret_も指定する必要があります。これは_任意_です。"
-" デフォルト値は_false_です。"
+"これは、基本認証もサポートするようにアダプターに指示します。このオプションを有効にすると、 _secret_ も指定する必要があります。これは _任意_"
+" です。 デフォルト値は _false_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:133
 #, no-wrap
 msgid "expose-token"
 msgstr "expose-token"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:137
 msgid ""
 "If `true`, an authenticated browser client (via a Javascript HTTP "
 "invocation) can obtain the signed access token via the URL "
 "`root/k_query_bearer_token`.  This is _OPTIONAL_.  The default value is "
 "_false_."
 msgstr ""
-"`true`の場合、（JavascriptのHTTP呼び出しを介して）認証されたブラウザ・クライアントが、`root/k_query_bearer_token`のURLを介して署名付きのアクセス・トークンを取得できます。"
-" これは_任意_です。デフォルト値は_false_です。"
+"`true` の場合、（JavascriptのHTTP呼び出しを介して）認証されたブラウザ・クライアントが、 "
+"`root/k_query_bearer_token` のURLを介して署名付きのアクセス・トークンを取得できます。これは _任意_ "
+"です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:138
-#: source/server_admin/topics/overview/concepts.adoc:14
 #, no-wrap
 msgid "credentials"
 msgstr "credentials"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:141
 msgid ""
 "Specify the credentials of the application. This is an object notation where"
 " the key is the credential type and the value is the value of the credential"
@@ -457,10 +420,9 @@ msgid ""
 " clients with 'Confidential' access type."
 msgstr ""
 "アプリケーションのクレデンシャルを指定します。これは、キーがクレデンシャル・タイプで、値がクレデンシャル・タイプの値であるオブジェクト表記法です。 "
-"現在、パスワードとJWTがサポートされています。これは、`コンフィデンシャル`・アクセス・タイプのクライアントの場合にのみ_必須_です。"
+"現在、パスワードとJWTがサポートされています。これは、 `コンフィデンシャル` のアクセス・タイプのクライアントの場合にのみ _必須_ です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:147
 msgid ""
 "Adapters will make separate HTTP invocations to the {project_name} server to"
 " turn an access code into an access token.  This config option defines how "
@@ -471,14 +433,11 @@ msgstr ""
 " これは _OPTIONAL_ です。デフォルトは`20`です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:148
 #, no-wrap
 msgid "disable-trust-manager"
 msgstr "disable-trust-manager"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:153
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:33
 msgid ""
 "If the {project_name} server requires HTTPS and this config option is set to"
 " `true` you do not have to specify a truststore.  This setting should only "
@@ -491,13 +450,11 @@ msgstr ""
 "*決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:154
 #, no-wrap
 msgid "allow-any-hostname"
 msgstr "allow-any-hostname"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:160
 msgid ""
 "If the {project_name} server requires HTTPS and this config option is set to"
 " `true` the {project_name} server's certificate is validated via the "
@@ -508,29 +465,24 @@ msgid ""
 msgstr ""
 "{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
 "に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。 "
-"SSL証明書の検証が無効となるため、この設定は開発時にのみ使用すべきで、本番環境では *決して使用してはいけません* 。これは_任意_です。デフォルトは"
-" `false` です。"
+"SSL証明書の検証が無効となるため、この設定は開発時にのみ使用すべきで、本番環境では *決して使用してはいけません* 。これは _任意_ "
+"です。デフォルトは `false` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:161
 #, no-wrap
 msgid "proxy-url"
 msgstr "proxy-url"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:163
 msgid "The URL for the HTTP proxy if one is used."
 msgstr "HTTPプロキシが使用されている場合のURL。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:164
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:43
 #, no-wrap
 msgid "truststore"
 msgstr "truststore"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:173
 msgid ""
 "The value is the file path to a keystore file.  If you prefix the path with "
 "`classpath:`, then the truststore will be obtained from the deployment's "
@@ -543,20 +495,16 @@ msgid ""
 " unless `ssl-required` is `none` or `disable-trust-manager` is `true`."
 msgstr ""
 "値は、キーストア・ファイルへのファイルパスです。 "
-"`classpath：`でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。{project_name}サーバーへのHTTPS通信に使用されます。"
-" "
-"HTTPSリクエストを行うクライアントは、通信しているサーバーのホストを確認する方法が必要です。これは、トラストアの役割です。キーストアには、1つ以上の信頼できるホストの証明書または証明機関が含まれています。このトラストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。"
-" `ssl-required`が`none`か`disable-trust-manager`が`true`でない限り、これは_必須_です。"
+"`classpath：`でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。{project_name}サーバーへのHTTPS通信に使用されます。HTTPSリクエストを行うクライアントは、通信しているサーバーのホストを確認する方法が必要です。これは、トラストアの役割です。キーストアには、1つ以上の信頼できるホストの証明書または証明機関が含まれています。このトラストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。"
+" `ssl-required`が `none` か `disable-trust-manager` が `true` でない限り、これは _必須_ "
+"です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:174
 #, no-wrap
 msgid "truststore-password"
 msgstr "truststore-password"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:177
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:56
 msgid ""
 "Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
 " set and the truststore requires a password."
@@ -565,8 +513,6 @@ msgstr ""
 "を設定すると、トラストストアはパスワードを必要とします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:182
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:61
 msgid ""
 "This is the file path to a keystore file.  This keystore contains client "
 "certificate for two-way SSL when the adapter makes HTTPS requests to the "
@@ -576,40 +522,35 @@ msgstr ""
 " _OPTIONAL_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:191
 #, no-wrap
 msgid "always-refresh-token"
 msgstr "always-refresh-token"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:193
 msgid "If _true_, the adapter will refresh token in every request."
-msgstr "_true_の場合、アダプターはリクエストごとにトークンを更新します。"
+msgstr "_true_ の場合、アダプターはリクエストごとにトークンを更新します。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:194
 #, no-wrap
 msgid "register-node-at-startup"
 msgstr "register-node-at-startup"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:198
 msgid ""
 "If _true_, then adapter will send registration request to {project_name}.  "
 "It's _false_ by default and useful only when application is clustered.  See "
 "<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
-"_true_の場合、アダプターは{project_name}に登録リクエストを送信します。これはデフォルトで_false_であり、アプリケーションがクラスタ化されている場合にのみ有効です。詳細は<<_applicationclustering,Application"
-" Clustering>>を参照してください。"
+"_true_ の場合、アダプターは{project_name}に登録リクエストを送信します。これはデフォルトで _false_ "
+"であり、アプリケーションがクラスタ化されている場合にのみ有効です。詳細は<<_applicationclustering,Application "
+"Clustering>>を参照してください。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:199
 #, no-wrap
 msgid "register-node-period"
 msgstr "register-node-period"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:203
 msgid ""
 "Period for re-registration adapter to {project_name}.  Useful when "
 "application is clustered.  See <<_applicationclustering,Application "
@@ -620,63 +561,58 @@ msgstr ""
 "Clustering>>を参照してください。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:204
 #, no-wrap
 msgid "token-store"
 msgstr "token-store"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:209
 msgid ""
 "Possible values are _session_ and _cookie_.  Default is _session_, which "
 "means that adapter stores account info in HTTP Session.  Alternative "
 "_cookie_ means storage of info in cookie.  See "
 "<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
-"可能な値は_session_と_cookie_です。デフォルトは_session_です。つまり、アダプターがアカウント情報をHTTPセッションに保管します。代わりの_cookie_は、情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,Application"
-" Clustering>>を参照してください。"
+"可能な値は _session_ と _cookie_ です。デフォルトは _session_ "
+"です。つまり、アダプターがアカウント情報をHTTPセッションに保管します。代わりの _cookie_ "
+"は、情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,Application "
+"Clustering>>を参照してください。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:210
 #, no-wrap
 msgid "principal-attribute"
 msgstr "principal-attribute"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:214
 msgid ""
 "OpenID Connect ID Token attribute to populate the UserPrincipal name with.  "
 "If token attribute is null, defaults to `sub`.  Possible values are `sub`, "
 "`preferred_username`, `email`, `name`, `nickname`, `given_name`, "
 "`family_name`."
 msgstr ""
-"OpenID "
-"ConnectのIDトークン属性を使用して、`UserPrincipal`の名前を入力します。トークン属性がnullの場合、デフォルトは`sub`です。可能な値は`sub`、`preferred_username`、`email`、`"
-" name`、`nickname`、`given_name`、`family_name`です。"
+"OpenID ConnectのIDトークン属性を使用して、 `UserPrincipal` "
+"の名前を入力します。トークン属性がnullの場合、デフォルトは `sub` です。可能な値は `sub` 、 `preferred_username` "
+"、 `email` 、 ` name` 、 `nickname` 、 `given_name` 、 `family_name` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:215
 #, no-wrap
 msgid "turn-off-change-session-id-on-login"
 msgstr "turn-off-change-session-id-on-login"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:218
 msgid ""
 "The session id is changed by default on a successful login on some platforms"
 " to plug a security attack vector.  Change this to true if you want to turn "
 "this off This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
-"セッションIDは、一部のプラットフォームで正常にログインすると、デフォルトで変更され、セキュリティ攻撃のベクターが挿入されます。これをオフにするには、これをtrueに変更します。これは_任意_です。デフォルト値は_false_です。"
+"セッションIDは、一部のプラットフォームで正常にログインすると、デフォルトで変更され、セキュリティ攻撃のベクターが挿入されます。これをオフにするには、これをtrueに変更します。これは"
+" _任意_ です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:219
 #, no-wrap
 msgid "token-minimum-time-to-live"
 msgstr "token-minimum-time-to-live"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:224
 msgid ""
 "Amount of time, in seconds, to preemptively refresh an active access token "
 "with the {project_name} server before it expires.  This is especially useful"
@@ -686,17 +622,15 @@ msgid ""
 "adapter will refresh access token just if it's expired."
 msgstr ""
 "有効期限が切れる前に{project_name}サーバーでアクティブなアクセス・トークンをプリエンプティブにリフレッシュする時間（秒単位）。 "
-"これは、アクセストークンが評価される前に期限切れになる可能性がある別のRESTクライアントに送信されるときに特に便利です。この値は、レルムのアクセス・トークンの寿命を超えてはなりません。これは_任意_です。"
-" デフォルト値は `0`秒なので、アダプターは期限切れになったときだけ、アクセス・トークンを更新します。"
+"これは、アクセストークンが評価される前に期限切れになる可能性がある別のRESTクライアントに送信されるときに特に便利です。この値は、レルムのアクセス・トークンの寿命を超えてはなりません。これは"
+" _任意_ です。 デフォルト値は `0` 秒なので、アダプターは期限切れになったときだけ、アクセス・トークンを更新します。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:225
 #, no-wrap
 msgid "min-time-between-jwks-requests"
 msgstr "min-time-between-jwks-requests"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:231
 msgid ""
 "Amount of time, in seconds, specifying minimum interval between two requests"
 " to {project_name} to retrieve new public keys.  It is 10 seconds by "
@@ -706,21 +640,21 @@ msgid ""
 "of tokens with bad `kid` forcing adapter to send lots of requests to "
 "{project_name}."
 msgstr ""
-"値は、キーストア・ファイルへのファイル・パスです。`classpath：`でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。"
-" {project_name}サーバーへの発信HTTPS通信に使用されます。 "
+"値は、キーストア・ファイルへのファイル・パスです。 `classpath：` "
+"でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。 "
+"{project_name}サーバーへの発信HTTPS通信に使用されます。 "
 "HTTPS要求を行うクライアントは、話しているサーバーのホストを確認する方法が必要です。 これは、トラストアの役割です。 "
 "キーストアには、1つ以上の信頼できるホスト証明書または証明機関が含まれています。 "
 "このtruststoreは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。 `ssl-"
-"required`が` none`か `disable-trust-manager`が` true`でない限り、これは_REQUIRED_です。"
+"required` が `none` か `disable-trust-manager` が `true` でない限り、これは _REQUIRED_ "
+"です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:232
 #, no-wrap
 msgid "public-key-cache-ttl"
 msgstr "public-key-cache-ttl"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:238
 msgid ""
 "Amount of time, in seconds, specifying maximum interval between two requests"
 " to {project_name} to retrieve new public keys.  It is 86400 seconds (1 day)"
@@ -730,38 +664,36 @@ msgid ""
 "once per this configured interval (1 day by default) will be new public key "
 "always downloaded even if the `kid` of token is already known."
 msgstr ""
-"新しい公開鍵を取得するための、{project_name}への2つのリクエスト間の最大間隔を指定する時間（秒単位）。 "
-"デフォルトでは86400秒（1日）です。アダプターは、未知の`kid`を含むトークンを認識すると、常に新しい公開鍵をダウンロードしようとします。それが既知の`kid`のトークンを認識すれば、以前にダウンロードした公開鍵だけを使用します。しかし、この設定された間隔（デフォルトでは1日）に少なくとも1回は、トークンの`kid`が既知でも常に新しい公開鍵がダウンロードされます。"
+"新しい公開鍵を取得するための、{project_name}への2つのリクエスト間の最大間隔を指定する時間（秒単位）。デフォルトでは86400秒（1日）です。アダプターは、未知の"
+" `kid` を含むトークンを認識すると、常に新しい公開鍵をダウンロードしようとします。それが既知の `kid` "
+"のトークンを認識すれば、以前にダウンロードした公開鍵だけを使用します。しかし、この設定された間隔（デフォルトでは1日）に少なくとも1回は、トークンの "
+"`kid` が既知でも常に新しい公開鍵がダウンロードされます。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:239
 #, no-wrap
 msgid "ignore-oauth-query-parameter"
 msgstr "ignore-oauth-query-parameter"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:243
 msgid ""
 "Defaults to `false`, if set to `true` will turn off processing of the "
 "`access_token` query parameter for bearer token processing.  Users will not "
 "be able to authenticate if they only pass in an `access_token`"
 msgstr ""
-"`false`にデフォルト設定されます。`true`に設定されていると、ベアラー・トークン処理のための`access_token`クエリー・パラメーターの処理が無効になります。"
-" ユーザーは、 `access_token`を渡すだけで認証することはできません。"
+"`false` にデフォルト設定されます。 `true` に設定されていると、ベアラー・トークン処理のための `access_token` "
+"クエリー・パラメーターの処理が無効になります。ユーザーは、 `access_token` を渡すだけで認証することはできません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:244
 #, no-wrap
 msgid "redirect-rewrite-rules"
 msgstr "redirect-rewrite-rules"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:246
 msgid ""
 "If needed, specify the Redirect URI rewrite rule. This is an object notation"
 " where the key is the regular expression to which the Redirect URI is to be "
 "matched and the value is the replacement String.  `$` character can be used "
 "for backreferences in the replacement String."
 msgstr ""
-"必要に応じて、リダイレクトURIリライトのルールを指定します。 "
-"これは、キーがリダイレクトURIが照合される正規表現であり、値が置換文字列であるオブジェクト表記法です。置換文字列の後方参照に`$`文字を使うことができます。"
+"必要に応じて、リダイレクトURIリライトのルールを指定します。これは、キーがリダイレクトURIが照合される正規表現であり、値が置換文字列であるオブジェクト表記法です。置換文字列の後方参照に"
+" `$` 文字を使用できます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
@@ -44,6 +43,7 @@ msgid ""
 "Password for the client keystore.  This is _REQUIRED_ if `client-keystore` "
 "is set."
 msgstr ""
+"クライアント・キーストア用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/outgoing.adoc:54
@@ -58,20 +58,20 @@ msgstr "client-key-password"
 msgid ""
 "Password for the client's key.  This is _REQUIRED_ if `client-keystore` is "
 "set."
-msgstr ""
+msgstr "クライアント・キー用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:3
 #, no-wrap
 msgid "Java Adapter Config"
-msgstr ""
+msgstr "Javaアダプターの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:7
 msgid ""
 "Each Java adapter supported by {project_name} can be configured by a simple "
 "JSON file.  This is what one might look like:"
-msgstr ""
+msgstr "{project_name}でサポートされている各Javaアダプターは、単純なJSONファイルで設定できます。これは、次のようになります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:27
@@ -152,36 +152,40 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:47
 msgid ""
-"You can use `${...}` enclosure for system property replacement. For example `"
-"${jboss.server.config.dir}` would be replaced by `/path/to/{project_name}`.  "
-"Replacement of environment variables is also supported via the `env` prefix, "
-"e.g. `${env.MY_ENVIRONMENT_VARIABLE}`."
+"You can use `${...}` enclosure for system property replacement. For example "
+"`${jboss.server.config.dir}` would be replaced by `/path/to/{project_name}`."
+"  Replacement of environment variables is also supported via the `env` "
+"prefix, e.g. `${env.MY_ENVIRONMENT_VARIABLE}`."
 msgstr ""
+"`${...}`エンクロージャーを使用して、システム・プロパティの置換を行うことができます。たとえば`${jboss.server.config.dir}`は`/path/to/{project_name}`に置換できます。環境変数の置換では、`env`プレフィックスもサポートされています。たとえば、`${env.MY_ENVIRONMENT_VARIABLE}`。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:50
 msgid ""
-"The initial config file can be obtained from the the admin console. This can "
-"be done by opening the admin console, select `Clients` from the menu and "
-"clicking on the corresponding client. Once the page for the client is opened "
-"click on the `Installation` tab and select `Keycloak OIDC JSON`."
+"The initial config file can be obtained from the the admin console. This can"
+" be done by opening the admin console, select `Clients` from the menu and "
+"clicking on the corresponding client. Once the page for the client is opened"
+" click on the `Installation` tab and select `Keycloak OIDC JSON`."
 msgstr ""
+"初期設定ファイルは、管理コンソールから取得できます。これを行うには、管理コンソールを開き、メニューから`クライアント`を選択し、対応するクライアントをクリックします。クライアントのページが開かれたら、`インストール`タブをクリックし、`Keycloak"
+" OIDC JSON`を選択します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:52
+#: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:67
 msgid "Here is a description of each configuration option:"
-msgstr ""
+msgstr "各設定オプションの説明は次のとおりです。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:53
 #, no-wrap
 msgid "realm"
-msgstr ""
+msgstr "レルム"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:56
 msgid "Name of the realm.  This is _REQUIRED._"
-msgstr ""
+msgstr "レルムの名前。 これは_必須_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:57
@@ -196,12 +200,14 @@ msgid ""
 "The client-id of the application. Each application has a client-id that is "
 "used to identify the application.  This is _REQUIRED._"
 msgstr ""
+"アプリケーションのクライアントID。 各アプリケーションには、アプリケーションを識別するために使用されるクライアントIDがあります。 "
+"これは_必須_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:61
 #, no-wrap
 msgid "realm-public-key"
-msgstr ""
+msgstr "realm-public-key"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:66
@@ -214,55 +220,65 @@ msgid ""
 "new keys from {project_name}, so when {project_name} rotate it's keys, "
 "adapter will break."
 msgstr ""
+"レルム公開鍵のPEM形式。 "
+"これは管理コンソールから取得できます。これは_任意_であり、設定することはお勧めしません。これが設定されていない場合、アダプターは必要に応じて({project_name}の鍵をローテーションさせる場合など)、{project_name}からいつでもそれをダウンロードします。"
+" しかし、realm-public-"
+"keyが設定されている場合、アダプターは{project_name}から新しい鍵をダウンロードすることは無いので、{project_name}の鍵をローテーションするとアダプターが正常に動作しなくなります。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:67
 #, no-wrap
 msgid "auth-server-url"
-msgstr ""
+msgstr "auth-server-url"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:70
 msgid ""
 "The base URL of the {project_name} server. All other {project_name} pages "
-"and REST service endpoints are derived from this. It is usually of the form `"
-"$$https://host:port/auth$$`.  This is _REQUIRED._"
+"and REST service endpoints are derived from this. It is usually of the form "
+"`$$https://host:port/auth$$`.  This is _REQUIRED._"
 msgstr ""
+"{project_name}サーバーのベースURL。 "
+"それ以外のすべての{project_name}ページとRESTサービスのエンドポイントは、これから派生しています。通常、 "
+"`$$https://host:port/auth$$`の形式です。 これは_必須_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:71
 #, no-wrap
 msgid "ssl-required"
-msgstr ""
+msgstr "ssl-required"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:77
 msgid ""
-"Ensures that all communication to and from the {project_name} server is over "
-"HTTPS.  In production this should be set to `all`.  This is _OPTIONAL_.  The "
-"default value is _external_ meaning that HTTPS is required by default for "
-"external requests.  Valid values are 'all', 'external' and 'none'."
+"Ensures that all communication to and from the {project_name} server is over"
+" HTTPS.  In production this should be set to `all`.  This is _OPTIONAL_.  "
+"The default value is _external_ meaning that HTTPS is required by default "
+"for external requests.  Valid values are 'all', 'external' and 'none'."
 msgstr ""
+"{project_name}サーバーとの間のすべての通信がHTTPS経由であることを保証します。プロダクション環境では、これを`all`に設定する必要があります。これは_任意_です。デフォルト値は_external_です。つまり、外部リクエストに対してデフォルトでHTTPSが必要です。有効な値は'all'、'external'、'none'です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:78
 #, no-wrap
 msgid "use-resource-role-mappings"
-msgstr ""
+msgstr "use-resource-role-mappings"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:82
 msgid ""
-"If set to true, the adapter will look inside the token for application level "
-"role mappings for the user. If false, it will look at the realm level for "
+"If set to true, the adapter will look inside the token for application level"
+" role mappings for the user. If false, it will look at the realm level for "
 "user role mappings.  This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
+"trueに設定すると、アダプターは、ユーザーのアプリケーション・レベルのロール・マッピングのトークンを調べます。falseの場合、ユーザー・ロール・マッピングのレルム・レベルが表示されます。"
+" これは_任意_です。デフォルト値は_false_です。 "
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:83
 #, no-wrap
 msgid "public-client"
-msgstr ""
+msgstr "public-client"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:87
@@ -270,12 +286,13 @@ msgid ""
 "If set to true, the adapter will not send credentials for the client to "
 "{project_name}.  This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
+"trueに設定すると、アダプターはクライアントのクレデンシャルを{project_name}に送信しません。これは_任意_です。デフォルト値は_false_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:88
 #, no-wrap
 msgid "enable-cors"
-msgstr ""
+msgstr "enable-cors"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:92
@@ -284,12 +301,14 @@ msgid ""
 "also look into the access token to determine valid origins.  This is "
 "_OPTIONAL_.  The default value is _false_."
 msgstr ""
+"これにより、CORSサポートが有効になります。 "
+"CORSプリフライト・リクエストを処理します。また、アクセス・トークンを調べて、有効な起点を特定します。これは_任意_です。デフォルト値は_false_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:93
 #, no-wrap
 msgid "cors-max-age"
-msgstr ""
+msgstr "cors-max-age"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:97
@@ -298,12 +317,14 @@ msgid ""
 "header.  This is _OPTIONAL_.  If not set, this header is not returned in "
 "CORS responses."
 msgstr ""
+"CORSが有効な場合、これは`Access-Control-Max-"
+"Age`ヘッダーの値を設定します。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:98
 #, no-wrap
 msgid "cors-allowed-methods"
-msgstr ""
+msgstr "cors-allowed-methods"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:103
@@ -312,6 +333,8 @@ msgid ""
 "Methods` header.  This should be a comma-separated string.  This is "
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
+"CORSが有効な場合、これは`Access-Control-Allow-Methods`ヘッダーの値を設定します。 "
+"これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:104
@@ -326,6 +349,8 @@ msgid ""
 "Headers` header.  This should be a comma-separated string.  This is "
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
+"CORSが有効な場合、これは`Access-Control-Allow-Headers`ヘッダーの値を設定します。 "
+"これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:110
@@ -340,6 +365,8 @@ msgid ""
 "Headers` header.  This should be a comma-separated string.  This is "
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
+"CORSが有効な場合、これは`Access-Control-Expose-Headers`ヘッダーの値を設定します。 "
+"これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:116
@@ -354,6 +381,8 @@ msgid ""
 "attempt to authenticate users, but only verify bearer tokens.  This is "
 "_OPTIONAL_.  The default value is _false_."
 msgstr ""
+"これは、サービスに対して_true_に設定する必要があります。 "
+"有効にすると、アダプターはユーザーを認証しようとせず、ベアラー・トークンのみを検証します。これは_任意_です。デフォルト値は_false_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:121
@@ -366,13 +395,18 @@ msgstr "autodetect-bearer-only"
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:58
 msgid ""
 "This should be set to __true__ if your application serves both a web "
-"application and web services (e.g. SOAP or REST).  It allows you to redirect "
-"unauthenticated users of the web application to the Keycloak login page, but "
-"send an HTTP `401` status code to unauthenticated SOAP or REST clients "
-"instead as they would not understand a redirect to the login page.  Keycloak "
-"auto-detects SOAP or REST clients based on typical headers like `X-Requested-"
-"With`, `SOAPAction` or `Accept`.  The default value is _false_."
+"application and web services (e.g. SOAP or REST).  It allows you to redirect"
+" unauthenticated users of the web application to the Keycloak login page, "
+"but send an HTTP `401` status code to unauthenticated SOAP or REST clients "
+"instead as they would not understand a redirect to the login page.  Keycloak"
+" auto-detects SOAP or REST clients based on typical headers like `X"
+"-Requested-With`, `SOAPAction` or `Accept`.  The default value is _false_."
 msgstr ""
+"アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
+"に設定する必要があります。 "
+"Webアプリケーションの未認証のユーザーをKeycloakログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
+" `401` ステータスコードを送信します。 Keycloakは、  `X-Requested-With` 、 `SOAPAction` 、 "
+"`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。 デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:128
@@ -387,6 +421,8 @@ msgid ""
 "is enabled, then _secret_ must also be provided.  This is _OPTIONAL_.  The "
 "default value is _false_."
 msgstr ""
+"これは、基本認証もサポートするようにアダプターに指示します。このオプションを有効にすると、_secret_も指定する必要があります。これは_任意_です。"
+" デフォルト値は_false_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:133
@@ -398,55 +434,61 @@ msgstr "expose-token"
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:137
 msgid ""
 "If `true`, an authenticated browser client (via a Javascript HTTP "
-"invocation) can obtain the signed access token via the URL `root/"
-"k_query_bearer_token`.  This is _OPTIONAL_.  The default value is _false_."
+"invocation) can obtain the signed access token via the URL "
+"`root/k_query_bearer_token`.  This is _OPTIONAL_.  The default value is "
+"_false_."
 msgstr ""
+"`true`の場合、（JavascriptのHTTP呼び出しを介して）認証されたブラウザ・クライアントが、`root/k_query_bearer_token`のURLを介して署名付きのアクセス・トークンを取得できます。"
+" これは_任意_です。デフォルト値は_false_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:138
 #: source/server_admin/topics/overview/concepts.adoc:14
 #, no-wrap
 msgid "credentials"
-msgstr ""
+msgstr "credentials"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:141
 msgid ""
-"Specify the credentials of the application. This is an object notation where "
-"the key is the credential type and the value is the value of the credential "
-"type.  Currently password and jwt is supported. This is _REQUIRED_ only for "
-"clients with 'Confidential' access type."
+"Specify the credentials of the application. This is an object notation where"
+" the key is the credential type and the value is the value of the credential"
+" type.  Currently password and jwt is supported. This is _REQUIRED_ only for"
+" clients with 'Confidential' access type."
 msgstr ""
+"アプリケーションのクレデンシャルを指定します。これは、キーがクレデンシャル・タイプで、値がクレデンシャル・タイプの値であるオブジェクト表記法です。 "
+"現在、パスワードとJWTがサポートされています。これは、`コンフィデンシャル`・アクセス・タイプのクライアントの場合にのみ_必須_です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:147
 msgid ""
-"Adapters will make separate HTTP invocations to the {project_name} server to "
-"turn an access code into an access token.  This config option defines how "
+"Adapters will make separate HTTP invocations to the {project_name} server to"
+" turn an access code into an access token.  This config option defines how "
 "many connections to the {project_name} server should be pooled.  This is "
 "_OPTIONAL_.  The default value is `20`."
 msgstr ""
+"アダプターは、アクセス・コードをアクセス・トークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。"
+" これは _OPTIONAL_ です。デフォルトは`20`です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:148
 #, no-wrap
 msgid "disable-trust-manager"
-msgstr ""
+msgstr "disable-trust-manager"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:153
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:33
 msgid ""
-"If the {project_name} server requires HTTPS and this config option is set to "
-"`true` you do not have to specify a truststore.  This setting should only be "
-"used during development and *never* in production as it will disable "
-"verification of SSL certificates.  This is _OPTIONAL_.  The default value is "
-"`false`."
+"If the {project_name} server requires HTTPS and this config option is set to"
+" `true` you do not have to specify a truststore.  This setting should only "
+"be used during development and *never* in production as it will disable "
+"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
+" `false`."
 msgstr ""
-"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` に設定す"
-"る場合は、トラスト・ストアを指定する必要はありません。この設定は、開発時にの"
-"み使用すべきで、 SSL証明書の検証を無効にできない本番環境では、 *決して使用し"
-"てはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
+"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、 本番環境では "
+"*決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:154
@@ -457,13 +499,17 @@ msgstr "allow-any-hostname"
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:160
 msgid ""
-"If the {project_name} server requires HTTPS and this config option is set to "
-"`true` the {project_name} server's certificate is validated via the "
+"If the {project_name} server requires HTTPS and this config option is set to"
+" `true` the {project_name} server's certificate is validated via the "
 "truststore, but host name validation is not done.  This setting should only "
 "be used during development and *never* in production as it will disable "
 "verification of SSL certificates.  This seting may be useful in test "
 "environments This is _OPTIONAL_.  The default value is `false`."
 msgstr ""
+"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。 "
+"SSL証明書の検証が無効となるため、この設定は開発時にのみ使用すべきで、本番環境では *決して使用してはいけません* 。これは_任意_です。デフォルトは"
+" `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:161
@@ -474,7 +520,7 @@ msgstr "proxy-url"
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:163
 msgid "The URL for the HTTP proxy if one is used."
-msgstr ""
+msgstr "HTTPプロキシが使用されている場合のURL。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:164
@@ -490,13 +536,17 @@ msgid ""
 "`classpath:`, then the truststore will be obtained from the deployment's "
 "classpath instead.  Used for outgoing HTTPS communications to the "
 "{project_name} server.  Client making HTTPS requests need a way to verify "
-"the host of the server they are talking to.  This is what the trustore "
-"does.  The keystore contains one or more trusted host certificates or "
-"certificate authorities.  You can create this truststore by extracting the "
-"public certificate of the {project_name} server's SSL keystore.  This is "
-"_REQUIRED_ unless `ssl-required` is `none` or `disable-trust-manager` is "
-"`true`."
+"the host of the server they are talking to.  This is what the trustore does."
+"  The keystore contains one or more trusted host certificates or certificate"
+" authorities.  You can create this truststore by extracting the public "
+"certificate of the {project_name} server's SSL keystore.  This is _REQUIRED_"
+" unless `ssl-required` is `none` or `disable-trust-manager` is `true`."
 msgstr ""
+"値は、キーストア・ファイルへのファイルパスです。 "
+"`classpath：`でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。{project_name}サーバーへのHTTPS通信に使用されます。"
+" "
+"HTTPSリクエストを行うクライアントは、通信しているサーバーのホストを確認する方法が必要です。これは、トラストアの役割です。キーストアには、1つ以上の信頼できるホストの証明書または証明機関が含まれています。このトラストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。"
+" `ssl-required`が`none`か`disable-trust-manager`が`true`でない限り、これは_必須_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:174
@@ -508,11 +558,11 @@ msgstr "truststore-password"
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:177
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:56
 msgid ""
-"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is "
-"set and the truststore requires a password."
+"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
+" set and the truststore requires a password."
 msgstr ""
-"トラスト・ストアのキーストアのパスワードです。これは _REQUIRED_ で、 "
-"`truststore` を設定すると、トラスト・ストアはパスワードを必要とします。"
+"トラストストアのキーストアのパスワードです。これは _REQUIRED_ で、 `truststore` "
+"を設定すると、トラストストアはパスワードを必要とします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:182
@@ -522,26 +572,25 @@ msgid ""
 "certificate for two-way SSL when the adapter makes HTTPS requests to the "
 "{project_name} server.  This is _OPTIONAL_."
 msgstr ""
-"キーストア・ファイルへのファイル・パスです。このキーストアには、アダプターが"
-"{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライア"
-"ント証明書が含まれます。これは _OPTIONAL_ です。"
+"キーストア・ファイルへのファイルパスです。このキーストアには、アダプターが{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライアント証明書を含めます。これは"
+" _OPTIONAL_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:191
 #, no-wrap
 msgid "always-refresh-token"
-msgstr ""
+msgstr "always-refresh-token"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:193
 msgid "If _true_, the adapter will refresh token in every request."
-msgstr ""
+msgstr "_true_の場合、アダプターはリクエストごとにトークンを更新します。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:194
 #, no-wrap
 msgid "register-node-at-startup"
-msgstr ""
+msgstr "register-node-at-startup"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:198
@@ -550,12 +599,14 @@ msgid ""
 "It's _false_ by default and useful only when application is clustered.  See "
 "<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
+"_true_の場合、アダプターは{project_name}に登録リクエストを送信します。これはデフォルトで_false_であり、アプリケーションがクラスタ化されている場合にのみ有効です。詳細は<<_applicationclustering,Application"
+" Clustering>>を参照してください。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:199
 #, no-wrap
 msgid "register-node-period"
-msgstr ""
+msgstr "register-node-period"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:203
@@ -564,109 +615,129 @@ msgid ""
 "application is clustered.  See <<_applicationclustering,Application "
 "Clustering>> for details"
 msgstr ""
+"{project_name}へのアダプター再登録の期間。 "
+"アプリケーションがクラスター化されている場合に便利です。詳細は<<_applicationclustering,Application "
+"Clustering>>を参照してください。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:204
 #, no-wrap
 msgid "token-store"
-msgstr ""
+msgstr "token-store"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:209
 msgid ""
 "Possible values are _session_ and _cookie_.  Default is _session_, which "
 "means that adapter stores account info in HTTP Session.  Alternative "
-"_cookie_ means storage of info in cookie.  See <<_applicationclustering,"
-"Application Clustering>> for details"
+"_cookie_ means storage of info in cookie.  See "
+"<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
+"可能な値は_session_と_cookie_です。デフォルトは_session_です。つまり、アダプターがアカウント情報をHTTPセッションに保管します。代わりの_cookie_は、情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,Application"
+" Clustering>>を参照してください。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:210
 #, no-wrap
 msgid "principal-attribute"
-msgstr ""
+msgstr "principal-attribute"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:214
 msgid ""
-"OpenID Connection ID Token attribute to populate the UserPrincipal name "
-"with.  If token attribute is null, defaults to `sub`.  Possible values are "
-"`sub`, `preferred_username`, `email`, `name`, `nickname`, `given_name`, "
+"OpenID Connect ID Token attribute to populate the UserPrincipal name with.  "
+"If token attribute is null, defaults to `sub`.  Possible values are `sub`, "
+"`preferred_username`, `email`, `name`, `nickname`, `given_name`, "
 "`family_name`."
 msgstr ""
+"OpenID "
+"ConnectのIDトークン属性を使用して、`UserPrincipal`の名前を入力します。トークン属性がnullの場合、デフォルトは`sub`です。可能な値は`sub`、`preferred_username`、`email`、`"
+" name`、`nickname`、`given_name`、`family_name`です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:215
 #, no-wrap
 msgid "turn-off-change-session-id-on-login"
-msgstr ""
+msgstr "turn-off-change-session-id-on-login"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:218
 msgid ""
-"The session id is changed by default on a successful login on some platforms "
-"to plug a security attack vector.  Change this to true if you want to turn "
+"The session id is changed by default on a successful login on some platforms"
+" to plug a security attack vector.  Change this to true if you want to turn "
 "this off This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
+"セッションIDは、一部のプラットフォームで正常にログインすると、デフォルトで変更され、セキュリティ攻撃のベクターが挿入されます。これをオフにするには、これをtrueに変更します。これは_任意_です。デフォルト値は_false_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:219
 #, no-wrap
 msgid "token-minimum-time-to-live"
-msgstr ""
+msgstr "token-minimum-time-to-live"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:224
 msgid ""
 "Amount of time, in seconds, to preemptively refresh an active access token "
-"with the {project_name} server before it expires.  This is especially useful "
-"when the access token is sent to another REST client where it could expire "
+"with the {project_name} server before it expires.  This is especially useful"
+" when the access token is sent to another REST client where it could expire "
 "before being evaluated.  This value should never exceed the realm's access "
 "token lifespan.  This is _OPTIONAL_.  The default value is `0` seconds, so "
 "adapter will refresh access token just if it's expired."
 msgstr ""
+"有効期限が切れる前に{project_name}サーバーでアクティブなアクセス・トークンをプリエンプティブにリフレッシュする時間（秒単位）。 "
+"これは、アクセストークンが評価される前に期限切れになる可能性がある別のRESTクライアントに送信されるときに特に便利です。この値は、レルムのアクセス・トークンの寿命を超えてはなりません。これは_任意_です。"
+" デフォルト値は `0`秒なので、アダプターは期限切れになったときだけ、アクセス・トークンを更新します。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:225
 #, no-wrap
 msgid "min-time-between-jwks-requests"
-msgstr ""
+msgstr "min-time-between-jwks-requests"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:231
 msgid ""
-"Amount of time, in seconds, specifying minimum interval between two requests "
-"to {project_name} to retrieve new public keys.  It is 10 seconds by "
+"Amount of time, in seconds, specifying minimum interval between two requests"
+" to {project_name} to retrieve new public keys.  It is 10 seconds by "
 "default.  Adapter will always try to download new public key when it "
 "recognize token with unknown `kid` . However it won't try it more than once "
 "per 10 seconds (by default). This is to avoid DoS when attacker sends lots "
 "of tokens with bad `kid` forcing adapter to send lots of requests to "
 "{project_name}."
 msgstr ""
+"値は、キーストア・ファイルへのファイル・パスです。`classpath：`でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。"
+" {project_name}サーバーへの発信HTTPS通信に使用されます。 "
+"HTTPS要求を行うクライアントは、話しているサーバーのホストを確認する方法が必要です。 これは、トラストアの役割です。 "
+"キーストアには、1つ以上の信頼できるホスト証明書または証明機関が含まれています。 "
+"このtruststoreは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。 `ssl-"
+"required`が` none`か `disable-trust-manager`が` true`でない限り、これは_REQUIRED_です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:232
 #, no-wrap
 msgid "public-key-cache-ttl"
-msgstr ""
+msgstr "public-key-cache-ttl"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:238
 msgid ""
-"Amount of time, in seconds, specifying maximum interval between two requests "
-"to {project_name} to retrieve new public keys.  It is 86400 seconds (1 day) "
-"by default.  Adapter will always try to download new public key when it "
-"recognize token with unknown `kid` . If it recognize token with known `kid`, "
-"it will just use the public key downloaded previously. However at least once "
-"per this configured interval (1 day by default) will be new public key "
+"Amount of time, in seconds, specifying maximum interval between two requests"
+" to {project_name} to retrieve new public keys.  It is 86400 seconds (1 day)"
+" by default.  Adapter will always try to download new public key when it "
+"recognize token with unknown `kid` . If it recognize token with known `kid`,"
+" it will just use the public key downloaded previously. However at least "
+"once per this configured interval (1 day by default) will be new public key "
 "always downloaded even if the `kid` of token is already known."
 msgstr ""
+"新しい公開鍵を取得するための、{project_name}への2つのリクエスト間の最大間隔を指定する時間（秒単位）。 "
+"デフォルトでは86400秒（1日）です。アダプターは、未知の`kid`を含むトークンを認識すると、常に新しい公開鍵をダウンロードしようとします。それが既知の`kid`のトークンを認識すれば、以前にダウンロードした公開鍵だけを使用します。しかし、この設定された間隔（デフォルトでは1日）に少なくとも1回は、トークンの`kid`が既知でも常に新しい公開鍵がダウンロードされます。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:239
 #, no-wrap
 msgid "ignore-oauth-query-parameter"
-msgstr ""
+msgstr "ignore-oauth-query-parameter"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:243
@@ -675,18 +746,22 @@ msgid ""
 "`access_token` query parameter for bearer token processing.  Users will not "
 "be able to authenticate if they only pass in an `access_token`"
 msgstr ""
+"`false`にデフォルト設定されます。`true`に設定されていると、ベアラー・トークン処理のための`access_token`クエリー・パラメーターの処理が無効になります。"
+" ユーザーは、 `access_token`を渡すだけで認証することはできません。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:244
 #, no-wrap
 msgid "redirect-rewrite-rules"
-msgstr ""
+msgstr "redirect-rewrite-rules"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:246
 msgid ""
-"If needed, specify the Redirect URI rewrite rule. This is an object notation "
-"where the key is the regular expression to which the Redirect URI is to be "
+"If needed, specify the Redirect URI rewrite rule. This is an object notation"
+" where the key is the regular expression to which the Redirect URI is to be "
 "matched and the value is the replacement String.  `$` character can be used "
 "for backreferences in the replacement String."
 msgstr ""
+"必要に応じて、リダイレクトURIリライトのルールを指定します。 "
+"これは、キーがリダイレクトURIが照合される正規表現であり、値が置換文字列であるオブジェクト表記法です。置換文字列の後方参照に`$`文字を使うことができます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -166,7 +166,7 @@ msgstr "realm"
 
 #. type: Plain text
 msgid "Name of the realm.  This is _REQUIRED._"
-msgstr "レルムの名前。 これは _必須_ です。"
+msgstr "レルムの名前。 これは _REQUIRED_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -178,8 +178,8 @@ msgid ""
 "The client-id of the application. Each application has a client-id that is "
 "used to identify the application.  This is _REQUIRED._"
 msgstr ""
-"アプリケーションのクライアントID。各アプリケーションには、アプリケーションを識別するために使用されるクライアントIDがあります。これは _必須_ "
-"です。"
+"アプリケーションのクライアントID。各アプリケーションには、アプリケーションを識別するために使用されるクライアントIDがあります。これは "
+"_REQUIRED_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -196,9 +196,9 @@ msgid ""
 "new keys from {project_name}, so when {project_name} rotate it's keys, "
 "adapter will break."
 msgstr ""
-"レルム公開鍵のPEM形式。これは管理コンソールから取得できます。これは _任意_ "
-"であり、設定することはお勧めしません。これが設定されていない場合、アダプターは必要に応じて（{project_name}の鍵をローテーションさせる場合など）、{project_name}からいつでもそれをダウンロードします。"
-" しかし、realm-public-"
+"レルム公開鍵のPEM形式です。これは管理コンソールから取得できます。これは _OPTIONAL_ "
+"であり、設定することはお勧めしません。これが設定されていない場合、アダプターは必要に応じて（{project_name}の鍵をローテーションさせる場合など）、{project_name}から常に再ダウンロードします。しかし"
+"、realm-public-"
 "keyが設定されている場合、アダプターは{project_name}から新しい鍵をダウンロードすることは無いので、{project_name}の鍵をローテーションするとアダプターが正常に動作しなくなります。"
 
 #. type: Labeled list
@@ -212,8 +212,8 @@ msgid ""
 "and REST service endpoints are derived from this. It is usually of the form "
 "`$$https://host:port/auth$$`.  This is _REQUIRED._"
 msgstr ""
-"{project_name}サーバーのベースURL。それ以外のすべての{project_name}ページとRESTサービスのエンドポイントは、これから派生しています。通常、"
-" `$$https://host:port/auth$$` の形式です。これは _必須_ です。"
+"{project_name}サーバーのベースURLです。すべての{project_name}ページとRESTサービスのエンドポイントは、これから派生しています。通常、"
+" `$$https://host:port/auth$$` の形式です。これは _REQUIRED_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -228,7 +228,7 @@ msgid ""
 "for external requests.  Valid values are 'all', 'external' and 'none'."
 msgstr ""
 "{project_name}サーバーとの間のすべての通信がHTTPS経由であることを保証します。プロダクション環境では、これを `all` "
-"に設定する必要があります。これは _任意_ です。デフォルト値は _external_ "
+"に設定する必要があります。これは _OPTIONAL_ です。デフォルト値は _external_ "
 "です。つまり、外部リクエストに対してデフォルトでHTTPSが必要です。有効な値は `all` 、 `external` 、 `none` です。"
 
 #. type: Labeled list
@@ -241,8 +241,8 @@ msgid ""
 "The confidential port used by the {project_name} server for secure "
 "connections over SSL/TLS.  This is _OPTIONAL_.  The default value is _8443_."
 msgstr ""
-"SSL/TLS.を介した安全な接続のために、{project_name}サーバーが使用する機密ポート。これは _OPTIONAL_ です。デフォルト値は"
-" _8443_ です。"
+"SSL/TLS.を介した安全な接続のために、{project_name}サーバーが使用する機密ポートです。これは _OPTIONAL_ "
+"です。デフォルト値は _8443_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -255,8 +255,8 @@ msgid ""
 " role mappings for the user. If false, it will look at the realm level for "
 "user role mappings.  This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
-"trueに設定すると、アダプターは、ユーザーのアプリケーション・レベルのロール・マッピングのトークンを調べます。falseの場合、ユーザー・ロール・マッピングのレルム・レベルが表示されます。"
-" これは _任意_ です。デフォルト値は _false_ です。 "
+"trueに設定すると、アダプターは、ユーザーのアプリケーション・レベルのロール・マッピングのトークンを調べます。falseの場合、ユーザー・ロール・マッピングのレルム・レベルを確認します。これは"
+" _OPTIONAL_ です。デフォルト値は _false_ です。 "
 
 #. type: Labeled list
 #, no-wrap
@@ -268,8 +268,8 @@ msgid ""
 "If set to true, the adapter will not send credentials for the client to "
 "{project_name}.  This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
-"trueに設定すると、アダプターはクライアントのクレデンシャルを{project_name}に送信しません。これは _任意_ です。デフォルト値は "
-"_false_ です。"
+"trueに設定すると、アダプターはクライアントのクレデンシャルを{project_name}に送信しません。これは _OPTIONAL_ "
+"です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -282,9 +282,8 @@ msgid ""
 "also look into the access token to determine valid origins.  This is "
 "_OPTIONAL_.  The default value is _false_."
 msgstr ""
-"これにより、CORSサポートが有効になります。 "
-"CORSプリフライト・リクエストを処理します。また、アクセス・トークンを調べて、有効な起点を特定します。これは _任意_ です。デフォルト値は "
-"_false_ です。"
+"これにより、CORSサポートが有効になります。CORSプリフライト・リクエストを処理します。また、アクセス・トークンを調べて、有効なオリジンを特定します。これは"
+" _OPTIONAL_ です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -297,7 +296,7 @@ msgid ""
 "header.  This is _OPTIONAL_.  If not set, this header is not returned in "
 "CORS responses."
 msgstr ""
-"CORSが有効な場合、これは `Access-Control-Max-Age` ヘッダーの値を設定します。これは _任意_ "
+"CORSが有効な場合、これは `Access-Control-Max-Age` ヘッダーの値を設定します。これは _OPTIONAL_ "
 "です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
@@ -312,7 +311,8 @@ msgid ""
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
 "CORSが有効な場合、これは `Access-Control-Allow-Methods` ヘッダーの値を設定します。 "
-"これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
+"これはカンマ区切りの文字列でなければなりません。これは _OPTIONAL_ "
+"です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #, no-wrap
@@ -326,7 +326,8 @@ msgid ""
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
 "CORSが有効な場合、これは `Access-Control-Allow-Headers` ヘッダーの値を設定します。 "
-"これはカンマ区切りの文字列でなければなりません。これは _任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
+"これはカンマ区切りの文字列でなければなりません。これは _OPTIONAL_ "
+"です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #, no-wrap
@@ -340,7 +341,8 @@ msgid ""
 "_OPTIONAL_.  If not set, this header is not returned in CORS responses."
 msgstr ""
 "CORSが有効な場合、これは `Access-Control-Expose-Headers` ヘッダーの値を設定します。 "
-"これはカンマ区切りの文字列でなければなりません。これは_任意_です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
+"これはカンマ区切りの文字列でなければなりません。これは _OPTIONAL_ "
+"です。設定されていない場合、このヘッダーはCORSレスポンスで返されません。"
 
 #. type: Labeled list
 #, no-wrap
@@ -353,8 +355,9 @@ msgid ""
 "attempt to authenticate users, but only verify bearer tokens.  This is "
 "_OPTIONAL_.  The default value is _false_."
 msgstr ""
-"これは、サービスに対して _true_ に設定する必要があります。 "
-"有効にすると、アダプターはユーザーを認証しようとせず、ベアラー・トークンのみを検証します。これは _任意_です。デフォルト値は _false_です。"
+"これは、サービスに対して _true_ "
+"に設定する必要があります。有効にすると、アダプターはユーザーを認証しようとせず、ベアラー・トークンのみを検証します。これは "
+"_OPTIONAL_です。デフォルト値は _false_です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -373,9 +376,9 @@ msgid ""
 msgstr ""
 "アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
 "に設定する必要があります。 "
-"Webアプリケーションの未認証のユーザーをKeycloakログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
-" `401` ステータスコードを送信します。 Keycloakは、  `X-Requested-With` 、 `SOAPAction` 、 "
-"`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。 デフォルト値は _false_ です。"
+"Webアプリケーションの未認証のユーザーをKeycloakのログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
+" `401` ステータスコードを送信します。Keycloakは、 `X-Requested-With` 、 `SOAPAction` 、 "
+"`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -388,8 +391,8 @@ msgid ""
 "is enabled, then _secret_ must also be provided.  This is _OPTIONAL_.  The "
 "default value is _false_."
 msgstr ""
-"これは、基本認証もサポートするようにアダプターに指示します。このオプションを有効にすると、 _secret_ も指定する必要があります。これは _任意_"
-" です。 デフォルト値は _false_ です。"
+"これは、BASIC認証もサポートするようにアダプターに指示します。このオプションを有効にすると、 _secret_ も指定する必要があります。これは "
+"_OPTIONAL_ です。 デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -403,8 +406,8 @@ msgid ""
 "`root/k_query_bearer_token`.  This is _OPTIONAL_.  The default value is "
 "_false_."
 msgstr ""
-"`true` の場合、（JavascriptのHTTP呼び出しを介して）認証されたブラウザ・クライアントが、 "
-"`root/k_query_bearer_token` のURLを介して署名付きのアクセス・トークンを取得できます。これは _任意_ "
+"`true` の場合、（JavascriptのHTTP呼び出しを介して）認証されたブラウザー・クライアントが、 "
+"`root/k_query_bearer_token` のURLを介して署名付きのアクセス・トークンを取得できます。これは _OPTIONAL_ "
 "です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
@@ -420,7 +423,8 @@ msgid ""
 " clients with 'Confidential' access type."
 msgstr ""
 "アプリケーションのクレデンシャルを指定します。これは、キーがクレデンシャル・タイプで、値がクレデンシャル・タイプの値であるオブジェクト表記法です。 "
-"現在、パスワードとJWTがサポートされています。これは、 `コンフィデンシャル` のアクセス・タイプのクライアントの場合にのみ _必須_ です。"
+"現在、パスワードとJWTがサポートされています。これは、 `Confidential` のアクセス・タイプのクライアントの場合にのみ "
+"_REQUIRED_ です。"
 
 #. type: Plain text
 msgid ""
@@ -429,8 +433,8 @@ msgid ""
 "many connections to the {project_name} server should be pooled.  This is "
 "_OPTIONAL_.  The default value is `20`."
 msgstr ""
-"アダプターは、アクセス・コードをアクセス・トークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。"
-" これは _OPTIONAL_ です。デフォルトは`20`です。"
+"アダプターは、アクセス・コードをアクセス・トークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。これは"
+" _OPTIONAL_ です。デフォルトは `20` です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -446,7 +450,7 @@ msgid ""
 " `false`."
 msgstr ""
 "{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
-"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、 本番環境では "
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、本番環境では "
 "*決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
@@ -464,9 +468,8 @@ msgid ""
 "environments This is _OPTIONAL_.  The default value is `false`."
 msgstr ""
 "{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
-"に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。 "
-"SSL証明書の検証が無効となるため、この設定は開発時にのみ使用すべきで、本番環境では *決して使用してはいけません* 。これは _任意_ "
-"です。デフォルトは `false` です。"
+"に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。SSL証明書の検証が無効となるため、この設定は開発時にのみ使用すべきで、本番環境では"
+" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -475,7 +478,7 @@ msgstr "proxy-url"
 
 #. type: Plain text
 msgid "The URL for the HTTP proxy if one is used."
-msgstr "HTTPプロキシが使用されている場合のURL。"
+msgstr "HTTPプロキシを使用する場合はそのURLを設定します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -494,10 +497,10 @@ msgid ""
 "certificate of the {project_name} server's SSL keystore.  This is _REQUIRED_"
 " unless `ssl-required` is `none` or `disable-trust-manager` is `true`."
 msgstr ""
-"値は、キーストア・ファイルへのファイルパスです。 "
-"`classpath：`でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。{project_name}サーバーへのHTTPS通信に使用されます。HTTPSリクエストを行うクライアントは、通信しているサーバーのホストを確認する方法が必要です。これは、トラストアの役割です。キーストアには、1つ以上の信頼できるホストの証明書または証明機関が含まれています。このトラストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。"
-" `ssl-required`が `none` か `disable-trust-manager` が `true` でない限り、これは _必須_ "
-"です。"
+"キーストア・ファイルへのファイルパスです。パスに `classpath:` "
+"を付けると、トラストストアはデプロイメントのクラスパスから取得されます。これは{project_name}サーバーへのHTTPS通信に使用されます。HTTPSリクエストを行うクライアントは、通信を行うサーバーのホストを検証する必要があります。これがトラストストアの役割です。キーストアには、1つ以上の信頼されたホストの証明書または認証局が含まれています。このトラストストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。これは、"
+" `ssl-required` が `none` か `disable-trust-manager` が `true` でない限り、 "
+"_REQUIRED_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -542,8 +545,7 @@ msgid ""
 "<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
 "_true_ の場合、アダプターは{project_name}に登録リクエストを送信します。これはデフォルトで _false_ "
-"であり、アプリケーションがクラスタ化されている場合にのみ有効です。詳細は<<_applicationclustering,Application "
-"Clustering>>を参照してください。"
+"であり、アプリケーションがクラスター化されている場合にのみ有効です。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -556,9 +558,7 @@ msgid ""
 "application is clustered.  See <<_applicationclustering,Application "
 "Clustering>> for details"
 msgstr ""
-"{project_name}へのアダプター再登録の期間。 "
-"アプリケーションがクラスター化されている場合に便利です。詳細は<<_applicationclustering,Application "
-"Clustering>>を参照してください。"
+"{project_name}へアダプターを再登録する期間です。アプリケーションがクラスター化されている場合に便利です。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -572,10 +572,9 @@ msgid ""
 "_cookie_ means storage of info in cookie.  See "
 "<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
-"可能な値は _session_ と _cookie_ です。デフォルトは _session_ "
+"設定可能な値は _session_ と _cookie_ です。デフォルトは _session_ "
 "です。つまり、アダプターがアカウント情報をHTTPセッションに保管します。代わりの _cookie_ "
-"は、情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,Application "
-"Clustering>>を参照してください。"
+"は、情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -589,9 +588,9 @@ msgid ""
 "`preferred_username`, `email`, `name`, `nickname`, `given_name`, "
 "`family_name`."
 msgstr ""
-"OpenID ConnectのIDトークン属性を使用して、 `UserPrincipal` "
-"の名前を入力します。トークン属性がnullの場合、デフォルトは `sub` です。可能な値は `sub` 、 `preferred_username` "
-"、 `email` 、 ` name` 、 `nickname` 、 `given_name` 、 `family_name` です。"
+"ユーザー・プリンシパル名とするOpenID ConnectのIDトークン属性を設定します。トークン属性がnullの場合は、デフォルトは `sub` "
+"になります。有効な値は `sub` 、 `preferred_username` 、 `email` 、 `name` 、 `nickname` 、 "
+"`given_name` 、 `family_name` です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -604,8 +603,8 @@ msgid ""
 " to plug a security attack vector.  Change this to true if you want to turn "
 "this off This is _OPTIONAL_.  The default value is _false_."
 msgstr ""
-"セッションIDは、一部のプラットフォームで正常にログインすると、デフォルトで変更され、セキュリティ攻撃のベクターが挿入されます。これをオフにするには、これをtrueに変更します。これは"
-" _任意_ です。デフォルト値は _false_ です。"
+"セッションIDは、セキュリティ攻撃口とならないように、一部のプラットフォームで正常にログインするとデフォルトで変更されます。これを無効にするにはtrueに変更します。これは"
+" _OPTIONAL_ です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -621,9 +620,8 @@ msgid ""
 "token lifespan.  This is _OPTIONAL_.  The default value is `0` seconds, so "
 "adapter will refresh access token just if it's expired."
 msgstr ""
-"有効期限が切れる前に{project_name}サーバーでアクティブなアクセス・トークンをプリエンプティブにリフレッシュする時間（秒単位）。 "
-"これは、アクセストークンが評価される前に期限切れになる可能性がある別のRESTクライアントに送信されるときに特に便利です。この値は、レルムのアクセス・トークンの寿命を超えてはなりません。これは"
-" _任意_ です。 デフォルト値は `0` 秒なので、アダプターは期限切れになったときだけ、アクセス・トークンを更新します。"
+"アクセス・トークンの有効期限が切れる前に、{project_name}サーバーでアクティブなアクセス・トークンを先にリフレッシュする時間です（秒単位）。これは、アクセス・トークンが評価される前に期限切れになる可能性がある別のRESTクライアントに送信されるときに特に便利です。この値は、レルムのアクセス・トークンの寿命を超えてはなりません。これは"
+" _OPTIONAL_ です。 デフォルト値は `0` 秒なので、アダプターは期限切れになったときだけ、アクセス・トークンを更新します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -640,14 +638,11 @@ msgid ""
 "of tokens with bad `kid` forcing adapter to send lots of requests to "
 "{project_name}."
 msgstr ""
-"値は、キーストア・ファイルへのファイル・パスです。 `classpath：` "
-"でパスの前にプレフィックスを付けると、代わりに配備のクラスパスからトラストストアが取得されます。 "
-"{project_name}サーバーへの発信HTTPS通信に使用されます。 "
-"HTTPS要求を行うクライアントは、話しているサーバーのホストを確認する方法が必要です。 これは、トラストアの役割です。 "
-"キーストアには、1つ以上の信頼できるホスト証明書または証明機関が含まれています。 "
-"このtruststoreは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。 `ssl-"
-"required` が `none` か `disable-trust-manager` が `true` でない限り、これは _REQUIRED_ "
-"です。"
+"新しい公開鍵を取得するための、{project_name}への2つのリクエスト間の最小間隔を指定する時間です（秒単位）。デフォルトでは10秒です。アダプターは、未知の"
+" `kid` "
+"を含むトークンを認識すると、常に新しい公開鍵をダウンロードしようとします。ただし、（デフォルトでは）10秒に1回以上試行しません。これは、攻撃者が不正な"
+" `kid` "
+"で大量のトークンを送りつけて、アダプターから{project_name}に大量のリクエストを送信させるというDoSを防ぐために使用されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -664,7 +659,7 @@ msgid ""
 "once per this configured interval (1 day by default) will be new public key "
 "always downloaded even if the `kid` of token is already known."
 msgstr ""
-"新しい公開鍵を取得するための、{project_name}への2つのリクエスト間の最大間隔を指定する時間（秒単位）。デフォルトでは86400秒（1日）です。アダプターは、未知の"
+"新しい公開鍵を取得するための、{project_name}への2つのリクエスト間の最大間隔を指定する時間です（秒単位）。デフォルトでは86400秒（1日）です。アダプターは、未知の"
 " `kid` を含むトークンを認識すると、常に新しい公開鍵をダウンロードしようとします。それが既知の `kid` "
 "のトークンを認識すれば、以前にダウンロードした公開鍵だけを使用します。しかし、この設定された間隔（デフォルトでは1日）に少なくとも1回は、トークンの "
 "`kid` が既知でも常に新しい公開鍵がダウンロードされます。"
@@ -680,7 +675,7 @@ msgid ""
 "`access_token` query parameter for bearer token processing.  Users will not "
 "be able to authenticate if they only pass in an `access_token`"
 msgstr ""
-"`false` にデフォルト設定されます。 `true` に設定されていると、ベアラー・トークン処理のための `access_token` "
+"デフォルトは `false` です。 `true` に設定されていると、ベアラー・トークン処理のための `access_token` "
 "クエリー・パラメーターの処理が無効になります。ユーザーは、 `access_token` を渡すだけで認証することはできません。"
 
 #. type: Labeled list


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__java-adapter-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__java-adapter-config/ja_JP/index.html
