### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -16,20 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/params_forwarding.adoc:21
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:63
 #, no-wrap
 msgid "scope"
 msgstr "scope"
 
 #. type: Title ==
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:4
 #, no-wrap
 msgid "Token Exchange"
 msgstr "トークンの交換"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:11
 msgid ""
 "In {project_name}, token exchange is the process of using a set of "
 "credentials or token to obtain an entirely different token.  A client may "
@@ -40,40 +36,30 @@ msgid ""
 "client may have a need to impersonate a user.  Here's a short summary of the"
 " current capabilities of {project_name} around token exchange."
 msgstr ""
-"{project_name} において、トークンの交換とはクレデンシャルまたはトークンのセットを使用して全く異なるトークンを取得するプロセスです。 "
-"クライアントは信頼性の低いアプリケーションを呼び出してもよいので、現在のトークンをダウングレードすることができます。 "
-"クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために格納されたトークンを、 {project_token} "
-"に交換したいことがあります。 他の {project_name} のレルムや外部IDPによって作成された外部トークンを信頼することができます。 "
-"クライアントはユーザーを偽装する必要があるかもしれません。 トークンの交換に関する {project_name} の現在の機能の概要を簡単に説明します。"
+"{project_name}において、トークンの交換とはクレデンシャルまたはトークンのセットを使用して、全く異なるトークンを取得するプロセスです。クライアントは信頼性の低いアプリケーションを呼び出してもよいので、現在のトークンをダウングレードすることができます。クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために保存されたトークンを、{project_token}に交換したいことがあります。他の{project_name}のレルムや外部IDPによって作成された外部トークンを信頼することができます。クライアントはユーザーを偽装する必要があるかもしれません。トークンの交換に関する{project_name}の現在の機能の概要を簡単に説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:13
 msgid ""
 "A client can exchange an existing {project_name} token created for a "
 "specific client for a new token targeted to a different client"
 msgstr ""
-"クライアントは、特定のクライアントに対して作成された既存の {project_name} "
-"トークンを、別のクライアントをターゲットとする新しいトークンと交換することができます"
+"クライアントは、特定のクライアントに対して作成された既存の{project_name}トークンを、別のクライアントをターゲットとする新しいトークンと交換することができます"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:14
 msgid ""
 "A client can exchange an existing {project_name} token for an external "
 "token, i.e. a linked Facebook account"
-msgstr "クライアントは既存の {project_name} トークンを外部トークン(つまりリンクされたFacebookアカウント)と交換できます"
+msgstr "クライアントは既存の{project_name}トークンを外部トークン(つまりリンクされたFacebookアカウント)と交換できます"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:15
 msgid "A client can exchange an external token for a {project_name} token."
-msgstr "クライアントは、外部トークンを {project_name} トークンに交換できます。"
+msgstr "クライアントは、外部トークンを{project_name}トークンに交換できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:16
 msgid "A client can impersonate a user"
 msgstr "クライアントはユーザーを偽装することができます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:20
 msgid ""
 "Token exchange in {project_name} is a very loose implementation of the "
 "link:http://www.ietf.org/id/draft-ietf-oauth-token-exchange-09.txt[OAuth "
@@ -82,19 +68,17 @@ msgid ""
 "specification.  It is a simple grant type invocation on a realm's OpenID "
 "Connect token endpoint."
 msgstr ""
-"{project_name} のトークンの交換は、 link:http://www.ietf.org/id/draft-ietf-oauth-"
-"token-exchange-09.txt[OAuth Token Exchange] 仕様の非常にルーズな実装です。 "
-"それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。 これは、あるレルムのOpenID "
-"Connectトークン・エンドポイントでの単純なグラント・タイプの呼び出しです。"
+"{project_name}のトークンの交換は、link:http://www.ietf.org/id/draft-ietf-oauth-token-"
+"exchange-09.txt[OAuth Token "
+"Exchange]仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
+" Connectトークン・エンドポイントでの単純なグラント・タイプの呼び出しです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:23
 #, no-wrap
 msgid "/realms/{realm}/protocol/openid-connect/token\n"
 msgstr "/realms/{realm}/protocol/openid-connect/token\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:30
 msgid ""
 "It accepts form parameters (`application/x-www-form-urlencoded`) as input "
 "and the output depends on the type of token you requested an exchange for.  "
@@ -105,22 +89,16 @@ msgid ""
 "admin has configured the client authentication flow in your realm.  Here's a"
 " list of form parameters"
 msgstr ""
-"フォーム・パラメータ (`application/x-www-form-urlencoded`) "
-"を入力として受け取り、出力はあなたが交換をリクエストしたトークンのタイプに依存します。 "
-"トークンの交換はクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。 "
-"パブリック・クライアントは、クライアント識別子をフォーム・パラメータとして指定します。 "
-"コンフィデンシャル・BASIC認証クライアントは、フォームパラメータを使用してクライアントIDとシークレット、Basic "
-"Authを渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。 フォームパラメータのリストは次のとおりです"
+"フォーム・パラメーター( `application/x-www-form-urlencoded` "
+")を入力として受け取り、出力は交換をリクエストしたトークンのタイプに依存します。トークンの交換はクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。パブリック・クライアントは、クライアント識別子をフォーム・パラメーターとして指定します。コンフィデンシャル・BASIC認証クライアントは、フォーム・パラメーターを使用してクライアントIDとシークレット、Basic"
+" Authを渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。 フォーム・パラメーターのリストは次のとおりです"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:31
-#: source/server_development/topics/identity-brokering/account-linking.adoc:33
 #, no-wrap
 msgid "client_id"
 msgstr "client_id"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:34
 msgid ""
 "_REQUIRED MAYBE._ This parameter is required for clients using form "
 "parameters for authentication.  If you are using Basic Auth, a client JWT "
@@ -130,13 +108,11 @@ msgstr ""
 "Auth、クライアントJWTトークン、またはクライアント証明書認証を使用している場合は、このパラメーターを指定しないでください。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:34
 #, no-wrap
 msgid "client_secret"
 msgstr "client_secret"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:37
 msgid ""
 "_REQUIRED MAYBE_.  This parameter is required for clients using form "
 "parameters for authentication and using a client secret as a credential.  Do"
@@ -148,13 +124,11 @@ msgstr ""
 "レルム内のクライアント呼び出しが別の方法で認証されている場合は、このパラメータを指定しないでください。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:38
 #, no-wrap
 msgid "grant_type"
 msgstr "grant_type"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:40
 msgid ""
 "_REQUIRED._ The value of the parameter must be `urn:ietf:params:oauth:grant-"
 "type:token-exchange`."
@@ -163,29 +137,25 @@ msgstr ""
 "でなければなりません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:40
 #, no-wrap
 msgid "subject_token"
 msgstr "subject_token"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:42
 msgid ""
 "_OPTIONAL._ A security token that represents the identity of the party on "
 "behalf of whom the request is being made.  It is required if you are "
 "exchanging an existing token for a new one."
 msgstr ""
-"_OPTIONAL._ リクエストを送信したユーザーの代りのパーティのアイデンティティを表すセキュリティトークン。 "
-"既存のトークンを新しいトークンと交換する場合に必要です。"
+"_OPTIONAL._ "
+"リクエストを送信したユーザーの代りのパーティのアイデンティティを表すセキュリティ・トークン。既存のトークンを新しいトークンと交換する場合に必要です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:42
 #, no-wrap
 msgid "subject_issuer"
 msgstr "subject_issuer"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:46
 msgid ""
 "_OPTIONAL._ Identifies the issuer of the `subject_token`.  It can be left "
 "blank if the token comes from the current realm or if the issuer can be "
@@ -194,19 +164,17 @@ msgid ""
 "for your realm.  Or an issuer claim identifier configured by a specific "
 "`Identity Provider`."
 msgstr ""
-"_OPTIONAL._ `subject_token` の発行者を識別します。 トークンが現在のレルムから来た場合、または発行者が "
-"`subject_token_type` から決定できる場合は、空白のままにすることができます。 それ以外の場合は、指定する必要があります。 "
-"有効な値は、レルムに設定された `Identity Provider` のエイリアスです。 または、特定の `Identity Provider` "
-"によって設定された発行者クレーム識別子です。"
+"_OPTIONAL._ `subject_token` の発行者を識別します。トークンが現在のレルムから来た場合、または発行者が "
+"`subject_token_type` "
+"から決定できる場合は、空白のままにすることができます。それ以外の場合は、指定する必要があります。有効な値は、レルムに設定された `Identity "
+"Provider` のエイリアスです。または、特定の `Identity Provider` によって設定された発行者クレーム識別子です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:46
 #, no-wrap
 msgid "subject_token_type"
 msgstr "subject_token_type"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:51
 msgid ""
 "_OPTIONAL._ This parameter is the type of the token passed with the "
 "`subject_token` parameter.  This defaults to `urn:ietf:params:oauth:token-"
@@ -216,17 +184,15 @@ msgid ""
 msgstr ""
 "_OPTIONAL._ このパラメータは `subject_token` パラメータで渡されるトークンのタイプです。 `subject_token` "
 "がレルムから来て、アクセス・トークンである場合、これはデフォルトで `urn:ietf:params:oauth:token-"
-"type:access_token` になります。 それが外部トークンである場合、このパラメータは `subject_issuer` "
-"の要件に応じて指定する必要がある場合とない場合があります。"
+"type:access_token` になります。それが外部トークンである場合、このパラメータは `subject_issuer` "
+"の要件に応じて、指定する必要がある場合とない場合があります。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:51
 #, no-wrap
 msgid "requested_token_type"
 msgstr "requested_token_type"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:56
 msgid ""
 "_OPTIONAL._ This parameter represents the type of token the client wants to "
 "exchange for.  Currently only oauth and OpenID Connect token types are "
@@ -236,79 +202,70 @@ msgid ""
 "appropriate values are `urn:ietf:params:oauth:token-type:access_token` and "
 "`urn:ietf:params:oauth:token-type:id_token`"
 msgstr ""
-"_OPTIONAL._ このパラメータは、クライアントが交換したいトークンのタイプを表します。 現在、トークン・タイプとしてOAuthとOpenID "
-"Connectのみがサポートされています。 デフォルト値は、これが `urn:ietf:params:oauth:token-"
+"_OPTIONAL._ このパラメータは、クライアントが交換したいトークンのタイプを表します。現在、トークン・タイプとしてOAuthとOpenID "
+"Connectのみがサポートされています。デフォルト値は、これが `urn:ietf:params:oauth:token-"
 "type:refresh_token` "
-"であるかどうかによって決まります。この場合、レスポンス内でアクセス・トークンとリフレッシュ・トークンの両方が返されます。 その他の適切な値は "
+"であるかどうかによって決まります。この場合、レスポンス内でアクセス・トークンとリフレッシュ・トークンの両方が返されます。その他の適切な値は "
 "`urn:ietf:params:oauth:token-type:access_token` と `urn:ietf:params:oauth"
 ":token-type:id_token` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:56
 #, no-wrap
 msgid "audience"
 msgstr "audience"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:58
 msgid ""
 "_OPTIONAL._ This parameter specifies the target client you want the new "
 "token minted for."
 msgstr "_OPTIONAL._ このパラメータには、新しいトークンを作成する対象となるクライアントを指定します。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:58
 #, no-wrap
 msgid "requested_issuer"
 msgstr "requested_issuer"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:61
 msgid ""
 "_OPTIONAL._ This parameter specifies that the client wants a token minted by"
 " an external provider.  It must be the alias of an `Identity Provider` "
 "configured within the realm."
 msgstr ""
-"_OPTIONAL._ このパラメーターは、クライアントが外部プロバイダーによって作成されたトークンを必要とすることを指定します。 "
-"これは、レルム内で設定された `Identity Provider` のエイリアスでなければなりません。"
+"_OPTIONAL._ "
+"このパラメーターは、クライアントが外部プロバイダーによって作成されたトークンを必要とすることを指定します。これは、レルム内で設定された "
+"`Identity Provider` のエイリアスでなければなりません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:61
 #, no-wrap
 msgid "requested_subject"
 msgstr "requested_subject"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:63
 msgid ""
 "_OPTIONAL._ This specifies a username or user id if your client wants to "
 "impersonate a different user."
 msgstr "_OPTIONAL._ クライアントが別のユーザーになりすます場合は、ユーザー名またはユーザーIDを指定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:67
 msgid ""
 "_NOT IMPLEMENTED._ This parameter represents the target set of OAuth and "
 "OpenID Connect scopes the client is requesting.  It is not implemented at "
 "this time but will be once {project_name} has better support for scopes in "
 "general."
 msgstr ""
-"_NOT IMPLEMENTED._ このパラメータは、クライアントが要求しているOAuthおよびOpenID "
-"Connectのスコープのセットを表します。 現時点では実装されていませんが、　{project_name} "
-"がスコープの一般的なサポートを強化した後に利用可能になります。"
+"_NOT IMPLEMENTED._ このパラメーターは、クライアントが要求しているOAuthおよびOpenID "
+"Connectのスコープのセットを表します。現時点では実装されていませんが、{project_name}がスコープの一般的なサポートを強化した後に利用可能になります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:69
 msgid ""
 "We currently only support OpenID Connect and OAuth exchanges.  Support for "
 "SAML based clients and identity providers may be added in the future "
 "depending on user demand."
 msgstr ""
-"現在のところ、OpenID ConnectとOAuthの交換のみサポートしています。 "
-"SAMLベースのクライアントおよびIDプロバイダのサポートは、将来、ユーザーの要求に応じて追加される可能性があります。"
+"現在のところ、OpenID "
+"ConnectとOAuthの交換のみサポートしています。SAMLベースのクライアントおよびIDプロバイダーのサポートは、将来、ユーザーの要求に応じて追加される可能性があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:73
 msgid ""
 "A successful response from an exchange invocation will return the HTTP 200 "
 "response code with a content type that depends on the `requested-token-type`"
@@ -317,12 +274,12 @@ msgid ""
 "/draft-ietf-oauth-token-exchange-09.txt[OAuth Token Exchange] specification."
 msgstr ""
 "交換の呼び出しからの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
-"`requested_issuer` に依存したコンテンツ・タイプとともにHTTP 200レスポンス・コードを返します。 "
-"OAuthでリクエストされたトークンタイプは、 link:http://www.ietf.org/id/draft-ietf-oauth-token-"
-"exchange-09.txt[OAuth Token Exchange] 仕様に記載されているJSONドキュメントを返します。"
+"`requested_issuer` に依存したコンテンツ・タイプとともにHTTP "
+"200レスポンス・コードを返します。OAuthでリクエストされたトークンタイプは、link:http://www.ietf.org/id/draft-"
+"ietf-oauth-token-exchange-09.txt[OAuth Token "
+"Exchange]仕様に記載されているJSONドキュメントを返します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:80
 #, no-wrap
 msgid ""
 "{\n"
@@ -338,7 +295,6 @@ msgstr ""
 " }\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:85
 msgid ""
 "Clients requesting a refresh token will get back both an access and refresh "
 "token in the response.  Clients requesting only access token type will only "
@@ -346,12 +302,11 @@ msgid ""
 "be included for clients requesting a an external issuer through the "
 "`requested_issuer`paramater."
 msgstr ""
-"リフレッシュ・トークンを要求するクライアントは、レスポンス内のアクセス・トークンとリフレッシュ・トークンの両方を取得しなおします。 "
-"アクセス・トークン・タイプのみを要求するクライアントは、レスポンス内のアクセス・トークンを取得します。 `requested_issuer` "
+"リフレッシュ・トークンを要求するクライアントは、レスポンス内のアクセス・トークンとリフレッシュ・トークンの両方を取得し直します。アクセス・トークン・タイプのみを要求するクライアントは、レスポンス内のアクセス・トークンを取得します。"
+" `requested_issuer` "
 "パラメータを介して外部発行者を要求するクライアントに対して、有効期限情報が含まれる場合と含まれない場合があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:89
 msgid ""
 "Error responses generally fall under the 400 HTTP response code category, "
 "but other error status codes may be returned depending on the severity of "
@@ -360,12 +315,10 @@ msgid ""
 "follows:"
 msgstr ""
 "エラー・レスポンスは一般に400 "
-"HTTPレスポンス・コード・カテゴリーに該当しますが、エラーの重大度に応じて他のエラー・ステータス・コードが返されることがあります。 "
-"エラー・レスポンスには、 `requested_issuer` に応じた内容が含まれます。 "
-"OAuthベースの交換では、次のようにJSON文書が返ることがあります："
+"HTTPレスポンス・コード・カテゴリーに該当しますが、エラーの重大度に応じて他のエラー・ステータス・コードが返されることがあります。エラー・レスポンスには、"
+" `requested_issuer` に応じた内容が含まれます。OAuthベースの交換では、次のようにJSON文書が返ることがあります："
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:95
 #, no-wrap
 msgid ""
 "{\n"
@@ -379,46 +332,39 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:100
 msgid ""
 "Additional error claims may be returned depending on the exchange type.  For"
 " example, OAuth Identity Providers may include an additional `account-link-"
 "url` claim if the user does not have a link to an identity provider.  This "
 "link can be used for a client initiated link request."
 msgstr ""
-"アイデンティティー・プロバイダーOAuth交換のタイプによっては追加のエラー・クレームが返されることがあります。 "
-"たとえば、ユーザーがアイデンティティ・プロバイダーへのリンクを持っていない場合、OAuth Identity Providerは追加の "
-"`account-link-url` クレームを含めることがあります。 このリンクは、クライアントが開始したリンク・リクエストに使用できます。"
+"アイデンティティー・プロバイダーOAuth交換のタイプによっては追加のエラー・クレームが返されることがあります。たとえば、ユーザーがアイデンティティ・プロバイダーへのリンクを持っていない場合、OAuthアイデンティティ・プロバイダーは追加の"
+" `account-link-url` クレームを含めることがあります。このリンクは、クライアントが開始したリンク・リクエストに使用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:103
 #, no-wrap
 msgid ""
 "Token exchange setup requires knowledge of fine grain admin permissions (See the link:{adminguide_link}[{adminguide_name}] for more information).  You will need to grant clients\n"
-"      permission to exchange.  This is discusssed more later in this chapter.\n"
+"      permission to exchange.  This is discussed more later in this chapter.\n"
 msgstr ""
-"トークン交換のセットアップには細かい粒度の管理権限が必要です（詳細はlink:{adminguide_link}[{adminguide_name}] "
-"のリンクを参照してください）。 クライアントに交換の権限を付与する必要があります。 これについては、この章の後半で説明します。\n"
+"トークン交換のセットアップには細かい粒度の管理権限が必要です（詳細はlink:{adminguide_link}[{adminguide_name}]のリンクを参照してください）。クライアントに交換の権限を付与する必要があります。これについては、この章の後半で説明します。\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:107
 msgid ""
 "The rest of this chapter discusses the setup requirements and provides "
 "examples for different exchange scenarios.  For simplicity's sake, let's "
 "call a token minted by the current realm as an _internal_ token and a token "
 "minted by an external realm or identity provider as an _external_ token."
 msgstr ""
-"この章では、セットアップの要件について説明し、さまざまな交換のシナリオの例を示します。 簡単にするために、現在のレルムで作成されたトークンを "
+"この章では、セットアップの要件について説明し、さまざまな交換のシナリオの例を示します。簡単にするために、現在のレルムで作成されたトークンを "
 "_internal_ トークン、外部レルムまたはアイデンティティ・プロバイダが作成したトークンを _external_ トークンとして呼び出してみます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:109
 #, no-wrap
 msgid "Internal Token to Internal Token Exchange"
 msgstr "内部トークンから内部トークンへの交換"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:117
 msgid ""
 "With an internal token to token exchange you have an existing token minted "
 "to a specific client and you want to exchange this token for a new one "
@@ -437,151 +383,113 @@ msgstr ""
 "このタイプの交換が必要なその他の理由は、信頼性の低いアプリケーションでアプリケーションを呼び出す必要があり、現在のアクセス・トークンを伝播したくない場合に「アクセス権のダウングレード」を実行する必要がある場合です。"
 
 #. type: Title ====
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:119
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:204
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:310
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:369
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:405
 #, no-wrap
 msgid "Granting Permission for the Exchange"
 msgstr "交換のアクセス権を付与します"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:123
 msgid ""
 "Clients that want to exchange tokens for a different client need to be "
 "authorized in the admin console to do so.  You'll need to define a `token-"
 "exchange` fine grain permission in the target client you want permission to "
 "exchange to."
 msgstr ""
-"別のクライアントとトークンを交換したいクライアントは、管理コンソールで認可される必要があります。交換するアクセス権を与えたいターゲット・クライアントに"
-"`token-exchange`のきめの細かいアクセス権を定義する必要があります。"
+"別のクライアントとトークンを交換したいクライアントは、管理コンソールで認可される必要があります。交換するアクセス権を与えたいターゲット・クライアントに "
+"`token-exchange` のきめの細かいアクセス権を定義する必要があります。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:124
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:129
 #, no-wrap
 msgid "Target Client Permission"
 msgstr "ターゲット・クライアントのアクセス権"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:126
 msgid "image:{project_images}/exchange-target-client-permission-unset.png[]"
 msgstr "image:{project_images}/exchange-target-client-permission-unset.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:128
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:214
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:417
 msgid "Toggle the `Permissions Enabled` switch to true."
-msgstr "`Permissions Enabled`スイッチをtrueに切り替えます。"
+msgstr "`Permissions Enabled` スイッチをtrueに切り替えます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:131
 msgid "image:{project_images}/exchange-target-client-permission-set.png[]"
 msgstr "image:{project_images}/exchange-target-client-permission-set.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:134
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:220
 msgid ""
 "You should see a `token-exchange` link on the page.  Click that to start "
 "defining the permission.  It will bring you to this page."
-msgstr ""
-"このページに`token-exchange`のリンクがあるはずです。 クリックすると、アクセス権の定義が開始されます。このページに移動します。"
+msgstr "このページに `token-exchange` のリンクがあります。クリックすると、アクセス権の定義が開始され、このページに移動します。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:135
 #, no-wrap
 msgid "Target Client Exchange Permission Setup"
 msgstr "ターゲット・クライアントの交換アクセス権のセットアップ"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:137
 msgid "image:{project_images}/exchange-target-client-permission-setup.png[]"
 msgstr "image:{project_images}/exchange-target-client-permission-setup.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:140
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:226
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:429
 msgid ""
 "You'll have to define a policy for this permission.  Click the "
 "`Authorization` link, go to the `Policies` tab and create a `Client` Policy."
 msgstr ""
-"このアクセス権に対するポリシーを定義する必要があります。`認可`のリンクをクリックし、`ポリシー`タブに行き、 "
-"`クライアント`ポリシーを作成してください。"
+"このアクセス権に対するポリシーを定義する必要があります。 `認可` のリンクをクリックし、 `ポリシー` タブに行き、  `クライアント` "
+"ポリシーを作成してください。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:141
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:227
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:430
 #, no-wrap
 msgid "Client Policy Creation"
 msgstr "クライアント・ポリシーの作成"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:143
 msgid "image:{project_images}/exchange-target-client-policy.png[]"
 msgstr "image:{project_images}/exchange-target-client-policy.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:147
 msgid ""
 "Here you enter in the starting client, that is the authenticated client that"
 " is requesting a token exchange.  After you create this policy, go back to "
 "the target client's `token-exchange` permission and add the client policy "
 "you just defined."
 msgstr ""
-"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ターゲット・クライアントの"
-"`token-exchange`アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ターゲット・クライアントの "
+"`token-exchange` のアクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:148
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:234
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:437
 #, no-wrap
 msgid "Apply Client Policy"
 msgstr "クライアント・ポリシーの適用"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:150
 msgid ""
 "image:{project_images}/exchange-target-client-exchange-apply-policy.png[]"
 msgstr ""
 "image:{project_images}/exchange-target-client-exchange-apply-policy.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:153
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:239
 msgid ""
 "Your client now has permission to invoke.  If you do not do this correctly, "
 "you will get a 403 Forbidden response if you try to make an exchange."
 msgstr ""
-"クライアントは起動するアクセス権を持っています。これを正しく行わないと、交換しようとすると403 Forbiddenのレスポンスが表示されます。"
+"クライアントは起動するアクセス権を持っています。これを正しく行わないで交換しようとすると、403 Forbiddenのレスポンスが表示されます。"
 
 #. type: Title ====
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:154
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:241
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:319
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:376
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:446
 #, no-wrap
 msgid "Making the Request"
 msgstr "リクエストの実行"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:158
 msgid ""
 "When your client is exchanging an existing token for a token targeting "
 "another client, you must use the `audience` parameter.  This parameter must "
 "be the client identifier for the target client that you configured in the "
 "admin console."
 msgstr ""
-"クライアントがターゲットとする別のクライアントのトークンを既存のトークンを交換しているときは、`audience`パラメータを使用する必要があります。このパラメータは、管理コンソールで設定したターゲット・クライアントのクライアント識別子である必要があります。"
+"クライアントがターゲットとする別のクライアントのトークンを既存のトークンと交換しているときは、 `audience` "
+"パラメーターを使用する必要があります。このパラメーターは、管理コンソールで設定したターゲット・クライアントのクライアント識別子である必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:169
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -603,19 +511,17 @@ msgstr ""
 "    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:175
 msgid ""
 "The `subject_token` parameter must be an access token for the target realm."
 "  If your `requested_token_type` parameter is a refresh token type, then the"
 " response will contain both an access token, refresh token, and expiration."
 "  Here's an example JSON response you get back from this call."
 msgstr ""
-"`subject_token`パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。 "
-"`requested_token_type`パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の全てが含まれます。この呼び出しから返されるJSONレスポンスの例を、次に示します。"
+"`subject_token` パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。  "
+"`requested_token_type` "
+"パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の全てが含まれます。この呼び出しから返されるJSONレスポンスの例を、次に示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:183
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:359
 #, no-wrap
 msgid ""
 "{\n"
@@ -631,13 +537,11 @@ msgstr ""
 "}\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:185
 #, no-wrap
 msgid "Internal Token to External Token Exchange"
 msgstr "内部トークンから外部のトークンへの交換"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:192
 msgid ""
 "You can exchange a realm token for an externl token minted by an external "
 "identity provider.  This external identity provider must be configured "
@@ -653,21 +557,18 @@ msgstr ""
 "Connectベースの外部アイデンティティ・プロバイダーのみがサポートされています。これには、すべてのソーシャル・プロバイダーが含まれます。{project_name}は、外部プロバイダーへのバックチャネル交換を実行しません。したがって、アカウントがリンクされていない場合、外部トークンを取得することはできません。外部トークンを取得するには、次のいずれかの条件を満たす必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:194
 msgid ""
 "The user must have logged in with the external identity provider at least "
 "once"
 msgstr "ユーザーは、外部アイデンティティ・プロバイダーに少なくとも1回はログインしている必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:195
 msgid ""
 "The user must have linked with the external identity provider through the "
 "User Account Service"
 msgstr "ユーザーは、外部アイデンティティ・プロバイダーにユーザー・アカウント・サービスを介してリンクしている必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:196
 msgid ""
 "The user account was linked through the external identity provider using "
 "link:{developerguide_link}[Client Initiated Account Linking] API."
@@ -676,16 +577,14 @@ msgstr ""
 "APIを使用して外部アイデンティティ・プロバイダーを介してリンクされています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:199
 msgid ""
 "Finally, the external identity provider must have been configured to store "
 "tokens, or, one of the above actions must have been performed with the same "
 "user session as the internal token you are exchanging."
 msgstr ""
-"最後に、外部アイデンティティ・プロバイダーがトークンを格納するように設定されている必要があります。または、上記のアクションの1つが、交換している内部トークンと同じユーザー・セッションで実行されている必要があります。"
+"最後に、外部アイデンティティ・プロバイダーがトークンを保存するように設定されている必要があります。または、上記のアクションの1つが、交換している内部トークンと同じユーザー・セッションで実行されている必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:202
 msgid ""
 "If the account is not linked, the exchange response will contain a link you "
 "can use to establish it.  This is discussed more in the "
@@ -695,7 +594,6 @@ msgstr ""
 " Making the Request>>のセクションで詳しく説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:209
 msgid ""
 "Internal to external token exchange requests will be denied with a 403, "
 "Forbidden response until you grant permission for the calling client to "
@@ -703,49 +601,36 @@ msgid ""
 " the client you must go to the identity provider's configuration page to the"
 " `Permissions` tab."
 msgstr ""
-"呼び出し側のクライアントが外部アイデンティティ・プロバイダーとトークンを交換するアクセス権を与えるまで、内部トークン交換リクエストと内部トークン交換リクエストは、403、Forbiddenレスポンスで拒否されます。クライアントにアクセス権を与えるには、アイデンティティ・プロバイダーの設定ページの`アクセス権`タブに移動する必要があります。"
+"呼び出し側のクライアントが外部アイデンティティ・プロバイダーとトークンを交換するアクセス権を与えるまで、内部トークン交換リクエストと内部トークン交換リクエストは、403、Forbiddenレスポンスで拒否されます。クライアントにアクセス権を与えるには、アイデンティティ・プロバイダーの設定ページの"
+" `アクセス権` タブに移動する必要があります。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:210
 #, no-wrap
 msgid "Identity Provider Permission"
 msgstr "アイデンティティ・プロバイダーのアクセス権"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:212
 msgid "image:{project_images}/exchange-idp-permission-unset.png[]"
 msgstr "image:{project_images}/exchange-idp-permission-unset.png[]"
 
-#. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:215
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:418
-#, no-wrap
-msgid "Identity Provier Permission"
-msgstr "アイデンティティ・プロバイダーのアクセス権"
-
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:217
 msgid "image:{project_images}/exchange-idp-permission-set.png[]"
 msgstr "image:{project_images}/exchange-idp-permission-set.png[]"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:221
 #, no-wrap
 msgid "Identity Provider Exchange Permission Setup"
 msgstr "アイデンティティ・プロバイダーの交換アクセス権のセットアップ"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:223
 msgid "image:{project_images}/exchange-idp-permission-setup.png[]"
 msgstr "image:{project_images}/exchange-idp-permission-setup.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:229
 msgid "image:{project_images}/exchange-idp-client-policy.png[]"
 msgstr "image:{project_images}/exchange-idp-client-policy.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:233
 msgid ""
 "Here you enter in the starting client, that is the authenticated client that"
 " is requesting a token exchange.  After you create this policy, go back to "
@@ -753,24 +638,22 @@ msgid ""
 "policy you just defined."
 msgstr ""
 "ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、アイデンティティ・プロバイダーの"
-"`token-exchange`アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+" `token-exchange` のアクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:236
 msgid "image:{project_images}/exchange-idp-apply-policy.png[]"
 msgstr "image:{project_images}/exchange-idp-apply-policy.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:245
 msgid ""
 "When your client is exchanging an existing internal token to an external "
 "one, you must provide the `requested_issuer` parameter.  The parameter must "
 "be the alias of a configured identity provider."
 msgstr ""
-"クライアントが既存の内部トークンを外部トークンと交換する場合は、`requested_issuer`パラメーターを指定する必要があります。パラメーターは、設定済みのアイデンティティ・プロバイダーのエイリアスでなければなりません。"
+"クライアントが既存の内部トークンを外部トークンと交換する場合は、 `requested_issuer` "
+"パラメーターを指定する必要があります。パラメーターは、設定済みのアイデンティティ・プロバイダーのエイリアスでなければなりません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:256
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -792,7 +675,6 @@ msgstr ""
 "    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:263
 msgid ""
 "The `subject_token` parameter must be an access token for the target realm."
 "  The `requested_token_type` parameter must be `urn:ietf:params:oauth:token-"
@@ -800,12 +682,12 @@ msgid ""
 "supported at this time.  Here's an example successful JSON response you get "
 "back from this call."
 msgstr ""
-"`subject_token`パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。 "
-"`requested_token_type`パラメーターは、`urn:ietf:params:oauth:token-"
-"type:access_token`またはブランクのままでなければなりません。現時点では、それ以外の要求されたトークン・タイプはサポートされていません。この呼び出しから返される成功のJSONレスポンスの例を次に示します。"
+"`subject_token` パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。  "
+"`requested_token_type` パラメーターは、 `urn:ietf:params:oauth:token-"
+"type:access_token` "
+"またはブランクのままでなければなりません。現時点では、それ以外の要求されたトークン・タイプはサポートされていません。この呼び出しから返される成功のJSONレスポンスの例を次に示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:271
 #, no-wrap
 msgid ""
 "{\n"
@@ -821,7 +703,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:275
 msgid ""
 "If the external identity provider is not linked for whatever reason, you "
 "will get an HTTP 400 response code with this JSON document:"
@@ -829,7 +710,6 @@ msgstr ""
 "外部アイデンティティ・プロバイダーが何らかの理由でリンクされていない場合は、このJSONドキュメントでHTTP 400レスポンス・コードを取得します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:283
 #, no-wrap
 msgid ""
 "{\n"
@@ -845,29 +725,26 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:289
 msgid ""
 "The `error` claim will be either `token_expired` or `not_linked`.  The "
 "`account-link-url` claim is provided so that the client can perform "
 "link:{developerguide_link}[Client Initiated Account Linking].  Most (all?)  "
-"providers requiring linking through browser OAuth protocol.  With the "
+"providers are requiring linking through browser OAuth protocol.  With the "
 "`account-link-url` just add a `redirect_uri` query parameter to it and you "
 "can forward browsers to perform the link."
 msgstr ""
-"`error`クレームは、`token_expired`か`not_linked`のどちらかになります。`account-link-"
-"url`クレームは、クライアントがlink:{developerguide_link}[Client Initiated Account "
-"Linking]を実行できるように提供されています。ほとんど(すべて？)のプロバイダーは、ブラウザーOAuthプロトコルを介してリンクする必要があります"
-"。`account-link-"
-"url`では、`redirect_uri`クエリー・パラメータを追加するだけで、ブラウザを転送してリンクを実行することができます。"
+"`error` クレームは、 `token_expired` か `not_linked` のどちらかになります。 `account-link-url`"
+" クレームは、クライアントがlink:{developerguide_link}[Client Initiated Account "
+"Linking]を実行できるように提供されています。ほとんど(すべて？)のプロバイダーは、ブラウザーOAuthプロトコルを介してリンクする必要があります。"
+" `account-link-url` では、 `redirect_uri` "
+"クエリー・パラメータを追加するだけで、ブラウザを転送してリンクを実行することができます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:290
 #, no-wrap
 msgid "External Token to Internal Token Exchange"
 msgstr "外部トークンから内部トークンへの交換"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:295
 msgid ""
 "You can trust and exchange external tokens minted by external identity "
 "providers for internal tokens.  This can be used to bridge between realms or"
@@ -875,11 +752,9 @@ msgid ""
 "identity provider browser login in that a new user is imported into your "
 "realm if it doesn't exist."
 msgstr ""
-"外部アイデンティティ・プロバイダーが発行した外部トークンを信頼して、内部トークンに交換することができます。 "
-"これは、レルム間のブリッジや、ソーシャル・プロバイダーのトークンの信頼に使用できます。これは、アイデンティティ・プロバイダーのブラウザのログインと同様に動作します。新しいユーザーが存在しない場合、そのユーザーはレルムにインポートされます。"
+"外部アイデンティティ・プロバイダーが発行した外部トークンを信頼して、内部トークンに交換することができます。これは、レルム間のブリッジや、ソーシャル・プロバイダーのトークンの信頼に使用できます。これは、アイデンティティ・プロバイダーのブラウザのログインと同様に動作します。新しいユーザーが存在しない場合、そのユーザーはレルムにインポートされます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:299
 #, no-wrap
 msgid ""
 "The current limitation on external token exchanges is that if the external token maps to an existing user an\n"
@@ -889,7 +764,6 @@ msgstr ""
 "外部トークン交換の現在の制限は、外部トークンが既存のユーザーにマップされている場合、既存のユーザーに外部アイデンティティ・プロバイダーへのアカウント・リンクがない限り、交換は許可されないということです。\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:304
 msgid ""
 "When the exchange is complete, a user session will be created within the "
 "realm, and you will receive an access and or refresh token depending on the "
@@ -897,24 +771,22 @@ msgid ""
 "session will remain active until it times out or until you call the logout "
 "endpoint of the realm passing this new access token."
 msgstr ""
-"交換が完了すると、レルム内にユーザー・セッションが作成され、`requested_toke_type`パラメーター値に応じて、アクセス・トークンまたはリフレッシュ・トークンが受け取れます。この新しいユーザー・セッションは、タイムアウトするまで、またはこの新しいアクセス・トークンを渡すレルムのログアウト・エンドポイントを呼び出すまで、アクティブなままです。"
+"交換が完了すると、レルム内にユーザー・セッションが作成され、 `requested_toke_type` "
+"パラメーター値に応じて、アクセス・トークンまたはリフレッシュ・トークンが受け取れます。この新しいユーザー・セッションは、タイムアウトするまで、またはこの新しいアクセス・トークンを渡すレルムのログアウト・エンドポイントを呼び出すまで、アクティブなままです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:306
 msgid ""
 "These types of changes required a configured identity provider in the admin "
 "console."
 msgstr "これらのタイプの変更には、管理コンソールで設定されたアイデンティティ・プロバイダーが必要でした。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:308
 msgid ""
 "SAML identity providers are not supported at this time.  Twitter tokens "
 "cannot be exchanged either."
 msgstr "現時点では、SAMLアイデンティティ・プロバイダーはサポートされていません。Twitterのトークンは交換できません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:314
 msgid ""
 "Before external token exchanges can be done, you must grant permission for "
 "the calling client to make the exchange.  This permission is granted in the "
@@ -926,7 +798,6 @@ msgstr ""
 "permission is granted>>と同じ方法で付与されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:318
 msgid ""
 "If you also provide an `audience` parameter whose value points to a "
 "different client other than the calling one, you must also grant the calling"
@@ -934,11 +805,11 @@ msgid ""
 "`audience` parameter.  How to do this is <<_client_to_client_permission, "
 "discussed earlier>> in this section."
 msgstr ""
-"値が呼び出し側以外の別のクライアントを指し示す`audience`パラメーターも指定した場合、呼び出し側クライアントに`audience`パラメーターで特定のターゲット・クライアントに交換するアクセス権を与える必要があります。"
-" これを行う方法は、このセクションの<<_client_to_client_permission, discussed earlier>>にあります。"
+"値が呼び出し側以外の別のクライアントを指し示す `audience` パラメーターも指定した場合、呼び出し側クライアントに `audience` "
+"パラメーターで特定のターゲット・クライアントに交換するアクセス権を与える必要があります。 "
+"これを行う方法は、このセクションの<<_client_to_client_permission, discussed earlier>>にあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:325
 msgid ""
 "The `subject_token_type` must either be `urn:ietf:params:oauth:token-"
 "type:access_token` or `urn:ietf:params:oauth:token-type:jwt`.  If the type "
@@ -949,15 +820,14 @@ msgid ""
 "must be the alias of the provider, or a registered issuer within the "
 "providers configuration."
 msgstr ""
-"`subject_token_type`は、`urn:ietf:params:oauth:token-"
-"type:access_token`または`urn:ietf:params:oauth:token-"
-"type:jwt`のいずれかでなければなりません。タイプが `urn:ietf:params:oauth:token-"
-"type:access_token`の場合、`subject_issuer`パラメーターを指定しなければなりません。また、設定されたアイデンティティ・プロバイダーのエイリアスでなければなりません。タイプが`urn:ietf:params:oauth"
-":token-"
-"type:jwt`の場合、プロバイダーは、プロバイダーのエイリアスであるJWT内の`issuer`クレームまたは、プロバイダ設定内の登録された発行者と一致します。"
+"`subject_token_type` は、 `urn:ietf:params:oauth:token-type:access_token` または "
+"`urn:ietf:params:oauth:token-type:jwt` のいずれかでなければなりません。タイプが "
+"`urn:ietf:params:oauth:token-type:access_token` の場合、 `subject_issuer` "
+"パラメーターを指定しなければなりません。また、設定されたアイデンティティ・プロバイダーのエイリアスでなければなりません。タイプが "
+"`urn:ietf:params:oauth:token-type:jwt` の場合、プロバイダーは、プロバイダーのエイリアスであるJWT内の "
+"`issuer` クレームまたは、プロバイダ設定内の登録された発行者と一致します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:329
 msgid ""
 "For validation, if the token is an access token, the provider's user info "
 "service will be invoked to validate the token.  A successful call will mean "
@@ -969,7 +839,6 @@ msgstr ""
 "検証のために、トークンがアクセス・トークンである場合、プロバイダーのユーザー情報サービスが呼び出されてトークンを検証します。呼び出しが成功することは、アクセス・トークンが有効であることを意味します。サブジェクト・トークンがJWTであり、プロバイダが署名検証を有効にしている場合は、それが試行され、そうでない場合は、デフォルトでトークンを検証するためにユーザー情報サービスが呼び出されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:333
 msgid ""
 "By default, the internal token minted will use the calling client to "
 "determine what's in the token using the protocol mappers defined for the "
@@ -977,10 +846,9 @@ msgid ""
 "using the `audience` parameter."
 msgstr ""
 "デフォルトでは、発行された内部トークンは、呼び出し元クライアント用に定義されたプロトコル・マッパーを使用してトークン内の内容を判断するため、呼び出し元クライアントを使用します。"
-" あるいは、`audience`パラメーターを使って別のターゲット・クライアントを指定することもできます。"
+" あるいは、 `audience` パラメーターを使って別のターゲット・クライアントを指定することもできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:345
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -1004,23 +872,20 @@ msgstr ""
 "    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:351
 msgid ""
 "If your `requested_token_type` parameter is a refresh token type, then the "
 "response will contain both an access token, refresh token, and expiration.  "
 "Here's an example JSON response you get back from this call."
 msgstr ""
-"`requested_token_type`パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の両方が含まれます。この呼び出しから返されるJSONレスポンスの例を次に示します。"
+"`requested_token_type` "
+"パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の両方が含まれます。この呼び出しから返されるJSONレスポンスの例を次に示します。"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:362
-#: source/server_admin/topics/users/impersonation.adoc:2
 #, no-wrap
 msgid "Impersonation"
 msgstr "偽装"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:367
 msgid ""
 "For internal and external token exchanges, the client can request on behalf "
 "of a user to impersonate a different user.  For example, you may have an "
@@ -1030,7 +895,6 @@ msgstr ""
 "内部トークン交換と外部トークン交換の場合、クライアントはユーザーの代わりに別のユーザーを偽装するように要求できます。たとえば、サポート・エンジニアが問題をデバッグできるように、ユーザーを偽装する必要がある管理アプリケーションがあるとします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:374
 msgid ""
 "The user that the subject token represents must have permission to "
 "impersonate other users.  See the link:{adminguide_link}[{adminguide_name}] "
@@ -1042,16 +906,15 @@ msgstr ""
 "それは、ロールを通じて、またはきめ細かい管理者アクセス権を使って行うことができます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:380
 msgid ""
 "Make the request as described in other chapters except additionally specify "
 "the `request_subject` parameter.  The value of this parameter must be a "
 "username or user id."
 msgstr ""
-"`request_subject`パラメーターを追加で指定しない限り、他の章で説明したようにリクエストを行います。このパラメーターの値は、ユーザー名またはユーザーIDでなければなりません。"
+"`request_subject` "
+"パラメーターを追加で指定しない限り、他の章で説明したようにリクエストを行います。このパラメーターの値は、ユーザー名またはユーザーIDでなければなりません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:392
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -1075,13 +938,11 @@ msgstr ""
 "    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:394
 #, no-wrap
 msgid "Direct Naked Impersonation"
 msgstr "ダイレクト・ネイキッド偽装"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:401
 msgid ""
 "You can make an internal token exchange request without providing a "
 "`subject_token`.  This is called a direct naked impersonation because it "
@@ -1092,10 +953,10 @@ msgid ""
 " that case, the legacy app is able to authenticate users itself, but not "
 "able to obtain a token."
 msgstr ""
-"`subject_token`を指定せずに、内部トークンの交換要求を行うことができます。これは、ダイレクト・ネイキッド偽装と呼ばれます。クライアントがそのレルム内の任意のユーザーを偽装する可能性があるため、クライアントに多くの信頼を置くからです。交換するサブジェクト・トークンを取得することが不可能なアプリケーションのためにブリッジする必要があるかもしれません。たとえば、LDAPに直接ログインするレガシー・アプリケーションを統合したいかもしれません。その場合、従来のアプリケーションはユーザー自身を認証できますが、トークンを取得することができません。"
+"`subject_token` "
+"を指定せずに、内部トークンの交換要求を行うことができます。これは、ダイレクト・ネイキッド偽装と呼ばれます。クライアントがそのレルム内の任意のユーザーを偽装する可能性があるため、クライアントに多くの信頼を置くからです。交換するサブジェクト・トークンを取得することが不可能なアプリケーションのためにブリッジする必要があるかもしれません。たとえば、LDAPに直接ログインするレガシー・アプリケーションを統合したいかもしれません。その場合、従来のアプリケーションはユーザー自身を認証できますが、トークンを取得することができません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:404
 #, no-wrap
 msgid ""
 "It is very risky to enable direct naked impersonation for a client.  If the client's credentials are ever\n"
@@ -1104,106 +965,94 @@ msgstr ""
 "クライアントにダイレクト・ネイキッド偽装を有効にすることは非常に危険です。クライアントのクレデンシャルが盗まれた場合、そのクライアントはシステム内のすべてのユーザーを偽装する可能性があります。\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:409
 msgid ""
 "If the `audience` parameter is provided, then the calling client must have "
 "permission to exchange to the client.  How to set this up is discussed "
 "earlier in this chapter."
 msgstr ""
-"`audience`パラメーターが提供されている場合、呼び出し側クライアントはクライアントとの交換のアクセス権を持っていなければなりません。 "
+"`audience` パラメーターが提供されている場合、呼び出し側クライアントはクライアントとの交換のアクセス権を持っていなければなりません。 "
 "これを設定する方法については、この章の前半で説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:412
 msgid ""
-"Additionaly, the calling client must be granted permission to impersonate "
+"Additionally, the calling client must be granted permission to impersonate "
 "users.  In the admin console, go to the `Users` screen and click on the "
 "`Permissions` tab."
 msgstr ""
-"さらに、呼び出し元のクライアントにユーザーを偽装するアクセス権が与えられている必要があります。 管理コンソールで、 "
-"`ユーザー`画面に行き、`アクセス権`タブをクリックしてください。"
+"さらに、呼び出し元のクライアントにユーザーを偽装するアクセス権が与えられている必要があります。管理コンソールで、 `ユーザー` 画面を表示し、 "
+"`アクセス権` タブをクリックしてください。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:413
 #, no-wrap
 msgid "Users Permission"
 msgstr "ユーザーのアクセス権"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:415
 msgid "image:{project_images}/exchange-users-permission-unset.png[]"
 msgstr "image:{project_images}/exchange-users-permission-unset.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:420
 msgid "image:{project_images}/exchange-users-permission-set.png[]"
 msgstr "image:{project_images}/exchange-users-permission-set.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:423
 msgid ""
 "You should see a `impersonation` link on the page.  Click that to start "
 "defining the permission.  It will bring you to this page."
-msgstr "ページに `偽装`リンクがあります。 クリックすると、アクセス権の定義が開始されます。 それにより、このページに移動します。"
+msgstr ""
+"ページに `impersonation` リンクがあります。クリックすると、アクセス権の定義が開始されます。それにより、このページに移動します。"
 
 #. type: Block title
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:424
 #, no-wrap
 msgid "Users Impersonation Permission Setup"
 msgstr "ユーザー偽装アクセス権のセットアップ"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:426
 msgid "image:{project_images}/exchange-users-permission-setup.png[]"
 msgstr "image:{project_images}/exchange-users-permission-setup.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:432
 msgid "image:{project_images}/exchange-users-client-policy.png[]"
 msgstr "image:{project_images}/exchange-users-client-policy.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:436
 msgid ""
 "Here you enter in the starting client, that is the authenticated client that"
 " is requesting a token exchange.  After you create this policy, go back to "
 "the users' `impersonation` permission and add the client policy you just "
 "defined."
 msgstr ""
-"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ユーザーの`impersonation`アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ユーザーの "
+"`impersonation` アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:439
 msgid "image:{project_images}/exchange-users-apply-policy.png[]"
 msgstr "image:{project_images}/exchange-users-apply-policy.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:442
 msgid ""
 "Your client now has permission to impersonate users.  If you do not do this "
 "correctly, you will get a 403 Forbidden response if you try to make this "
 "type of exchange."
 msgstr ""
-"クライアントはユーザーを偽装するアクセス権を持っています。これを正しく行わないと、これを交換のタイプにしようとすると403 "
+"クライアントはユーザーを偽装するアクセス権を持っています。これを正しく行わないと、これを交換のタイプにしようとする際に、403 "
 "Forbiddenのレスポンスが表示されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:444
 msgid "Public clients are not allowed to do direct naked impersonations."
 msgstr "パブリック・クライアントはダイレクト・ネイキッド偽装を行うことができません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:450
 msgid ""
 "To make the request, simply specify the `requested_subject` parameter.  This"
 " must be the username or user id of a valid user.  You can also specify an "
 "`audience` parameter if you wish."
 msgstr ""
-"リクエストを行うには、`requested_subject`パラメーターを指定するだけです。これは、有効なユーザーのユーザー名またはユーザーIDでなければなりません。また、必要に応じて"
-" `audience`パラメーターを指定することもできます。"
+"リクエストを行うには、 `requested_subject` "
+"パラメーターを指定してください。これは、有効なユーザーのユーザー名またはユーザーIDでなければなりません。また、必要に応じて `audience` "
+"パラメーターを指定することもできます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:459
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -1221,13 +1070,11 @@ msgstr ""
 "    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:461
 #, no-wrap
 msgid "Expand Permission Model With Service Accounts"
 msgstr "サービス・アカウントのアクセス権モデルの展開"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:467
 msgid ""
 "When granting clients permission to exchange, you don't necessarily have to "
 "manually enable those permissions for each and every client.  If the client "
@@ -1237,25 +1084,21 @@ msgid ""
 "exchange` role and any service account that has that role can do a naked "
 "exchange."
 msgstr ""
-"クライアントに交換のアクセス権を付与すると、クライアントごとにこれらのアクセス権を手動で有効にする必要はなくなります。 "
-"クライアントに関連付けられているサービス・アカウントがある場合は、ロールを使用してアクセス権をグループ化し、クライアントのサービス・アカウントにロールを割り当てて、交換権のアクセス権を割り当てることができます。"
-" たとえば、`naked-exchange`ロールを定義し、そのロールを持つサービス・アカウントでネイキッドな交換を行うことができます。"
+"クライアントに交換のアクセス権を付与すると、クライアントごとにこれらのアクセス権を手動で有効にする必要がなくなります。クライアントに関連付けられているサービス・アカウントがある場合は、ロールを使用してアクセス権をグループ化し、クライアントのサービス・アカウントにロールを割り当てて、交換権のアクセス権を割り当てることができます。たとえば、"
+" `naked-exchange` ロールを定義し、そのロールを持つサービス・アカウントでネイキッドな交換を行うことができます。"
 
 #. type: Title ===
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:468
 #, no-wrap
 msgid "Exchange Vulnerabilities"
 msgstr "交換の脆弱性"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:471
 msgid ""
 "When you start allowing token exchanges, there's various things you have to "
 "both be aware of and careful of."
 msgstr "トークン交換の許可を始める上で、意識して気をつけなければならない様々なことがあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:476
 msgid ""
 "The first is public clients.  Public clients do not have or require a client"
 " credential in order to perform an exchange.  Anybody that has a valid token"
@@ -1266,10 +1109,9 @@ msgid ""
 "exchanges do not allow public clients and will abort with an error if the "
 "calling client is public."
 msgstr ""
-"1つはパブリック・クライアントです。パブリック・クライアントは、交換を実行するためにクライアント・クレデンシャルを持たない、または必要としません。有効なトークンを持っていれば、パブリック・クライアントを__偽装する__することができ、パブリック・クライアントが実行できる交換を実行できます。レルムよって管理されている信頼できないクライアントがある場合、パブリック・クライアントは許可モデルで脆弱性を公開する可能性があります。このため、ダイレクト・ネイキッド交換ではパブリック・クライアントが許可されず、呼び出し元のクライアントが公開されている場合はエラーで中止されます。"
+"1つはパブリック・クライアントです。パブリック・クライアントは、交換を実行するためにクライアント・クレデンシャルを持たない、または必要としません。有効なトークンを持っていれば、パブリック・クライアントを__偽装する__することができ、パブリック・クライアントが実行できる交換を実行できます。レルムよって管理されている信頼できないクライアントがある場合、パブリック・クライアントは許可モデルで脆弱性を公開する可能性があります。このため、ダイレクト・ネイキッド交換ではパブリック・クライアントが許可されず、呼び出し元のクライアントが公開されている場合は、エラーで中止されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:480
 msgid ""
 "It is possible to exchange social tokens provided by Facebook, Google, etc. "
 "for a realm token.  Be careful and vigilante on what the exchange token is "
@@ -1280,7 +1122,6 @@ msgstr ""
 "FacebookやGoogleなどが提供するソーシャル・トークンをレルム・トークンと交換することは可能です。これらのソーシャル・ウェブサイト上で偽のアカウントを作成するのが難しくないため、交換するトークンで何ができるのかを注意して自警してください。デフォルトのロール、グループ、およびアイデンティティ・プロバイダーのマッパーを使用して、外部ソーシャル・ユーザーに割り当てられる属性とロールを制御します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/token-exchange/token-exchange.adoc:485
 msgid ""
 "Direct naked exchanges are quite dangerous.  You are putting a lot of trust "
 "in the calling client that it will never leak out its client credentials.  "

--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -36,7 +36,7 @@ msgid ""
 "client may have a need to impersonate a user.  Here's a short summary of the"
 " current capabilities of {project_name} around token exchange."
 msgstr ""
-"{project_name}において、トークンの交換とはクレデンシャルまたはトークンのセットを使用して、全く異なるトークンを取得するプロセスです。クライアントは信頼性の低いアプリケーションを呼び出してもよいので、現在のトークンをダウングレードすることができます。クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために保存されたトークンを、{project_token}に交換したいことがあります。他の{project_name}のレルムや外部IDPによって作成された外部トークンを信頼することができます。クライアントはユーザーを偽装する必要があるかもしれません。トークンの交換に関する{project_name}の現在の機能の概要を簡単に説明します。"
+"{project_name}において、トークンの交換とはクレデンシャルまたはトークンのセットを使用して、全く異なるトークンを取得するプロセスです。クライアントは信頼性の低いアプリケーションを呼び出すかもしれず、現在のトークンをダウングレードしたい場合があります。クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために保存されたトークンを、{project_token}に交換したいことがあります。他の{project_name}のレルムや外部IDPによって作成された外部トークンを信頼することができます。クライアントはあるユーザーに成り代わる必要があるかもしれません。トークンの交換に関する{project_name}の現在の機能の概要を簡単に説明します。"
 
 #. type: Plain text
 msgid ""
@@ -49,7 +49,7 @@ msgstr ""
 msgid ""
 "A client can exchange an existing {project_name} token for an external "
 "token, i.e. a linked Facebook account"
-msgstr "クライアントは既存の{project_name}トークンを外部トークン(つまりリンクされたFacebookアカウント)と交換できます"
+msgstr "クライアントは既存の{project_name}トークンを外部トークン（つまりリンクされたFacebookアカウント）と交換できます"
 
 #. type: Plain text
 msgid "A client can exchange an external token for a {project_name} token."
@@ -57,7 +57,7 @@ msgstr "クライアントは、外部トークンを{project_name}トークン�
 
 #. type: Plain text
 msgid "A client can impersonate a user"
-msgstr "クライアントはユーザーを偽装することができます。"
+msgstr "クライアントはユーザーに成り代わることができます。"
 
 #. type: Plain text
 msgid ""
@@ -70,7 +70,7 @@ msgid ""
 msgstr ""
 "{project_name}のトークンの交換は、link:http://www.ietf.org/id/draft-ietf-oauth-token-"
 "exchange-10.txt[OAuth Token "
-"Exchange]仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
+"Exchange]の仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
 " Connectトークン・エンドポイントでの単純なグラント・タイプの呼び出しです。"
 
 #. type: delimited block -
@@ -89,9 +89,9 @@ msgid ""
 "admin has configured the client authentication flow in your realm.  Here's a"
 " list of form parameters"
 msgstr ""
-"フォーム・パラメーター( `application/x-www-form-urlencoded` "
-")を入力として受け取り、出力は交換をリクエストしたトークンのタイプに依存します。トークンの交換はクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。パブリック・クライアントは、クライアント識別子をフォーム・パラメーターとして指定します。コンフィデンシャル・BASIC認証クライアントは、フォーム・パラメーターを使用してクライアントIDとシークレット、Basic"
-" Authを渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。 フォーム・パラメーターのリストは次のとおりです"
+"フォーム・パラメーター（ `application/x-www-form-urlencoded` "
+"）を入力として受け取り、出力は交換をリクエストしたトークンのタイプに依存します。トークンの交換はクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。パブリック・クライアントは、クライアント識別子をフォーム・パラメーターとして指定します。コンフィデンシャルクライアントは、フォーム・パラメーターを使用してクライアントIDとシークレット、BASIC認証を渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。"
+" フォーム・パラメーターのリストは次のとおりです"
 
 #. type: Labeled list
 #, no-wrap
@@ -104,8 +104,8 @@ msgid ""
 "parameters for authentication.  If you are using Basic Auth, a client JWT "
 "token, or client cert authentication, then do not specify this parameter."
 msgstr ""
-"_REQUIRED MAYBE._ このパラメーターは、認証にフォーム・パラメーターを使用するクライアントに必要です。 Basic "
-"Auth、クライアントJWTトークン、またはクライアント証明書認証を使用している場合は、このパラメーターを指定しないでください。"
+"_REQUIRED MAYBE_ "
+"。このパラメーターは、認証にフォーム・パラメーターを使用するクライアントに必要です。BASIC認証、クライアントJWTトークン、またはクライアント証明書認証を使用している場合は、このパラメーターを指定しないでください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -119,9 +119,8 @@ msgid ""
 " not specify this parameter if client invocations in your realm are "
 "authenticated by a different means."
 msgstr ""
-"_REQUIRED MAYBE_.  "
-"このパラメーターは、認証にフォーム・パラメーターを使用し、クレデンシャルとしてクライアント・シークレットを使用するクライアントに必要です。 "
-"レルム内のクライアント呼び出しが別の方法で認証されている場合は、このパラメータを指定しないでください。"
+"_REQUIRED MAYBE_ 。 "
+"このパラメーターは、認証にフォーム・パラメーターを使用し、クレデンシャルとしてクライアント・シークレットを使用するクライアントに必要です。レルム内のクライアント呼び出しが別の方法で認証されている場合は、このパラメータを指定しないでください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -133,7 +132,7 @@ msgid ""
 "_REQUIRED._ The value of the parameter must be `urn:ietf:params:oauth:grant-"
 "type:token-exchange`."
 msgstr ""
-"_REQUIRED._ パラメータの値は `urn:ietf:params:oauth:grant-type:token-exchange` "
+"_REQUIRED_ 。パラメータの値は `urn:ietf:params:oauth:grant-type:token-exchange` "
 "でなければなりません。"
 
 #. type: Labeled list
@@ -147,8 +146,8 @@ msgid ""
 "behalf of whom the request is being made.  It is required if you are "
 "exchanging an existing token for a new one."
 msgstr ""
-"_OPTIONAL._ "
-"リクエストを送信したユーザーの代りのパーティのアイデンティティを表すセキュリティ・トークン。既存のトークンを新しいトークンと交換する場合に必要です。"
+"_OPTIONAL_ "
+"。リクエストを送信したユーザーの代りのパーティのアイデンティティーを表すセキュリティ・トークンです。既存のトークンを新しいトークンと交換する場合に必要です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -164,7 +163,7 @@ msgid ""
 "for your realm.  Or an issuer claim identifier configured by a specific "
 "`Identity Provider`."
 msgstr ""
-"_OPTIONAL._ `subject_token` の発行者を識別します。トークンが現在のレルムから来た場合、または発行者が "
+"_OPTIONAL_ 。 `subject_token` の発行者を識別します。トークンが現在のレルムによるものの場合、または発行者が "
 "`subject_token_type` "
 "から決定できる場合は、空白のままにすることができます。それ以外の場合は、指定する必要があります。有効な値は、レルムに設定された `Identity "
 "Provider` のエイリアスです。または、特定の `Identity Provider` によって設定された発行者クレーム識別子です。"
@@ -182,8 +181,8 @@ msgid ""
 "access token.  If it is an external token, this parameter may or may not "
 "have to be specified depending on the requirements of the `subject_issuer`."
 msgstr ""
-"_OPTIONAL._ このパラメータは `subject_token` パラメータで渡されるトークンのタイプです。 `subject_token` "
-"がレルムから来て、アクセス・トークンである場合、これはデフォルトで `urn:ietf:params:oauth:token-"
+"_OPTIONAL_ 。このパラメータは `subject_token` パラメータで渡されるトークンのタイプです。 `subject_token` "
+"がレルムのものでアクセス・トークンである場合、これはデフォルトで `urn:ietf:params:oauth:token-"
 "type:access_token` になります。それが外部トークンである場合、このパラメータは `subject_issuer` "
 "の要件に応じて、指定する必要がある場合とない場合があります。"
 
@@ -202,7 +201,7 @@ msgid ""
 "appropriate values are `urn:ietf:params:oauth:token-type:access_token` and "
 "`urn:ietf:params:oauth:token-type:id_token`"
 msgstr ""
-"_OPTIONAL._ このパラメータは、クライアントが交換したいトークンのタイプを表します。現在、トークン・タイプとしてOAuthとOpenID "
+"_OPTIONAL_ 。このパラメータは、クライアントが交換したいトークンのタイプを表します。現在、トークン・タイプとしてOAuthとOpenID "
 "Connectのみがサポートされています。デフォルト値は、これが `urn:ietf:params:oauth:token-"
 "type:refresh_token` "
 "であるかどうかによって決まります。この場合、レスポンス内でアクセス・トークンとリフレッシュ・トークンの両方が返されます。その他の適切な値は "
@@ -218,7 +217,7 @@ msgstr "audience"
 msgid ""
 "_OPTIONAL._ This parameter specifies the target client you want the new "
 "token minted for."
-msgstr "_OPTIONAL._ このパラメータには、新しいトークンを作成する対象となるクライアントを指定します。"
+msgstr "_OPTIONAL_ 。このパラメータには、新しいトークンを作成する対象となるクライアントを指定します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -231,8 +230,8 @@ msgid ""
 " an external provider.  It must be the alias of an `Identity Provider` "
 "configured within the realm."
 msgstr ""
-"_OPTIONAL._ "
-"このパラメーターは、クライアントが外部プロバイダーによって作成されたトークンを必要とすることを指定します。これは、レルム内で設定された "
+"_OPTIONAL_ "
+"。このパラメーターは、クライアントが外部プロバイダーによって作成されたトークンを必要とすることを指定します。これは、レルム内で設定された "
 "`Identity Provider` のエイリアスでなければなりません。"
 
 #. type: Labeled list
@@ -244,7 +243,7 @@ msgstr "requested_subject"
 msgid ""
 "_OPTIONAL._ This specifies a username or user id if your client wants to "
 "impersonate a different user."
-msgstr "_OPTIONAL._ クライアントが別のユーザーになりすます場合は、ユーザー名またはユーザーIDを指定します。"
+msgstr "_OPTIONAL_ 。クライアントが別のユーザーに成り代わる場合は、ユーザー名またはユーザーIDを指定します。"
 
 #. type: Plain text
 msgid ""
@@ -253,7 +252,7 @@ msgid ""
 "this time but will be once {project_name} has better support for scopes in "
 "general."
 msgstr ""
-"_NOT IMPLEMENTED._ このパラメーターは、クライアントが要求しているOAuthおよびOpenID "
+"_NOT IMPLEMENTED_ 。このパラメーターは、クライアントが要求しているOAuthおよびOpenID "
 "Connectのスコープのセットを表します。現時点では実装されていませんが、{project_name}がスコープの一般的なサポートを強化した後に利用可能になります。"
 
 #. type: Plain text
@@ -263,7 +262,7 @@ msgid ""
 "depending on user demand."
 msgstr ""
 "現在のところ、OpenID "
-"ConnectとOAuthの交換のみサポートしています。SAMLベースのクライアントおよびIDプロバイダーのサポートは、将来、ユーザーの要求に応じて追加される可能性があります。"
+"ConnectとOAuthの交換のみサポートしています。SAMLベースのクライアントおよびアイデンティティー・プロバイダーのサポートは、将来、ユーザーの要求に応じて追加される可能性があります。"
 
 #. type: Plain text
 msgid ""
@@ -273,11 +272,11 @@ msgid ""
 "will return a JSON document as described in the link:http://www.ietf.org/id"
 "/draft-ietf-oauth-token-exchange-10.txt[OAuth Token Exchange] specification."
 msgstr ""
-"交換の呼び出しからの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
+"トークン交換の呼び出しの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
 "`requested_issuer` に依存したコンテンツ・タイプとともにHTTP "
-"200レスポンス・コードを返します。OAuthでリクエストされたトークンタイプは、link:http://www.ietf.org/id/draft-"
-"ietf-oauth-token-exchange-10.txt[OAuth Token "
-"Exchange]仕様に記載されているJSONドキュメントを返します。"
+"200レスポンス・コードを返します。OAuthでリクエストされたトークン・タイプの場合は、link:http://www.ietf.org/id"
+"/draft-ietf-oauth-token-exchange-10.txt[OAuth Token "
+"Exchange]の仕様に記載されているJSONドキュメントを返します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -314,9 +313,9 @@ msgid ""
 "`requested_issuer`.  OAuth based exchanges may return a JSON document as "
 "follows:"
 msgstr ""
-"エラー・レスポンスは一般に400 "
+"エラー・レスポンスは一般的に400 "
 "HTTPレスポンス・コード・カテゴリーに該当しますが、エラーの重大度に応じて他のエラー・ステータス・コードが返されることがあります。エラー・レスポンスには、"
-" `requested_issuer` に応じた内容が含まれます。OAuthベースの交換では、次のようにJSON文書が返ることがあります："
+" `requested_issuer` に応じた内容が含まれます。OAuthベースのトークン交換では、次のようにJSON文書が返ることがあります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -338,7 +337,7 @@ msgid ""
 "url` claim if the user does not have a link to an identity provider.  This "
 "link can be used for a client initiated link request."
 msgstr ""
-"アイデンティティー・プロバイダーOAuth交換のタイプによっては追加のエラー・クレームが返されることがあります。たとえば、ユーザーがアイデンティティ・プロバイダーへのリンクを持っていない場合、OAuthアイデンティティ・プロバイダーは追加の"
+"トークン交換のタイプによっては追加のエラー・クレームが返されることがあります。たとえば、ユーザーがアイデンティティー・プロバイダーへのリンクを持っていない場合、OAuthアイデンティティー・プロバイダーは追加の"
 " `account-link-url` クレームを含めることがあります。このリンクは、クライアントが開始したリンク・リクエストに使用できます。"
 
 #. type: Plain text
@@ -356,8 +355,8 @@ msgid ""
 "call a token minted by the current realm as an _internal_ token and a token "
 "minted by an external realm or identity provider as an _external_ token."
 msgstr ""
-"この章では、セットアップの要件について説明し、さまざまな交換のシナリオの例を示します。簡単にするために、現在のレルムで作成されたトークンを "
-"_internal_ トークン、外部レルムまたはアイデンティティ・プロバイダが作成したトークンを _external_ トークンとして呼び出してみます。"
+"この章では、セットアップの要件について説明し、さまざまな交換のシナリオの例を示します。簡単にするために、現在のレルムで作成されたトークンを _内部_ "
+"トークン、外部レルムまたはアイデンティティー・プロバイダーが作成したトークンを _外部_ トークンとして呼ぶことにします。"
 
 #. type: Title ===
 #, no-wrap
@@ -376,16 +375,12 @@ msgid ""
 "downgrade\" where your app needs to invoke on a less trusted app and you "
 "don't want to propagate your current access token."
 msgstr ""
-"内部トークンから内部トークンへの交換で、特定のクライアントに発行された既存のトークンを、別のターゲット・クライアント用に作成された新しいトークンと交換する必要があります。"
-" なぜこれをしたいのでしょうか？ "
-"これは一般に、クライアントがトークンを持っていて、アクセス・トークン内で異なるリクエストとアクセス権を必要とする他のアプリケーションに追加のリクエストを行う必要がある場合に発生します。"
-" "
-"このタイプの交換が必要なその他の理由は、信頼性の低いアプリケーションでアプリケーションを呼び出す必要があり、現在のアクセス・トークンを伝播したくない場合に「アクセス権のダウングレード」を実行する必要がある場合です。"
+"内部トークンから内部トークンへの交換で、特定のクライアントに発行された既存のトークンを、別のターゲット・クライアント用に作成された新しいトークンと交換する必要があります。なぜこれをしたいのでしょうか？これは一般に、クライアントはトークンを持っているが、別のアクセス・トークンのクレームと権限を必要とする他のアプリケーションに対して、追加のリクエストを行う必要がある場合に発生します。このタイプの交換が必要なその他の理由は、信頼性の低いアプリケーションでアプリケーションを呼び出す必要があり、現在のアクセス・トークンを伝播したくない場合に\"権限のダウングレード\"を実行する必要がある場合です。"
 
 #. type: Title ====
 #, no-wrap
 msgid "Granting Permission for the Exchange"
-msgstr "交換のアクセス権を付与します"
+msgstr "交換のための権限を付与"
 
 #. type: Plain text
 msgid ""
@@ -394,13 +389,13 @@ msgid ""
 "exchange` fine grain permission in the target client you want permission to "
 "exchange to."
 msgstr ""
-"別のクライアントとトークンを交換したいクライアントは、管理コンソールで認可される必要があります。交換するアクセス権を与えたいターゲット・クライアントに "
-"`token-exchange` のきめの細かいアクセス権を定義する必要があります。"
+"別のクライアントとトークンを交換したいクライアントは、管理コンソールで認可される必要があります。交換の権限を与えたいターゲット・クライアントに "
+"`token-exchange` のきめ細かい権限を定義する必要があります。"
 
 #. type: Block title
 #, no-wrap
 msgid "Target Client Permission"
-msgstr "ターゲット・クライアントのアクセス権"
+msgstr "ターゲット・クライアントの権限"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-target-client-permission-unset.png[]"
@@ -418,12 +413,12 @@ msgstr "image:{project_images}/exchange-target-client-permission-set.png[]"
 msgid ""
 "You should see a `token-exchange` link on the page.  Click that to start "
 "defining the permission.  It will bring you to this page."
-msgstr "このページに `token-exchange` のリンクがあります。クリックすると、アクセス権の定義が開始され、このページに移動します。"
+msgstr "このページに `token-exchange` のリンクがあります。クリックすると、権限の定義が開始され、このページに移動します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Target Client Exchange Permission Setup"
-msgstr "ターゲット・クライアントの交換アクセス権のセットアップ"
+msgstr "ターゲット・クライアントの交換権限のセットアップ"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-target-client-permission-setup.png[]"
@@ -434,8 +429,8 @@ msgid ""
 "You'll have to define a policy for this permission.  Click the "
 "`Authorization` link, go to the `Policies` tab and create a `Client` Policy."
 msgstr ""
-"このアクセス権に対するポリシーを定義する必要があります。 `認可` のリンクをクリックし、 `ポリシー` タブに行き、  `クライアント` "
-"ポリシーを作成してください。"
+"この権限に対するポリシーを定義する必要があります。 `Authorization` のリンクをクリックし、 `Policies` タブに行き、  "
+"`Client` ポリシーを作成してください。"
 
 #. type: Block title
 #, no-wrap
@@ -454,7 +449,7 @@ msgid ""
 "you just defined."
 msgstr ""
 "ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ターゲット・クライアントの "
-"`token-exchange` のアクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+"`token-exchange` の権限に戻り、今定義したクライアント・ポリシーを追加します。"
 
 #. type: Block title
 #, no-wrap
@@ -472,7 +467,7 @@ msgid ""
 "Your client now has permission to invoke.  If you do not do this correctly, "
 "you will get a 403 Forbidden response if you try to make an exchange."
 msgstr ""
-"クライアントは起動するアクセス権を持っています。これを正しく行わないで交換しようとすると、403 Forbiddenのレスポンスが表示されます。"
+"これでクライアントは交換を実行する権限を持ちます。これを正しく行わないで交換しようとすると、403 Forbiddenのレスポンスが表示されます。"
 
 #. type: Title ====
 #, no-wrap
@@ -517,7 +512,7 @@ msgid ""
 " response will contain both an access token, refresh token, and expiration."
 "  Here's an example JSON response you get back from this call."
 msgstr ""
-"`subject_token` パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。  "
+"`subject_token` パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。 "
 "`requested_token_type` "
 "パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の全てが含まれます。この呼び出しから返されるJSONレスポンスの例を、次に示します。"
 
@@ -552,21 +547,21 @@ msgid ""
 "linked, you will not be able to get the external token.  To be able to "
 "obtain an external token one of these conditions must be met:"
 msgstr ""
-"外部アイデンティティ・プロバイダーによって作成された外部トークンに対して、レルムのトークンを交換できます。この外部アイデンティティ・プロバイダーは、管理コンソールの「アイデンティティ・プロバイダー」セクション内で設定する必要があります。現在のところ、OAuth"
-" / OpenID "
-"Connectベースの外部アイデンティティ・プロバイダーのみがサポートされています。これには、すべてのソーシャル・プロバイダーが含まれます。{project_name}は、外部プロバイダーへのバックチャネル交換を実行しません。したがって、アカウントがリンクされていない場合、外部トークンを取得することはできません。外部トークンを取得するには、次のいずれかの条件を満たす必要があります。"
+"レルムのトークンを、外部アイデンティティー・プロバイダーによって作成された外部トークンに交換することができます。この外部アイデンティティー・プロバイダーは、管理コンソールの"
+" `Identity Provider` セクション内で設定する必要があります。現在のところ、OAuth/OpenID "
+"Connectベースの外部アイデンティティー・プロバイダーのみがサポートされています。これには、すべてのソーシャル・プロバイダーが含まれます。{project_name}は、外部プロバイダーへのバックチャネル交換を実行しません。したがって、アカウントがリンクされていない場合、外部トークンを取得することはできません。外部トークンを取得するには、次のいずれかの条件を満たす必要があります。"
 
 #. type: Plain text
 msgid ""
 "The user must have logged in with the external identity provider at least "
 "once"
-msgstr "ユーザーは、外部アイデンティティ・プロバイダーに少なくとも1回はログインしている必要があります。"
+msgstr "ユーザーは、外部アイデンティティー・プロバイダーに少なくとも1回はログインしている必要があります。"
 
 #. type: Plain text
 msgid ""
 "The user must have linked with the external identity provider through the "
 "User Account Service"
-msgstr "ユーザーは、外部アイデンティティ・プロバイダーにユーザー・アカウント・サービスを介してリンクしている必要があります。"
+msgstr "ユーザーは、外部アイデンティティー・プロバイダーにユーザー・アカウント・サービスを介してリンクしている必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -574,7 +569,7 @@ msgid ""
 "link:{developerguide_link}[Client Initiated Account Linking] API."
 msgstr ""
 "ユーザー・アカウントは、link:{developerguide_link}[Client Initiated Account Linking] "
-"APIを使用して外部アイデンティティ・プロバイダーを介してリンクされています。"
+"APIを使用して外部アイデンティティー・プロバイダーを介してリンクされています。"
 
 #. type: Plain text
 msgid ""
@@ -582,7 +577,7 @@ msgid ""
 "tokens, or, one of the above actions must have been performed with the same "
 "user session as the internal token you are exchanging."
 msgstr ""
-"最後に、外部アイデンティティ・プロバイダーがトークンを保存するように設定されている必要があります。または、上記のアクションの1つが、交換している内部トークンと同じユーザー・セッションで実行されている必要があります。"
+"最後に、外部アイデンティティー・プロバイダーがトークンを保存するように設定されている必要があります。または、上記のアクションの1つが、交換する内部トークンと同じユーザー・セッションで実行されている必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -591,7 +586,7 @@ msgid ""
 "<<_internal_external_making_request, Making the Request>> section."
 msgstr ""
 "アカウントがリンクされていない場合、交換レスポンスにはリンクの確立に使用できるリンクが含まれます。これについては、<<_internal_external_making_request,"
-" Making the Request>>のセクションで詳しく説明します。"
+" リクエストの実行>>のセクションで詳しく説明します。"
 
 #. type: Plain text
 msgid ""
@@ -601,13 +596,14 @@ msgid ""
 " the client you must go to the identity provider's configuration page to the"
 " `Permissions` tab."
 msgstr ""
-"呼び出し側のクライアントが外部アイデンティティ・プロバイダーとトークンを交換するアクセス権を与えるまで、内部トークン交換リクエストと内部トークン交換リクエストは、403、Forbiddenレスポンスで拒否されます。クライアントにアクセス権を与えるには、アイデンティティ・プロバイダーの設定ページの"
-" `アクセス権` タブに移動する必要があります。"
+"呼び出し側のクライアントに外部アイデンティティー・プロバイダーとトークンを交換する権限を与えるまで、内部トークンから外部トークンへの交換リクエストは、403"
+" Forbiddenレスポンスで拒否されます。クライアントに権限を与えるには、アイデンティティー・プロバイダーの設定ページの `Permissions`"
+" タブに移動する必要があります。"
 
 #. type: Block title
 #, no-wrap
 msgid "Identity Provider Permission"
-msgstr "アイデンティティ・プロバイダーのアクセス権"
+msgstr "アイデンティティー・プロバイダーの権限"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-idp-permission-unset.png[]"
@@ -620,7 +616,7 @@ msgstr "image:{project_images}/exchange-idp-permission-set.png[]"
 #. type: Block title
 #, no-wrap
 msgid "Identity Provider Exchange Permission Setup"
-msgstr "アイデンティティ・プロバイダーの交換アクセス権のセットアップ"
+msgstr "アイデンティティー・プロバイダーの交換権限のセットアップ"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-idp-permission-setup.png[]"
@@ -637,8 +633,8 @@ msgid ""
 "the identity providers's `token-exchange` permission and add the client "
 "policy you just defined."
 msgstr ""
-"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、アイデンティティ・プロバイダーの"
-" `token-exchange` のアクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、アイデンティティー・プロバイダーの"
+" `token-exchange` の権限に戻り、今定義したクライアント・ポリシーを追加します。"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-idp-apply-policy.png[]"
@@ -651,7 +647,7 @@ msgid ""
 "be the alias of a configured identity provider."
 msgstr ""
 "クライアントが既存の内部トークンを外部トークンと交換する場合は、 `requested_issuer` "
-"パラメーターを指定する必要があります。パラメーターは、設定済みのアイデンティティ・プロバイダーのエイリアスでなければなりません。"
+"パラメーターを指定する必要があります。パラメーターは、設定済みのアイデンティティー・プロバイダーのエイリアスでなければなりません。"
 
 #. type: delimited block -
 #, no-wrap
@@ -682,7 +678,7 @@ msgid ""
 "supported at this time.  Here's an example successful JSON response you get "
 "back from this call."
 msgstr ""
-"`subject_token` パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。  "
+"`subject_token` パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。 "
 "`requested_token_type` パラメーターは、 `urn:ietf:params:oauth:token-"
 "type:access_token` "
 "またはブランクのままでなければなりません。現時点では、それ以外の要求されたトークン・タイプはサポートされていません。この呼び出しから返される成功のJSONレスポンスの例を次に示します。"
@@ -707,7 +703,7 @@ msgid ""
 "If the external identity provider is not linked for whatever reason, you "
 "will get an HTTP 400 response code with this JSON document:"
 msgstr ""
-"外部アイデンティティ・プロバイダーが何らかの理由でリンクされていない場合は、このJSONドキュメントでHTTP 400レスポンス・コードを取得します。"
+"外部アイデンティティー・プロバイダーが何らかの理由でリンクされていない場合は、このJSONドキュメントでHTTP 400レスポンス・コードが返ります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -735,9 +731,9 @@ msgid ""
 msgstr ""
 "`error` クレームは、 `token_expired` か `not_linked` のどちらかになります。 `account-link-url`"
 " クレームは、クライアントがlink:{developerguide_link}[Client Initiated Account "
-"Linking]を実行できるように提供されています。ほとんど(すべて？)のプロバイダーは、ブラウザーOAuthプロトコルを介してリンクする必要があります。"
+"Linking]を実行できるように提供されています。ほとんど（すべて？）のプロバイダーは、ブラウザーOAuthプロトコルを介してリンクする必要があります。"
 " `account-link-url` では、 `redirect_uri` "
-"クエリー・パラメータを追加するだけで、ブラウザを転送してリンクを実行することができます。"
+"クエリー・パラメータを追加するだけで、ブラウザーを転送してリンクを実行することができます。"
 
 #. type: Title ===
 #, no-wrap
@@ -752,7 +748,7 @@ msgid ""
 "identity provider browser login in that a new user is imported into your "
 "realm if it doesn't exist."
 msgstr ""
-"外部アイデンティティ・プロバイダーが発行した外部トークンを信頼して、内部トークンに交換することができます。これは、レルム間のブリッジや、ソーシャル・プロバイダーのトークンの信頼に使用できます。これは、アイデンティティ・プロバイダーのブラウザのログインと同様に動作します。新しいユーザーが存在しない場合、そのユーザーはレルムにインポートされます。"
+"外部アイデンティティー・プロバイダーが発行した外部トークンを信頼して、内部トークンに交換することができます。これは、レルム間のブリッジや、ソーシャル・プロバイダーのトークンの信頼に使用できます。これは、アイデンティティー・プロバイダーのブラウザのログインと同様に動作します。新しいユーザーが存在しない場合、そのユーザーはレルムにインポートされます。"
 
 #. type: Plain text
 #, no-wrap
@@ -761,7 +757,7 @@ msgid ""
 "       exchange will not be allowed unless the existing user already has an account link to the external identity\n"
 "       provider.\n"
 msgstr ""
-"外部トークン交換の現在の制限は、外部トークンが既存のユーザーにマップされている場合、既存のユーザーに外部アイデンティティ・プロバイダーへのアカウント・リンクがない限り、交換は許可されないということです。\n"
+"外部トークン交換の現在の制限は、外部トークンが既存のユーザーにマップされている場合、既存のユーザーに外部アイデンティティー・プロバイダーへのアカウント・リンクがない限り、交換は許可されないということです。\n"
 
 #. type: Plain text
 msgid ""
@@ -772,19 +768,19 @@ msgid ""
 "endpoint of the realm passing this new access token."
 msgstr ""
 "交換が完了すると、レルム内にユーザー・セッションが作成され、 `requested_token_type` "
-"パラメーター値に応じて、アクセス・トークンまたはリフレッシュ・トークンが受け取れます。この新しいユーザー・セッションは、タイムアウトするまで、またはこの新しいアクセス・トークンを渡すレルムのログアウト・エンドポイントを呼び出すまで、アクティブなままです。"
+"パラメーター値に応じて、アクセス・トークンまたはリフレッシュ・トークンを受け取れます。この新しいユーザー・セッションは、タイムアウトするまで、またはこの新しいアクセス・トークンを渡すレルムのログアウト・エンドポイントを呼び出すまで、アクティブなままであることに注意してください。"
 
 #. type: Plain text
 msgid ""
 "These types of changes required a configured identity provider in the admin "
 "console."
-msgstr "これらのタイプの変更には、管理コンソールで設定されたアイデンティティ・プロバイダーが必要でした。"
+msgstr "これらのタイプの変更には、管理コンソールで設定されたアイデンティティー・プロバイダーが必要でした。"
 
 #. type: Plain text
 msgid ""
 "SAML identity providers are not supported at this time.  Twitter tokens "
 "cannot be exchanged either."
-msgstr "現時点では、SAMLアイデンティティ・プロバイダーはサポートされていません。Twitterのトークンは交換できません。"
+msgstr "現時点では、SAMLアイデンティティー・プロバイダーはサポートされていません。Twitterのトークンも交換できません。"
 
 #. type: Plain text
 msgid ""
@@ -793,9 +789,8 @@ msgid ""
 "same manner as <<_grant_permission_external_exchange, interal to external "
 "permission is granted>>."
 msgstr ""
-"外部トークンの交換が可能になる前に、発信側のクライアントが交換を行うためのアクセス権を与える必要があります。 "
-"このアクセス権は、<<_grant_permission_external_exchange, interal to external "
-"permission is granted>>と同じ方法で付与されます。"
+"外部トークンの交換が可能になる前に、発信側のクライアントが交換を行うための権限を与える必要があります。この権限は、<<_grant_permission_external_exchange,"
+" 内部トークンから外部トークンへの交換権限の付与>>と同じ方法で付与されます。"
 
 #. type: Plain text
 msgid ""
@@ -806,8 +801,8 @@ msgid ""
 "discussed earlier>> in this section."
 msgstr ""
 "値が呼び出し側以外の別のクライアントを指し示す `audience` パラメーターも指定した場合、呼び出し側クライアントに `audience` "
-"パラメーターで特定のターゲット・クライアントに交換するアクセス権を与える必要があります。 "
-"これを行う方法は、このセクションの<<_client_to_client_permission, discussed earlier>>にあります。"
+"パラメーターで特定のターゲット・クライアントに交換する権限を与える必要があります。これを行う方法については、このセクションの<<_client_to_client_permission,"
+" 前半>>で説明しています。"
 
 #. type: Plain text
 msgid ""
@@ -823,9 +818,9 @@ msgstr ""
 "`subject_token_type` は、 `urn:ietf:params:oauth:token-type:access_token` または "
 "`urn:ietf:params:oauth:token-type:jwt` のいずれかでなければなりません。タイプが "
 "`urn:ietf:params:oauth:token-type:access_token` の場合、 `subject_issuer` "
-"パラメーターを指定しなければなりません。また、設定されたアイデンティティ・プロバイダーのエイリアスでなければなりません。タイプが "
+"パラメーターを指定しなければなりません。また、設定されたアイデンティティー・プロバイダーのエイリアスでなければなりません。タイプが "
 "`urn:ietf:params:oauth:token-type:jwt` の場合、プロバイダーは、プロバイダーのエイリアスであるJWT内の "
-"`issuer` クレームまたは、プロバイダ設定内の登録された発行者と一致します。"
+"`issuer` クレームまたは、プロバイダー設定内の登録された発行者と一致します。"
 
 #. type: Plain text
 msgid ""
@@ -836,7 +831,7 @@ msgid ""
 "otherwise, it will default to also invoking on the user info service to "
 "validate the token."
 msgstr ""
-"検証のために、トークンがアクセス・トークンである場合、プロバイダーのユーザー情報サービスが呼び出されてトークンを検証します。呼び出しが成功することは、アクセス・トークンが有効であることを意味します。サブジェクト・トークンがJWTであり、プロバイダが署名検証を有効にしている場合は、それが試行され、そうでない場合は、デフォルトでトークンを検証するためにユーザー情報サービスが呼び出されます。"
+"トークンがアクセス・トークンである場合、プロバイダーのUserInfoサービスが呼び出されてトークンを検証します。呼び出しが成功することは、アクセス・トークンが有効であることを意味します。サブジェクト・トークンがJWTであり、プロバイダーが署名検証を有効にしている場合は、それが試行され、そうでない場合は、デフォルトでトークンを検証するためにUserInfoサービスが呼び出されます。"
 
 #. type: Plain text
 msgid ""
@@ -845,8 +840,8 @@ msgid ""
 "calling client.  Alternatively, you can specify a different target client "
 "using the `audience` parameter."
 msgstr ""
-"デフォルトでは、発行された内部トークンは、呼び出し元クライアント用に定義されたプロトコル・マッパーを使用してトークン内の内容を判断するため、呼び出し元クライアントを使用します。"
-" あるいは、 `audience` パラメーターを使って別のターゲット・クライアントを指定することもできます。"
+"デフォルトでは、発行された内部トークンは、呼び出し元クライアント用に定義されたプロトコル・マッパーを使用してトークンの内容を判断するため、呼び出し元クライアントを使用します。あるいは、"
+" `audience` パラメーターを使って別のターゲット・クライアントを指定することもできます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -878,7 +873,7 @@ msgid ""
 "Here's an example JSON response you get back from this call."
 msgstr ""
 "`requested_token_type` "
-"パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の両方が含まれます。この呼び出しから返されるJSONレスポンスの例を次に示します。"
+"パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の両方が含まれます。この呼び出しで返されるJSONレスポンスの例を次に示します。"
 
 #. type: Title ===
 #, no-wrap
@@ -901,9 +896,7 @@ msgid ""
 "on how to enable this permission.  It can be done through a role or through "
 "fine grain admin permissions."
 msgstr ""
-"サブジェクト・トークンが表すユーザーには、他のユーザーを偽装するアクセス権が必要です。 "
-"このアクセス権を有効にする方法については、link:{adminguide_link}[{adminguide_name}]をご覧ください。 "
-"それは、ロールを通じて、またはきめ細かい管理者アクセス権を使って行うことができます。"
+"サブジェクト・トークンが表すユーザーには、他のユーザーに成り代わる権限が必要です。この権限を有効にする方法については、link:{adminguide_link}[{adminguide_name}]をご覧ください。ロールを通じて、またはきめ細かい管理権限を使って行うことができます。"
 
 #. type: Plain text
 msgid ""
@@ -940,7 +933,7 @@ msgstr ""
 #. type: Title ===
 #, no-wrap
 msgid "Direct Naked Impersonation"
-msgstr "ダイレクト・ネイキッド偽装"
+msgstr "ダイレクト・ネイキッドな成り代わり"
 
 #. type: Plain text
 msgid ""
@@ -954,7 +947,7 @@ msgid ""
 "able to obtain a token."
 msgstr ""
 "`subject_token` "
-"を指定せずに、内部トークンの交換要求を行うことができます。これは、ダイレクト・ネイキッド偽装と呼ばれます。クライアントがそのレルム内の任意のユーザーを偽装する可能性があるため、クライアントに多くの信頼を置くからです。交換するサブジェクト・トークンを取得することが不可能なアプリケーションのためにブリッジする必要があるかもしれません。たとえば、LDAPに直接ログインするレガシー・アプリケーションを統合したいかもしれません。その場合、従来のアプリケーションはユーザー自身を認証できますが、トークンを取得することができません。"
+"を指定せずに、内部トークンの交換要求を行うことができます。これは、ダイレクト・ネイキッドな成り代わりと呼ばれます。クライアントがそのレルム内の任意のユーザーに成り代わる可能性があるため、クライアントに多くの信頼を置くからです。交換するサブジェクト・トークンを取得することが不可能なアプリケーションをブリッジするためにこれが必要となるかもしれません。たとえば、LDAPに直接ログインするレガシー・アプリケーションを統合したいかもしれません。その場合、従来のアプリケーションはユーザー自身を認証できますが、トークンを取得することができません。"
 
 #. type: Plain text
 #, no-wrap
@@ -962,7 +955,7 @@ msgid ""
 "It is very risky to enable direct naked impersonation for a client.  If the client's credentials are ever\n"
 "         stolen, that client can impersonate any user in the system.\n"
 msgstr ""
-"クライアントにダイレクト・ネイキッド偽装を有効にすることは非常に危険です。クライアントのクレデンシャルが盗まれた場合、そのクライアントはシステム内のすべてのユーザーを偽装する可能性があります。\n"
+"クライアントにダイレクト・ネイキッドな成り代わりを有効にすることは非常に危険です。クライアントのクレデンシャルが盗まれた場合、そのクライアントはシステム内のすべてのユーザーに成り代わる可能性があります。\n"
 
 #. type: Plain text
 msgid ""
@@ -970,8 +963,8 @@ msgid ""
 "permission to exchange to the client.  How to set this up is discussed "
 "earlier in this chapter."
 msgstr ""
-"`audience` パラメーターが提供されている場合、呼び出し側クライアントはクライアントとの交換のアクセス権を持っていなければなりません。 "
-"これを設定する方法については、この章の前半で説明します。"
+"`audience` "
+"パラメーターが提供されている場合、呼び出し側クライアントはクライアントとの交換権限を持っていなければなりません。これを設定する方法については、この章の前半で説明します。"
 
 #. type: Plain text
 msgid ""
@@ -979,13 +972,13 @@ msgid ""
 "users.  In the admin console, go to the `Users` screen and click on the "
 "`Permissions` tab."
 msgstr ""
-"さらに、呼び出し元のクライアントにユーザーを偽装するアクセス権が与えられている必要があります。管理コンソールで、 `Users` 画面を表示し、 "
+"さらに、呼び出し元のクライアントにユーザーに成り代わる権限が与えられている必要があります。管理コンソールで、 `Users` 画面を表示し、 "
 "`Permissions` タブをクリックしてください。"
 
 #. type: Block title
 #, no-wrap
 msgid "Users Permission"
-msgstr "ユーザーのアクセス権"
+msgstr "ユーザーの権限"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-users-permission-unset.png[]"
@@ -999,13 +992,12 @@ msgstr "image:{project_images}/exchange-users-permission-set.png[]"
 msgid ""
 "You should see a `impersonation` link on the page.  Click that to start "
 "defining the permission.  It will bring you to this page."
-msgstr ""
-"ページに `impersonation` リンクがあります。クリックすると、アクセス権の定義が開始されます。それにより、このページに移動します。"
+msgstr "ページに `impersonation` リンクがあります。クリックすると、権限の定義が開始され、このページに移動します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Users Impersonation Permission Setup"
-msgstr "ユーザー偽装アクセス権のセットアップ"
+msgstr "ユーザー成り代わり権限のセットアップ"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-users-permission-setup.png[]"
@@ -1023,7 +1015,7 @@ msgid ""
 "defined."
 msgstr ""
 "ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ユーザーの "
-"`impersonation` アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+"`impersonation` 権限に戻り、今定義したクライアント・ポリシーを追加します。"
 
 #. type: Plain text
 msgid "image:{project_images}/exchange-users-apply-policy.png[]"
@@ -1035,12 +1027,12 @@ msgid ""
 "correctly, you will get a 403 Forbidden response if you try to make this "
 "type of exchange."
 msgstr ""
-"クライアントはユーザーを偽装するアクセス権を持っています。これを正しく行わないと、これを交換のタイプにしようとする際に、403 "
+"クライアントにユーザーに成り代わる権限が付与されました。これを正しく行わないと、これを交換のタイプにしようとする際に、403 "
 "Forbiddenのレスポンスが表示されます。"
 
 #. type: Plain text
 msgid "Public clients are not allowed to do direct naked impersonations."
-msgstr "パブリック・クライアントはダイレクト・ネイキッド偽装を行うことができません。"
+msgstr "パブリック・クライアントはダイレクト・ネイキッドな成り代わりを行うことができません。"
 
 #. type: Plain text
 msgid ""
@@ -1072,7 +1064,7 @@ msgstr ""
 #. type: Title ===
 #, no-wrap
 msgid "Expand Permission Model With Service Accounts"
-msgstr "サービス・アカウントのアクセス権モデルの展開"
+msgstr "サービス・アカウントの権限モデルの拡張"
 
 #. type: Plain text
 msgid ""
@@ -1084,7 +1076,7 @@ msgid ""
 "exchange` role and any service account that has that role can do a naked "
 "exchange."
 msgstr ""
-"クライアントに交換のアクセス権を付与すると、クライアントごとにこれらのアクセス権を手動で有効にする必要がなくなります。クライアントに関連付けられているサービス・アカウントがある場合は、ロールを使用してアクセス権をグループ化し、クライアントのサービス・アカウントにロールを割り当てて、交換権のアクセス権を割り当てることができます。たとえば、"
+"クライアントに交換の権限を付与する際に、クライアントごとに権限を手動で有効にする必要はありません。クライアントに関連付けられているサービス・アカウントがある場合は、ロールを使用して権限をグループ化し、クライアントのサービス・アカウントにロールを割り当てて、交換の権限を割り当てることができます。たとえば、"
 " `naked-exchange` ロールを定義し、そのロールを持つサービス・アカウントでネイキッドな交換を行うことができます。"
 
 #. type: Title ===
@@ -1096,7 +1088,7 @@ msgstr "交換の脆弱性"
 msgid ""
 "When you start allowing token exchanges, there's various things you have to "
 "both be aware of and careful of."
-msgstr "トークン交換の許可を始める上で、意識して気をつけなければならない様々なことがあります。"
+msgstr "トークン交換の許可を行う上で、意識して気をつけなければならない様々なことがあります。"
 
 #. type: Plain text
 msgid ""
@@ -1109,7 +1101,7 @@ msgid ""
 "exchanges do not allow public clients and will abort with an error if the "
 "calling client is public."
 msgstr ""
-"1つはパブリック・クライアントです。パブリック・クライアントは、交換を実行するためにクライアント・クレデンシャルを持たない、または必要としません。有効なトークンを持っていれば、パブリック・クライアントを__偽装する__することができ、パブリック・クライアントが実行できる交換を実行できます。レルムよって管理されている信頼できないクライアントがある場合、パブリック・クライアントは許可モデルで脆弱性を公開する可能性があります。このため、ダイレクト・ネイキッド交換ではパブリック・クライアントが許可されず、呼び出し元のクライアントが公開されている場合は、エラーで中止されます。"
+"1つはパブリック・クライアントです。パブリック・クライアントは、交換を実行するためにクライアント・クレデンシャルを持たない、または必要としません。有効なトークンを持っていれば、パブリック・クライアントに__偽装__することができ、パブリック・クライアントに実行が許可されている交換を実行できます。レルムで管理されている信頼できないクライアントがある場合、パブリック・クライアントは許可モデルで脆弱性を公開する可能性があります。このため、ダイレクト・ネイキッド交換ではパブリック・クライアントは許可されず、呼び出し元のクライアントがパブリックの場合は、エラーで中止されます。"
 
 #. type: Plain text
 msgid ""
@@ -1119,7 +1111,7 @@ msgid ""
 "websites.  Use default roles, groups, and identity provider mappers to "
 "control what attributes and roles are assigned to the external social user."
 msgstr ""
-"FacebookやGoogleなどが提供するソーシャル・トークンをレルム・トークンと交換することは可能です。これらのソーシャル・ウェブサイト上で偽のアカウントを作成するのが難しくないため、交換するトークンで何ができるのかを注意して自警してください。デフォルトのロール、グループ、およびアイデンティティ・プロバイダーのマッパーを使用して、外部ソーシャル・ユーザーに割り当てられる属性とロールを制御します。"
+"FacebookやGoogleなどが提供するソーシャル・トークンをレルム・トークンと交換することが可能です。これらのソーシャル・ウェブサイト上で偽のアカウントを作成するのが難しくないため、交換するトークンで何ができるのかを注意して自警してください。デフォルトのロール、グループ、およびアイデンティティー・プロバイダーのマッパーを使用して、外部ソーシャル・ユーザーに割り当てられる属性とロールを制御します。"
 
 #. type: Plain text
 msgid ""
@@ -1131,6 +1123,4 @@ msgid ""
 "and the client credentials, and you're only dealing with one user.  So use "
 "direct naked exchanges sparingly."
 msgstr ""
-"ダイレクト・ネイキッド交換は非常に危険です。呼び出し元のクライアントに対して、クライアントのクレデンシャルが漏洩しないということを非常に信頼しています。これらのクレデンシャルが漏洩した場合、攻撃者はシステム内の誰かを偽装する可能性があります。これは、既存のトークンを持つコンフィデンシャル・クライアントとはまったく対照的です。"
-" "
-"認証の2つの要因(アクセス・トークンとクライアントのクレデンシャル)があり、1ユーザーしか扱っていません。したがって、ダイレクト・ネイキッド交換は控えめに使用してください。"
+"ダイレクト・ネイキッド交換は非常に危険です。呼び出し元のクライアントに対して、クライアントのクレデンシャルが漏洩しないということを非常に信頼しています。これらのクレデンシャルが漏洩した場合、攻撃者はシステム内の誰かに偽装する可能性があります。これは、既存のトークンを持つコンフィデンシャル・クライアントとはまったく対照的です。2要素の認証（アクセス・トークンとクライアントのクレデンシャル）がありますが、1ユーザーしか扱っていません。したがって、ダイレクト・ネイキッド交換は控えめに使用してください。"

--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -979,8 +979,8 @@ msgid ""
 "users.  In the admin console, go to the `Users` screen and click on the "
 "`Permissions` tab."
 msgstr ""
-"さらに、呼び出し元のクライアントにユーザーを偽装するアクセス権が与えられている必要があります。管理コンソールで、 `ユーザー` 画面を表示し、 "
-"`アクセス権` タブをクリックしてください。"
+"さらに、呼び出し元のクライアントにユーザーを偽装するアクセス権が与えられている必要があります。管理コンソールで、 `Users` 画面を表示し、 "
+"`Permissions` タブをクリックしてください。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -62,14 +62,14 @@ msgstr "クライアントはユーザーを偽装することができます。
 #. type: Plain text
 msgid ""
 "Token exchange in {project_name} is a very loose implementation of the "
-"link:http://www.ietf.org/id/draft-ietf-oauth-token-exchange-09.txt[OAuth "
+"link:http://www.ietf.org/id/draft-ietf-oauth-token-exchange-10.txt[OAuth "
 "Token Exchange] specification at the IETF.  We have extended it a little, "
 "ignored some of it, and loosely interpreted other parts of the "
 "specification.  It is a simple grant type invocation on a realm's OpenID "
 "Connect token endpoint."
 msgstr ""
 "{project_name}のトークンの交換は、link:http://www.ietf.org/id/draft-ietf-oauth-token-"
-"exchange-09.txt[OAuth Token "
+"exchange-10.txt[OAuth Token "
 "Exchange]仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
 " Connectトークン・エンドポイントでの単純なグラント・タイプの呼び出しです。"
 
@@ -271,12 +271,12 @@ msgid ""
 "response code with a content type that depends on the `requested-token-type`"
 " and `requested_issuer` the client asks for.  OAuth requested token types "
 "will return a JSON document as described in the link:http://www.ietf.org/id"
-"/draft-ietf-oauth-token-exchange-09.txt[OAuth Token Exchange] specification."
+"/draft-ietf-oauth-token-exchange-10.txt[OAuth Token Exchange] specification."
 msgstr ""
 "交換の呼び出しからの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
 "`requested_issuer` に依存したコンテンツ・タイプとともにHTTP "
 "200レスポンス・コードを返します。OAuthでリクエストされたトークンタイプは、link:http://www.ietf.org/id/draft-"
-"ietf-oauth-token-exchange-09.txt[OAuth Token "
+"ietf-oauth-token-exchange-10.txt[OAuth Token "
 "Exchange]仕様に記載されているJSONドキュメントを返します。"
 
 #. type: delimited block -
@@ -767,11 +767,11 @@ msgstr ""
 msgid ""
 "When the exchange is complete, a user session will be created within the "
 "realm, and you will receive an access and or refresh token depending on the "
-"`requested_toke_type` parameter value.  You should note that this new user "
+"`requested_token_type` parameter value.  You should note that this new user "
 "session will remain active until it times out or until you call the logout "
 "endpoint of the realm passing this new access token."
 msgstr ""
-"交換が完了すると、レルム内にユーザー・セッションが作成され、 `requested_toke_type` "
+"交換が完了すると、レルム内にユーザー・セッションが作成され、 `requested_token_type` "
 "パラメーター値に応じて、アクセス・トークンまたはリフレッシュ・トークンが受け取れます。この新しいユーザー・セッションは、タイムアウトするまで、またはこの新しいアクセス・トークンを渡すレルムのログアウト・エンドポイントを呼び出すまで、アクティブなままです。"
 
 #. type: Plain text
@@ -883,7 +883,7 @@ msgstr ""
 #. type: Title ===
 #, no-wrap
 msgid "Impersonation"
-msgstr "偽装"
+msgstr "成り代わり"
 
 #. type: Plain text
 msgid ""
@@ -892,7 +892,7 @@ msgid ""
 "admin application that needs to impersonate a user so that a support "
 "engineer can debug a problem."
 msgstr ""
-"内部トークン交換と外部トークン交換の場合、クライアントはユーザーの代わりに別のユーザーを偽装するように要求できます。たとえば、サポート・エンジニアが問題をデバッグできるように、ユーザーを偽装する必要がある管理アプリケーションがあるとします。"
+"内部トークン交換と外部トークン交換の場合、クライアントはユーザーの代わりに別のユーザーに成り代わるように要求できます。たとえば、サポート・エンジニアが問題をデバッグできるように、ユーザーに成り変わる必要がある管理アプリケーションがあるとします。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -1,0 +1,1295 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Labeled list
+#: source/securing_apps/topics/oidc/java/params_forwarding.adoc:21
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:63
+#, no-wrap
+msgid "scope"
+msgstr "scope"
+
+#. type: Title ==
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:4
+#, no-wrap
+msgid "Token Exchange"
+msgstr "トークンの交換"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:11
+msgid ""
+"In {project_name}, token exchange is the process of using a set of "
+"credentials or token to obtain an entirely different token.  A client may "
+"want to invoke on a less trusted application so it may want to downgrade the"
+" current token it has.  A client may want to exchange a {project_token} for "
+"a token stored for a linked social provider account.  You may want to trust "
+"external tokens minted by other {project_name} realms or foreign IDPs. A "
+"client may have a need to impersonate a user.  Here's a short summary of the"
+" current capabilities of {project_name} around token exchange."
+msgstr ""
+"{project_name} において、トークンの交換とはクレデンシャルまたはトークンのセットを使用して全く異なるトークンを取得するプロセスです。 "
+"クライアントは信頼性の低いアプリケーションを呼び出してもよいので、現在のトークンをダウングレードすることができます。 "
+"クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために格納されたトークンを、 {project_token} "
+"に交換したいことがあります。 他の {project_name} のレルムや外部IDPによって作成された外部トークンを信頼することができます。 "
+"クライアントはユーザーを偽装する必要があるかもしれません。 トークンの交換に関する {project_name} の現在の機能の概要を簡単に説明します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:13
+msgid ""
+"A client can exchange an existing {project_name} token created for a "
+"specific client for a new token targeted to a different client"
+msgstr ""
+"クライアントは、特定のクライアントに対して作成された既存の {project_name} "
+"トークンを、別のクライアントをターゲットとする新しいトークンと交換することができます"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:14
+msgid ""
+"A client can exchange an existing {project_name} token for an external "
+"token, i.e. a linked Facebook account"
+msgstr "クライアントは既存の {project_name} トークンを外部トークン(つまりリンクされたFacebookアカウント)と交換できます"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:15
+msgid "A client can exchange an external token for a {project_name} token."
+msgstr "クライアントは、外部トークンを {project_name} トークンに交換できます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:16
+msgid "A client can impersonate a user"
+msgstr "クライアントはユーザーを偽装することができます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:20
+msgid ""
+"Token exchange in {project_name} is a very loose implementation of the "
+"link:http://www.ietf.org/id/draft-ietf-oauth-token-exchange-09.txt[OAuth "
+"Token Exchange] specification at the IETF.  We have extended it a little, "
+"ignored some of it, and loosely interpreted other parts of the "
+"specification.  It is a simple grant type invocation on a realm's OpenID "
+"Connect token endpoint."
+msgstr ""
+"{project_name} のトークンの交換は、 link:http://www.ietf.org/id/draft-ietf-oauth-"
+"token-exchange-09.txt[OAuth Token Exchange] 仕様の非常にルーズな実装です。 "
+"それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。 これは、あるレルムのOpenID "
+"Connectトークン・エンドポイントでの単純なグラント・タイプの呼び出しです。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:23
+#, no-wrap
+msgid "/realms/{realm}/protocol/openid-connect/token\n"
+msgstr "/realms/{realm}/protocol/openid-connect/token\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:30
+msgid ""
+"It accepts form parameters (`application/x-www-form-urlencoded`) as input "
+"and the output depends on the type of token you requested an exchange for.  "
+"Token exchange is a client endpoint so requests must provide authentication "
+"information for the calling client.  Public clients specify their client "
+"identifier as a form parameter.  Confidential clients can also use form "
+"parameters to pass their client id and secret, Basic Auth, or however your "
+"admin has configured the client authentication flow in your realm.  Here's a"
+" list of form parameters"
+msgstr ""
+"フォーム・パラメータ (`application/x-www-form-urlencoded`) "
+"を入力として受け取り、出力はあなたが交換をリクエストしたトークンのタイプに依存します。 "
+"トークンの交換はクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。 "
+"パブリック・クライアントは、クライアント識別子をフォーム・パラメータとして指定します。 "
+"コンフィデンシャル・BASIC認証クライアントは、フォームパラメータを使用してクライアントIDとシークレット、Basic "
+"Authを渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。 フォームパラメータのリストは次のとおりです"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:31
+#: source/server_development/topics/identity-brokering/account-linking.adoc:33
+#, no-wrap
+msgid "client_id"
+msgstr "client_id"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:34
+msgid ""
+"_REQUIRED MAYBE._ This parameter is required for clients using form "
+"parameters for authentication.  If you are using Basic Auth, a client JWT "
+"token, or client cert authentication, then do not specify this parameter."
+msgstr ""
+"_REQUIRED MAYBE._ このパラメーターは、認証にフォーム・パラメーターを使用するクライアントに必要です。 Basic "
+"Auth、クライアントJWTトークン、またはクライアント証明書認証を使用している場合は、このパラメーターを指定しないでください。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:34
+#, no-wrap
+msgid "client_secret"
+msgstr "client_secret"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:37
+msgid ""
+"_REQUIRED MAYBE_.  This parameter is required for clients using form "
+"parameters for authentication and using a client secret as a credential.  Do"
+" not specify this parameter if client invocations in your realm are "
+"authenticated by a different means."
+msgstr ""
+"_REQUIRED MAYBE_.  "
+"このパラメーターは、認証にフォーム・パラメーターを使用し、クレデンシャルとしてクライアント・シークレットを使用するクライアントに必要です。 "
+"レルム内のクライアント呼び出しが別の方法で認証されている場合は、このパラメータを指定しないでください。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:38
+#, no-wrap
+msgid "grant_type"
+msgstr "grant_type"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:40
+msgid ""
+"_REQUIRED._ The value of the parameter must be `urn:ietf:params:oauth:grant-"
+"type:token-exchange`."
+msgstr ""
+"_REQUIRED._ パラメータの値は `urn:ietf:params:oauth:grant-type:token-exchange` "
+"でなければなりません。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:40
+#, no-wrap
+msgid "subject_token"
+msgstr "subject_token"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:42
+msgid ""
+"_OPTIONAL._ A security token that represents the identity of the party on "
+"behalf of whom the request is being made.  It is required if you are "
+"exchanging an existing token for a new one."
+msgstr ""
+"_OPTIONAL._ リクエストを送信したユーザーの代りのパーティのアイデンティティを表すセキュリティトークン。 "
+"既存のトークンを新しいトークンと交換する場合に必要です。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:42
+#, no-wrap
+msgid "subject_issuer"
+msgstr "subject_issuer"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:46
+msgid ""
+"_OPTIONAL._ Identifies the issuer of the `subject_token`.  It can be left "
+"blank if the token comes from the current realm or if the issuer can be "
+"determined from the `subject_token_type`.  Otherwise it is required to be "
+"specified. Valid values are the alias of an `Identity Provider` configured "
+"for your realm.  Or an issuer claim identifier configured by a specific "
+"`Identity Provider`."
+msgstr ""
+"_OPTIONAL._ `subject_token` の発行者を識別します。 トークンが現在のレルムから来た場合、または発行者が "
+"`subject_token_type` から決定できる場合は、空白のままにすることができます。 それ以外の場合は、指定する必要があります。 "
+"有効な値は、レルムに設定された `Identity Provider` のエイリアスです。 または、特定の `Identity Provider` "
+"によって設定された発行者クレーム識別子です。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:46
+#, no-wrap
+msgid "subject_token_type"
+msgstr "subject_token_type"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:51
+msgid ""
+"_OPTIONAL._ This parameter is the type of the token passed with the "
+"`subject_token` parameter.  This defaults to `urn:ietf:params:oauth:token-"
+"type:access_token` if the `subject_token` comes from the realm and is an "
+"access token.  If it is an external token, this parameter may or may not "
+"have to be specified depending on the requirements of the `subject_issuer`."
+msgstr ""
+"_OPTIONAL._ このパラメータは `subject_token` パラメータで渡されるトークンのタイプです。 `subject_token` "
+"がレルムから来て、アクセス・トークンである場合、これはデフォルトで `urn:ietf:params:oauth:token-"
+"type:access_token` になります。 それが外部トークンである場合、このパラメータは `subject_issuer` "
+"の要件に応じて指定する必要がある場合とない場合があります。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:51
+#, no-wrap
+msgid "requested_token_type"
+msgstr "requested_token_type"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:56
+msgid ""
+"_OPTIONAL._ This parameter represents the type of token the client wants to "
+"exchange for.  Currently only oauth and OpenID Connect token types are "
+"supported.  The default value for this depends on whether the is "
+"`urn:ietf:params:oauth:token-type:refresh_token` in which case you will be "
+"returned both an access token and refresh token within the response.  Other "
+"appropriate values are `urn:ietf:params:oauth:token-type:access_token` and "
+"`urn:ietf:params:oauth:token-type:id_token`"
+msgstr ""
+"_OPTIONAL._ このパラメータは、クライアントが交換したいトークンのタイプを表します。 現在、トークン・タイプとしてOAuthとOpenID "
+"Connectのみがサポートされています。 デフォルト値は、これが `urn:ietf:params:oauth:token-"
+"type:refresh_token` "
+"であるかどうかによって決まります。この場合、レスポンス内でアクセス・トークンとリフレッシュ・トークンの両方が返されます。 その他の適切な値は "
+"`urn:ietf:params:oauth:token-type:access_token` と `urn:ietf:params:oauth"
+":token-type:id_token` です。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:56
+#, no-wrap
+msgid "audience"
+msgstr "audience"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:58
+msgid ""
+"_OPTIONAL._ This parameter specifies the target client you want the new "
+"token minted for."
+msgstr "_OPTIONAL._ このパラメータには、新しいトークンを作成する対象となるクライアントを指定します。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:58
+#, no-wrap
+msgid "requested_issuer"
+msgstr "requested_issuer"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:61
+msgid ""
+"_OPTIONAL._ This parameter specifies that the client wants a token minted by"
+" an external provider.  It must be the alias of an `Identity Provider` "
+"configured within the realm."
+msgstr ""
+"_OPTIONAL._ このパラメーターは、クライアントが外部プロバイダーによって作成されたトークンを必要とすることを指定します。 "
+"これは、レルム内で設定された `Identity Provider` のエイリアスでなければなりません。"
+
+#. type: Labeled list
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:61
+#, no-wrap
+msgid "requested_subject"
+msgstr "requested_subject"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:63
+msgid ""
+"_OPTIONAL._ This specifies a username or user id if your client wants to "
+"impersonate a different user."
+msgstr "_OPTIONAL._ クライアントが別のユーザーになりすます場合は、ユーザー名またはユーザーIDを指定します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:67
+msgid ""
+"_NOT IMPLEMENTED._ This parameter represents the target set of OAuth and "
+"OpenID Connect scopes the client is requesting.  It is not implemented at "
+"this time but will be once {project_name} has better support for scopes in "
+"general."
+msgstr ""
+"_NOT IMPLEMENTED._ このパラメータは、クライアントが要求しているOAuthおよびOpenID "
+"Connectのスコープのセットを表します。 現時点では実装されていませんが、　{project_name} "
+"がスコープの一般的なサポートを強化した後に利用可能になります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:69
+msgid ""
+"We currently only support OpenID Connect and OAuth exchanges.  Support for "
+"SAML based clients and identity providers may be added in the future "
+"depending on user demand."
+msgstr ""
+"現在のところ、OpenID ConnectとOAuthの交換のみサポートしています。 "
+"SAMLベースのクライアントおよびIDプロバイダのサポートは、将来、ユーザーの要求に応じて追加される可能性があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:73
+msgid ""
+"A successful response from an exchange invocation will return the HTTP 200 "
+"response code with a content type that depends on the `requested-token-type`"
+" and `requested_issuer` the client asks for.  OAuth requested token types "
+"will return a JSON document as described in the link:http://www.ietf.org/id"
+"/draft-ietf-oauth-token-exchange-09.txt[OAuth Token Exchange] specification."
+msgstr ""
+"交換の呼び出しからの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
+"`requested_issuer` に依存したコンテンツ・タイプとともにHTTP 200レスポンス・コードを返します。 "
+"OAuthでリクエストされたトークンタイプは、 link:http://www.ietf.org/id/draft-ietf-oauth-token-"
+"exchange-09.txt[OAuth Token Exchange] 仕様に記載されているJSONドキュメントを返します。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:80
+#, no-wrap
+msgid ""
+"{\n"
+"   \"access_token\" : \".....\",\n"
+"   \"refresh_token\" : \".....\",\n"
+"   \"expires_in\" : \"....\"\n"
+" }\n"
+msgstr ""
+"{\n"
+"   \"access_token\" : \".....\",\n"
+"   \"refresh_token\" : \".....\",\n"
+"   \"expires_in\" : \"....\"\n"
+" }\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:85
+msgid ""
+"Clients requesting a refresh token will get back both an access and refresh "
+"token in the response.  Clients requesting only access token type will only "
+"get an access token in the response.  Expiration information may or may not "
+"be included for clients requesting a an external issuer through the "
+"`requested_issuer`paramater."
+msgstr ""
+"リフレッシュ・トークンを要求するクライアントは、レスポンス内のアクセス・トークンとリフレッシュ・トークンの両方を取得しなおします。 "
+"アクセス・トークン・タイプのみを要求するクライアントは、レスポンス内のアクセス・トークンを取得します。 `requested_issuer` "
+"パラメータを介して外部発行者を要求するクライアントに対して、有効期限情報が含まれる場合と含まれない場合があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:89
+msgid ""
+"Error responses generally fall under the 400 HTTP response code category, "
+"but other error status codes may be returned depending on the severity of "
+"the error.  Error responses may include content depending on the "
+"`requested_issuer`.  OAuth based exchanges may return a JSON document as "
+"follows:"
+msgstr ""
+"エラー・レスポンスは一般に400 "
+"HTTPレスポンス・コード・カテゴリーに該当しますが、エラーの重大度に応じて他のエラー・ステータス・コードが返されることがあります。 "
+"エラー・レスポンスには、 `requested_issuer` に応じた内容が含まれます。 "
+"OAuthベースの交換では、次のようにJSON文書が返ることがあります："
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:95
+#, no-wrap
+msgid ""
+"{\n"
+"   \"error\" : \"....\"\n"
+"   \"error_description\" : \"....\"\n"
+"}\n"
+msgstr ""
+"{\n"
+"   \"error\" : \"....\"\n"
+"   \"error_description\" : \"....\"\n"
+"}\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:100
+msgid ""
+"Additional error claims may be returned depending on the exchange type.  For"
+" example, OAuth Identity Providers may include an additional `account-link-"
+"url` claim if the user does not have a link to an identity provider.  This "
+"link can be used for a client initiated link request."
+msgstr ""
+"アイデンティティー・プロバイダーOAuth交換のタイプによっては追加のエラー・クレームが返されることがあります。 "
+"たとえば、ユーザーがアイデンティティ・プロバイダーへのリンクを持っていない場合、OAuth Identity Providerは追加の "
+"`account-link-url` クレームを含めることがあります。 このリンクは、クライアントが開始したリンク・リクエストに使用できます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:103
+#, no-wrap
+msgid ""
+"Token exchange setup requires knowledge of fine grain admin permissions (See the link:{adminguide_link}[{adminguide_name}] for more information).  You will need to grant clients\n"
+"      permission to exchange.  This is discusssed more later in this chapter.\n"
+msgstr ""
+"トークン交換のセットアップには細かい粒度の管理権限が必要です（詳細はlink:{adminguide_link}[{adminguide_name}] "
+"のリンクを参照してください）。 クライアントに交換の権限を付与する必要があります。 これについては、この章の後半で説明します。\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:107
+msgid ""
+"The rest of this chapter discusses the setup requirements and provides "
+"examples for different exchange scenarios.  For simplicity's sake, let's "
+"call a token minted by the current realm as an _internal_ token and a token "
+"minted by an external realm or identity provider as an _external_ token."
+msgstr ""
+"この章では、セットアップの要件について説明し、さまざまな交換のシナリオの例を示します。 簡単にするために、現在のレルムで作成されたトークンを "
+"_internal_ トークン、外部レルムまたはアイデンティティ・プロバイダが作成したトークンを _external_ トークンとして呼び出してみます。"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:109
+#, no-wrap
+msgid "Internal Token to Internal Token Exchange"
+msgstr "内部トークンから内部トークンへの交換"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:117
+msgid ""
+"With an internal token to token exchange you have an existing token minted "
+"to a specific client and you want to exchange this token for a new one "
+"minted for a different target client.  Why would you want to do this? This "
+"generally happens when a client has a token minted for itself, and needs to "
+"make additional requests to other applications that require different claims"
+" and permissions within the access token.  Other reasons this type of "
+"exchange might be required is if you need to perform a \"permission "
+"downgrade\" where your app needs to invoke on a less trusted app and you "
+"don't want to propagate your current access token."
+msgstr ""
+"内部トークンから内部トークンへの交換で、特定のクライアントに発行された既存のトークンを、別のターゲット・クライアント用に作成された新しいトークンと交換する必要があります。"
+" なぜこれをしたいのでしょうか？ "
+"これは一般に、クライアントがトークンを持っていて、アクセス・トークン内で異なるリクエストとアクセス権を必要とする他のアプリケーションに追加のリクエストを行う必要がある場合に発生します。"
+" "
+"このタイプの交換が必要なその他の理由は、信頼性の低いアプリケーションでアプリケーションを呼び出す必要があり、現在のアクセス・トークンを伝播したくない場合に「アクセス権のダウングレード」を実行する必要がある場合です。"
+
+#. type: Title ====
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:119
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:204
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:310
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:369
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:405
+#, no-wrap
+msgid "Granting Permission for the Exchange"
+msgstr "交換のアクセス権を付与します"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:123
+msgid ""
+"Clients that want to exchange tokens for a different client need to be "
+"authorized in the admin console to do so.  You'll need to define a `token-"
+"exchange` fine grain permission in the target client you want permission to "
+"exchange to."
+msgstr ""
+"別のクライアントとトークンを交換したいクライアントは、管理コンソールで認可される必要があります。交換するアクセス権を与えたいターゲット・クライアントに"
+"`token-exchange`のきめの細かいアクセス権を定義する必要があります。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:124
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:129
+#, no-wrap
+msgid "Target Client Permission"
+msgstr "ターゲット・クライアントのアクセス権"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:126
+msgid "image:{project_images}/exchange-target-client-permission-unset.png[]"
+msgstr "image:{project_images}/exchange-target-client-permission-unset.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:128
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:214
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:417
+msgid "Toggle the `Permissions Enabled` switch to true."
+msgstr "`Permissions Enabled`スイッチをtrueに切り替えます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:131
+msgid "image:{project_images}/exchange-target-client-permission-set.png[]"
+msgstr "image:{project_images}/exchange-target-client-permission-set.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:134
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:220
+msgid ""
+"You should see a `token-exchange` link on the page.  Click that to start "
+"defining the permission.  It will bring you to this page."
+msgstr ""
+"このページに`token-exchange`のリンクがあるはずです。 クリックすると、アクセス権の定義が開始されます。このページに移動します。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:135
+#, no-wrap
+msgid "Target Client Exchange Permission Setup"
+msgstr "ターゲット・クライアントの交換アクセス権のセットアップ"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:137
+msgid "image:{project_images}/exchange-target-client-permission-setup.png[]"
+msgstr "image:{project_images}/exchange-target-client-permission-setup.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:140
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:226
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:429
+msgid ""
+"You'll have to define a policy for this permission.  Click the "
+"`Authorization` link, go to the `Policies` tab and create a `Client` Policy."
+msgstr ""
+"このアクセス権に対するポリシーを定義する必要があります。`認可`のリンクをクリックし、`ポリシー`タブに行き、 "
+"`クライアント`ポリシーを作成してください。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:141
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:227
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:430
+#, no-wrap
+msgid "Client Policy Creation"
+msgstr "クライアント・ポリシーの作成"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:143
+msgid "image:{project_images}/exchange-target-client-policy.png[]"
+msgstr "image:{project_images}/exchange-target-client-policy.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:147
+msgid ""
+"Here you enter in the starting client, that is the authenticated client that"
+" is requesting a token exchange.  After you create this policy, go back to "
+"the target client's `token-exchange` permission and add the client policy "
+"you just defined."
+msgstr ""
+"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ターゲット・クライアントの"
+"`token-exchange`アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:148
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:234
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:437
+#, no-wrap
+msgid "Apply Client Policy"
+msgstr "クライアント・ポリシーの適用"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:150
+msgid ""
+"image:{project_images}/exchange-target-client-exchange-apply-policy.png[]"
+msgstr ""
+"image:{project_images}/exchange-target-client-exchange-apply-policy.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:153
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:239
+msgid ""
+"Your client now has permission to invoke.  If you do not do this correctly, "
+"you will get a 403 Forbidden response if you try to make an exchange."
+msgstr ""
+"クライアントは起動するアクセス権を持っています。これを正しく行わないと、交換しようとすると403 Forbiddenのレスポンスが表示されます。"
+
+#. type: Title ====
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:154
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:241
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:319
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:376
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:446
+#, no-wrap
+msgid "Making the Request"
+msgstr "リクエストの実行"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:158
+msgid ""
+"When your client is exchanging an existing token for a token targeting "
+"another client, you must use the `audience` parameter.  This parameter must "
+"be the client identifier for the target client that you configured in the "
+"admin console."
+msgstr ""
+"クライアントがターゲットとする別のクライアントのトークンを既存のトークンを交換しているときは、`audience`パラメータを使用する必要があります。このパラメータは、管理コンソールで設定したターゲット・クライアントのクライアント識別子である必要があります。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:169
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    --data-urlencode \"requested_token_type=urn:ietf:params:oauth:token-type:refresh_token\"\n"
+"    -d \"audience=target-client\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+msgstr ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    --data-urlencode \"requested_token_type=urn:ietf:params:oauth:token-type:refresh_token\"\n"
+"    -d \"audience=target-client\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:175
+msgid ""
+"The `subject_token` parameter must be an access token for the target realm."
+"  If your `requested_token_type` parameter is a refresh token type, then the"
+" response will contain both an access token, refresh token, and expiration."
+"  Here's an example JSON response you get back from this call."
+msgstr ""
+"`subject_token`パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。 "
+"`requested_token_type`パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の全てが含まれます。この呼び出しから返されるJSONレスポンスの例を、次に示します。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:183
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:359
+#, no-wrap
+msgid ""
+"{\n"
+"   \"access_token\" : \"....\",\n"
+"   \"refresh_token\" : \"....\",\n"
+"   \"expires_in\" : 3600\n"
+"}\n"
+msgstr ""
+"{\n"
+"   \"access_token\" : \"....\",\n"
+"   \"refresh_token\" : \"....\",\n"
+"   \"expires_in\" : 3600\n"
+"}\n"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:185
+#, no-wrap
+msgid "Internal Token to External Token Exchange"
+msgstr "内部トークンから外部のトークンへの交換"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:192
+msgid ""
+"You can exchange a realm token for an externl token minted by an external "
+"identity provider.  This external identity provider must be configured "
+"within the `Identity Provider` section of the admin console.  Currently only"
+" OAuth/OpenID Connect based external identity providers are supported, this "
+"includes all social providers.  {project_name} does not perform a "
+"backchannel exchange to the external provider.  So if the account is not "
+"linked, you will not be able to get the external token.  To be able to "
+"obtain an external token one of these conditions must be met:"
+msgstr ""
+"外部アイデンティティ・プロバイダーによって作成された外部トークンに対して、レルムのトークンを交換できます。この外部アイデンティティ・プロバイダーは、管理コンソールの「アイデンティティ・プロバイダー」セクション内で設定する必要があります。現在のところ、OAuth"
+" / OpenID "
+"Connectベースの外部アイデンティティ・プロバイダーのみがサポートされています。これには、すべてのソーシャル・プロバイダーが含まれます。{project_name}は、外部プロバイダーへのバックチャネル交換を実行しません。したがって、アカウントがリンクされていない場合、外部トークンを取得することはできません。外部トークンを取得するには、次のいずれかの条件を満たす必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:194
+msgid ""
+"The user must have logged in with the external identity provider at least "
+"once"
+msgstr "ユーザーは、外部アイデンティティ・プロバイダーに少なくとも1回はログインしている必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:195
+msgid ""
+"The user must have linked with the external identity provider through the "
+"User Account Service"
+msgstr "ユーザーは、外部アイデンティティ・プロバイダーにユーザー・アカウント・サービスを介してリンクしている必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:196
+msgid ""
+"The user account was linked through the external identity provider using "
+"link:{developerguide_link}[Client Initiated Account Linking] API."
+msgstr ""
+"ユーザー・アカウントは、link:{developerguide_link}[Client Initiated Account Linking] "
+"APIを使用して外部アイデンティティ・プロバイダーを介してリンクされています。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:199
+msgid ""
+"Finally, the external identity provider must have been configured to store "
+"tokens, or, one of the above actions must have been performed with the same "
+"user session as the internal token you are exchanging."
+msgstr ""
+"最後に、外部アイデンティティ・プロバイダーがトークンを格納するように設定されている必要があります。または、上記のアクションの1つが、交換している内部トークンと同じユーザー・セッションで実行されている必要があります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:202
+msgid ""
+"If the account is not linked, the exchange response will contain a link you "
+"can use to establish it.  This is discussed more in the "
+"<<_internal_external_making_request, Making the Request>> section."
+msgstr ""
+"アカウントがリンクされていない場合、交換レスポンスにはリンクの確立に使用できるリンクが含まれます。これについては、<<_internal_external_making_request,"
+" Making the Request>>のセクションで詳しく説明します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:209
+msgid ""
+"Internal to external token exchange requests will be denied with a 403, "
+"Forbidden response until you grant permission for the calling client to "
+"exchange tokens with the external identity provider.  To grant permission to"
+" the client you must go to the identity provider's configuration page to the"
+" `Permissions` tab."
+msgstr ""
+"呼び出し側のクライアントが外部アイデンティティ・プロバイダーとトークンを交換するアクセス権を与えるまで、内部トークン交換リクエストと内部トークン交換リクエストは、403、Forbiddenレスポンスで拒否されます。クライアントにアクセス権を与えるには、アイデンティティ・プロバイダーの設定ページの`アクセス権`タブに移動する必要があります。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:210
+#, no-wrap
+msgid "Identity Provider Permission"
+msgstr "アイデンティティ・プロバイダーのアクセス権"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:212
+msgid "image:{project_images}/exchange-idp-permission-unset.png[]"
+msgstr "image:{project_images}/exchange-idp-permission-unset.png[]"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:215
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:418
+#, no-wrap
+msgid "Identity Provier Permission"
+msgstr "アイデンティティ・プロバイダーのアクセス権"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:217
+msgid "image:{project_images}/exchange-idp-permission-set.png[]"
+msgstr "image:{project_images}/exchange-idp-permission-set.png[]"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:221
+#, no-wrap
+msgid "Identity Provider Exchange Permission Setup"
+msgstr "アイデンティティ・プロバイダーの交換アクセス権のセットアップ"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:223
+msgid "image:{project_images}/exchange-idp-permission-setup.png[]"
+msgstr "image:{project_images}/exchange-idp-permission-setup.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:229
+msgid "image:{project_images}/exchange-idp-client-policy.png[]"
+msgstr "image:{project_images}/exchange-idp-client-policy.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:233
+msgid ""
+"Here you enter in the starting client, that is the authenticated client that"
+" is requesting a token exchange.  After you create this policy, go back to "
+"the identity providers's `token-exchange` permission and add the client "
+"policy you just defined."
+msgstr ""
+"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、アイデンティティ・プロバイダーの"
+"`token-exchange`アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:236
+msgid "image:{project_images}/exchange-idp-apply-policy.png[]"
+msgstr "image:{project_images}/exchange-idp-apply-policy.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:245
+msgid ""
+"When your client is exchanging an existing internal token to an external "
+"one, you must provide the `requested_issuer` parameter.  The parameter must "
+"be the alias of a configured identity provider."
+msgstr ""
+"クライアントが既存の内部トークンを外部トークンと交換する場合は、`requested_issuer`パラメーターを指定する必要があります。パラメーターは、設定済みのアイデンティティ・プロバイダーのエイリアスでなければなりません。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:256
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    --data-urlencode \"requested_token_type=urn:ietf:params:oauth:token-type:refresh_token\"\n"
+"    -d \"requested_issuer=google\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+msgstr ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    --data-urlencode \"requested_token_type=urn:ietf:params:oauth:token-type:refresh_token\"\n"
+"    -d \"requested_issuer=google\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:263
+msgid ""
+"The `subject_token` parameter must be an access token for the target realm."
+"  The `requested_token_type` parameter must be `urn:ietf:params:oauth:token-"
+"type:access_token` or left blank.  No other requested token type is "
+"supported at this time.  Here's an example successful JSON response you get "
+"back from this call."
+msgstr ""
+"`subject_token`パラメーターは、ターゲット・レルムのアクセス・トークンでなければなりません。 "
+"`requested_token_type`パラメーターは、`urn:ietf:params:oauth:token-"
+"type:access_token`またはブランクのままでなければなりません。現時点では、それ以外の要求されたトークン・タイプはサポートされていません。この呼び出しから返される成功のJSONレスポンスの例を次に示します。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:271
+#, no-wrap
+msgid ""
+"{\n"
+"   \"access_token\" : \"....\",\n"
+"   \"expires_in\" : 3600\n"
+"   \"account-link-url\" : \"https://....\"\n"
+"}\n"
+msgstr ""
+"{\n"
+"   \"access_token\" : \"....\",\n"
+"   \"expires_in\" : 3600\n"
+"   \"account-link-url\" : \"https://....\"\n"
+"}\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:275
+msgid ""
+"If the external identity provider is not linked for whatever reason, you "
+"will get an HTTP 400 response code with this JSON document:"
+msgstr ""
+"外部アイデンティティ・プロバイダーが何らかの理由でリンクされていない場合は、このJSONドキュメントでHTTP 400レスポンス・コードを取得します。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:283
+#, no-wrap
+msgid ""
+"{\n"
+"   \"error\" : \"....\",\n"
+"   \"error_description\" : \"...\"\n"
+"   \"account-link-url\" : \"https://....\"\n"
+"}\n"
+msgstr ""
+"{\n"
+"   \"error\" : \"....\",\n"
+"   \"error_description\" : \"...\"\n"
+"   \"account-link-url\" : \"https://....\"\n"
+"}\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:289
+msgid ""
+"The `error` claim will be either `token_expired` or `not_linked`.  The "
+"`account-link-url` claim is provided so that the client can perform "
+"link:{developerguide_link}[Client Initiated Account Linking].  Most (all?)  "
+"providers requiring linking through browser OAuth protocol.  With the "
+"`account-link-url` just add a `redirect_uri` query parameter to it and you "
+"can forward browsers to perform the link."
+msgstr ""
+"`error`クレームは、`token_expired`か`not_linked`のどちらかになります。`account-link-"
+"url`クレームは、クライアントがlink:{developerguide_link}[Client Initiated Account "
+"Linking]を実行できるように提供されています。ほとんど(すべて？)のプロバイダーは、ブラウザーOAuthプロトコルを介してリンクする必要があります"
+"。`account-link-"
+"url`では、`redirect_uri`クエリー・パラメータを追加するだけで、ブラウザを転送してリンクを実行することができます。"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:290
+#, no-wrap
+msgid "External Token to Internal Token Exchange"
+msgstr "外部トークンから内部トークンへの交換"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:295
+msgid ""
+"You can trust and exchange external tokens minted by external identity "
+"providers for internal tokens.  This can be used to bridge between realms or"
+" just to trust tokens from your social provider.  It works similarly to an "
+"identity provider browser login in that a new user is imported into your "
+"realm if it doesn't exist."
+msgstr ""
+"外部アイデンティティ・プロバイダーが発行した外部トークンを信頼して、内部トークンに交換することができます。 "
+"これは、レルム間のブリッジや、ソーシャル・プロバイダーのトークンの信頼に使用できます。これは、アイデンティティ・プロバイダーのブラウザのログインと同様に動作します。新しいユーザーが存在しない場合、そのユーザーはレルムにインポートされます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:299
+#, no-wrap
+msgid ""
+"The current limitation on external token exchanges is that if the external token maps to an existing user an\n"
+"       exchange will not be allowed unless the existing user already has an account link to the external identity\n"
+"       provider.\n"
+msgstr ""
+"外部トークン交換の現在の制限は、外部トークンが既存のユーザーにマップされている場合、既存のユーザーに外部アイデンティティ・プロバイダーへのアカウント・リンクがない限り、交換は許可されないということです。\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:304
+msgid ""
+"When the exchange is complete, a user session will be created within the "
+"realm, and you will receive an access and or refresh token depending on the "
+"`requested_toke_type` parameter value.  You should note that this new user "
+"session will remain active until it times out or until you call the logout "
+"endpoint of the realm passing this new access token."
+msgstr ""
+"交換が完了すると、レルム内にユーザー・セッションが作成され、`requested_toke_type`パラメーター値に応じて、アクセス・トークンまたはリフレッシュ・トークンが受け取れます。この新しいユーザー・セッションは、タイムアウトするまで、またはこの新しいアクセス・トークンを渡すレルムのログアウト・エンドポイントを呼び出すまで、アクティブなままです。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:306
+msgid ""
+"These types of changes required a configured identity provider in the admin "
+"console."
+msgstr "これらのタイプの変更には、管理コンソールで設定されたアイデンティティ・プロバイダーが必要でした。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:308
+msgid ""
+"SAML identity providers are not supported at this time.  Twitter tokens "
+"cannot be exchanged either."
+msgstr "現時点では、SAMLアイデンティティ・プロバイダーはサポートされていません。Twitterのトークンは交換できません。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:314
+msgid ""
+"Before external token exchanges can be done, you must grant permission for "
+"the calling client to make the exchange.  This permission is granted in the "
+"same manner as <<_grant_permission_external_exchange, interal to external "
+"permission is granted>>."
+msgstr ""
+"外部トークンの交換が可能になる前に、発信側のクライアントが交換を行うためのアクセス権を与える必要があります。 "
+"このアクセス権は、<<_grant_permission_external_exchange, interal to external "
+"permission is granted>>と同じ方法で付与されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:318
+msgid ""
+"If you also provide an `audience` parameter whose value points to a "
+"different client other than the calling one, you must also grant the calling"
+" client permission to exchange to the target client specific in the "
+"`audience` parameter.  How to do this is <<_client_to_client_permission, "
+"discussed earlier>> in this section."
+msgstr ""
+"値が呼び出し側以外の別のクライアントを指し示す`audience`パラメーターも指定した場合、呼び出し側クライアントに`audience`パラメーターで特定のターゲット・クライアントに交換するアクセス権を与える必要があります。"
+" これを行う方法は、このセクションの<<_client_to_client_permission, discussed earlier>>にあります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:325
+msgid ""
+"The `subject_token_type` must either be `urn:ietf:params:oauth:token-"
+"type:access_token` or `urn:ietf:params:oauth:token-type:jwt`.  If the type "
+"is `urn:ietf:params:oauth:token-type:access_token` you must specify the "
+"`subject_issuer` parameter and it must be the alias of the configured "
+"identity provider.  If the type is `urn:ietf:params:oauth:token-type:jwt`, "
+"the provider will be matched via the `issuer` claim within the JWT which "
+"must be the alias of the provider, or a registered issuer within the "
+"providers configuration."
+msgstr ""
+"`subject_token_type`は、`urn:ietf:params:oauth:token-"
+"type:access_token`または`urn:ietf:params:oauth:token-"
+"type:jwt`のいずれかでなければなりません。タイプが `urn:ietf:params:oauth:token-"
+"type:access_token`の場合、`subject_issuer`パラメーターを指定しなければなりません。また、設定されたアイデンティティ・プロバイダーのエイリアスでなければなりません。タイプが`urn:ietf:params:oauth"
+":token-"
+"type:jwt`の場合、プロバイダーは、プロバイダーのエイリアスであるJWT内の`issuer`クレームまたは、プロバイダ設定内の登録された発行者と一致します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:329
+msgid ""
+"For validation, if the token is an access token, the provider's user info "
+"service will be invoked to validate the token.  A successful call will mean "
+"that the access token is valid.  If the subject token is a JWT and if the "
+"provider has signature validation enabled, that will be attempted, "
+"otherwise, it will default to also invoking on the user info service to "
+"validate the token."
+msgstr ""
+"検証のために、トークンがアクセス・トークンである場合、プロバイダーのユーザー情報サービスが呼び出されてトークンを検証します。呼び出しが成功することは、アクセス・トークンが有効であることを意味します。サブジェクト・トークンがJWTであり、プロバイダが署名検証を有効にしている場合は、それが試行され、そうでない場合は、デフォルトでトークンを検証するためにユーザー情報サービスが呼び出されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:333
+msgid ""
+"By default, the internal token minted will use the calling client to "
+"determine what's in the token using the protocol mappers defined for the "
+"calling client.  Alternatively, you can specify a different target client "
+"using the `audience` parameter."
+msgstr ""
+"デフォルトでは、発行された内部トークンは、呼び出し元クライアント用に定義されたプロトコル・マッパーを使用してトークン内の内容を判断するため、呼び出し元クライアントを使用します。"
+" あるいは、`audience`パラメーターを使って別のターゲット・クライアントを指定することもできます。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:345
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    -d \"subject_issuer=myOidcProvider\" \\\n"
+"    --data-urlencode \"subject_token_type=urn:ietf:params:oauth:token-type:access_token\"\n"
+"    -d \"audience=target-client\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+msgstr ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    -d \"subject_issuer=myOidcProvider\" \\\n"
+"    --data-urlencode \"subject_token_type=urn:ietf:params:oauth:token-type:access_token\"\n"
+"    -d \"audience=target-client\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:351
+msgid ""
+"If your `requested_token_type` parameter is a refresh token type, then the "
+"response will contain both an access token, refresh token, and expiration.  "
+"Here's an example JSON response you get back from this call."
+msgstr ""
+"`requested_token_type`パラメーターがリフレッシュ・トークン・タイプの場合、レスポンスにはアクセス・トークン、リフレッシュ・トークン、および有効期限の両方が含まれます。この呼び出しから返されるJSONレスポンスの例を次に示します。"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:362
+#: source/server_admin/topics/users/impersonation.adoc:2
+#, no-wrap
+msgid "Impersonation"
+msgstr "偽装"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:367
+msgid ""
+"For internal and external token exchanges, the client can request on behalf "
+"of a user to impersonate a different user.  For example, you may have an "
+"admin application that needs to impersonate a user so that a support "
+"engineer can debug a problem."
+msgstr ""
+"内部トークン交換と外部トークン交換の場合、クライアントはユーザーの代わりに別のユーザーを偽装するように要求できます。たとえば、サポート・エンジニアが問題をデバッグできるように、ユーザーを偽装する必要がある管理アプリケーションがあるとします。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:374
+msgid ""
+"The user that the subject token represents must have permission to "
+"impersonate other users.  See the link:{adminguide_link}[{adminguide_name}] "
+"on how to enable this permission.  It can be done through a role or through "
+"fine grain admin permissions."
+msgstr ""
+"サブジェクト・トークンが表すユーザーには、他のユーザーを偽装するアクセス権が必要です。 "
+"このアクセス権を有効にする方法については、link:{adminguide_link}[{adminguide_name}]をご覧ください。 "
+"それは、ロールを通じて、またはきめ細かい管理者アクセス権を使って行うことができます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:380
+msgid ""
+"Make the request as described in other chapters except additionally specify "
+"the `request_subject` parameter.  The value of this parameter must be a "
+"username or user id."
+msgstr ""
+"`request_subject`パラメーターを追加で指定しない限り、他の章で説明したようにリクエストを行います。このパラメーターの値は、ユーザー名またはユーザーIDでなければなりません。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:392
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    --data-urlencode \"requested_token_type=urn:ietf:params:oauth:token-type:access_token\" \\\n"
+"    -d \"audience=target-client\" \\\n"
+"    -d \"requested_subject=wburke\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+msgstr ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"subject_token=....\" \\\n"
+"    --data-urlencode \"requested_token_type=urn:ietf:params:oauth:token-type:access_token\" \\\n"
+"    -d \"audience=target-client\" \\\n"
+"    -d \"requested_subject=wburke\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:394
+#, no-wrap
+msgid "Direct Naked Impersonation"
+msgstr "ダイレクト・ネイキッド偽装"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:401
+msgid ""
+"You can make an internal token exchange request without providing a "
+"`subject_token`.  This is called a direct naked impersonation because it "
+"places a lot of trust in a client as that client can impersonate any user in"
+" the realm.  You might need this to bridge for applications where it is "
+"impossible to obtain a subject token to exchange.  For example, you may be "
+"integrating a legacy application that performs login directly with LDAP.  In"
+" that case, the legacy app is able to authenticate users itself, but not "
+"able to obtain a token."
+msgstr ""
+"`subject_token`を指定せずに、内部トークンの交換要求を行うことができます。これは、ダイレクト・ネイキッド偽装と呼ばれます。クライアントがそのレルム内の任意のユーザーを偽装する可能性があるため、クライアントに多くの信頼を置くからです。交換するサブジェクト・トークンを取得することが不可能なアプリケーションのためにブリッジする必要があるかもしれません。たとえば、LDAPに直接ログインするレガシー・アプリケーションを統合したいかもしれません。その場合、従来のアプリケーションはユーザー自身を認証できますが、トークンを取得することができません。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:404
+#, no-wrap
+msgid ""
+"It is very risky to enable direct naked impersonation for a client.  If the client's credentials are ever\n"
+"         stolen, that client can impersonate any user in the system.\n"
+msgstr ""
+"クライアントにダイレクト・ネイキッド偽装を有効にすることは非常に危険です。クライアントのクレデンシャルが盗まれた場合、そのクライアントはシステム内のすべてのユーザーを偽装する可能性があります。\n"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:409
+msgid ""
+"If the `audience` parameter is provided, then the calling client must have "
+"permission to exchange to the client.  How to set this up is discussed "
+"earlier in this chapter."
+msgstr ""
+"`audience`パラメーターが提供されている場合、呼び出し側クライアントはクライアントとの交換のアクセス権を持っていなければなりません。 "
+"これを設定する方法については、この章の前半で説明します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:412
+msgid ""
+"Additionaly, the calling client must be granted permission to impersonate "
+"users.  In the admin console, go to the `Users` screen and click on the "
+"`Permissions` tab."
+msgstr ""
+"さらに、呼び出し元のクライアントにユーザーを偽装するアクセス権が与えられている必要があります。 管理コンソールで、 "
+"`ユーザー`画面に行き、`アクセス権`タブをクリックしてください。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:413
+#, no-wrap
+msgid "Users Permission"
+msgstr "ユーザーのアクセス権"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:415
+msgid "image:{project_images}/exchange-users-permission-unset.png[]"
+msgstr "image:{project_images}/exchange-users-permission-unset.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:420
+msgid "image:{project_images}/exchange-users-permission-set.png[]"
+msgstr "image:{project_images}/exchange-users-permission-set.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:423
+msgid ""
+"You should see a `impersonation` link on the page.  Click that to start "
+"defining the permission.  It will bring you to this page."
+msgstr "ページに `偽装`リンクがあります。 クリックすると、アクセス権の定義が開始されます。 それにより、このページに移動します。"
+
+#. type: Block title
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:424
+#, no-wrap
+msgid "Users Impersonation Permission Setup"
+msgstr "ユーザー偽装アクセス権のセットアップ"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:426
+msgid "image:{project_images}/exchange-users-permission-setup.png[]"
+msgstr "image:{project_images}/exchange-users-permission-setup.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:432
+msgid "image:{project_images}/exchange-users-client-policy.png[]"
+msgstr "image:{project_images}/exchange-users-client-policy.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:436
+msgid ""
+"Here you enter in the starting client, that is the authenticated client that"
+" is requesting a token exchange.  After you create this policy, go back to "
+"the users' `impersonation` permission and add the client policy you just "
+"defined."
+msgstr ""
+"ここでは、開始するクライアント、つまりトークン交換を要求している認証済みクライアントを入力します。このポリシーを作成したら、ユーザーの`impersonation`アクセス権に戻り、今定義したクライアント・ポリシーを追加します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:439
+msgid "image:{project_images}/exchange-users-apply-policy.png[]"
+msgstr "image:{project_images}/exchange-users-apply-policy.png[]"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:442
+msgid ""
+"Your client now has permission to impersonate users.  If you do not do this "
+"correctly, you will get a 403 Forbidden response if you try to make this "
+"type of exchange."
+msgstr ""
+"クライアントはユーザーを偽装するアクセス権を持っています。これを正しく行わないと、これを交換のタイプにしようとすると403 "
+"Forbiddenのレスポンスが表示されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:444
+msgid "Public clients are not allowed to do direct naked impersonations."
+msgstr "パブリック・クライアントはダイレクト・ネイキッド偽装を行うことができません。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:450
+msgid ""
+"To make the request, simply specify the `requested_subject` parameter.  This"
+" must be the username or user id of a valid user.  You can also specify an "
+"`audience` parameter if you wish."
+msgstr ""
+"リクエストを行うには、`requested_subject`パラメーターを指定するだけです。これは、有効なユーザーのユーザー名またはユーザーIDでなければなりません。また、必要に応じて"
+" `audience`パラメーターを指定することもできます。"
+
+#. type: delimited block -
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:459
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"requested_subject=wburke\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+msgstr ""
+"curl -X POST \\\n"
+"    -d \"client_id=starting-client\" \\\n"
+"    -d \"client_secret=geheim\" \\\n"
+"    --data-urlencode \"grant_type=urn:ietf:params:oauth:grant-type:token-exchange\" \\\n"
+"    -d \"requested_subject=wburke\" \\\n"
+"    http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token\n"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:461
+#, no-wrap
+msgid "Expand Permission Model With Service Accounts"
+msgstr "サービス・アカウントのアクセス権モデルの展開"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:467
+msgid ""
+"When granting clients permission to exchange, you don't necessarily have to "
+"manually enable those permissions for each and every client.  If the client "
+"has a service account associated with it, you can use a role to group "
+"permissions together and assign exchange permissions by assigning a role to "
+"the client's service account.  For example, you might define a `naked-"
+"exchange` role and any service account that has that role can do a naked "
+"exchange."
+msgstr ""
+"クライアントに交換のアクセス権を付与すると、クライアントごとにこれらのアクセス権を手動で有効にする必要はなくなります。 "
+"クライアントに関連付けられているサービス・アカウントがある場合は、ロールを使用してアクセス権をグループ化し、クライアントのサービス・アカウントにロールを割り当てて、交換権のアクセス権を割り当てることができます。"
+" たとえば、`naked-exchange`ロールを定義し、そのロールを持つサービス・アカウントでネイキッドな交換を行うことができます。"
+
+#. type: Title ===
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:468
+#, no-wrap
+msgid "Exchange Vulnerabilities"
+msgstr "交換の脆弱性"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:471
+msgid ""
+"When you start allowing token exchanges, there's various things you have to "
+"both be aware of and careful of."
+msgstr "トークン交換の許可を始める上で、意識して気をつけなければならない様々なことがあります。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:476
+msgid ""
+"The first is public clients.  Public clients do not have or require a client"
+" credential in order to perform an exchange.  Anybody that has a valid token"
+" will be able to __impersonate__ the public client and perform the exchanges"
+" that public client is allowed to perform.  If there are any untrustworthy "
+"clients that are managed by your realm, public clients may open up "
+"vulnerabilities in your permission models.  This is why direct naked "
+"exchanges do not allow public clients and will abort with an error if the "
+"calling client is public."
+msgstr ""
+"1つはパブリック・クライアントです。パブリック・クライアントは、交換を実行するためにクライアント・クレデンシャルを持たない、または必要としません。有効なトークンを持っていれば、パブリック・クライアントを__偽装する__することができ、パブリック・クライアントが実行できる交換を実行できます。レルムよって管理されている信頼できないクライアントがある場合、パブリック・クライアントは許可モデルで脆弱性を公開する可能性があります。このため、ダイレクト・ネイキッド交換ではパブリック・クライアントが許可されず、呼び出し元のクライアントが公開されている場合はエラーで中止されます。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:480
+msgid ""
+"It is possible to exchange social tokens provided by Facebook, Google, etc. "
+"for a realm token.  Be careful and vigilante on what the exchange token is "
+"allowed to do as its not hard to create fake accounts on these social "
+"websites.  Use default roles, groups, and identity provider mappers to "
+"control what attributes and roles are assigned to the external social user."
+msgstr ""
+"FacebookやGoogleなどが提供するソーシャル・トークンをレルム・トークンと交換することは可能です。これらのソーシャル・ウェブサイト上で偽のアカウントを作成するのが難しくないため、交換するトークンで何ができるのかを注意して自警してください。デフォルトのロール、グループ、およびアイデンティティ・プロバイダーのマッパーを使用して、外部ソーシャル・ユーザーに割り当てられる属性とロールを制御します。"
+
+#. type: Plain text
+#: source/securing_apps/topics/token-exchange/token-exchange.adoc:485
+msgid ""
+"Direct naked exchanges are quite dangerous.  You are putting a lot of trust "
+"in the calling client that it will never leak out its client credentials.  "
+"If those credentials are leaked, then the thief can impersonate anybody in "
+"your system.  This is in direct contrast to confidential clients that have "
+"existing tokens.  You have two factors of authentication, the access token "
+"and the client credentials, and you're only dealing with one user.  So use "
+"direct naked exchanges sparingly."
+msgstr ""
+"ダイレクト・ネイキッド交換は非常に危険です。呼び出し元のクライアントに対して、クライアントのクレデンシャルが漏洩しないということを非常に信頼しています。これらのクレデンシャルが漏洩した場合、攻撃者はシステム内の誰かを偽装する可能性があります。これは、既存のトークンを持つコンフィデンシャル・クライアントとはまったく対照的です。"
+" "
+"認証の2つの要因(アクセス・トークンとクライアントのクレデンシャル)があり、1ユーザーしか扱っていません。したがって、ダイレクト・ネイキッド交換は控えめに使用してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__token-exchange__token-exchange/ja_JP/index.html
