### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,8 +42,8 @@ msgid ""
 "If you are upgrading to a new minor release, for example from 7.0.0 to "
 "7.1.0, follow the steps in xref:_upgrading_minor[Minor Upgrades]."
 msgstr ""
-"新しいマイナーリリースをアップグレードする場合、サンプルとしては7.0.0から7.1.0になりますが、xref:_upgrading_minor[Minor"
-" Upgrades]の手順に沿い行ってください。"
+"新しいマイナーリリースをアップグレードする場合（例えば7.0.0から7.1.0の場合）、xref:_upgrading_minor[Minor "
+"Upgrades]の手順に沿い行ってください。"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/upgrading.adoc:11

--- a/i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
@@ -20,21 +20,21 @@ msgstr ""
 #: source/upgrading/topics/rhsso/upgrading.adoc:3
 #, no-wrap
 msgid "Upgrading {project_name} Server"
-msgstr ""
+msgstr "{project_name}サーバーのアップグレード"
 
 #. type: Title ==
 #: source/upgrading/topics/keycloak/upgrading.adoc:14
 #: source/upgrading/topics/rhsso/upgrading.adoc:29
 #, no-wrap
 msgid "Upgrading {project_name} Adapters"
-msgstr ""
+msgstr "{project_name}アダプターのアップグレード"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/upgrading.adoc:7
 msgid ""
 "The upgrade process for the {project_name} server is different if you are "
 "upgrading to a different minor release or not."
-msgstr ""
+msgstr "{project_name}サーバーのアップグレードプロセスは、異なるマイナーリリースをアップグレードするか否かによって変わります。"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/upgrading.adoc:9
@@ -42,6 +42,8 @@ msgid ""
 "If you are upgrading to a new minor release, for example from 7.0.0 to "
 "7.1.0, follow the steps in xref:_upgrading_minor[Minor Upgrades]."
 msgstr ""
+"新しいマイナーリリースをアップグレードする場合、サンプルとしては7.0.0から7.1.0になりますが、xref:_upgrading_minor[Minor"
+" Upgrades]の手順に沿い行ってください。"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/upgrading.adoc:11
@@ -49,15 +51,17 @@ msgid ""
 "If you are upgrading to a new micro release, for example from 7.1.0 to "
 "7.1.1, follow the steps in xref:_upgrading_micro[Micro Upgrades]."
 msgstr ""
+"新しいマイクロリリースをアップグレードする場合、サンプルとしては7.1.0から7.1.1になりますが、xref:_upgrading_micro[Micro"
+" Upgrades]の手順に沿い行ってください。"
 
 #. type: Title ===
 #: source/upgrading/topics/rhsso/upgrading.adoc:13
 #, no-wrap
 msgid "Minor Upgrades"
-msgstr ""
+msgstr "マイナーアップグレード"
 
 #. type: Title ===
 #: source/upgrading/topics/rhsso/upgrading.adoc:24
 #, no-wrap
 msgid "Micro Upgrades"
-msgstr ""
+msgstr "マイクロアップグレード"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__rhsso__upgrading
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-upgrading__topics__rhsso__upgrading/ja_JP/index.html
