### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po
@@ -18,13 +18,13 @@ msgstr ""
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:2
 msgid "The changes that have been made for RH-SSO 7.1 include:"
-msgstr "RH-SSO7.1用の変更は、以下を含みます。"
+msgstr "RH-SSO 7.1用の変更は、以下を含みます。"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:4
 #, no-wrap
 msgid "**Templates**\n"
-msgstr "**Templates** \n"
+msgstr "**テンプレート**\n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:6
@@ -65,7 +65,7 @@ msgstr "ログイン：login.ftl"
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:14
 #, no-wrap
 msgid "**Messages**\n"
-msgstr "**Messages** \n"
+msgstr "**メッセージ**\n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:16
@@ -101,7 +101,7 @@ msgstr "ログイン：clientDisabledMessageが追加されました"
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:23
 #, no-wrap
 msgid "**Styles**\n"
-msgstr "**Styles** \n"
+msgstr "**スタイル**\n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:25

--- a/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po
@@ -2,113 +2,113 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:2
 msgid "The changes that have been made for RH-SSO 7.1 include:"
-msgstr ""
+msgstr "RH-SSO7.1用の変更は、以下を含みます。"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:4
 #, no-wrap
 msgid "**Templates**\n"
-msgstr ""
+msgstr "**Templates** \n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:6
 msgid "Account: account.ftl"
-msgstr ""
+msgstr "アカウント：account.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:7
 msgid "Account: federatedIdentity.ftl"
-msgstr ""
+msgstr "アカウント：federatedIdentity.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:8
 msgid "Account: totp.ftl"
-msgstr ""
+msgstr "アカウント：totp.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:9
 msgid "Login: info.ftl"
-msgstr ""
+msgstr "ログイン：info.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:10
 msgid "Login: login-config-totp.ftl"
-msgstr ""
+msgstr "ログイン：login-config-totp.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:11
 msgid "Login: login-reset-password.ftl"
-msgstr ""
+msgstr "ログイン：login-reset-password.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:12
 msgid "Login: login.ftl"
-msgstr ""
+msgstr "ログイン：login.ftl"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:14
 #, no-wrap
 msgid "**Messages**\n"
-msgstr ""
+msgstr "**Messages** \n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:16
 msgid "Account: editAccountHtmlTtile renamed to editAccountHtmlTitle"
-msgstr ""
+msgstr "アカウント：editAccountHtmlTtileはeditAccountHtmlTitleに名前が書き換えられました"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:17
 msgid "Account: role_uma_authorization added"
-msgstr ""
+msgstr "アカウント：role_uma_authorizationが追加されました"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:18
 msgid "Login: loginTotpStep1 value changed"
-msgstr ""
+msgstr "ログイン：loginTotpStep1の値が変更されました"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:19
 msgid "Login: invalidPasswordGenericMessage added"
-msgstr ""
+msgstr "ログイン：invalidPasswordGenericMessageが追加されました"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:20
 msgid "Login: invlidRequesterMessage renamed to invalidRequesterMessage"
-msgstr ""
+msgstr "ログイン：invlidRequesterMessageはinvalidRequesterMessageに名前が書き換えられました"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:21
 msgid "Login: clientDisabledMessage added"
-msgstr ""
+msgstr "ログイン：clientDisabledMessageが追加されました"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:23
 #, no-wrap
 msgid "**Styles**\n"
-msgstr ""
+msgstr "**Styles** \n"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:25
 msgid "Account: account.css"
-msgstr ""
+msgstr "アカウント：account.css"
 
 #. type: Plain text
 #: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:25
 msgid "Login: login.css"
-msgstr ""
+msgstr "ログイン：login.css"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__rhsso__migrate_themes-changes-71
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-upgrading__topics__rhsso__migrate_themes-changes-71/ja_JP/index.html
