### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
@@ -1,33 +1,34 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: hitanaka156 <thiroya@fsi.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/resource-server-overview.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Installing the Server"
+#, no-wrap
 msgid "Managing Resource Servers"
-msgstr "サーバーのインストール"
+msgstr "リソースサーバーの管理"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-overview.adoc:5
 msgid ""
-"According to the OAuth2 specification, a resource server is a server hosting "
-"the protected resources and capable of accepting and responding to protected "
-"resource requests."
+"According to the OAuth2 specification, a resource server is a server hosting"
+" the protected resources and capable of accepting and responding to "
+"protected resource requests."
 msgstr ""
+"OAuth2の仕様によれば、リソースサーバーは保護されたリソースをホストし、保護されたリソースへのリクエストを受け入れて応答することができるサーバーです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-overview.adoc:7
@@ -37,6 +38,7 @@ msgid ""
 "authorization decisions can be made based on different access control "
 "mechanisms."
 msgstr ""
+"{project_name}では、リソースサーバーに保護されたリソースに対してきめ細かい認可を与えるために豊富なプラットフォームが用意されており、異なるアクセス制御の仕組みに基いた認可決定を行うことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-overview.adoc:8
@@ -45,3 +47,5 @@ msgid ""
 "permissions. In doing so, you are conceptually turning the client "
 "application into a resource server."
 msgstr ""
+"きめ細かい権限をサポートするクライアントアプリケーションを構成することができます。\n"
+"その際に、概念的にクライアントアプリケーションをリソースサーバーに変換します。"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: hitanaka156 <thiroya@fsi.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgid ""
 " the protected resources and capable of accepting and responding to "
 "protected resource requests."
 msgstr ""
-"OAuth2の仕様によれば、リソースサーバーは保護されたリソースをホストし、保護されたリソースへのリクエストを受け入れて応答することができるサーバーです。"
+"OAuth2の仕様によれば、リソース・サーバーは保護されたリソースをホストし、保護されたリソースへのリクエストを受け入れて応答することができるサーバーです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-overview.adoc:7
@@ -38,7 +38,7 @@ msgid ""
 "authorization decisions can be made based on different access control "
 "mechanisms."
 msgstr ""
-"{project_name}では、リソースサーバーに保護されたリソースに対してきめ細かい認可を与えるために豊富なプラットフォームが用意されており、異なるアクセス制御の仕組みに基いた認可決定を行うことができます。"
+"{project_name}では、リソース・サーバーに保護されたリソースに対してきめ細かい認可を与えるための豊富なプラットフォームが用意されており、異なるアクセス制御の仕組みに基いた認可決定を行うことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-overview.adoc:8
@@ -47,5 +47,4 @@ msgid ""
 "permissions. In doing so, you are conceptually turning the client "
 "application into a resource server."
 msgstr ""
-"きめ細かい権限をサポートするクライアントアプリケーションを構成することができます。\n"
-"その際に、概念的にクライアントアプリケーションをリソースサーバーに変換します。"
+"きめ細かいパーミッションをサポートするクライアント・アプリケーションを設定することができます。その際に、概念的にクライアント・アプリケーションをリソース・サーバーに変換します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__resource-server-overview/ja_JP/index.html
