### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -2,39 +2,42 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:3
 #, no-wrap
 msgid "mod_auth_mellon Apache HTTPD Module"
-msgstr ""
+msgstr "mod_auth_mellon Apache HTTPDモジュール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:6
 msgid ""
-"The https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] module is an "
-"Apache HTTPD plugin for SAML. If your language/environment supports using "
-"Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your web "
-"application with SAML. For more details on this module see the "
+"The https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] module is an"
+" Apache HTTPD plugin for SAML. If your language/environment supports using "
+"Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your web"
+" application with SAML. For more details on this module see the "
 "_mod_auth_mellon_ Github repo."
 msgstr ""
+"https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon]モジュールは、SAML用のApache"
+" HTTPDプラグインです。使用している言語/環境がApache "
+"HTTPDをプロキシーとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティ保護できます。このモジュールの詳細については、_mod_auth_mellon_のGithubリポジトリーを参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:8
 msgid "To configure mod_auth_mellon you'll need:"
-msgstr ""
+msgstr "Mod_auth_mellonを設定するには、以下が必要です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:10
@@ -42,32 +45,34 @@ msgid ""
 "An Identity Provider (IdP) entity descriptor XML file, which describes the "
 "connection to {project_name} or another SAML IdP"
 msgstr ""
+"{project_name}または別のSAML "
+"IdPへの接続を記述するアイデンティティ・プロバイダー(IdP)のエンティティディスクリプタXMLファイル"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:11
 msgid ""
 "An SP entity descriptor XML file, which describes the SAML connections and "
 "configuration for the application you are securing."
-msgstr ""
+msgstr "SPエンティティ記述子XMLファイル。セキュアにするアプリケーションのSAML接続と設定を記述します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:12
 msgid ""
 "A private key PEM file, which is a text file in the PEM format that defines "
 "the private key the application uses to sign documents."
-msgstr ""
+msgstr "秘密鍵PEMファイル。アプリケーションが文書に署名するために使用する秘密鍵を定義するPEM形式のテキストファイルです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:13
 msgid ""
 "A certificate PEM file, which is a text file that defines the certificate "
 "for your application."
-msgstr ""
+msgstr "証明書のPEMファイル。アプリケーションの証明書を定義するテキストファイルです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:14
 msgid "mod_auth_mellon-specific Apache HTTPD module configuration."
-msgstr ""
+msgstr "mod_auth_mellon-specific Apache HTTPDモジュールの設定。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:17
@@ -76,49 +81,51 @@ msgid ""
 "realm on the {project_name} application server, {project_name} can generate "
 "all the files you need except the Apache HTTPD module configuration."
 msgstr ""
+"{project_name}アプリケーション・サーバーのレルム内にクライアント・アプリケーションを定義して登録している場合、{project_name}はApache"
+" HTTPDモジュールの設定を除くすべての必要なファイルを生成できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:19
 msgid ""
 "To generate the Apache HTTPD module configuration, complete the following "
 "steps:"
-msgstr ""
+msgstr "Apache HTTPDモジュールの設定を生成するには、以下のステップを実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:21
 msgid ""
 "Go to the Installation page of your SAML client and select the Mod Auth "
 "Mellon files option."
-msgstr ""
+msgstr "SAMLクライアントのインストール・ページに移動し、Mod Auth Mellonファイル・オプションを選択します。"
 
 #. type: Block title
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:22
 #, no-wrap
 msgid "mod_auth_mellon config download"
-msgstr ""
+msgstr "mod_auth_mellon設定のダウンロード"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:24
 msgid "image:{project_images}/mod-auth-mellon-config-download.png[]"
-msgstr ""
+msgstr "image:{project_images}/mod-auth-mellon-config-download.png[]"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:26
 msgid ""
-"Click *Download* to download a zip file that contains the XML descriptor and "
-"PEM files you need."
-msgstr ""
+"Click *Download* to download a zip file that contains the XML descriptor and"
+" PEM files you need."
+msgstr "必要なXML記述子とPEMファイルを含むzipファイルをダウンロードするには、*ダウンロード*をクリックします。"
 
 #. type: Title ====
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:28
 #, no-wrap
 msgid "Configuring mod_auth_mellon with {project_name}"
-msgstr ""
+msgstr "{project_name}とmod_auth_mellonの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:31
 msgid "There are two hosts involved:"
-msgstr ""
+msgstr "関連するホストは2つあります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:33
@@ -126,6 +133,7 @@ msgid ""
 "The host on which {project_name} is running, which will be referred to as "
 "$idp_host because {project_name} is a SAML identity provider (IdP)."
 msgstr ""
+"{project_name}が実行されているホスト。{project_name}がSAMLアイデンティティ・プロバイダー(IdP)であるため、$idp_hostと呼ばれます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:35
@@ -134,108 +142,110 @@ msgid ""
 "as $sp_host. In SAML an application using an IdP is called a service "
 "provider (SP)."
 msgstr ""
+"Webアプリケーションが実行されているホスト。$sp_hostと呼ばれます。SAMLでは、IdPを使用するアプリケーションをサービスプロバイダ(SP)と呼びます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:37
 msgid ""
 "All of the following steps need to performed on $sp_host with root "
 "privileges."
-msgstr ""
+msgstr "次のすべての手順は、root特権で$sp_hostに対して実行される必要があります。"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:38
 #, no-wrap
 msgid "Installing the Packages"
-msgstr ""
+msgstr "パッケージのインストール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:41
 msgid "To install the necessary packages, you will need:"
-msgstr ""
+msgstr "必要なパッケージをインストールするには、次のものが必要です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:43
 msgid "Apache Web Server (httpd)"
-msgstr ""
+msgstr "Apache Webサーバー(httpd)"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:44
 msgid "Mellon SAML SP add-on module for Apache"
-msgstr ""
+msgstr "Apache用のメロンMellon SAML SPアドオン・モジュール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:45
 msgid "Tools to create X509 certificates"
-msgstr ""
+msgstr "X509証明書を作成するためのツール"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:47
 msgid "To install the necessary packages, run this command:"
-msgstr ""
+msgstr "必要なパッケージをインストールするには、次のコマンドを実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:49
 #, no-wrap
 msgid " yum install httpd mod_auth_mellon mod_ssl openssl\n"
-msgstr ""
+msgstr " yum install httpd mod_auth_mellon mod_ssl openssl\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:50
 #, no-wrap
 msgid "Creating a Configuration Directory for Apache SAML"
-msgstr ""
+msgstr "Apache SAMLの設定ディレクトリの作成"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:53
 msgid ""
 "It is advisable to keep configuration files related to Apache's use of SAML "
 "in one location."
-msgstr ""
+msgstr "ApacheのSAML使用に関する設定ファイルは、1か所に保存することをお勧めします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:55
 msgid ""
 "Create a new directory named saml2 located under the Apache configuration "
 "root /etc/httpd:"
-msgstr ""
+msgstr "Apache設定ルート(/etc/httpd)の下に、saml2という名前の新しいディレクトリを作成します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:57
 #, no-wrap
 msgid " mkdir /etc/httpd/saml2\n"
-msgstr ""
+msgstr " mkdir /etc/httpd/saml2\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:58
 #, no-wrap
 msgid "Configuring the Mellon Service Provider"
-msgstr ""
+msgstr "Mellon サービス・プロバイダーの設定"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:61
 msgid ""
-"Configuration files for Apache add-on modules are located in the /etc/httpd/"
-"conf.d directory and have a file name extension of .conf. You need to create "
-"the /etc/httpd/conf.d/mellon.conf file and place Mellon's configuration "
-"directives in it."
+"Configuration files for Apache add-on modules are located in the "
+"/etc/httpd/conf.d directory and have a file name extension of .conf. You "
+"need to create the /etc/httpd/conf.d/mellon.conf file and place Mellon's "
+"configuration directives in it."
 msgstr ""
+"Apacheアドオン・モジュールの設定ファイルは/etc/httpd/conf.dディレクトリにあり、拡張子は.confです。/etc/httpd/conf.d/mellon.confファイルを作成し、Mellonの設定ディレクティブをその中に置く必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:63
 msgid ""
 "Mellon's configuration directives can roughly be broken down into two "
 "classes of information:"
-msgstr ""
+msgstr "Mellonの設定ディレクティブは、大まかに2つのクラスの情報に分類できます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:65
 msgid "Which URLs to protect with SAML authentication"
-msgstr ""
+msgstr "SAML認証で保護するURL"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:66
 msgid "What SAML parameters will be used when a protected URL is referenced."
-msgstr ""
+msgstr "保護されたURLが参照されるときに使用されるSAMLパラメーター。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:68
@@ -247,29 +257,32 @@ msgid ""
 "location. You can either add all the necessary parameters to the location "
 "block or you can add Mellon parameters to a common location high up in the "
 "URL location hierarchy that specific protected locations inherit (or some "
-"combination of the two). Since it is common for an SP to operate in the same "
-"way no matter which location triggers SAML actions, the example "
-"configuration used here places common Mellon configuration directives in the "
-"root of the hierarchy and then specific locations to be protected by Mellon "
-"can be defined with minimal directives. This strategy avoids duplicating the "
-"same parameters for each protected location."
+"combination of the two). Since it is common for an SP to operate in the same"
+" way no matter which location triggers SAML actions, the example "
+"configuration used here places common Mellon configuration directives in the"
+" root of the hierarchy and then specific locations to be protected by Mellon"
+" can be defined with minimal directives. This strategy avoids duplicating "
+"the same parameters for each protected location."
 msgstr ""
+"Apacheの設定ディレクティブは通常、URL空間の階層ツリー構造に従います。これらは、ロケーションとして知られています。Mellonが保護するURLのロケーションを1つ以上指定する必要があります。各場所に適用される設定パラメータの追加方法には柔軟性があります。ロケーション・ブロックに必要なすべてのパラメータを追加するか、特定の保護されたロケーションが継承するURLロケーション階層の上位の共通の場所(またはその両方の組み合わせ)にMellonパラメータを追加できます。どのロケーションがSAMLアクションをトリガーするかにかかわらず、同じ方法でSPが動作するのが一般的であるため、ここで使用されている設定例では、Mellon設定ディレクティブを階層のルートに置き、Mellonによって保護される特定のロケーションを"
+" 最小限のディレクティブで定義できます。この戦略は、保護された各ロケーションで同じパラメータを複製することを回避します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:70
 msgid ""
 "This example has just one protected location: \\https://$sp_host/protected."
-msgstr ""
+msgstr "この例では、保護された場所は1つだけです: \\https://$sp_host/protected."
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:72
-msgid "To configure the Mellon service provider, complete the following steps:"
-msgstr ""
+msgid ""
+"To configure the Mellon service provider, complete the following steps:"
+msgstr "Mellonサービス・プロバイダーを設定するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:74
 msgid "Create the file /etc/httpd/conf.d/mellon.conf with this content:"
-msgstr ""
+msgstr "`/etc/httpd/conf.d/mellon.conf`ファイルを次の内容で作成します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:90
@@ -289,18 +302,31 @@ msgid ""
 "    Require valid-user\n"
 " </Location>\n"
 msgstr ""
+" <Location / >\n"
+"    MellonEnable info\n"
+"    MellonEndpointPath /mellon/\n"
+"    MellonSPMetadataFile /etc/httpd/saml2/mellon_metadata.xml\n"
+"    MellonSPPrivateKeyFile /etc/httpd/saml2/mellon.key\n"
+"    MellonSPCertFile /etc/httpd/saml2/mellon.crt\n"
+"    MellonIdPMetadataFile /etc/httpd/saml2/idp_metadata.xml\n"
+" </Location>\n"
+" <Location /private >\n"
+"    AuthType Mellon\n"
+"    MellonEnable auth\n"
+"    Require valid-user\n"
+" </Location>\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:93
 msgid ""
 "Some of the files referenced in the code above are created in later steps."
-msgstr ""
+msgstr "上記のコードで参照されているファイルの一部は、後の手順で作成されます。"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:94
 #, no-wrap
 msgid "Creating the Service Provider Metadata"
-msgstr ""
+msgstr "サービス・プロバイダーのメタデータの作成"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:97
@@ -309,30 +335,31 @@ msgid ""
 "schema for the metadata is a standard, thus assuring participating SAML "
 "entities can consume each other's metadata. You need:"
 msgstr ""
+"SAMLではIdPとSPがXML形式のSAMLメタデータを交換します。メタデータのスキーマは標準であるため、参加するSAMLエンティティが互いのメタデータを消費できることが保証されます。必要なものは:"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:99
 msgid "Metadata for the IdP that the SP utilizes"
-msgstr ""
+msgstr "SPが利用するIdPのメタデータ"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:100
 msgid "Metadata describing the SP provided to the IdP"
-msgstr ""
+msgstr "IdPに提供されたSPを記述するメタデータ"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:102
 msgid ""
 "One of the components of SAML metadata is X509 certificates. These "
 "certificates are used for two purposes:"
-msgstr ""
+msgstr "SAMLメタデータのコンポーネントの1つはX509証明書です。これらの証明書は、2つの目的で使用されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:104
 msgid ""
 "Sign SAML messages so the receiving end can prove the message originated "
 "from the expected party."
-msgstr ""
+msgstr "受信側が予想される相手から発信されたメッセージを証明できるように、SAMLメッセージに署名します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:105
@@ -340,14 +367,16 @@ msgid ""
 "Encrypt the message during transport (seldom used because SAML messages "
 "typically occur on TLS-protected transports)"
 msgstr ""
+"トランスポート中にメッセージを暗号化する(ほとんどの場合、SAMLメッセージはTLSで保護されたトランスポートで発生するため、使用されません)"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:107
 msgid ""
 "You can use your own certificates if you already have a Certificate "
-"Authority (CA) or you can generate a self-signed certificate. For simplicity "
-"in this example a self-signed certificate is used."
+"Authority (CA) or you can generate a self-signed certificate. For simplicity"
+" in this example a self-signed certificate is used."
 msgstr ""
+"既に認証局（CA）がある場合、または自己署名証明書を生成できる場合は、独自の証明書を使用できます。この例では、簡単のため、自己署名証明書が使用されています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:109
@@ -361,6 +390,7 @@ msgid ""
 "later because it is a text file. The tool also creates your X509 key and "
 "certificate."
 msgstr ""
+"MellonのSPメタデータは、mod_auth_mellonのインストールされたバージョンの機能を反映する必要があるため、有効なSPメタデータXMLでなければならず、X509証明書(X509証明書の生成に慣れていない限り、その作成は愚鈍になることがあります)を含む必要があります。SPメタデータを生成する最も便利な方法は、mod_auth_mellonパッケージに含まれているツール(`mellon_create_metadata.sh)`を使用することです。生成されたメタデータは、テキストファイルであるため、後で編集することができます。このツールは、X509の鍵と証明書も作成します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:111
@@ -368,30 +398,31 @@ msgid ""
 "SAML IdPs and SPs identify themselves using a unique name known as an "
 "EntityID. To use the Mellon metadata creation tool you need:"
 msgstr ""
+"SAMLのIdPとSPは、`EntityID`という固有の名前を使用して自分自身を識別します。Mellonのメタデータ作成ツールを使用するには、次のものが必要です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:113
 msgid ""
-"The EntityID, which is typically the URL of the SP, and often the URL of the "
-"SP where the SP metadata can be retrieved"
-msgstr ""
+"The EntityID, which is typically the URL of the SP, and often the URL of the"
+" SP where the SP metadata can be retrieved"
+msgstr "EntityID。通常SPのURLであり、しばしばSPメタデータを取得できるSPのURLです"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:114
 msgid ""
 "The URL where SAML messages for the SP will be consumed, which Mellon calls "
 "the MellonEndPointPath."
-msgstr ""
+msgstr "SPのSAMLメッセージが消費されるURL（MellonがMellonEndPointPathを呼び出すURL）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:116
 msgid "To create the SP metadata, complete the following steps:"
-msgstr ""
+msgstr "SPメタデータを作成するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:118
 msgid "Create a few helper shell variables:"
-msgstr ""
+msgstr "ヘルパーのシェル変数をいくつか作成します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:125
@@ -402,24 +433,32 @@ msgid ""
 "mellon_entity_id=\"${mellon_endpoint_url}/metadata\"\n"
 "file_prefix=\"$(echo \"$mellon_entity_id\" | sed 's/[^A-Za-z.]/_/g' | sed 's/__*/_/g')\"\n"
 msgstr ""
+"fqdn=`hostname`\n"
+"mellon_endpoint_url=\"https://${fqdn}/mellon\"\n"
+"mellon_entity_id=\"${mellon_endpoint_url}/metadata\"\n"
+"file_prefix=\"$(echo \"$mellon_entity_id\" | sed 's/[^A-Za-z.]/_/g' | sed 's/__*/_/g')\"\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:128
 msgid "Invoke the Mellon metadata creation tool by running this command:"
-msgstr ""
+msgstr "次のコマンドを実行して、Mellonメタデータ作成ツールを呼び出します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:132
 #, no-wrap
-msgid "/usr/libexec/mod_auth_mellon/mellon_create_metadata.sh $mellon_entity_id $mellon_endpoint_url\n"
+msgid ""
+"/usr/libexec/mod_auth_mellon/mellon_create_metadata.sh $mellon_entity_id "
+"$mellon_endpoint_url\n"
 msgstr ""
+"/usr/libexec/mod_auth_mellon/mellon_create_metadata.sh $mellon_entity_id "
+"$mellon_endpoint_url\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:135
 msgid ""
-"Move the generated files to their destination (referenced in the /etc/httpd/"
-"conf.d/mellon.conf file created above):"
-msgstr ""
+"Move the generated files to their destination (referenced in the "
+"/etc/httpd/conf.d/mellon.conf file created above):"
+msgstr "生成されたファイルを目的の場所に移動します（上記の`/etc/httpd/conf.d/mellon.conf`ファイルを参照）。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:141
@@ -429,28 +468,36 @@ msgid ""
 "mv ${file_prefix}.key /etc/httpd/saml2/mellon.key\n"
 "mv ${file_prefix}.xml /etc/httpd/saml2/mellon_metadata.xml\n"
 msgstr ""
+"mv ${file_prefix}.cert /etc/httpd/saml2/mellon.crt\n"
+"mv ${file_prefix}.key /etc/httpd/saml2/mellon.key\n"
+"mv ${file_prefix}.xml /etc/httpd/saml2/mellon_metadata.xml\n"
 
 #. type: Title =====
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:143
 #, no-wrap
-msgid "Adding the Mellon Service Provider to the {project_name} Identity Provider"
-msgstr ""
+msgid ""
+"Adding the Mellon Service Provider to the {project_name} Identity Provider"
+msgstr "{project_name}アイデンティティ・プロバイダーにMellonサービス・プロバイダーを追加する"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:146
 msgid ""
 "Assumption: The {project_name} IdP has already been installed on the "
 "$idp_host."
-msgstr ""
+msgstr "仮定: project_name}のIdPはすでに$idp_hostにインストールされています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:148
 msgid ""
-"{project_name} supports multiple tenancy where all users, clients, and so on "
-"are grouped in what is called a realm. Each realm is independent of other "
+"{project_name} supports multiple tenancy where all users, clients, and so on"
+" are grouped in what is called a realm. Each realm is independent of other "
 "realms. You can use an existing realm in your {project_name}, but this "
-"example shows how to create a new realm called test_realm and use that realm."
+"example shows how to create a new realm called test_realm and use that "
+"realm."
 msgstr ""
+"{project_name}は、すべてのユーザー、クライアントなどがレルムと呼ばれる領域にグループ化されている複数のテナントをサポートしています。 "
+"各レルムは他のレルムとは独立しています。 "
+"{project_name}に既存のレルムを使用できますが、この例では、test_realmという新しいレルムを作成し、そのレルムを使用する方法を示しています。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:150
@@ -458,18 +505,20 @@ msgid ""
 "All these operations are performed using the {project_name} administration "
 "web console. You must have the admin username and password for $idp_host."
 msgstr ""
+"これらの操作はすべて、{project_name}管理者Webコンソールを使用して実行されます。 "
+"$idp_hostの管理者ユーザー名とパスワードが必要です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:152
 msgid "To complete the following steps:"
-msgstr ""
+msgstr "次の手順を完了するには:"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:154
 msgid ""
 "Open the Admin Console and log on by entering the admin username and "
 "password."
-msgstr ""
+msgstr "管理者のユーザー名とパスワードを入力して、管理コンソールを開き、ログオンします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:156
@@ -479,106 +528,115 @@ msgid ""
 "by default. Any previously created realms are listed in the upper left "
 "corner of the administration console in a drop-down list."
 msgstr ""
+"管理コンソールにログインすると、既存のレルムが存在します。 "
+"{project_name}を最初に設定すると、デフォルトでルートレルムmasterが作成されます。 "
+"以前に作成されたレルムは、管理コンソールの左上隅にドロップダウン・リストに表示されます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:158
 msgid "From the realm drop-down list select *Add realm*."
-msgstr ""
+msgstr "レルムのドロップダウン・リストから*レルムを追加*を選択します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:160
 msgid "In the Name field type `test_realm` and click *Create*."
-msgstr ""
+msgstr "名前フィールドに`test_realm`と入力し、*作成*をクリックします。"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:162
-msgid "====== Adding the Mellon Service Provider as a Client of the Realm"
-msgstr ""
+#. type: Title ======
+#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:161
+#, no-wrap
+msgid "Adding the Mellon Service Provider as a Client of the Realm"
+msgstr "Mellonサービス・プロバイダーをレルムのクライアントとして追加する"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:164
 msgid ""
-"In {project_name} SAML SPs are known as clients. To add the SP we must be in "
-"the Clients section of the realm."
+"In {project_name} SAML SPs are known as clients. To add the SP we must be in"
+" the Clients section of the realm."
 msgstr ""
+"{project_name}では、SAML SPはクライアントと呼ばれます。 SPを追加するには、レルムのクライアントのセクションに移動します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:166
 msgid ""
 "Click the Clients menu item on the left and click *Create* in the upper "
 "right corner to create a new client."
-msgstr ""
+msgstr "左側のクライアント・メニュー項目をクリックし、右上の*作成*をクリックして新しいクライアントを作成します。"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:168
-msgid "====== Adding the Mellon SP Client"
-msgstr ""
+#. type: Title ======
+#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:167
+#, no-wrap
+msgid "Adding the Mellon SP Client"
+msgstr "Mellon SPクライアントの追加"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:170
 msgid "To add the Mellon SP client, complete the following steps:"
-msgstr ""
+msgstr "Mellon SPクライアントを追加するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:172
 msgid ""
 "Set the client protocol to SAML. From the Client Protocol drop down list, "
 "select *saml*."
-msgstr ""
+msgstr "クライアント・プロトコルをSAMLに設定します。 「クライアント・プロトコル」ドロップダウン・リストから、*saml*を選択します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:173
 msgid ""
-"Provide the Mellon SP metadata file created above (/etc/httpd/saml2/"
-"mellon_metadata.xml). Depending on where your browser is running you might "
-"have to copy the SP metadata from $sp_host to the machine on which your "
-"browser is running so the browser can find the file."
+"Provide the Mellon SP metadata file created above "
+"(/etc/httpd/saml2/mellon_metadata.xml). Depending on where your browser is "
+"running you might have to copy the SP metadata from $sp_host to the machine "
+"on which your browser is running so the browser can find the file."
 msgstr ""
+"上記で作成したMellon SPメタデータ・ファイル（`/etc/httpd/saml2/mellon_metadata.xml`）を提供します。 "
+"ブラウザーが実行されている場所によっては、$sp_hostからブラウザーが実行されているマシンにSPメタデータをコピーして、ブラウザーがそのファイルを見つけなければならない場合があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:174
-#: source/server_admin/topics/user-federation/sssd.adoc:147
+#: source/server_admin/topics/user-federation/sssd.adoc:151
 msgid "Click *Save*."
-msgstr ""
+msgstr "*保存*をクリックします。"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:176
-msgid "====== Editing the Mellon SP Client"
-msgstr ""
+#. type: Title ======
+#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:175
+#, no-wrap
+msgid "Editing the Mellon SP Client"
+msgstr "Mellon SPクライアントの編集"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:178
 msgid "There are several client configuration parameters we suggest setting:"
-msgstr ""
+msgstr "いくつかのクライアント設定パラメータがあります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:180
 msgid "Ensure \"Force POST Binding\" is On."
-msgstr ""
+msgstr "\"Force POST Binding\"がオンになっていることを確認します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:181
 msgid "Add paosResponse to the Valid Redirect URIs list:"
-msgstr ""
+msgstr "有効なリダイレクトURIリストにpaosResponseを追加します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:182
 msgid ""
 "Copy the postResponse URL in \"Valid Redirect URIs\" and paste it into the "
 "empty add text fields just below the \"+\"."
-msgstr ""
+msgstr "\"有効なリダイレクトURI\"内のpostResponse URLをコピーし、 \"+\"のすぐ下の空の追加テキスト・フィールドに貼り付けます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:183
 msgid ""
-"Change \"postResponse\" to \"paosResponse\". (The paosResponse URL is needed "
-"for SAML ECP.)"
-msgstr ""
+"Change \"postResponse\" to \"paosResponse\". (The paosResponse URL is needed"
+" for SAML ECP.)"
+msgstr "\"postResponse\"を \"paosResponse\"に変更します(SAML ECPにはpaosResponse URLが必要です)。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:184
 msgid "Click *Save* at the bottom."
-msgstr ""
+msgstr "下部の*保存*をクリックして下さい。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:186
@@ -588,71 +646,76 @@ msgid ""
 "not supply the user's groups unless the IdP is configured to supply it as a "
 "SAML attribute."
 msgstr ""
+"多くのSAML SPは、グループ内のユーザーのメンバーシップに基づいて認可を決定します。 "
+"{project_name}のIdPはユーザー・グループ情報を管理できますが、IdPがSAML属性としてそれを提供するように設定されていない限り、ユーザーのグループは提供されません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:188
 msgid ""
 "To configure the IdP to supply the user's groups as as a SAML attribute, "
 "complete the following steps:"
-msgstr ""
+msgstr "ユーザーのグループにSAML属性を提供するようにIdPを設定するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:190
 msgid "Click the Mappers tab of the client."
-msgstr ""
+msgstr "クライアントのマッパー・タブをクリックします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:191
 msgid "In the upper right corner of the Mappers page, click *Create*."
-msgstr ""
+msgstr "マッパー・ページの右上にある*作成*をクリックします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:192
 msgid "From the Mapper Type drop-down list select *Group list*."
-msgstr ""
+msgstr "マッパー・タイプのドロップダウン・リストから*グループリスト*を選択します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:193
 msgid "Set Name to \"group list.\""
-msgstr ""
+msgstr "「グループリスト」に名前を設定します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:194
 msgid "Set the SAML attribute name to \"groups.\""
-msgstr ""
+msgstr "グループにSAML属性名を設定します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:195
 msgid "Click *Save.*"
-msgstr ""
+msgstr "*保存*をクリックします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:197
 msgid "The remaining steps are performed on $sp_host."
-msgstr ""
+msgstr "残りの手順は$sp_hostで実行されます。"
 
-#. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:199
-msgid "====== Retrieving the Identity Provider Metadata"
-msgstr ""
+#. type: Title ======
+#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:198
+#, no-wrap
+msgid "Retrieving the Identity Provider Metadata"
+msgstr "アイデンティティ・プロバイダー・メタデータの取得"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:201
 msgid ""
 "Now that you have created the realm on the IdP you need to retrieve the IdP "
-"metadata associated with it so the Mellon SP recognizes it. In the /etc/"
-"httpd/conf.d/mellon.conf file created previously, the MellonIdPMetadataFile "
-"is specified as /etc/httpd/saml2/idp_metadata.xml but until now that file "
-"has not existed on $sp_host. To get that file we will retrieve it from the "
-"IdP."
+"metadata associated with it so the Mellon SP recognizes it. In the "
+"/etc/httpd/conf.d/mellon.conf file created previously, the "
+"MellonIdPMetadataFile is specified as /etc/httpd/saml2/idp_metadata.xml but "
+"until now that file has not existed on $sp_host. To get that file we will "
+"retrieve it from the IdP."
 msgstr ""
+"IdPでレルムを作成したので、それに関連付けられたIdPメタデータを取得して、Mellon SPがそれを認識できるようにする必要があります。 "
+"前に作成した`/etc/httpd/conf.d/mellon.conf`ファイルでは、`MellonIdPMetadataFile`は`/etc/httpd/saml2/idp_metadata.xml`として指定されていますが、そのファイルは$sp_host上に存在しませんでした。そのファイルを取得するには、IdPからファイルを検索します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:203
 msgid ""
 "Retrieve the file from the IdP by substituting $idp_host with the correct "
 "value:"
-msgstr ""
+msgstr "$idp_hostを正しい値に置き換えて、IdPからファイルを取得します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:208
@@ -661,22 +724,24 @@ msgid ""
 "curl -k -o /etc/httpd/saml2/idp_metadata.xml \\\n"
 "https://$idp_host/auth/realms/test_realm/protocol/saml/descriptor\n"
 msgstr ""
+"curl -k -o /etc/httpd/saml2/idp_metadata.xml \\\n"
+"https://$idp_host/auth/realms/test_realm/protocol/saml/descriptor\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:211
 msgid "Mellon is now fully configured."
-msgstr ""
+msgstr "Mellonは完全に設定されました。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:213
 msgid "To run a syntax check for Apache configuration files:"
-msgstr ""
+msgstr "Apache設定ファイルの構文チェックを実行するには、次のようにします。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:217
 #, no-wrap
 msgid "apachectl configtest\n"
-msgstr ""
+msgstr "apachectl configtest\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:220
@@ -684,17 +749,18 @@ msgid ""
 "Configtest is equivalent to the -t argument to apachectl. If the "
 "configuration test shows any errors, correct them before proceeding."
 msgstr ""
+"`configtest`は`apachectl`の`-t`引数に相当します。 設定テストでエラーが示された場合は、先に進む前に修正してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:222
 msgid "Restart the Apache server:"
-msgstr ""
+msgstr "Apacheサーバを再起動します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:226
 #, no-wrap
 msgid "systemctl restart httpd.service\n"
-msgstr ""
+msgstr "systemctl restart httpd.service\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/mod-auth-mellon.adoc:228
@@ -703,3 +769,6 @@ msgid ""
 "mod_auth_mellon as SAML SP protecting the URL $sp_host/protected (and "
 "everything beneath it) by authenticating against the ``$idp_host`` IdP."
 msgstr ""
+"`$ "
+"idp_host``のIdPに対して認証することで、$sp_host/protected（とその配下すべて）のURLを保護するように、test_realmのSAML"
+" IdPとして{project_name}を、SAML SPとしてmod_auth_mellonを設定しました。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:3
 #, no-wrap
 msgid "mod_auth_mellon Apache HTTPD Module"
 msgstr "mod_auth_mellon Apache HTTPDモジュール"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:6
 msgid ""
 "The https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] module is an"
 " Apache HTTPD plugin for SAML. If your language/environment supports using "
@@ -30,52 +28,46 @@ msgid ""
 " application with SAML. For more details on this module see the "
 "_mod_auth_mellon_ Github repo."
 msgstr ""
-"https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon]モジュールは、SAML用のApache"
-" HTTPDプラグインです。使用している言語/環境がApache "
-"HTTPDをプロキシーとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティ保護できます。このモジュールの詳細については、_mod_auth_mellon_のGithubリポジトリーを参照してください。"
+"https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] "
+"モジュールは、SAML用のApache HTTPDプラグインです。使用している言語/環境がApache "
+"HTTPDをプロキシとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティ保護できます。このモジュールの詳細については、"
+" _mod_auth_mellon_ のGithubリポジトリを参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:8
 msgid "To configure mod_auth_mellon you'll need:"
-msgstr "Mod_auth_mellonを設定するには、以下が必要です。"
+msgstr "mod_auth_mellonを設定するには、以下が必要です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:10
 msgid ""
 "An Identity Provider (IdP) entity descriptor XML file, which describes the "
 "connection to {project_name} or another SAML IdP"
 msgstr ""
-"{project_name}または別のSAML "
-"IdPへの接続を記述するアイデンティティ・プロバイダー(IdP)のエンティティディスクリプタXMLファイル"
+"アイデンティティ・プロバイダー（IdP）のエンティティ記述子XMLファイル。{project_name}または別のSAML "
+"IdPへの接続情報を記述します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:11
 msgid ""
 "An SP entity descriptor XML file, which describes the SAML connections and "
 "configuration for the application you are securing."
 msgstr "SPエンティティ記述子XMLファイル。セキュアにするアプリケーションのSAML接続と設定を記述します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:12
 msgid ""
 "A private key PEM file, which is a text file in the PEM format that defines "
 "the private key the application uses to sign documents."
 msgstr "秘密鍵PEMファイル。アプリケーションが文書に署名するために使用する秘密鍵を定義するPEM形式のテキストファイルです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:13
 msgid ""
 "A certificate PEM file, which is a text file that defines the certificate "
 "for your application."
 msgstr "証明書のPEMファイル。アプリケーションの証明書を定義するテキストファイルです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:14
 msgid "mod_auth_mellon-specific Apache HTTPD module configuration."
-msgstr "mod_auth_mellon-specific Apache HTTPDモジュールの設定。"
+msgstr "mod_auth_mellon特有のApache HTTPDモジュールの設定。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:17
 msgid ""
 "If you have already defined and registered the client application within a "
 "realm on the {project_name} application server, {project_name} can generate "
@@ -85,143 +77,120 @@ msgstr ""
 " HTTPDモジュールの設定を除くすべての必要なファイルを生成できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:19
 msgid ""
 "To generate the Apache HTTPD module configuration, complete the following "
 "steps:"
 msgstr "Apache HTTPDモジュールの設定を生成するには、以下のステップを実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:21
 msgid ""
 "Go to the Installation page of your SAML client and select the Mod Auth "
 "Mellon files option."
 msgstr "SAMLクライアントのインストール・ページに移動し、Mod Auth Mellonファイル・オプションを選択します。"
 
 #. type: Block title
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:22
 #, no-wrap
 msgid "mod_auth_mellon config download"
 msgstr "mod_auth_mellon設定のダウンロード"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:24
 msgid "image:{project_images}/mod-auth-mellon-config-download.png[]"
 msgstr "image:{project_images}/mod-auth-mellon-config-download.png[]"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:26
 msgid ""
 "Click *Download* to download a zip file that contains the XML descriptor and"
 " PEM files you need."
-msgstr "必要なXML記述子とPEMファイルを含むzipファイルをダウンロードするには、*ダウンロード*をクリックします。"
+msgstr "必要なXML記述子とPEMファイルを含むzipファイルをダウンロードするには、 *Download* をクリックします。"
 
 #. type: Title ====
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:28
 #, no-wrap
 msgid "Configuring mod_auth_mellon with {project_name}"
-msgstr "{project_name}とmod_auth_mellonの設定"
+msgstr "mod_auth_mellonの{project_name}との設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:31
 msgid "There are two hosts involved:"
 msgstr "関連するホストは2つあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:33
 msgid ""
 "The host on which {project_name} is running, which will be referred to as "
 "$idp_host because {project_name} is a SAML identity provider (IdP)."
 msgstr ""
-"{project_name}が実行されているホスト。{project_name}がSAMLアイデンティティ・プロバイダー(IdP)であるため、$idp_hostと呼ばれます。"
+"{project_name}が実行されているホスト。{project_name}がSAMLアイデンティティー・プロバイダー（IdP）であるため、$idp_hostと呼ばれます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:35
 msgid ""
 "The host on which the web application is running, which will be referred to "
 "as $sp_host. In SAML an application using an IdP is called a service "
 "provider (SP)."
 msgstr ""
-"Webアプリケーションが実行されているホスト。$sp_hostと呼ばれます。SAMLでは、IdPを使用するアプリケーションをサービスプロバイダ(SP)と呼びます。"
+"Webアプリケーションが実行されているホスト。$sp_hostと呼ばれます。SAMLでは、IdPを使用するアプリケーションをサービス・プロバイダー（SP）と呼びます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:37
 msgid ""
 "All of the following steps need to performed on $sp_host with root "
 "privileges."
 msgstr "次のすべての手順は、root特権で$sp_hostに対して実行される必要があります。"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:38
 #, no-wrap
 msgid "Installing the Packages"
 msgstr "パッケージのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:41
 msgid "To install the necessary packages, you will need:"
 msgstr "必要なパッケージをインストールするには、次のものが必要です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:43
 msgid "Apache Web Server (httpd)"
-msgstr "Apache Webサーバー(httpd)"
+msgstr "Apache Webサーバー（httpd）"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:44
 msgid "Mellon SAML SP add-on module for Apache"
-msgstr "Apache用のメロンMellon SAML SPアドオン・モジュール"
+msgstr "Apache用のMellon SAML SPアドオン・モジュール"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:45
 msgid "Tools to create X509 certificates"
 msgstr "X509証明書を作成するためのツール"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:47
 msgid "To install the necessary packages, run this command:"
 msgstr "必要なパッケージをインストールするには、次のコマンドを実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:49
 #, no-wrap
 msgid " yum install httpd mod_auth_mellon mod_ssl openssl\n"
 msgstr " yum install httpd mod_auth_mellon mod_ssl openssl\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:50
 #, no-wrap
 msgid "Creating a Configuration Directory for Apache SAML"
-msgstr "Apache SAMLの設定ディレクトリの作成"
+msgstr "Apache SAMLの設定ディレクトリーの作成"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:53
 msgid ""
 "It is advisable to keep configuration files related to Apache's use of SAML "
 "in one location."
 msgstr "ApacheのSAML使用に関する設定ファイルは、1か所に保存することをお勧めします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:55
 msgid ""
 "Create a new directory named saml2 located under the Apache configuration "
 "root /etc/httpd:"
-msgstr "Apache設定ルート(/etc/httpd)の下に、saml2という名前の新しいディレクトリを作成します。"
+msgstr "Apache設定ルート（/etc/httpd）の下に、saml2という名前の新しいディレクトリを作成します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:57
 #, no-wrap
 msgid " mkdir /etc/httpd/saml2\n"
 msgstr " mkdir /etc/httpd/saml2\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:58
 #, no-wrap
 msgid "Configuring the Mellon Service Provider"
-msgstr "Mellon サービス・プロバイダーの設定"
+msgstr "Mellonサービス・プロバイダーの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:61
 msgid ""
 "Configuration files for Apache add-on modules are located in the "
 "/etc/httpd/conf.d directory and have a file name extension of .conf. You "
@@ -231,24 +200,20 @@ msgstr ""
 "Apacheアドオン・モジュールの設定ファイルは/etc/httpd/conf.dディレクトリにあり、拡張子は.confです。/etc/httpd/conf.d/mellon.confファイルを作成し、Mellonの設定ディレクティブをその中に置く必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:63
 msgid ""
 "Mellon's configuration directives can roughly be broken down into two "
 "classes of information:"
 msgstr "Mellonの設定ディレクティブは、大まかに2つのクラスの情報に分類できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:65
 msgid "Which URLs to protect with SAML authentication"
 msgstr "SAML認証で保護するURL"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:66
 msgid "What SAML parameters will be used when a protected URL is referenced."
 msgstr "保護されたURLが参照されるときに使用されるSAMLパラメーター。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:68
 msgid ""
 "Apache configuration directives typically follow a hierarchical tree "
 "structure in the URL space, which are known as locations. You need to "
@@ -264,28 +229,23 @@ msgid ""
 " can be defined with minimal directives. This strategy avoids duplicating "
 "the same parameters for each protected location."
 msgstr ""
-"Apacheの設定ディレクティブは通常、URL空間の階層ツリー構造に従います。これらは、ロケーションとして知られています。Mellonが保護するURLのロケーションを1つ以上指定する必要があります。各場所に適用される設定パラメータの追加方法には柔軟性があります。ロケーション・ブロックに必要なすべてのパラメータを追加するか、特定の保護されたロケーションが継承するURLロケーション階層の上位の共通の場所(またはその両方の組み合わせ)にMellonパラメータを追加できます。どのロケーションがSAMLアクションをトリガーするかにかかわらず、同じ方法でSPが動作するのが一般的であるため、ここで使用されている設定例では、Mellon設定ディレクティブを階層のルートに置き、Mellonによって保護される特定のロケーションを"
-" 最小限のディレクティブで定義できます。この戦略は、保護された各ロケーションで同じパラメータを複製することを回避します。"
+"Apacheの設定ディレクティブは通常、URL空間の階層ツリー構造に従います。これらは、ロケーションとして知られています。Mellonが保護するURLのロケーションを1つ以上指定する必要があります。各場所に適用される設定パラメーターの追加方法には柔軟性があります。ロケーション・ブロックに必要なすべてのパラメーターを追加するか、特定の保護されたロケーションが継承するURLロケーション階層の上位の共通の場所（またはその両方の組み合わせ）にMellonパラメーターを追加できます。どのロケーションがSAMLアクションをトリガーするかにかかわらず、同じ方法でSPが動作するのが一般的であるため、ここで使用されている設定例では、Mellon設定ディレクティブを階層のルートに置き、Mellonによって保護される特定のロケーションを最小限のディレクティブで定義できます。この戦略は、保護された各ロケーションで同じパラメーターを複製することを回避します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:70
 msgid ""
 "This example has just one protected location: \\https://$sp_host/protected."
-msgstr "この例では、保護された場所は1つだけです: \\https://$sp_host/protected."
+msgstr "この例では、保護された場所は \\https://$sp_host/protected 1つだけです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:72
 msgid ""
 "To configure the Mellon service provider, complete the following steps:"
 msgstr "Mellonサービス・プロバイダーを設定するには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:74
 msgid "Create the file /etc/httpd/conf.d/mellon.conf with this content:"
-msgstr "`/etc/httpd/conf.d/mellon.conf`ファイルを次の内容で作成します。"
+msgstr "/etc/httpd/conf.d/mellon.confファイルを次の内容で作成します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:90
 #, no-wrap
 msgid ""
 " <Location / >\n"
@@ -317,60 +277,51 @@ msgstr ""
 " </Location>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:93
 msgid ""
 "Some of the files referenced in the code above are created in later steps."
 msgstr "上記のコードで参照されているファイルの一部は、後の手順で作成されます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:94
 #, no-wrap
 msgid "Creating the Service Provider Metadata"
 msgstr "サービス・プロバイダーのメタデータの作成"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:97
 msgid ""
 "In SAML IdPs and SPs exchange SAML metadata, which is in XML format. The "
 "schema for the metadata is a standard, thus assuring participating SAML "
 "entities can consume each other's metadata. You need:"
 msgstr ""
-"SAMLではIdPとSPがXML形式のSAMLメタデータを交換します。メタデータのスキーマは標準であるため、参加するSAMLエンティティが互いのメタデータを消費できることが保証されます。必要なものは:"
+"SAMLではIdPとSPがXML形式のSAMLメタデータを交換します。メタデータのスキーマは標準であるため、参加するSAMLエンティティが互いのメタデータを消費できることが保証されます。必要なものは次のとおりです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:99
 msgid "Metadata for the IdP that the SP utilizes"
 msgstr "SPが利用するIdPのメタデータ"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:100
 msgid "Metadata describing the SP provided to the IdP"
 msgstr "IdPに提供されたSPを記述するメタデータ"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:102
 msgid ""
 "One of the components of SAML metadata is X509 certificates. These "
 "certificates are used for two purposes:"
-msgstr "SAMLメタデータのコンポーネントの1つはX509証明書です。これらの証明書は、2つの目的で使用されます。"
+msgstr "SAMLメタデータのコンポーネントの1つはX509証明書です。この証明書は、2つの目的で使用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:104
 msgid ""
 "Sign SAML messages so the receiving end can prove the message originated "
 "from the expected party."
 msgstr "受信側が予想される相手から発信されたメッセージを証明できるように、SAMLメッセージに署名します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:105
 msgid ""
 "Encrypt the message during transport (seldom used because SAML messages "
 "typically occur on TLS-protected transports)"
 msgstr ""
-"トランスポート中にメッセージを暗号化する(ほとんどの場合、SAMLメッセージはTLSで保護されたトランスポートで発生するため、使用されません)"
+"トランスポート中にメッセージを暗号化します（ほとんどの場合、SAMLメッセージはTLSで保護されたトランスポートで発生するため、使用されません）"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:107
 msgid ""
 "You can use your own certificates if you already have a Certificate "
 "Authority (CA) or you can generate a self-signed certificate. For simplicity"
@@ -379,7 +330,6 @@ msgstr ""
 "既に認証局（CA）がある場合、または自己署名証明書を生成できる場合は、独自の証明書を使用できます。この例では、簡単のため、自己署名証明書が使用されています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:109
 msgid ""
 "Because Mellon's SP metadata must reflect the capabilities of the installed "
 "version of mod_auth_mellon, must be valid SP metadata XML, and must contain "
@@ -390,42 +340,38 @@ msgid ""
 "later because it is a text file. The tool also creates your X509 key and "
 "certificate."
 msgstr ""
-"MellonのSPメタデータは、mod_auth_mellonのインストールされたバージョンの機能を反映する必要があるため、有効なSPメタデータXMLでなければならず、X509証明書(X509証明書の生成に慣れていない限り、その作成は愚鈍になることがあります)を含む必要があります。SPメタデータを生成する最も便利な方法は、mod_auth_mellonパッケージに含まれているツール(`mellon_create_metadata.sh)`を使用することです。生成されたメタデータは、テキストファイルであるため、後で編集することができます。このツールは、X509の鍵と証明書も作成します。"
+"MellonのSPメタデータは、mod_auth_mellonのインストールされたバージョンの機能を反映する必要があるため、有効なSPメタデータXMLでなければならず、X509証明書（X509証明書の生成に慣れていない限り、その作成は難解になることがあります）を含む必要があります。SPメタデータを生成する最も便利な方法は、mod_auth_mellonパッケージに含まれているツール（"
+" `mellon_create_metadata.sh` "
+"）を使用することです。生成されたメタデータは、テキスト・ファイルであるため、後で編集することができます。このツールは、X509の鍵と証明書も作成します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:111
 msgid ""
 "SAML IdPs and SPs identify themselves using a unique name known as an "
 "EntityID. To use the Mellon metadata creation tool you need:"
 msgstr ""
-"SAMLのIdPとSPは、`EntityID`という固有の名前を使用して自分自身を識別します。Mellonのメタデータ作成ツールを使用するには、次のものが必要です。"
+"SAMLのIdPとSPは、EntityIDという固有の名前を使用して自分自身を識別します。Mellonのメタデータ作成ツールを使用するには、次のものが必要です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:113
 msgid ""
 "The EntityID, which is typically the URL of the SP, and often the URL of the"
 " SP where the SP metadata can be retrieved"
-msgstr "EntityID。通常SPのURLであり、しばしばSPメタデータを取得できるSPのURLです"
+msgstr "EntityID。通常SPのURLであり、しばしばSPメタデータを取得できるSPのURLです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:114
 msgid ""
 "The URL where SAML messages for the SP will be consumed, which Mellon calls "
 "the MellonEndPointPath."
 msgstr "SPのSAMLメッセージが消費されるURL（MellonがMellonEndPointPathを呼び出すURL）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:116
 msgid "To create the SP metadata, complete the following steps:"
 msgstr "SPメタデータを作成するには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:118
 msgid "Create a few helper shell variables:"
 msgstr "ヘルパーのシェル変数をいくつか作成します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:125
 #, no-wrap
 msgid ""
 "fqdn=`hostname`\n"
@@ -439,12 +385,10 @@ msgstr ""
 "file_prefix=\"$(echo \"$mellon_entity_id\" | sed 's/[^A-Za-z.]/_/g' | sed 's/__*/_/g')\"\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:128
 msgid "Invoke the Mellon metadata creation tool by running this command:"
 msgstr "次のコマンドを実行して、Mellonメタデータ作成ツールを呼び出します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:132
 #, no-wrap
 msgid ""
 "/usr/libexec/mod_auth_mellon/mellon_create_metadata.sh $mellon_entity_id "
@@ -454,14 +398,12 @@ msgstr ""
 "$mellon_endpoint_url\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:135
 msgid ""
 "Move the generated files to their destination (referenced in the "
 "/etc/httpd/conf.d/mellon.conf file created above):"
-msgstr "生成されたファイルを目的の場所に移動します（上記の`/etc/httpd/conf.d/mellon.conf`ファイルを参照）。"
+msgstr "生成されたファイルを目的の場所に移動します（上記の/etc/httpd/conf.d/mellon.confファイルを参照）。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:141
 #, no-wrap
 msgid ""
 "mv ${file_prefix}.cert /etc/httpd/saml2/mellon.crt\n"
@@ -473,21 +415,18 @@ msgstr ""
 "mv ${file_prefix}.xml /etc/httpd/saml2/mellon_metadata.xml\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:143
 #, no-wrap
 msgid ""
 "Adding the Mellon Service Provider to the {project_name} Identity Provider"
-msgstr "{project_name}アイデンティティ・プロバイダーにMellonサービス・プロバイダーを追加する"
+msgstr "{project_name}アイデンティティー・プロバイダーにMellonサービス・プロバイダーを追加する"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:146
 msgid ""
 "Assumption: The {project_name} IdP has already been installed on the "
 "$idp_host."
 msgstr "仮定: project_name}のIdPはすでに$idp_hostにインストールされています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:148
 msgid ""
 "{project_name} supports multiple tenancy where all users, clients, and so on"
 " are grouped in what is called a realm. Each realm is independent of other "
@@ -495,210 +434,170 @@ msgid ""
 "example shows how to create a new realm called test_realm and use that "
 "realm."
 msgstr ""
-"{project_name}は、すべてのユーザー、クライアントなどがレルムと呼ばれる領域にグループ化されている複数のテナントをサポートしています。 "
-"各レルムは他のレルムとは独立しています。 "
-"{project_name}に既存のレルムを使用できますが、この例では、test_realmという新しいレルムを作成し、そのレルムを使用する方法を示しています。"
+"{project_name}は複数のテナントをサポートしており、すべてのユーザー、クライアントなどがレルムと呼ばれる領域にグループ化されます。各レルムは他のレルムとは独立しています。{project_name}に既存のレルムを使用できますが、この例では、test_realmという新しいレルムを作成し、そのレルムを使用する方法を示しています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:150
 msgid ""
 "All these operations are performed using the {project_name} administration "
 "web console. You must have the admin username and password for $idp_host."
 msgstr ""
-"これらの操作はすべて、{project_name}管理者Webコンソールを使用して実行されます。 "
-"$idp_hostの管理者ユーザー名とパスワードが必要です。"
+"これらの操作はすべて、{project_name}管理Webコンソールを使用して実行されます。$idp_hostの管理者ユーザー名とパスワードが必要です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:152
 msgid "To complete the following steps:"
-msgstr "次の手順を完了するには:"
+msgstr "次の手順を完了してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:154
 msgid ""
 "Open the Admin Console and log on by entering the admin username and "
 "password."
-msgstr "管理者のユーザー名とパスワードを入力して、管理コンソールを開き、ログオンします。"
+msgstr "管理コンソールを開き、管理者のユーザー名とパスワードを入力してログオンします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:156
 msgid ""
 "After logging into the administration console there will be an existing "
 "realm. When {project_name} is first set up a root realm, master, is created "
 "by default. Any previously created realms are listed in the upper left "
 "corner of the administration console in a drop-down list."
 msgstr ""
-"管理コンソールにログインすると、既存のレルムが存在します。 "
-"{project_name}を最初に設定すると、デフォルトでルートレルムmasterが作成されます。 "
-"以前に作成されたレルムは、管理コンソールの左上隅にドロップダウン・リストに表示されます。"
+"管理コンソールにログインすると、既存のレルムが存在します。{project_name}を最初に設定すると、デフォルトでルート・レルムのmasterが作成されます。以前に作成されたレルムは、管理コンソールの左上隅にドロップダウン・リストに表示されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:158
 msgid "From the realm drop-down list select *Add realm*."
-msgstr "レルムのドロップダウン・リストから*レルムを追加*を選択します。"
+msgstr "レルムのドロップダウン・リストから *Add realm* を選択します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:160
 msgid "In the Name field type `test_realm` and click *Create*."
-msgstr "名前フィールドに`test_realm`と入力し、*作成*をクリックします。"
+msgstr "名前フィールドに `test_realm` と入力し、 *Create* をクリックします。"
 
 #. type: Title ======
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:161
 #, no-wrap
 msgid "Adding the Mellon Service Provider as a Client of the Realm"
 msgstr "Mellonサービス・プロバイダーをレルムのクライアントとして追加する"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:164
 msgid ""
 "In {project_name} SAML SPs are known as clients. To add the SP we must be in"
 " the Clients section of the realm."
 msgstr ""
-"{project_name}では、SAML SPはクライアントと呼ばれます。 SPを追加するには、レルムのクライアントのセクションに移動します。"
+"{project_name}では、SAML SPはクライアントと呼ばれます。SPを追加するには、レルムのクライアントのセクションに移動します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:166
 msgid ""
 "Click the Clients menu item on the left and click *Create* in the upper "
 "right corner to create a new client."
-msgstr "左側のクライアント・メニュー項目をクリックし、右上の*作成*をクリックして新しいクライアントを作成します。"
+msgstr "左側のClientsメニュー項目をクリックし、右上の *Create* をクリックして新しいクライアントを作成します。"
 
 #. type: Title ======
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:167
 #, no-wrap
 msgid "Adding the Mellon SP Client"
 msgstr "Mellon SPクライアントの追加"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:170
 msgid "To add the Mellon SP client, complete the following steps:"
 msgstr "Mellon SPクライアントを追加するには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:172
 msgid ""
 "Set the client protocol to SAML. From the Client Protocol drop down list, "
 "select *saml*."
-msgstr "クライアント・プロトコルをSAMLに設定します。 「クライアント・プロトコル」ドロップダウン・リストから、*saml*を選択します。"
+msgstr "クライアント・プロトコルをSAMLに設定します。Client Protocolドロップダウン・リストから、 *saml* を選択します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:173
 msgid ""
 "Provide the Mellon SP metadata file created above "
 "(/etc/httpd/saml2/mellon_metadata.xml). Depending on where your browser is "
 "running you might have to copy the SP metadata from $sp_host to the machine "
 "on which your browser is running so the browser can find the file."
 msgstr ""
-"上記で作成したMellon SPメタデータ・ファイル（`/etc/httpd/saml2/mellon_metadata.xml`）を提供します。 "
-"ブラウザーが実行されている場所によっては、$sp_hostからブラウザーが実行されているマシンにSPメタデータをコピーして、ブラウザーがそのファイルを見つけなければならない場合があります。"
+"上記で作成したMellon "
+"SPメタデータ・ファイル（/etc/httpd/saml2/mellon_metadata.xml）を提供します。ブラウザーが実行されている場所によっては、$sp_hostからブラウザーが実行されているマシンにSPメタデータをコピーして、ブラウザーがそのファイルを見つけなければならない場合があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:174
-#: source/server_admin/topics/user-federation/sssd.adoc:151
 msgid "Click *Save*."
-msgstr "*保存*をクリックします。"
+msgstr "*Save* をクリックします。"
 
 #. type: Title ======
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:175
 #, no-wrap
 msgid "Editing the Mellon SP Client"
 msgstr "Mellon SPクライアントの編集"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:178
 msgid "There are several client configuration parameters we suggest setting:"
 msgstr "いくつかのクライアント設定パラメータがあります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:180
 msgid "Ensure \"Force POST Binding\" is On."
 msgstr "\"Force POST Binding\"がオンになっていることを確認します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:181
 msgid "Add paosResponse to the Valid Redirect URIs list:"
 msgstr "有効なリダイレクトURIリストにpaosResponseを追加します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:182
 msgid ""
 "Copy the postResponse URL in \"Valid Redirect URIs\" and paste it into the "
 "empty add text fields just below the \"+\"."
-msgstr "\"有効なリダイレクトURI\"内のpostResponse URLをコピーし、 \"+\"のすぐ下の空の追加テキスト・フィールドに貼り付けます。"
+msgstr ""
+"\"Valid Redirect URIs\"内のpostResponse URLをコピーし、 "
+"\"+\"のすぐ下の空の追加テキスト・フィールドに貼り付けます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:183
 msgid ""
 "Change \"postResponse\" to \"paosResponse\". (The paosResponse URL is needed"
 " for SAML ECP.)"
-msgstr "\"postResponse\"を \"paosResponse\"に変更します(SAML ECPにはpaosResponse URLが必要です)。"
+msgstr "\"postResponse\"を\"paosResponse\"に変更します（SAML ECPにはpaosResponse URLが必要です）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:184
 msgid "Click *Save* at the bottom."
-msgstr "下部の*保存*をクリックして下さい。"
+msgstr "下部の *Save* をクリックして下さい。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:186
 msgid ""
 "Many SAML SPs determine authorization based on a user's membership in a "
 "group. The {project_name} IdP can manage user group information but it does "
 "not supply the user's groups unless the IdP is configured to supply it as a "
 "SAML attribute."
 msgstr ""
-"多くのSAML SPは、グループ内のユーザーのメンバーシップに基づいて認可を決定します。 "
-"{project_name}のIdPはユーザー・グループ情報を管理できますが、IdPがSAML属性としてそれを提供するように設定されていない限り、ユーザーのグループは提供されません。"
+"多くのSAML "
+"SPは、グループ内のユーザーのメンバーシップに基づいて認可を決定します。{project_name}のIdPはユーザー・グループ情報を管理できますが、IdPがSAML属性としてそれを提供するように設定されていない限り、ユーザーのグループは提供されません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:188
 msgid ""
 "To configure the IdP to supply the user's groups as as a SAML attribute, "
 "complete the following steps:"
-msgstr "ユーザーのグループにSAML属性を提供するようにIdPを設定するには、次の手順を実行します。"
+msgstr "ユーザーのグループをSAML属性として提供するようにIdPを設定するには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:190
 msgid "Click the Mappers tab of the client."
-msgstr "クライアントのマッパー・タブをクリックします。"
+msgstr "クライアントのMapperタブをクリックします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:191
 msgid "In the upper right corner of the Mappers page, click *Create*."
-msgstr "マッパー・ページの右上にある*作成*をクリックします。"
+msgstr "Mapperページの右上にある *Create* をクリックします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:192
 msgid "From the Mapper Type drop-down list select *Group list*."
-msgstr "マッパー・タイプのドロップダウン・リストから*グループリスト*を選択します。"
+msgstr "Mapper Typeのドロップダウン・リストから *Group list* を選択します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:193
 msgid "Set Name to \"group list.\""
-msgstr "「グループリスト」に名前を設定します。"
+msgstr "*group list* に名前を設定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:194
 msgid "Set the SAML attribute name to \"groups.\""
-msgstr "グループにSAML属性名を設定します。"
+msgstr "*groups* にSAML属性名を設定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:195
-msgid "Click *Save.*"
-msgstr "*保存*をクリックします。"
-
-#. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:197
 msgid "The remaining steps are performed on $sp_host."
 msgstr "残りの手順は$sp_hostで実行されます。"
 
 #. type: Title ======
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:198
 #, no-wrap
 msgid "Retrieving the Identity Provider Metadata"
-msgstr "アイデンティティ・プロバイダー・メタデータの取得"
+msgstr "アイデンティティー・プロバイダー・メタデータの取得"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:201
 msgid ""
 "Now that you have created the realm on the IdP you need to retrieve the IdP "
 "metadata associated with it so the Mellon SP recognizes it. In the "
@@ -707,18 +606,16 @@ msgid ""
 "until now that file has not existed on $sp_host. To get that file we will "
 "retrieve it from the IdP."
 msgstr ""
-"IdPでレルムを作成したので、それに関連付けられたIdPメタデータを取得して、Mellon SPがそれを認識できるようにする必要があります。 "
-"前に作成した`/etc/httpd/conf.d/mellon.conf`ファイルでは、`MellonIdPMetadataFile`は`/etc/httpd/saml2/idp_metadata.xml`として指定されていますが、そのファイルは$sp_host上に存在しませんでした。そのファイルを取得するには、IdPからファイルを検索します。"
+"IdPでレルムを作成したので、それに関連付けられたIdPメタデータを取得して、Mellon "
+"SPがそれを認識できるようにする必要があります。前に作成した/etc/httpd/conf.d/mellon.confファイルでは、MellonIdPMetadataFileは/etc/httpd/saml2/idp_metadata.xmlとして指定されていますが、そのファイルは$sp_host上に存在しませんでした。そのファイルを取得するには、IdPからファイルを検索します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:203
 msgid ""
 "Retrieve the file from the IdP by substituting $idp_host with the correct "
 "value:"
 msgstr "$idp_hostを正しい値に置き換えて、IdPからファイルを取得します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:208
 #, no-wrap
 msgid ""
 "curl -k -o /etc/httpd/saml2/idp_metadata.xml \\\n"
@@ -728,47 +625,39 @@ msgstr ""
 "https://$idp_host/auth/realms/test_realm/protocol/saml/descriptor\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:211
 msgid "Mellon is now fully configured."
-msgstr "Mellonは完全に設定されました。"
+msgstr "これでMellonの設定は完了となります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:213
 msgid "To run a syntax check for Apache configuration files:"
 msgstr "Apache設定ファイルの構文チェックを実行するには、次のようにします。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:217
 #, no-wrap
 msgid "apachectl configtest\n"
 msgstr "apachectl configtest\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:220
 msgid ""
 "Configtest is equivalent to the -t argument to apachectl. If the "
 "configuration test shows any errors, correct them before proceeding."
-msgstr ""
-"`configtest`は`apachectl`の`-t`引数に相当します。 設定テストでエラーが示された場合は、先に進む前に修正してください。"
+msgstr "Configtestは apachectl の -t 引数に相当します。設定テストでエラーが示された場合は、先に進む前に修正してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:222
 msgid "Restart the Apache server:"
 msgstr "Apacheサーバを再起動します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:226
 #, no-wrap
 msgid "systemctl restart httpd.service\n"
 msgstr "systemctl restart httpd.service\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/mod-auth-mellon.adoc:228
 msgid ""
 "You have now set up both {project_name} as a SAML IdP in the test_realm and "
 "mod_auth_mellon as SAML SP protecting the URL $sp_host/protected (and "
 "everything beneath it) by authenticating against the ``$idp_host`` IdP."
 msgstr ""
-"`$ "
-"idp_host``のIdPに対して認証することで、$sp_host/protected（とその配下すべて）のURLを保護するように、test_realmのSAML"
-" IdPとして{project_name}を、SAML SPとしてmod_auth_mellonを設定しました。"
+"``$ idp_host`` "
+"のIdPに対して認証することで、$sp_host/protected（とその配下すべて）のURLを保護するように、test_realmのSAML "
+"IdPとして{project_name}を、SAML SPとしてmod_auth_mellonを設定しました。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__mod-auth-mellon
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__mod-auth-mellon/ja_JP/index.html
