### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -43,7 +43,9 @@ msgid ""
 "JavaScript apps — the goal was to be flexible enough to integrate with "
 "frameworks like https://expressjs.com/[Express.js]."
 msgstr ""
-"{project_name}は、サーバー・サイドのJavaScriptアプリケーションを保護するために、https://github.com/senchalabs/connect[Connect]の上に構築されたNode.jsアダプターを提供します。目標は、https://expressjs.com/[Express.js]などのフレームワークと統合するのに十分な柔軟性を得ることです。"
+"{project_name}は、サーバー・サイドのJavaScriptアプリケーションを保護するために、 "
+"https://github.com/senchalabs/connect[Connect]の上に構築されたNode.jsアダプターを提供します。目標は、"
+" https://expressjs.com/[Express.js]などのフレームワークと統合するのに十分な柔軟性を得ることです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:9
@@ -52,9 +54,9 @@ msgid ""
 "/keycloak-connect[ {project_name} organization] and the source is available "
 "at https://github.com/keycloak/keycloak-nodejs-connect[GitHub]."
 msgstr ""
-"ライブラリはhttps://www.npmjs.com/package/keycloak-connect[ "
-"{project_name}から直接ダウンロードすることができ、ソースはhttps://github.com/keycloak/keycloak-"
-"nodejs-connect[GitHub]で利用可能です。"
+"ライブラリは https://www.npmjs.com/package/keycloak-"
+"connect[{project_name}から直接ダウンロードすることができ、ソースは https://github.com/keycloak"
+"/keycloak-nodejs-connect[GitHub]で利用可能です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:12
@@ -64,7 +66,8 @@ msgid ""
 "supports public, confidential, and bearer-only access type. Which one to "
 "choose depends on the use-case scenario."
 msgstr ""
-"Node.jsアダプターを使用するには、まず、{project_name}管理コンソールでアプリケーションのクライアントを作成する必要があります。アダプターは、パブリック、コンフィデンシャル、ベアラーのみのアクセス・タイプをサポートします。どれを選択するかは、ユースケースのシナリオに依存します。"
+"Node.jsアダプターを使用するには、まず、{project_name}管理コンソールでアプリケーションのクライアントを作成する必要があります。アダプターは、public、confidential"
+"、bearer-onlyのアクセス・タイプをサポートします。どれを選択するかは、ユースケースのシナリオに依存します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:14
@@ -74,8 +77,9 @@ msgid ""
 "The downloaded `keycloak.json` file should be at the root folder of your "
 "project."
 msgstr ""
-"クライアントが作成されたら、`インストール`タブをクリックし、`形式オプション`に`{project_name} OIDC JSON`を選択し、` "
-"ダウンロード`をクリックします。ダウンロードした`keycloak.json`ファイルはプロジェクトのルート・フォルダーにあるはずです。"
+"クライアントが作成されたら、 `Installation` タブをクリックし、 `Format Option` で `{project_name} "
+"OIDC JSON` を選択し、 `Download` をクリックします。ダウンロードした `keycloak.json` "
+"ファイルはプロジェクトのルート・フォルダーに配置します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:18
@@ -83,7 +87,7 @@ msgid ""
 "Assuming you've already installed https://nodejs.org[Node.js], create a "
 "folder for your application:"
 msgstr ""
-"すでにhttps://nodejs.org[Node.js]がインストールされていると仮定して、アプリケーション用のフォルダーを作成します。"
+"すでに https://nodejs.org[Node.js]がインストールされていると仮定して、アプリケーション用のフォルダーを作成します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:20
@@ -97,8 +101,8 @@ msgid ""
 "Use `npm init` command to create a `package.json` for your application. Now "
 "add the {project_name} connect adapter in the dependencies list:"
 msgstr ""
-"`npm init`コマンドを使ってアプリケーション用の`package.json`を作成してください。 "
-"依存関係リストに{project_name}接続アダプターを追加します。"
+"`npm init` コマンドを使ってアプリケーション用の `package.json` "
+"を作成してください。依存関係リストに{project_name}接続アダプターを追加します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:30
@@ -136,7 +140,7 @@ msgid ""
 "The `Keycloak` class provides a central point for configuration and "
 "integration with your application.  The simplest creation involves no "
 "arguments."
-msgstr "`Keycloak`クラスは、アプリケーションの設定と統合のための中心的なポイントを提供します。最も簡単な作成では引数はありません。"
+msgstr "`Keycloak` クラスは、アプリケーションの設定と統合のための中心的なポイントを提供します。最も簡単な作成では引数はありません。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:56
@@ -166,7 +170,9 @@ msgid ""
 "(public key, realm name, various URLs).  The `keycloak.json` file is "
 "obtained from the {project_name} Admin Console."
 msgstr ""
-"デフォルトでは、keycloak固有の設定(公開鍵、レルム名、さまざまなURL)を初期化するために、アプリケーションのメイン実行可能ファイルの横に`keycloak.json`という名前のファイルがあります。`keycloak.json`ファイルは、{project_name}管理者コンソールから取得できます。"
+"デフォルトでは、keycloak固有の設定（公開鍵、レルム名、さまざまなURL）を初期化するために、アプリケーションのメイン実行可能ファイルの横に "
+"`keycloak.json` という名前のファイルがあります。 `keycloak.json` "
+"ファイルは、{project_name}管理者コンソールから取得できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:69
@@ -175,7 +181,8 @@ msgid ""
 "being used. As alternative, it's also possible to provide a configuration "
 "object, rather than the `keycloak.json` file:"
 msgstr ""
-"このメソッドでインスタンス化すると、すべてに合理的なデフォルトが使用されます。代替として、`keycloak.json`ファイルではなく、設定オブジェクトを提供することも可能です："
+"このメソッドでインスタンス化すると、合理的なデフォルトが使用されます。代替として、 `keycloak.json` "
+"ファイルではなく、次のように設定オブジェクトを提供することも可能です。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:79
@@ -190,18 +197,18 @@ msgid ""
 "};\n"
 msgstr ""
 "    let kcConfig = {\n"
-"    clientId: 'myclient',\n"
-"    bearerOnly: true,\n"
-"    serverUrl: 'http://localhost:8080/auth',\n"
-"    realm: 'myrealm',\n"
-"    realmPublicKey: 'MIIBIjANB...'\n"
-"};\n"
+"        clientId: 'myclient',\n"
+"        bearerOnly: true,\n"
+"        serverUrl: 'http://localhost:8080/auth',\n"
+"        realm: 'myrealm',\n"
+"        realmPublicKey: 'MIIBIjANB...'\n"
+"    };\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:81
 #, no-wrap
 msgid "let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
-msgstr "let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
+msgstr "    let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:84
@@ -217,8 +224,8 @@ msgid ""
 "`store` parameter, passing in the actual session store that `express-"
 "session` is using."
 msgstr ""
-"認証のために、Webセッションを使用してサーバー・サイドの状態を管理する場合は、少なくとも`store`パラメータで`Keycloak(...)`を初期化し、実際のセッション・ストアで"
-"`express-session`使用しています。"
+"認証のために、Webセッションを使用してサーバー・サイドの状態を管理する場合は、少なくとも `store` パラメータで `Keycloak(...)`"
+" を初期化し、実際のセッション・ストアで `express-session` 使用する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:94
@@ -248,7 +255,8 @@ msgid ""
 "By default, the scope value `openid` is passed as a query parameter to "
 "{project_name}'s login URL, but you can add an additional custom value:"
 msgstr ""
-"デフォルトでは、スコープ値`openid`はクエリー・パラメーターとして{project_name}のログインURLに渡されますが、カスタム値を新たに追加することもできます："
+"デフォルトでは、スコープ値 `openid` "
+"はクエリー・パラメーターとして{project_name}のログインURLに渡されますが、次のようにカスタム値を新たに追加することもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:102
@@ -260,13 +268,13 @@ msgstr "    var keycloak = new Keycloak({ scope: 'offline_access' });\n"
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:103
 #, no-wrap
 msgid "Installing Middleware"
-msgstr "ミドルウェアのインストール"
+msgstr "Middlewareのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:106
 msgid ""
 "Once instantiated, install the middleware into your connect-capable app:"
-msgstr "インスタンス化が完了したら、ミドルウェアを接続可能なアプリケーションにインストールします。"
+msgstr "インスタンス化が完了したら、Middlewareをconnectに対応したアプリケーションにインストールします。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:110
@@ -297,7 +305,7 @@ msgstr "単純な認証"
 msgid ""
 "To enforce that an user must be authenticated before accessing a resource, "
 "simply use a no-argument version of `keycloak.protect()`:"
-msgstr "リソースにアクセスする前にユーザーの認証を強制するには、引数のないバージョンの`keycloak.protect()`を使うだけです："
+msgstr "リソースにアクセスする前にユーザーの認証を強制するには、引数のないバージョンの `keycloak.protect()` を使うだけです。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:124
@@ -309,12 +317,12 @@ msgstr "    app.get( '/complain', keycloak.protect(), complaintHandler );\n"
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:126
 #, no-wrap
 msgid "Role-based authorization"
-msgstr "ロール ベースの認可"
+msgstr "ロール・ベースの認可"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:129
 msgid "To secure a resource with an application role for the current app:"
-msgstr "現在のアプリケーションのアプリケーション・ロールでリソースを保護するには:"
+msgstr "現在のアプリケーションのアプリケーション・ロールでリソースを保護するには次のようにします。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:133
@@ -327,7 +335,7 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:136
 msgid "To secure a resource with an application role for a *different* app:"
-msgstr "*別の*アプリケーションのアプリケーション・ロールでリソースを保護するには:"
+msgstr "*別の* アプリケーションのアプリケーション・ロールでリソースを保護するには次のようにします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:139
@@ -342,7 +350,7 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:141
 msgid "To secure a resource with a realm role:"
-msgstr "レルム・ロールを使用してリソースを保護するには:"
+msgstr "レルム・ロールを使用してリソースを保護するには次のようにします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:144
@@ -363,7 +371,7 @@ msgstr "高度な認可"
 msgid ""
 "To secure resources based on parts of the URL itself, assuming a role exists"
 " for each section:"
-msgstr "URLの一部に基づいてリソースを保護するには(各セクションにロールが存在すると仮定します):"
+msgstr "URLの一部に基づいてリソースを保護するには次のようにします（各セクションにロールが存在すると仮定します）。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:155
@@ -391,7 +399,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:159
 #, no-wrap
 msgid "Additional URLs"
-msgstr "追加のURI"
+msgstr "追加のURL"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:161
@@ -406,8 +414,9 @@ msgid ""
 "through a {project_name}-centric logout workflow. This can be changed by "
 "specifying a `logout` configuration parameter to the `middleware()` call:"
 msgstr ""
-"デフォルトでは、{project_name}中心のログアウト・ワークフローを通して、ユーザーを送信するために、ミドルウェアは`/logout`の呼び出しをキャッチします。これは、"
-" `logout`設定パラメーターを`middleware()`呼び出しに指定することで変更できます："
+"デフォルトでは、Middlewareは `/logout` "
+"の呼び出しをキャッチし、ユーザーに{project_name}中心のログアウト・ワークフローを経由させます。これは、 `logout` "
+"設定パラメーターを `middleware()` の呼び出しに指定することで変更できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:168
@@ -418,7 +427,7 @@ msgstr "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:170
 msgid "{project_name} Admin Callbacks::"
-msgstr "{project_name}管理者コールバック:"
+msgstr "{project_name} Adminコールバック"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:175
@@ -428,8 +437,8 @@ msgid ""
 "callbacks occur relative to the root URL of `/` but can be changed by "
 "providing an `admin` parameter to the `middleware()` call:"
 msgstr ""
-"また、ミドルウェアは{project_name}コンソールからのコールバックをサポートして、単一セッションまたはすべてのセッションをログアウトします。デフォルトでは、これらのタイプの管理者コールバックは`/`のルートURLに関連して発生しますが、"
-" `admin`パラメータを`middleware()`の呼び出しに与えることで変更できます："
+"また、Middlewareは{project_name}コンソールからのコールバックをサポートしており、単一セッションまたはすべてのセッションをログアウトします。デフォルトでは、これらのタイプのAdminコールバックは"
+" `/` のルートURLを基準に発生しますが、 `admin` パラメーターを `middleware()` の呼び出しに与えることで変更できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:176

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
@@ -23,28 +22,39 @@ msgstr ""
 msgid "Installation"
 msgstr "インストール"
 
+#. type: Title ====
+#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:60
+#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:45
+#, no-wrap
+msgid "Usage"
+msgstr "使い方"
+
 #. type: Title ===
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:2
 #, no-wrap
 msgid "Node.js Adapter"
-msgstr ""
+msgstr "Node.jsアダプター"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:5
 msgid ""
-"{project_name} provides a Node.js adapter built on top of https://github.com/"
-"senchalabs/connect[Connect] to protect server-side JavaScript apps — the "
-"goal was to be flexible enough to integrate with frameworks like https://"
-"expressjs.com/[Express.js]."
+"{project_name} provides a Node.js adapter built on top of "
+"https://github.com/senchalabs/connect[Connect] to protect server-side "
+"JavaScript apps — the goal was to be flexible enough to integrate with "
+"frameworks like https://expressjs.com/[Express.js]."
 msgstr ""
+"{project_name}は、サーバー・サイドのJavaScriptアプリケーションを保護するために、https://github.com/senchalabs/connect[Connect]の上に構築されたNode.jsアダプターを提供します。目標は、https://expressjs.com/[Express.js]などのフレームワークと統合するのに十分な柔軟性を得ることです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:9
 msgid ""
-"The library can be downloaded directly from https://www.npmjs.com/package/"
-"keycloak-connect[ {project_name} organization] and the source is available "
+"The library can be downloaded directly from https://www.npmjs.com/package"
+"/keycloak-connect[ {project_name} organization] and the source is available "
 "at https://github.com/keycloak/keycloak-nodejs-connect[GitHub]."
 msgstr ""
+"ライブラリはhttps://www.npmjs.com/package/keycloak-connect[ "
+"{project_name}から直接ダウンロードすることができ、ソースはhttps://github.com/keycloak/keycloak-"
+"nodejs-connect[GitHub]で利用可能です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:12
@@ -54,6 +64,7 @@ msgid ""
 "supports public, confidential, and bearer-only access type. Which one to "
 "choose depends on the use-case scenario."
 msgstr ""
+"Node.jsアダプターを使用するには、まず、{project_name}管理コンソールでアプリケーションのクライアントを作成する必要があります。アダプターは、パブリック、コンフィデンシャル、ベアラーのみのアクセス・タイプをサポートします。どれを選択するかは、ユースケースのシナリオに依存します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:14
@@ -63,6 +74,8 @@ msgid ""
 "The downloaded `keycloak.json` file should be at the root folder of your "
 "project."
 msgstr ""
+"クライアントが作成されたら、`インストール`タブをクリックし、`形式オプション`に`{project_name} OIDC JSON`を選択し、` "
+"ダウンロード`をクリックします。ダウンロードした`keycloak.json`ファイルはプロジェクトのルート・フォルダーにあるはずです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:18
@@ -70,12 +83,13 @@ msgid ""
 "Assuming you've already installed https://nodejs.org[Node.js], create a "
 "folder for your application:"
 msgstr ""
+"すでにhttps://nodejs.org[Node.js]がインストールされていると仮定して、アプリケーション用のフォルダーを作成します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:20
 #, no-wrap
 msgid "    mkdir myapp && cd myapp\n"
-msgstr ""
+msgstr "    mkdir myapp && cd myapp\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:22
@@ -83,6 +97,8 @@ msgid ""
 "Use `npm init` command to create a `package.json` for your application. Now "
 "add the {project_name} connect adapter in the dependencies list:"
 msgstr ""
+"`npm init`コマンドを使ってアプリケーション用の`package.json`を作成してください。 "
+"依存関係リストに{project_name}接続アダプターを追加します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:30
@@ -92,6 +108,9 @@ msgid ""
 "        \"keycloak-connect\": \"{project_versionNpm}\"\n"
 "    }\n"
 msgstr ""
+"    \"dependencies\": {\n"
+"        \"keycloak-connect\": \"{project_versionNpm}\"\n"
+"    }\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:41
@@ -101,18 +120,15 @@ msgid ""
 "        \"keycloak-connect\": \"file:keycloak-connect-{project_versionNpm}.tgz\"\n"
 "    }\n"
 msgstr ""
-
-#. type: Title ====
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:45
-#, no-wrap
-msgid "Usage"
-msgstr ""
+"    \"dependencies\": {\n"
+"        \"keycloak-connect\": \"file:keycloak-connect-{project_versionNpm}.tgz\"\n"
+"    }\n"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:46
 #, no-wrap
 msgid "Instantiate a Keycloak class"
-msgstr ""
+msgstr "Keycloakクラスのインスタンスの作成"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:51
@@ -120,7 +136,7 @@ msgid ""
 "The `Keycloak` class provides a central point for configuration and "
 "integration with your application.  The simplest creation involves no "
 "arguments."
-msgstr ""
+msgstr "`Keycloak`クラスは、アプリケーションの設定と統合のための中心的なポイントを提供します。最も簡単な作成では引数はありません。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:56
@@ -129,6 +145,8 @@ msgid ""
 "    var session = require('express-session');\n"
 "    var Keycloak = require('keycloak-connect');\n"
 msgstr ""
+"    var session = require('express-session');\n"
+"    var Keycloak = require('keycloak-connect');\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:59
@@ -137,15 +155,18 @@ msgid ""
 "    var memoryStore = new session.MemoryStore();\n"
 "    var keycloak = new Keycloak({ store: memoryStore });\n"
 msgstr ""
+"    var memoryStore = new session.MemoryStore();\n"
+"    var keycloak = new Keycloak({ store: memoryStore });\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:65
 msgid ""
-"By default, this will locate a file named `keycloak.json` alongside the main "
-"executable of your application to initialize keycloak-specific settings "
+"By default, this will locate a file named `keycloak.json` alongside the main"
+" executable of your application to initialize keycloak-specific settings "
 "(public key, realm name, various URLs).  The `keycloak.json` file is "
 "obtained from the {project_name} Admin Console."
 msgstr ""
+"デフォルトでは、keycloak固有の設定(公開鍵、レルム名、さまざまなURL)を初期化するために、アプリケーションのメイン実行可能ファイルの横に`keycloak.json`という名前のファイルがあります。`keycloak.json`ファイルは、{project_name}管理者コンソールから取得できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:69
@@ -154,6 +175,7 @@ msgid ""
 "being used. As alternative, it's also possible to provide a configuration "
 "object, rather than the `keycloak.json` file:"
 msgstr ""
+"このメソッドでインスタンス化すると、すべてに合理的なデフォルトが使用されます。代替として、`keycloak.json`ファイルではなく、設定オブジェクトを提供することも可能です："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:79
@@ -167,18 +189,25 @@ msgid ""
 "    realmPublicKey: 'MIIBIjANB...'\n"
 "};\n"
 msgstr ""
+"    let kcConfig = {\n"
+"    clientId: 'myclient',\n"
+"    bearerOnly: true,\n"
+"    serverUrl: 'http://localhost:8080/auth',\n"
+"    realm: 'myrealm',\n"
+"    realmPublicKey: 'MIIBIjANB...'\n"
+"};\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:81
 #, no-wrap
 msgid "let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
-msgstr ""
+msgstr "let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:84
 #, no-wrap
 msgid "Configuring a web session store"
-msgstr ""
+msgstr "Webセッションストアの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:90
@@ -188,6 +217,8 @@ msgid ""
 "`store` parameter, passing in the actual session store that `express-"
 "session` is using."
 msgstr ""
+"認証のために、Webセッションを使用してサーバー・サイドの状態を管理する場合は、少なくとも`store`パラメータで`Keycloak(...)`を初期化し、実際のセッション・ストアで"
+"`express-session`使用しています。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:94
@@ -196,18 +227,20 @@ msgid ""
 "    var session = require('express-session');\n"
 "    var memoryStore = new session.MemoryStore();\n"
 msgstr ""
+"    var session = require('express-session');\n"
+"    var memoryStore = new session.MemoryStore();\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:96
 #, no-wrap
 msgid "    var keycloak = new Keycloak({ store: memoryStore });\n"
-msgstr ""
+msgstr "    var keycloak = new Keycloak({ store: memoryStore });\n"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:97
 #, no-wrap
 msgid "Passing a custom scope value"
-msgstr ""
+msgstr "カスタム・スコープ値を渡す"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:100
@@ -215,113 +248,122 @@ msgid ""
 "By default, the scope value `openid` is passed as a query parameter to "
 "{project_name}'s login URL, but you can add an additional custom value:"
 msgstr ""
+"デフォルトでは、スコープ値`openid`はクエリー・パラメーターとして{project_name}のログインURLに渡されますが、カスタム値を新たに追加することもできます："
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:102
 #, no-wrap
 msgid "    var keycloak = new Keycloak({ scope: 'offline_access' });\n"
-msgstr ""
+msgstr "    var keycloak = new Keycloak({ scope: 'offline_access' });\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:103
 #, no-wrap
 msgid "Installing Middleware"
-msgstr ""
+msgstr "ミドルウェアのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:106
 msgid ""
 "Once instantiated, install the middleware into your connect-capable app:"
-msgstr ""
+msgstr "インスタンス化が完了したら、ミドルウェアを接続可能なアプリケーションにインストールします。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:110
 #, no-wrap
 msgid "    var app = express();\n"
-msgstr ""
+msgstr "    var app = express();\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:112
 #, no-wrap
 msgid "    app.use( keycloak.middleware() );\n"
-msgstr ""
+msgstr "    app.use( keycloak.middleware() );\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:114
 #, no-wrap
 msgid "Protecting Resources"
-msgstr ""
+msgstr "リソースの保護"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:116
 #, no-wrap
 msgid "Simple authentication"
-msgstr ""
+msgstr "単純な認証"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:120
 msgid ""
 "To enforce that an user must be authenticated before accessing a resource, "
 "simply use a no-argument version of `keycloak.protect()`:"
-msgstr ""
+msgstr "リソースにアクセスする前にユーザーの認証を強制するには、引数のないバージョンの`keycloak.protect()`を使うだけです："
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:124
 #, no-wrap
 msgid "    app.get( '/complain', keycloak.protect(), complaintHandler );\n"
-msgstr ""
+msgstr "    app.get( '/complain', keycloak.protect(), complaintHandler );\n"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:126
 #, no-wrap
 msgid "Role-based authorization"
-msgstr ""
+msgstr "ロール ベースの認可"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:129
 msgid "To secure a resource with an application role for the current app:"
-msgstr ""
+msgstr "現在のアプリケーションのアプリケーション・ロールでリソースを保護するには:"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:133
 #, no-wrap
-msgid "    app.get( '/special', keycloak.protect('special'), specialHandler );\n"
+msgid ""
+"    app.get( '/special', keycloak.protect('special'), specialHandler );\n"
 msgstr ""
+"    app.get( '/special', keycloak.protect('special'), specialHandler );\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:136
 msgid "To secure a resource with an application role for a *different* app:"
-msgstr ""
+msgstr "*別の*アプリケーションのアプリケーション・ロールでリソースを保護するには:"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:139
 #, no-wrap
-msgid "    app.get( '/extra-special', keycloak.protect('other-app:special', extraSpecialHandler );\n"
+msgid ""
+"    app.get( '/extra-special', keycloak.protect('other-app:special', "
+"extraSpecialHandler );\n"
 msgstr ""
+"    app.get( '/extra-special', keycloak.protect('other-app:special', "
+"extraSpecialHandler );\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:141
 msgid "To secure a resource with a realm role:"
-msgstr ""
+msgstr "レルム・ロールを使用してリソースを保護するには:"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:144
 #, no-wrap
-msgid "    app.get( '/admin', keycloak.protect( 'realm:admin' ), adminHandler );\n"
+msgid ""
+"    app.get( '/admin', keycloak.protect( 'realm:admin' ), adminHandler );\n"
 msgstr ""
+"    app.get( '/admin', keycloak.protect( 'realm:admin' ), adminHandler );\n"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:145
 #, no-wrap
 msgid "Advanced authorization"
-msgstr ""
+msgstr "高度な認可"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:149
 msgid ""
-"To secure resources based on parts of the URL itself, assuming a role exists "
-"for each section:"
-msgstr ""
+"To secure resources based on parts of the URL itself, assuming a role exists"
+" for each section:"
+msgstr "URLの一部に基づいてリソースを保護するには(各セクションにロールが存在すると仮定します):"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:155
@@ -331,24 +373,31 @@ msgid ""
 "      return token.hasRole( request.params.section );\n"
 "    }\n"
 msgstr ""
+"    function protectBySection(token, request) {\n"
+"      return token.hasRole( request.params.section );\n"
+"    }\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:157
 #, no-wrap
-msgid "    app.get( '/:section/:page', keycloak.protect( protectBySection ), sectionHandler );\n"
+msgid ""
+"    app.get( '/:section/:page', keycloak.protect( protectBySection ), "
+"sectionHandler );\n"
 msgstr ""
+"    app.get( '/:section/:page', keycloak.protect( protectBySection ), "
+"sectionHandler );\n"
 
 #. type: Title ====
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:159
 #, no-wrap
 msgid "Additional URLs"
-msgstr ""
+msgstr "追加のURI"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:161
 #, no-wrap
 msgid "Explicit user-triggered logout"
-msgstr ""
+msgstr "明示的なユーザー・トリガー・ログアウト"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:166
@@ -357,17 +406,19 @@ msgid ""
 "through a {project_name}-centric logout workflow. This can be changed by "
 "specifying a `logout` configuration parameter to the `middleware()` call:"
 msgstr ""
+"デフォルトでは、{project_name}中心のログアウト・ワークフローを通して、ユーザーを送信するために、ミドルウェアは`/logout`の呼び出しをキャッチします。これは、"
+" `logout`設定パラメーターを`middleware()`呼び出しに指定することで変更できます："
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:168
 #, no-wrap
 msgid "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
-msgstr ""
+msgstr "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:170
 msgid "{project_name} Admin Callbacks::"
-msgstr ""
+msgstr "{project_name}管理者コールバック:"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:175
@@ -377,9 +428,11 @@ msgid ""
 "callbacks occur relative to the root URL of `/` but can be changed by "
 "providing an `admin` parameter to the `middleware()` call:"
 msgstr ""
+"また、ミドルウェアは{project_name}コンソールからのコールバックをサポートして、単一セッションまたはすべてのセッションをログアウトします。デフォルトでは、これらのタイプの管理者コールバックは`/`のルートURLに関連して発生しますが、"
+" `admin`パラメータを`middleware()`の呼び出しに与えることで変更できます："
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:176
 #, no-wrap
 msgid "    app.use( keycloak.middleware( { admin: '/callbacks' } );\n"
-msgstr ""
+msgstr "    app.use( keycloak.middleware( { admin: '/callbacks' } );\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__nodejs-adapter/ja_JP/index.html
