### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -16,172 +16,67 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:63
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:244
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:304
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:341
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:359
-#: source/server_admin/topics/admin-cli.adoc:17
-#: source/server_admin/topics/admin-cli.adoc:381
-#: source/server_admin/topics/admin-cli.adoc:392
 msgid "On Linux:"
 msgstr "Linuxの場合："
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:70
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:206
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:250
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:275
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:290
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:312
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:329
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:347
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:365
-#: source/server_admin/topics/admin-cli.adoc:22
 msgid "On Windows:"
 msgstr "Windowsの場合："
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:85
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:108
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:144
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:191
-#: source/server_admin/topics/admin-cli.adoc:42
-#: source/server_admin/topics/admin-cli.adoc:62
-#: source/server_admin/topics/admin-cli.adoc:221
-#: source/server_admin/topics/admin-cli.adoc:301
 msgid "For example on Linux:"
 msgstr "例えば、Linux の場合："
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:94
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:114
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:151
-#: source/server_admin/topics/admin-cli.adoc:50
-#: source/server_admin/topics/admin-cli.adoc:66
-#: source/server_admin/topics/admin-cli.adoc:227
-#: source/server_admin/topics/admin-cli.adoc:305
-#: source/server_admin/topics/admin-cli.adoc:322
-#: source/server_admin/topics/admin-cli.adoc:343
-#: source/server_admin/topics/admin-cli.adoc:385
-#: source/server_admin/topics/admin-cli.adoc:396
-#: source/server_admin/topics/admin-cli.adoc:708
-#: source/server_admin/topics/admin-cli.adoc:760
 msgid "Or on Windows:"
 msgstr "または、Windowsの場合："
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:161
-#: source/server_admin/topics/admin-cli.adoc:110
 #, no-wrap
 msgid "Working with alternative configurations"
 msgstr "代替設定の使用"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:22
-#: source/securing_apps/topics/oidc/java/fuse/camel.adoc:8
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:13
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:55
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:321
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:368
-#: source/server_admin/topics/admin-cli.adoc:101
-#: source/server_admin/topics/admin-cli.adoc:169
-#: source/server_admin/topics/admin-cli.adoc:281
-#: source/server_admin/topics/admin-cli.adoc:426
-#: source/server_admin/topics/admin-cli.adoc:452
-#: source/server_admin/topics/admin-cli.adoc:475
-#: source/server_admin/topics/admin-cli.adoc:485
-#: source/server_admin/topics/admin-cli.adoc:493
-#: source/server_admin/topics/admin-cli.adoc:504
-#: source/server_admin/topics/admin-cli.adoc:543
-#: source/server_admin/topics/admin-cli.adoc:550
-#: source/server_admin/topics/admin-cli.adoc:557
-#: source/server_admin/topics/admin-cli.adoc:569
-#: source/server_admin/topics/admin-cli.adoc:576
-#: source/server_admin/topics/admin-cli.adoc:583
-#: source/server_admin/topics/admin-cli.adoc:688
-#: source/server_admin/topics/admin-cli.adoc:697
-#: source/server_admin/topics/admin-cli.adoc:749
-#: source/server_admin/topics/admin-cli.adoc:784
-#: source/server_admin/topics/admin-cli.adoc:798
-#: source/server_admin/topics/admin-cli.adoc:805
-#: source/server_admin/topics/admin-cli.adoc:812
-#: source/server_admin/topics/admin-cli.adoc:824
-#: source/server_admin/topics/admin-cli.adoc:831
-#: source/server_admin/topics/admin-cli.adoc:838
-#: source/server_admin/topics/admin-cli.adoc:885
-#: source/server_admin/topics/admin-cli.adoc:932
-#: source/server_admin/topics/admin-cli.adoc:955
-#: source/server_admin/topics/admin-cli.adoc:973
-#: source/server_admin/topics/admin-cli.adoc:982
-#: source/server_admin/topics/admin-cli.adoc:991
-#: source/server_admin/topics/admin-cli.adoc:1004
-#: source/server_admin/topics/admin-cli.adoc:1011
-#: source/server_admin/topics/admin-cli.adoc:1018
-#: source/server_admin/topics/admin-cli.adoc:1030
-#: source/server_admin/topics/admin-cli.adoc:1037
-#: source/server_admin/topics/admin-cli.adoc:1044
-#: source/server_admin/topics/admin-cli.adoc:1073
-#: source/server_admin/topics/admin-cli.adoc:1091
-#: source/server_admin/topics/admin-cli.adoc:1106
-#: source/server_admin/topics/admin-cli.adoc:1173
-#: source/server_admin/topics/admin-cli.adoc:1201
-#: source/server_admin/topics/admin-cli.adoc:1211
-#: source/server_admin/topics/admin-cli.adoc:1220
-#: source/server_admin/topics/admin-cli.adoc:1229
-#: source/server_admin/topics/admin-cli.adoc:1242
-#: source/server_admin/topics/admin-cli.adoc:1252
-#: source/server_admin/topics/admin-cli.adoc:1262
-#: source/server_admin/topics/admin-cli.adoc:1272
-#: source/server_admin/topics/admin-cli.adoc:1282
 msgid "For example:"
 msgstr "例："
 
 #. type: Title ==
-#: source/server_admin/topics/admin-cli.adoc:2
 #, no-wrap
 msgid "Admin CLI"
 msgstr "管理CLI"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:6
 msgid ""
 "In previous chapters we have described how to use {project_name} Admin "
 "Console to perform administrative tasks.  All those tasks can also be "
 "performed from command line by using Admin CLI command line tool."
 msgstr ""
-"前の章では、{project_name} "
-"管理コンソールを使用して管理タスクを実行する方法について説明しました。これらのタスクはすべて、管理CLIコマンドライン・ツールを使用してコマンドラインから実行することもできます。"
+"前の章では、{project_name}管理コンソールを使用して管理タスクを実行する方法について説明しました。これらのタスクはすべて、管理CLIコマンドライン・ツールを使用してコマンドラインから実行することもできます。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:8
 #, no-wrap
 msgid "Installing Admin CLI"
 msgstr "管理CLIのインストール"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:11
 msgid ""
 "Admin CLI is packaged inside {project_name} Server distribution. You can "
 "find execution scripts inside `bin` directory."
 msgstr "管理CLIは、{project_name}サーバーの配布物に含まれています。 `bin` ディレクトリに実行スクリプトがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:13
 msgid ""
 "The Linux script is called `kcadm.sh`, and the one for Windows is called "
 "`kcadm.bat`."
-msgstr "Linuxの実行スクリプトは `kcadm.sh` 、Windowsの実行スクリプトは ` kcadm.bat` です。"
+msgstr "Linuxの実行スクリプトは `kcadm.sh` 、Windowsの実行スクリプトは `kcadm.bat` です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:15
 msgid ""
 "In order to use the client from any location on your filesystem you may want"
 " to add {project_name} server directory to your PATH."
 msgstr "ファイルシステム上の任意の場所からクライアントを使用するには、{project_name}サーバー・ディレクトリをPATHに追加します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:20
 #, no-wrap
 msgid ""
 "    $ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
@@ -191,7 +86,6 @@ msgstr ""
 " $ kcadm.sh\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:25
 #, no-wrap
 msgid ""
 "    c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
@@ -201,14 +95,12 @@ msgstr ""
 " c:\\> kcadm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:28
 msgid ""
 "We assume KEYCLOAK_HOME env variable is set to the path where you extracted "
 "{project_name} Server distribution."
 msgstr "環境変数KEYCLOAK_HOMEは、{project_name}サーバーの配布物を展開したパスに設定されているものとします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:31
 msgid ""
 "To avoid unnecessary repetition the rest of this document will only give "
 "Windows examples in places where difference in command line is more than "
@@ -218,35 +110,30 @@ msgstr ""
 "コマンド名以外にもある場所でのみ示します。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:33
 #, no-wrap
 msgid "Using Admin CLI"
 msgstr "管理CLIの利用"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:36
 msgid ""
 "Admin CLI works by making HTTP requests to Admin REST endpoints. Access to "
 "them is protected and requires authentication."
 msgstr ""
-"管理CLIは、管理RESTエンドポイントへのHTTP要求を作成することによって機能します。管理RESTエンドポイントへのアクセスは保護されており、認証が必要です。"
+"管理CLIは、管理RESTエンドポイントへのHTTPリクエストを作成することによって機能します。管理RESTエンドポイントへのアクセスは保護されており、認証が必要です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:38
 msgid ""
 "Consult Admin REST API documentation for details about JSON attributes for "
 "specific endpoints."
 msgstr "エンドポイントのJSON属性の詳細については、Admin REST APIのドキュメントを参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:40
 msgid ""
 "You start an authenticated session by providing credentials (i.e. logging "
 "in), then you are ready to perform some CRUD operations."
 msgstr "クレデンシャルを入力（例えばログイン）することで認証セッションを開始すると、CRUD操作を実行する準備が整います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:47
 #, no-wrap
 msgid ""
 "    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
@@ -260,7 +147,6 @@ msgstr ""
 " $ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:56
 #, no-wrap
 msgid ""
 "    c:\\> kcadm config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
@@ -276,7 +162,6 @@ msgstr ""
 " c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:60
 msgid ""
 "In a production environment {project_name} has to be accessed with `https:` "
 "to avoid exposing tokens to network sniffers. If server's certificate is not"
@@ -289,7 +174,6 @@ msgstr ""
 " `truststore.jks` ファイルを準備し、それを使用するように `管理CLI` に指示する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:64
 #, no-wrap
 msgid ""
 "    $ kcadm.sh config truststore --trustpass $PASSWORD "
@@ -299,7 +183,6 @@ msgstr ""
 "~/.keycloak/truststore.jks\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:68
 #, no-wrap
 msgid ""
 "    c:\\> kcadm config truststore --trustpass %PASSWORD% "
@@ -309,13 +192,11 @@ msgstr ""
 "%HOMEPATH%\\.keycloak\\truststore.jks\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:70
 #, no-wrap
 msgid "Authenticating"
-msgstr "認証する"
+msgstr "認証"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:76
 msgid ""
 "When logging in with `Admin CLI` you specify a server endpoint url, and a "
 "realm. Then you specify a username, or alternatively you can specify only a "
@@ -326,10 +207,9 @@ msgid ""
 msgstr ""
 "`管理CLI` "
 "でログインするときに、サーバーのエンドポイントのURLとレルムを指定します。その後、ユーザー名かクライアントIDを指定します。クライアントIDを指定することで、特別な、いわゆる「サービスアカウント」が使用されます。ユーザー名を指定する場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。クライアントIDを指定する場合、ユーザー・パスワードはなく、クライアント・シークレットのみです。"
-" '署名付きJWT' を使用することもできます。"
+" `署名付きJWT` を使用することもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:79
 msgid ""
 "The account used for the session needs to have proper permissions in order "
 "to be able to invoke Admin REST API operations.  For example, `realm-admin` "
@@ -340,7 +220,6 @@ msgstr ""
 "クライアントの `realm-admin` ロールは、ユーザが定義されているレルムを管理することを許可します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:82
 msgid ""
 "There are two primary mechanisms for authentication. One is using `kcadm "
 "config credentials` to start an authenticated session:"
@@ -348,7 +227,6 @@ msgstr ""
 "認証には主に2つのメカニズムがあります。1つは認証されたセッションを開始するために `kcadm config credentials` を使用します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:84
 #, no-wrap
 msgid ""
 "    $ kcadm.sh config credentials --server http://localhost:8080/auth "
@@ -358,7 +236,6 @@ msgstr ""
 "master --user admin --password admin\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:87
 msgid ""
 "This approach maintains an authenticated session between `kcadm` command "
 "invocations by saving the obtained access token, and associated refresh "
@@ -372,7 +249,6 @@ msgstr ""
 " 次の章>>を参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:91
 msgid ""
 "Another approach is to authenticate with each command invocation for the "
 "duration of that invocation only. This approach results in more load on the "
@@ -385,14 +261,12 @@ msgstr ""
 " `--no-config` 引数が指定されている場合に使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:93
 msgid ""
 "For example, when performing an operation we specify all the information "
 "required for authentication:"
 msgstr "たとえば、操作を実行するときには、認証に必要なすべての情報を指定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:95
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get realms --no-config --server http://localhost:8080/auth "
@@ -402,18 +276,15 @@ msgstr ""
 "--realm master --user admin --password admin\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:98
 msgid "See built-in help for more information on using `Admin CLI`."
 msgstr "`管理CLI` の使用方法の詳細については、組み込みヘルプを参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:103
 #, no-wrap
 msgid "    $ kcadm.sh help\n"
 msgstr "$ kcadm.sh help\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:106
 msgid ""
 "See `kcadm.sh config credentials --help` for more information about starting"
 " an authenticated session."
@@ -421,7 +292,6 @@ msgstr ""
 "認証されたセッションの開始の詳細については、 `kcadm.sh config credentials --help` を参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:114
 msgid ""
 "By default, `Admin CLI` automatically maintains a configuration file called "
 "`kcadm.config` located under user's home directory - it's full pathname is "
@@ -433,7 +303,6 @@ msgstr ""
 "`%HOMEPATH%\\.keycloak\\kcadm.config` ）。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:117
 msgid ""
 "You can use `--config` option to point to a different file / location. This "
 "way you can maintain multiple authenticated sessions in parallel."
@@ -441,14 +310,12 @@ msgstr ""
 "`--config` オプションを使うと、別のファイル／場所を指すことができます。これにより、複数の認証済みセッションを並行して維持できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:119
 msgid ""
 "It's best to perform operations tied to a single config file from a single "
 "thread."
 msgstr "単一のスレッドから単一の設定ファイルに結び付けられた操作を実行するのが最善です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:123
 msgid ""
 "Make sure to not make config file visible to other users on the system as it"
 " contains access tokens, and secrets that should be kept private.  By "
@@ -459,7 +326,6 @@ msgstr ""
 "非公開とすべきアクセス・トークンとシークレットを含んでいるため、設定ファイルは他のユーザーに見えないようにしてください。デフォルトでは~/.keycloakディレクトリとその内容は、適切なアクセス制限で自動的に作成されます。ただし、デフォルト以外のアクセス権を持つディレクトリがすでに存在する場合、そのアクセス権は更新されません。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:127
 msgid ""
 "You may want to avoid storing any secrets at all inside a config file for "
 "the price of less convenience and having to do more token requests.  In that"
@@ -472,13 +338,11 @@ msgstr ""
 "コマンドが必要とするすべての認証情報を指定する必要があります。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:130
 #, no-wrap
 msgid "Basic operations, and resource URIs"
 msgstr "基本操作、およびリソースURI"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:134
 msgid ""
 "Admin CLI allows you to perform CRUD operations against Admin REST API "
 "endpoints in quite a generic way, with additional commands that simplify "
@@ -488,12 +352,10 @@ msgstr ""
 "APIエンドポイントに対してCRUD操作を実行できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:136
 msgid "Main usage pattern is the following:"
 msgstr "主な使用パターンは次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:141
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create ENDPOINT [ARGUMENTS]\n"
@@ -507,7 +369,6 @@ msgstr ""
 " $ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:145
 msgid ""
 "Where operations `create`, `get`, `update`, and `delete` are mapped to HTTP "
 "verbs POST, GET, PUT, and DELETE, respectively.  ENDPOINT is a target "
@@ -520,13 +381,11 @@ msgstr ""
 "'http:' または 'https:' で始まる、絶対パスか相対パスです。相対パスは次の形式の絶対URLを作成するために使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:147
 #, no-wrap
 msgid "    SERVER_URI/admin/realms/REALM/ENDPOINT\n"
 msgstr "SERVER_URI/admin/realms/REALM/ENDPOINT\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:151
 msgid ""
 "For example, if the server we authenticate against is "
 "`http://localhost:8080/auth`, and realm is `master`, then using `users` as "
@@ -538,7 +397,6 @@ msgstr ""
 "`http://localhost:8080/auth/admin/realms/master/users`"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:153
 msgid ""
 "If we set ENDPOINT to `clients` the effective resource URI would be: "
 "`http://localhost:8080/auth/admin/realms/master/clients`."
@@ -547,27 +405,23 @@ msgstr ""
 "`http://localhost:8080/auth/admin/realms/master/clients`"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:155
 msgid ""
 "There is `realms` endpoint which is treated slightly differently since it is"
 " the container for realms. It resolves simply to:"
 msgstr "レルムのコンテナであるため、わずかに異なって扱われる `realms` エンドポイントがあり、単純に次のように解決されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:157
 #, no-wrap
 msgid "    SERVER_URI/admin/realms\n"
 msgstr "SERVER_URI/admin/realms\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:160
 msgid ""
 "There is also `serverinfo` which is treated the same way since it is "
 "independent of realms."
 msgstr "レルムから独立している`serverinfo` も同様に扱われます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:164
 msgid ""
 "When authenticating as a user with realm-admin powers you may need to "
 "perform operations on multiple different realms. In that case you can "
@@ -580,13 +434,11 @@ msgstr ""
 "credentials` の `--realm` オプションで指定されたREALMを使用する代わりに、TARGET_REALMが使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:166
 #, no-wrap
 msgid "    SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
 msgstr "SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:172
 #, no-wrap
 msgid ""
 "    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
@@ -596,23 +448,20 @@ msgstr ""
 " $ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:175
 msgid ""
 "In this example we first start a session authenticated as `admin` user in "
 "`master` realm. Then we perform a POST call against the following resource "
 "URL:"
 msgstr ""
 "この例では、最初に `master` レルムで `admin` "
-"ユーザとして認証されたセッションを開始してから、次のリソースURLに対してPOST呼び出しを実行します。"
+"ユーザーとして認証されたセッションを開始してから、次のリソースURLに対してPOST呼び出しを実行します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:177
 #, no-wrap
 msgid "    http://localhost:8080/auth/admin/realms/demorealm/users\n"
 msgstr "http://localhost:8080/auth/admin/realms/demorealm/users\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:182
 msgid ""
 "Commands `create` and `update` by default send JSON body to the server. You "
 "can use `-f FILENAME` to read a pre-made document from a file.  You can use "
@@ -626,7 +475,6 @@ msgstr ""
 "`create users` の例に見られるように、個々の属性とその値を指定することもでき、それらはJSON本体に合成されてサーバーに送られます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:186
 msgid ""
 "When using `update` there are several ways to update a resource. You can "
 "first get current state of a resource, and save it into a file, then edit "
@@ -636,8 +484,6 @@ msgstr ""
 "を使うときは、リソースを更新するいくつかの方法があります。まず、最初にリソースの現在の状態を取得してファイルに保存してから、そのファイルを編集してサーバーに送信して更新する方法があります。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:190
-#: source/server_admin/topics/admin-cli.adoc:267
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get realms/demorealm > demorealm.json\n"
@@ -649,33 +495,27 @@ msgstr ""
 " $ kcadm.sh update realms/demorealm -f demorealm.json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:192
 msgid ""
 "This way the resource on the server will be updated with all the attributes "
 "in the sent JSON document."
 msgstr "この方法では、サーバー上のリソースは、送信されたJSONドキュメントのすべての属性で更新されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:194
 msgid ""
 "Another option is to perform an update on-the-fly using `-s, --set` options "
 "to set new values. For example:"
 msgstr "別の選択肢としては `-s、--set` オプションを使ってその場でアップデートを実行して新しい値を設定することです。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:196
-#: source/server_admin/topics/admin-cli.adoc:261
 #, no-wrap
 msgid "    $ kcadm.sh update realms/demorealm -s enabled=false\n"
 msgstr "$ kcadm.sh update realms/demorealm -s enabled=false\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:198
 msgid "That would only update `enabled` attribute to `false`."
 msgstr "とすると `enabled` 属性を ` false` に更新するだけです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:202
 msgid ""
 "By default `update` operation first performs a `get`, and then merges new "
 "attribute values with existing.  Mostly this is a preferred behaviour. In "
@@ -689,19 +529,16 @@ msgstr ""
 "アップデートを実行できます。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:204
 #, no-wrap
 msgid "Realm operations"
 msgstr "レルム操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:206
 #, no-wrap
 msgid "Creating a new realm"
 msgstr "新しいレルムを作成する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:209
 msgid ""
 "To create a new enabled realm use `create` operation on `realms` endpoint, "
 "and set attributes `realm` and `enabled`:"
@@ -710,38 +547,32 @@ msgstr ""
 "属性を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:211
 #, no-wrap
 msgid "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
 msgstr "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:213
 msgid ""
 "Realm is not enabled by default. By enabling it, it can be used for "
 "authentication immediately."
 msgstr "レルムはデフォルトでは有効になっていません。有効にすると、すぐに認証に使用できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:215
 msgid "A description for a new object can be in JSON format as well:"
 msgstr "新しいオブジェクトはJSON形式で記述することもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:217
 #, no-wrap
 msgid "    $ kcadm.sh create realms -f demorealm.json\n"
 msgstr "$ kcadm.sh create realms -f demorealm.json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:219
 msgid ""
 "JSON document with realm attributes can be sent directly from file or piped "
 "to standard input."
 msgstr "レルム属性を持つJSONドキュメントは、ファイルから直接、またはパイプで標準入力に送信できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:225
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create realms -f - << EOF\n"
@@ -753,7 +584,6 @@ msgstr ""
 " EOF\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:229
 #, no-wrap
 msgid ""
 "    c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm "
@@ -763,31 +593,26 @@ msgstr ""
 "realms -f -\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:231
 #, no-wrap
 msgid "Listing existing realms"
 msgstr "既存レルムの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:234
 msgid "The following will return a list of all realms:"
 msgstr "次の例は、すべてのレルムのリストを返します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:236
 #, no-wrap
 msgid "    $ kcadm.sh get realms\n"
 msgstr "    $ kcadm.sh get realms\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:238
 msgid ""
 "Note that a list of realms is additionally filtered on the server to only "
 "return realms user is allowed to see."
-msgstr "レルムのリストは、ユーザが見ることができるレルムだけを返すために、サーバ上でさらにフィルタリングされることに注意してください。"
+msgstr "レルムのリストは、ユーザーが参照できるレルムだけを返すように、サーバー上でさらにフィルタリングされることに注意してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:241
 msgid ""
 "Returning the whole realm description is often too much information as we "
 "are often only interested in a subset of attributes like realm name, and if "
@@ -798,56 +623,47 @@ msgstr ""
 " `fields` オプションを使って返す属性を指定することができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:243
 #, no-wrap
 msgid "    $ kcadm.sh get realms --fields realm,enabled\n"
 msgstr "    $ kcadm.sh get realms --fields realm,enabled\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:245
 msgid "You can even display the result as comma separated values:"
 msgstr "結果をカンマ区切りの値として表示することもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:247
 #, no-wrap
 msgid "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
 msgstr "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:249
 #, no-wrap
 msgid "Getting a specific realm"
 msgstr "特定のレルムを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:252
 msgid ""
 "As is common for REST web services, in order to get an individual item of a "
 "collection, append an id to collection URI:"
 msgstr "REST Webサービスに共通するように、コレクションの個々の項目を取得するには、コレクションURIにIDを追加します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:254
 #, no-wrap
 msgid "    $ kcadm.sh get realms/master\n"
 msgstr "    $ kcadm.sh get realms/master\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:256
 #, no-wrap
 msgid "Updating a realm"
 msgstr "レルムの更新"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:259
 msgid ""
 "In order to only change some attributes of the realm use `-s` to set new "
 "values for the attributes. For example:"
 msgstr "レルムの一部の属性のみを変更するには、 `-s` を使って属性の新しい値を設定します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:263
 msgid ""
 "If you want to set all writable attributes with new values, perform a `get` "
 "first, edit current values in JSON file, and resubmit. For example:"
@@ -855,35 +671,29 @@ msgstr ""
 "書き込み可能なすべての属性を新しい値に設定する場合は、最初に `get` を実行し、JSONファイルの現在の値を編集して再送信してください。例えば："
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:269
 #, no-wrap
 msgid "Deleting a realm"
 msgstr "レルムの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:272
 msgid "Here is how to delete a realm:"
 msgstr "レルムを削除する方法は次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:274
 #, no-wrap
 msgid "    $ kcadm.sh delete realms/demorealm\n"
 msgstr "    $ kcadm.sh delete realms/demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:276
 #, no-wrap
 msgid "Turning on all login page options for the realm"
 msgstr "レルムのすべてのログイン・ページ・オプションを有効にする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:279
 msgid "Set the attributes controlling specific capabilities to `true`."
 msgstr "特定の機能を制御する属性を `true` に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:283
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update realms/demorealm -s registrationAllowed=true -s "
@@ -895,46 +705,37 @@ msgstr ""
 "resetPasswordAllowed=true -s editUsernameAllowed=true\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:285
 #, no-wrap
 msgid "Listing the realm keys"
 msgstr "レルム鍵の一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:288
 msgid "Use `get` operation on `keys` endpoint of the target realm:"
 msgstr "対象レルムの `keys` エンドポイントで `get` 操作を使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:290
-#: source/server_admin/topics/admin-cli.adoc:335
-#: source/server_admin/topics/admin-cli.adoc:362
 #, no-wrap
 msgid "    $ kcadm.sh get keys -r demorealm\n"
 msgstr "$ kcadm.sh get keys -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:292
 #, no-wrap
 msgid "Generating new realm keys"
 msgstr "新しいレルム鍵の生成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:295
 msgid ""
 "To add a new RSA generated keypair, first get `id` of the target realm. For "
 "example:"
-msgstr "新しいRSAキーペアを追加するには、まず対象レルムの `id` を取得します。例えば："
+msgstr "新たにRSAで生成されたキーペアを追加するには、まず対象レルムの `id` を取得します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:297
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
 msgstr "$ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:299
 msgid ""
 "Then add a new key provider with higher priority than any of the existing "
 "providers as revealed by `kcadm.sh get keys -r demorealm`:"
@@ -943,7 +744,6 @@ msgstr ""
 "で判明したどの既存のプロバイダーよりも高い優先順位で、新しいキー・プロバイダーを追加します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:303
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=rsa-generated -s "
@@ -959,7 +759,6 @@ msgstr ""
 "'config.keySize=[\"2048\"]'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:307
 #, no-wrap
 msgid ""
 "    c:\\> kcadm create components -r demorealm -s name=rsa-generated -s "
@@ -975,39 +774,32 @@ msgstr ""
 "\"config.active=[\\\"true\\\"]\" -s \"config.keySize=[\\\"2048\\\"]\"\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:309
-#: source/server_admin/topics/admin-cli.adoc:328
 msgid ""
 "Attribute `parentId` should be set to the value of target realm's `id`."
 msgstr "`parentId` 属性は対象レルムの `id` の値に設定されなければなりません。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:311
 msgid ""
 "The newly added key should now become the active key as revealed by "
 "`kcadm.sh get keys -r demorealm`."
 msgstr "`kcadm.sh get keys -r demorealm` で確認すると、新しく追加した鍵がアクティブな鍵になっているはずです。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:313
 #, no-wrap
 msgid "Adding new realm keys from Java Key Store file"
 msgstr "Javaキーストア・ファイルから新しいレルム鍵を追加する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:316
 msgid ""
 "To add a new keypair already prepared as a JKS file on the server, add a new"
 " key provider as follows:"
 msgstr "すでにサーバー上にJKSファイルとして準備されている新しい鍵ペアを追加するには、次のように新しい鍵プロバイダーを追加します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:318
 msgid "For exmple on Linux:"
 msgstr "例えば、Linux の場合："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:320
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=java-keystore -s "
@@ -1027,7 +819,6 @@ msgstr ""
 "-s 'config.alias=[\"localhost\"]'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:324
 #, no-wrap
 msgid ""
 "    c:\\> kcadm create components -r demorealm -s name=java-keystore -s "
@@ -1051,7 +842,6 @@ msgstr ""
 "\"config.alias=[\\\"localhost\\\"]\"\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:326
 msgid ""
 "Make sure to change attribute values for `keystore`, `keystorePassword`, "
 "`keyPassword`, and `alias` to match your specific keystore."
@@ -1060,19 +850,15 @@ msgstr ""
 "`alias` の属性値を必ず変更してください。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:330
 #, no-wrap
 msgid "Making key passive or disabling it"
 msgstr "鍵をパッシブにするか無効にする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:333
-#: source/server_admin/topics/admin-cli.adoc:360
 msgid "Identify the key you wish to make passive:"
 msgstr "パッシブにする鍵を特定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:337
 msgid ""
 "Use `providerId` attribute of the key to construct an endpoint uri - "
 "`components/PROVIDER_ID`."
@@ -1080,12 +866,10 @@ msgstr ""
 "エンドポイントURI `components/PROVIDER_ID` を構築するのに鍵の `providerId` 属性を使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:339
 msgid "Then perform an `update`. For example on Linux:"
 msgstr "次に、 `update` を実行します。たとえばLinuxの場合："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:341
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update components/PROVIDER_ID -r demorealm -s "
@@ -1095,7 +879,6 @@ msgstr ""
 "'config.active=[\"false\"]'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:345
 #, no-wrap
 msgid ""
 "    c:\\> kcadm update components/PROVIDER_ID -r demorealm -s "
@@ -1105,32 +888,27 @@ msgstr ""
 "\"config.active=[\\\"false\\\"]\"\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:348
 msgid "Analogously, other key attributes can be updated."
 msgstr "同様に、他の鍵属性も更新できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:350
 msgid ""
 "To disable the key set new `enabled` value, for example: "
 "`'config.enabled=[\"false\"]'`"
 msgstr "鍵を無効にするには、新しい `enabled` 値を設定します。たとえば： `'config.enabled=[\"false\"]'`"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:352
 msgid ""
 "To change key's priority set new `priority` value, for example: "
 "`'config.priority=[\"110\"]'`"
 msgstr "鍵の優先度を変更するには、新しい `priority` 値を設定します。たとえば： `'config.priority=[\"110\"]'`"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:354
 #, no-wrap
 msgid "Deleting an old key"
 msgstr "古い鍵を削除する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:358
 msgid ""
 "Make sure that the key you are deleting has been passive for some time, and "
 "then disabled for some time in order to prevent any existing tokens held by "
@@ -1139,29 +917,24 @@ msgstr ""
 "必ず、削除する鍵がしばらくの間パッシブであることを確認してから、さらにしばらくの間無効にして、アプリケーションやユーザーが保持している既存のトークンが突然動作しなくなることを防止してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:364
 msgid "Use the `providerId` of that key to perform a delete. For example:"
 msgstr "その鍵の `providerId` を使って削除を行います。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:366
 #, no-wrap
 msgid "    $ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
 msgstr "$ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:368
 #, no-wrap
 msgid "Configuring event logging for a realm"
 msgstr "レルムのイベントログの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:371
 msgid "Use `update` on `events/config` endpoint."
 msgstr "`events/config` エンドポイントで `update` を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:376
 msgid ""
 "Attribute `eventsListeners` contains a list of EventListenerProviderFactory "
 "ids, specifying all event listeners receiving events.  Separately, there are"
@@ -1180,7 +953,6 @@ msgstr ""
 "'eventsExpiration' は有効期限（秒単位）に設定されています。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:379
 msgid ""
 "Here is an example of setting up a built-in event listener that will receive"
 " all the events and log them through jboss-logging (error events are logged "
@@ -1190,7 +962,6 @@ msgstr ""
 " `WARN` として、他は `DEBUG` として `org.keycloak.events` というロガーを使って記録されます）。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:383
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update events/config -r demorealm -s 'eventsListeners"
@@ -1200,7 +971,6 @@ msgstr ""
 "logging\"]'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:387
 #, no-wrap
 msgid ""
 "    c:\\> kcadm update events/config -r demorealm -s \"eventsListeners"
@@ -1210,7 +980,6 @@ msgstr ""
 "=[\\\"jboss-logging\\\"]\"\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:390
 msgid ""
 "Here is an example of turning on storage of all available ERROR events - not"
 " including auditing events - for 2 days so they can be retrieved via Admin "
@@ -1218,7 +987,6 @@ msgid ""
 msgstr "次に、利用可能なすべてのERRORイベント（監査イベントを除く）の保管を2日間有効にする例を示します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:394
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update events/config -r demorealm -s eventsEnabled=true -s "
@@ -1230,7 +998,6 @@ msgstr ""
 " -s eventsExpiration=172800\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:398
 #, no-wrap
 msgid ""
 "    c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s "
@@ -1242,7 +1009,6 @@ msgstr ""
 " -s eventsExpiration=172800\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:400
 msgid ""
 "Here is how you reset stored event types to *all available event types* - "
 "setting to empty list is the same as enumerating all:"
@@ -1251,19 +1017,16 @@ msgstr ""
 "にリセットする方法を示します。空のリストに設定することは、すべてを列挙することと同じです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:402
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
 msgstr "$ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:405
 msgid "And here is how you enable storage of auditing events:"
 msgstr "監査イベントの保管を有効にする方法は次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:407
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true "
@@ -1273,37 +1036,31 @@ msgstr ""
 "adminEventsDetailsEnabled=true\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:410
 msgid ""
 "Here is how you get the last 100 events - they are ordered from newest to "
 "oldest:"
 msgstr "最後の100イベントを取得する方法は次のとおりです。最新のものから古いものまで順番に並べ替えられています。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:412
 #, no-wrap
 msgid "    $ kcadm.sh get events --offset 0 --limit 100\n"
 msgstr "$ kcadm.sh get events --offset 0 --limit 100\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:415
 msgid "Here is how you delete all saved events:"
 msgstr "保存されたすべてのイベントを削除する方法は次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:417
 #, no-wrap
 msgid "    $ kcadm delete events\n"
 msgstr "$ kcadm delete events\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:419
 #, no-wrap
 msgid "Flushing the caches"
 msgstr "キャッシュのフラッシュ"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:422
 msgid ""
 "Use `create` operation, and one of the following endpoints: `clear-realm-"
 "cache`, `clear-user-cache`, `clear-keys-cache`."
@@ -1312,48 +1069,40 @@ msgstr ""
 " エンドポイントのいずれかを使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:424
 msgid "Set `realm` to the same value as target realm."
 msgstr "`realm` の値を対象のレルムに設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:428
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
 msgstr "$ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:430
 #, no-wrap
 msgid "    $ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
 msgstr "$ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:432
 #, no-wrap
 msgid "    $ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
 msgstr "$ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:434
 #, no-wrap
 msgid "Role operations"
 msgstr "ロール操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:436
 #, no-wrap
 msgid "Creating a realm role"
 msgstr "レルム・ロールの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:439
 msgid "To create a realm role use `roles` endpoint:"
 msgstr "レルム・ロールを作成するには `roles` エンドポイントを使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:441
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create roles -r demorealm -s name=user -s "
@@ -1363,27 +1112,22 @@ msgstr ""
 "user with limited set of permissions'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:443
 #, no-wrap
 msgid "Creating a client role"
 msgstr "クライアント・ロールの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:446
 msgid ""
 "To create a client role identify the client first - use `get` to list "
 "available clients:"
 msgstr "クライアント・ロールを作成するには、まずクライアントを確認します。利用可能なクライアントを一覧表示するには `get` を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:448
-#: source/server_admin/topics/admin-cli.adoc:665
 #, no-wrap
 msgid "    $ kcadm.sh get clients -r demorealm --fields id,clientId\n"
 msgstr "$ kcadm.sh get clients -r demorealm --fields id,clientId\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:450
 msgid ""
 "Then, create a new role by using client's `id` attribute to construct an "
 "endpoint uri - `clients/ID/roles`."
@@ -1391,7 +1135,6 @@ msgstr ""
 "次に、クライアントの `id` 属性を使用して構築したエンドポイントuri `clients/ID/roles` によって新しいロールを作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:454
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles -r "
@@ -1403,41 +1146,34 @@ msgstr ""
 "article'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:456
 #, no-wrap
 msgid "Listing realm roles"
 msgstr "レルム・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:459
 msgid "To list existing realm roles use `get` command on `roles` endpoint:"
 msgstr "既存のレルム・ロールを一覧表示するには、 `roles` エンドポイントで `get` コマンドを使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:461
 #, no-wrap
 msgid "    $ kcadm.sh get roles -r demorealm\n"
 msgstr "$ kcadm.sh get roles -r demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:463
 msgid "You can also use `get-roles` command:"
 msgstr "`get-roles` コマンドを使うこともできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:465
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm\n"
 msgstr "$ kcadm.sh get-roles -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:467
 #, no-wrap
 msgid "Listing client roles"
 msgstr "クライアント・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:471
 msgid ""
 "There is a dedicated `get-roles` command to simplify listing of both realm "
 "and client roles. It is an extension of `get` command and so it behaves the "
@@ -1447,7 +1183,6 @@ msgstr ""
 "コマンドの拡張であるため、ロールを一覧表示するための追加のセマンティクスで同じように動作します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:473
 msgid ""
 "To list client roles use `get-roles` command, passing it either `clientId` "
 "(via `--cclientid` option) or `id` (via `--cid` option) to identify the "
@@ -1457,19 +1192,16 @@ msgstr ""
 "オプションで）または `id` （ `--cid` オプションで）を渡してクライアントを識別します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:477
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:480
 #, no-wrap
 msgid "Getting a specific realm role"
 msgstr "特定のレルム・ロールを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:483
 msgid ""
 "Use `get` command, and role `name` to construct an endpoint uri for a "
 "specific realm role - `roles/ROLE_NAME`"
@@ -1477,18 +1209,15 @@ msgstr ""
 "`get` コマンドとロール ` name` を使用して特定のレルム・ロールのエンドポイントuri `roles/ROLE_NAME` を構築します"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:487
 #, no-wrap
 msgid "    $ kcadm.sh get roles/user -r demorealm\n"
 msgstr "$ kcadm.sh get roles/user -r demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:489
 msgid "Where `user` is the name of existing role."
 msgstr "`user` は既存のロール名です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:491
 msgid ""
 "Alternatively, use special `get-roles` command, passing it role `name` (via "
 "`--rolename` option) or `id` (via `--roleid` option)."
@@ -1497,19 +1226,16 @@ msgstr ""
 "`--roleid` オプションで）を渡してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:495
 #, no-wrap
 msgid "   $ kcadm.sh get-roles -r demorealm --rolename user\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rolename user\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:498
 #, no-wrap
 msgid "Getting a specific client role"
 msgstr "特定のクライアント・ロールを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:502
 msgid ""
 "Use a dedicated `get-roles` command, passing it either `clientId` (via "
 "`--cclientid` option) or `id` (via `--cid` option) to identify the client, "
@@ -1521,7 +1247,6 @@ msgstr ""
 "オプションで）を使用して特定のクライアント・ロールを識別します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:506
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --cclientid realm-management "
@@ -1531,20 +1256,17 @@ msgstr ""
 "manage-clients\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:508
 #, no-wrap
 msgid "Updating a realm role"
 msgstr "レルム・ロールの更新"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:511
 msgid ""
 "Use `update` operation with the same endpoint uri as for getting a specific "
 "realm role. For example:"
 msgstr "特定のレルム・ロールを取得する場合と同じエンドポイントuriで `update` オペレーションを使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:513
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update roles/user -r demorealm -s 'description=Role "
@@ -1554,20 +1276,17 @@ msgstr ""
 "a regular user'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:515
 #, no-wrap
 msgid "Updating a client role"
 msgstr "クライアント・ロールの更新"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:518
 msgid ""
 "Use `update` operation with the same endpoint uri as for getting a specific "
 "client role. For example:"
 msgstr "特定のクライアント・ロールを取得する場合と同じエンドポイントuriで `update` オペレーションを使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:520
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-"
@@ -1578,39 +1297,33 @@ msgstr ""
 "-r demorealm -s 'description=User that can edit, and publish articles'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:522
 #, no-wrap
 msgid "Deleting a realm role"
 msgstr "レルム・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:525
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "realm role. For example:"
 msgstr "特定のレルム・ロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:527
 #, no-wrap
 msgid "    $ kcadm.sh delete roles/user -r demorealm\n"
 msgstr "$ kcadm.sh delete roles/user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:529
 #, no-wrap
 msgid "Deleting a client role"
 msgstr "クライアント・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:532
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "client role. For example:"
-msgstr "特定のクライアントロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
+msgstr "特定のクライアント・ロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:534
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-"
@@ -1620,22 +1333,16 @@ msgstr ""
 "-r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:536
 #, no-wrap
 msgid ""
 "Listing assigned, available and effective realm roles for a composite role"
 msgstr "複合ロールに割り当てられた、利用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:539
-#: source/server_admin/topics/admin-cli.adoc:564
-#: source/server_admin/topics/admin-cli.adoc:794
-#: source/server_admin/topics/admin-cli.adoc:819
 msgid "Use a dedicated `get-roles` command."
 msgstr "専用の `get-roles` コマンドを使用してください"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:541
 msgid ""
 "To list *assigned* realm roles for the composite role you can specify the "
 "target composite role by either `name` (via --rname option) or `id` (via "
@@ -1645,49 +1352,37 @@ msgstr ""
 "`--rid` オプションで）のいずれかで対象の複合ロールを指定できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:545
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:548
-#: source/server_admin/topics/admin-cli.adoc:574
-#: source/server_admin/topics/admin-cli.adoc:803
-#: source/server_admin/topics/admin-cli.adoc:829
-#: source/server_admin/topics/admin-cli.adoc:1009
-#: source/server_admin/topics/admin-cli.adoc:1035
 msgid "To list *effective* realm roles, use additional `--effective` option."
 msgstr "*有効な* レルム・ロールを一覧表示するには、 `--effective` オプションを追加してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:552
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:555
 msgid ""
 "To list realm roles that can still be added to the composite role, use "
 "`--available` option instead."
 msgstr "複合ロールにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:559
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:561
 #, no-wrap
 msgid ""
 "Listing assigned, available, and effective client roles for a composite role"
 msgstr "複合ロールに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:567
 msgid ""
 "To list *assigned* client roles for the composite role you can specify the "
 "target composite role by either `name` (via --rname option)  or `id` (via "
@@ -1699,7 +1394,6 @@ msgstr ""
 "`id` （ `--cid` オプションで）のどちらかでクライアントを指定できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:571
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1709,7 +1403,6 @@ msgstr ""
 "management\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:578
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1719,14 +1412,12 @@ msgstr ""
 "management --effective\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:581
 msgid ""
 "To list realm roles that can still be added to the target composite role, "
 "use `--available` option instead."
 msgstr "対象の複合ロールにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:585
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1736,75 +1427,63 @@ msgstr ""
 "management --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:587
 #, no-wrap
 msgid "Adding realm roles to a composite role"
 msgstr "レルム・ロールを複合ロールに追加する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:590
 msgid ""
 "There is a dedicated `add-roles` command that can be used for adding both "
 "realm roles and client roles."
 msgstr "レルム・ロールとクライアント・ロールの両方を追加するために使用できる専用の `add-roles` コマンドがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:592
 msgid "For example, to add 'user' role to composite role 'testrole' :"
 msgstr "たとえば、 'user' ロールを複合ロール 'testrole' に追加するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:594
 #, no-wrap
 msgid "    $ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
 msgstr "$ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:596
 #, no-wrap
 msgid "Removing realm roles from a composite role"
 msgstr "複合ロールからレルム・ロールを削除する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:599
 msgid ""
 "There is a dedicated `remove-roles` command that can be used to remove both "
 "realm roles and client roles."
 msgstr "レルム・ロールとクライアント・ロールの両方を削除するために使用できる専用の `remove-roles` コマンドがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:601
 msgid ""
 "For example, to remove 'user' role from target composite role 'testrole':"
 msgstr "たとえば、対象の複合ロール 'testrole' から 'user' ロールを削除するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:603
 #, no-wrap
 msgid ""
 "    $ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
 msgstr "$ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:605
 #, no-wrap
 msgid "Adding client roles to a realm role"
 msgstr "レルム・ロールへのクライアント・ロールの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:608
 msgid "This is how you create or modify a composite realm role."
 msgstr "これは、複合レルムロールを作成または変更する方法です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:610
 msgid ""
 "Use a dedicated `add-roles` command that can be used for adding both realm "
 "roles and client roles."
 msgstr "レルム・ロールとクライアント・ロールの両方を追加するために使用できる専用の `add-roles` コマンドを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:612
 msgid ""
 "For example, to add to `testrole` composite role two roles defined on client"
 " `realm-management` - `create-client` role and `view-users` role:"
@@ -1813,7 +1492,6 @@ msgstr ""
 "client` ロールと `view-users` ロール）を追加するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:614
 #, no-wrap
 msgid ""
 "    $ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1823,25 +1501,21 @@ msgstr ""
 "management --rolename create-client --rolename view-users\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:616
 #, no-wrap
 msgid "Adding client roles to a client role"
 msgstr "クライアント・ロールへのクライアント・ロールの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:619
 msgid "This is how you create or modify a composite client role."
 msgstr "これは、複合クライアントロールを作成または変更する方法です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:621
 msgid ""
 "First, find out an `id` of the composite client role - by using `get-roles` "
 "command for example:"
 msgstr "まず、 `get-roles` コマンドを使って複合クライアントロールの `id` を見つけます。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:623
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --cclientid test-client --rolename "
@@ -1851,7 +1525,6 @@ msgstr ""
 "operations\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:625
 msgid ""
 "Let's assume that there exists a client with \"clientId\": 'test-client', a "
 "client role called 'support', and another client role - that will become "
@@ -1860,22 +1533,19 @@ msgid ""
 msgstr ""
 "\"clientId\": 'test-client' "
 "であるクライアント、'support'というクライアント・ロール、複合ロールになるもう1つのクライアント・ロール（\"id\": \"fc400897"
-"-ef6a-4e8c-872b-1581b7fa8a71\", \"name\":\"operations\"）が存在するとしましょう。"
+"-ef6a-4e8c-872b-1581b7fa8a71\", \"name\":\"operations\"）が存在するとします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:627
 msgid ""
 "In this example 'operations' is our target composite role, and we just got "
 "its `id`."
-msgstr "この例では、 'operations'　は目標とする複合ロールで、その `id` も得ています。"
+msgstr "この例では、 'operations' は対象とする複合ロールで、その `id` も取得しています。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:629
 msgid "We can now add another role to it:"
 msgstr "これで別のロールを追加できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:631
 #, no-wrap
 msgid ""
 "    $ kcadm.sh add-roles -r demorealm --cclientid test-client --rid fc400897"
@@ -1885,34 +1555,27 @@ msgstr ""
 "-ef6a-4e8c-872b-1581b7fa8a71 --rolename support\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:634
 msgid ""
 "Afterwards all the roles of a composite role can be listed by using `get-"
 "roles --all`. For example:"
 msgstr "その後、 `get-roles --all` を使用して複合ロールのすべてのロールを一覧表示することができます。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:636
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
 msgstr "$ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:638
 #, no-wrap
 msgid "Removing client roles from a composite role"
 msgstr "複合ロールからのクライアント・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:641
-#: source/server_admin/topics/admin-cli.adoc:854
-#: source/server_admin/topics/admin-cli.adoc:872
 msgid "Use a dedicated `remove-roles` command."
 msgstr "専用の `remove-roles` コマンドを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:643
 msgid ""
 "For example, to remove from `testrole` composite role two roles defined on "
 "client `realm management` - `create-client` role and `view-users` role:"
@@ -1921,7 +1584,6 @@ msgstr ""
 "client` ロールと ` view-users` ロール）を削除するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:645
 #, no-wrap
 msgid ""
 "    $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1931,26 +1593,22 @@ msgstr ""
 "management --rolename create-client --rolename view-users\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:647
 #, no-wrap
 msgid "Client operations"
 msgstr "クライアント操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:649
 #, no-wrap
 msgid "Creating a client"
 msgstr "クライアントの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:652
 msgid ""
 "To create a new client perform `create` command on `clients` endpoint. For "
 "example:"
 msgstr "新しいクライアントを作成するには、 `clients` エンドポイントで `create` コマンドを実行します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:654
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s "
@@ -1959,14 +1617,12 @@ msgstr ""
 "$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:656
 msgid ""
 "If you want to set a secret for adapters to authenticate specify a `secret`."
 " For example:"
 msgstr "認証するためのアダプターのシークレットを設定する場合は、 `secret` を指定します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:658
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true"
@@ -1978,37 +1634,31 @@ msgstr ""
 "f5cc4e25d000\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:660
 #, no-wrap
 msgid "Listing clients"
 msgstr "クライアントの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:663
 msgid "Use `get` operation on `clients` endpoint. For example:"
 msgstr "`clients` エンドポイントで `get` 操作を使います。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:667
 msgid ""
 "Here we filter the output to only list `id`, and `clientId` attributes."
 msgstr "ここでは、出力を `id` と `clientId` 属性だけにフィルタリングします。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:669
 #, no-wrap
 msgid "Getting a specific client"
 msgstr "特定のクライアントを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:672
 msgid ""
 "Use client's `id` to construct an endpoint uri targeting specific client - "
 "`clients/ID`. For example:"
 msgstr "クライアントの `id` を使用して、特定のクライアントを対象とするエンドポイントuri `clients/ID` を構築します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:674
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
@@ -2017,32 +1667,27 @@ msgstr ""
 "$ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:676
 #, no-wrap
 msgid "Getting current secret for specific client"
 msgstr "特定のクライアントの現在のシークレットを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:679
 msgid ""
 "Use client's `id` to construct an endpoint uri - `clients/ID/client-secret`."
 " For example"
 msgstr "クライアントの `id` を使ってエンドポイントuri 'clients/ID/client-secret` を構築します。例えば"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:681
 #, no-wrap
 msgid "    $ kcadm.sh get clients/$CID/client-secret\n"
 msgstr "$ kcadm.sh get clients/$CID/client-secret\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:683
 #, no-wrap
 msgid "Getting adapter configuration file (keycloak.json) for specific client"
 msgstr "特定のクライアント用のアダプター構成ファイル（keycloak.json）の取得"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:686
 msgid ""
 "Use client's `id` to construct an endpoint uri targeting specific client - "
 "`clients/ID/installation/providers/keycloak-oidc-keycloak-json`."
@@ -2051,7 +1696,6 @@ msgstr ""
 "`clients/ID/installation/providers/keycloak-oidc-keycloak-json` を構築します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:690
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get "
@@ -2063,13 +1707,11 @@ msgstr ""
 "/keycloak-oidc-keycloak-json -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:692
 #, no-wrap
 msgid "Getting Wildfly subsystem adapter configuration for specific client"
 msgstr "特定のクライアントのためのWildflyサブシステム・アダプタ設定の取得"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:695
 msgid ""
 "Use client's `id` to construct an endpoint uri targeting specific client - "
 "`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem`."
@@ -2078,7 +1720,6 @@ msgstr ""
 "`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem` を構築します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:699
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get "
@@ -2090,20 +1731,17 @@ msgstr ""
 "/keycloak-oidc-jboss-subsystem -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:701
 #, no-wrap
 msgid "Updating a client"
 msgstr "クライアントの更新"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:704
 msgid ""
 "Use `update` operation with the same endpoint uri as for getting a specific "
 "client. For example on Linux:"
 msgstr "特定のクライアントを取得する場合と同じエンドポイントuriで `update` 操作を使用してください。たとえばLinuxの場合："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:706
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
@@ -2119,7 +1757,6 @@ msgstr ""
 "adminUrl=http://localhost:8080/myapp\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:710
 #, no-wrap
 msgid ""
 "    c:\\> kcadm update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
@@ -2135,20 +1772,17 @@ msgstr ""
 "adminUrl=http://localhost:8080/myapp\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:711
 #, no-wrap
 msgid "Deleting a client"
 msgstr "クライアントの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:714
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "client. For example:"
 msgstr "特定のクライアントを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:716
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
@@ -2158,26 +1792,22 @@ msgstr ""
 "demorealm\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:718
 #, no-wrap
 msgid "User operations"
 msgstr "ユーザー操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:720
 #, no-wrap
 msgid "Creating a user"
 msgstr "ユーザーの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:723
 msgid ""
 "To create a new user perform `create` operation on `users` endpoint. For "
 "example:"
 msgstr "新しいユーザーを作成するには、 `users` エンドポイントで `create` 操作を実行します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:725
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create users -r demorealm -s username=testuser -s "
@@ -2186,26 +1816,22 @@ msgstr ""
 "$ kcadm.sh create users -r demorealm -s username=testuser -s enabled=true\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:727
 #, no-wrap
 msgid "Listing users"
 msgstr "ユーザーの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:730
 msgid ""
 "Use `users` endpoint to list users. Number of users may be large, and you "
 "may want to limit how many are returned:"
 msgstr "ユーザーを一覧表示するには `users` エンドポイントを使います。ユーザー数が多く、返される数を制限したい場合は："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:732
 #, no-wrap
 msgid "    $ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
 msgstr "$ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:734
 msgid ""
 "It's also possible to filter users by `username`, `firstName`, `lastName`, "
 "or `email`. For example:"
@@ -2214,7 +1840,6 @@ msgstr ""
 "によってユーザをフィルタすることも可能です。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:737
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get users -r demorealm -q email=google.com\n"
@@ -2224,7 +1849,6 @@ msgstr ""
 " $ kcadm.sh get users -r demorealm -q username=testuser\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:739
 msgid ""
 "Note that filtering doesn't use exact matching. For example, the above would"
 " match the value of `username` attribute against '\\*testuser*' pattern."
@@ -2233,7 +1857,6 @@ msgstr ""
 "パターンを一致させます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:742
 msgid ""
 "You can also filter across multiple attributes by specifying multiple `-q` "
 "options, which would return only users that match condition for all the "
@@ -2243,18 +1866,15 @@ msgstr ""
 "オプションを複数指定することで、複数の属性をフィルタリングをすることもできます。このオプションは、すべての属性の条件に一致するユーザのみを返します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:744
 #, no-wrap
 msgid "Getting a specific user"
 msgstr "特定のユーザーを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:747
 msgid "Use user's `id` to compose an endpoint uri - `users/USER_ID`."
 msgstr "ユーザーの `id` を使用してエンドポイントuri `users/USER_ID` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:751
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
@@ -2262,20 +1882,17 @@ msgstr ""
 "$ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:753
 #, no-wrap
 msgid "Updating a user"
 msgstr "ユーザーの更新"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:756
 msgid ""
 "Use `update` operation with the same endpoint uri as for getting a specific "
 "user. For example on Linux:"
 msgstr "特定のユーザーを取得する場合と同じエンドポイントuriで `update` 操作を使用します。たとえばLinuxの場合："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:758
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
@@ -2287,7 +1904,6 @@ msgstr ""
 "'requiredActions=[\"VERIFY_EMAIL\",\"UPDATE_PROFILE\",\"CONFIGURE_TOTP\",\"UPDATE_PASSWORD\"]'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:762
 #, no-wrap
 msgid ""
 "    c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
@@ -2299,20 +1915,17 @@ msgstr ""
 "\"requiredActions=[\\\"VERIFY_EMAIL\\\",\\\"UPDATE_PROFILE\\\",\\\"CONFIGURE_TOTP\\\",\\\"UPDATE_PASSWORD\\\"]\"\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:763
 #, no-wrap
 msgid "Deleting a user"
 msgstr "ユーザーの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:766
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "user. For example:"
 msgstr "特定のユーザーを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:768
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
@@ -2321,20 +1934,17 @@ msgstr ""
 "$ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:770
 #, no-wrap
 msgid "Resetting user's password"
 msgstr "ユーザーのパスワードをリセットする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:773
 msgid ""
 "There is a dedicated `set-password` command specifically to reset user's "
 "password. For example:"
 msgstr "ユーザーのパスワードをリセットするための専用コマンド `set-password` があります。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:775
 #, no-wrap
 msgid ""
 "    $ kcadm.sh set-password -r demorealm --username testuser --new-password "
@@ -2344,21 +1954,18 @@ msgstr ""
 "NEWPASSWORD --temporary\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:777
 msgid ""
 "That will set a temporary password for the user, which they will have to "
 "change the next time they login."
-msgstr "これにより、ユーザーの次回のログイン時に変更が必要となる仮パスワードが設定されます。"
+msgstr "これにより、ユーザーが次回ログイン時に変更を求められる仮パスワードが設定されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:779
 msgid ""
 "You can use `--userid` if you want to specify the user by using `id` "
 "attribute."
 msgstr "`id` 属性を使ってユーザを指定したい場合、 `--userid` を使うことができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:782
 msgid ""
 "The same can be achieved using `update` operation on an endpoint constructed"
 " from one for getting a specific user - `users/USER_ID/reset-password`."
@@ -2367,7 +1974,6 @@ msgstr ""
 "操作を行うことで、同じことができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:786
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-"
@@ -2378,7 +1984,6 @@ msgstr ""
 "-r demorealm -s type=password -s value=NEWPASSWORD -s temporary=true -n\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:788
 msgid ""
 "The last parameter (`-n`) ensures that only PUT is performed without a prior"
 " GET. In this case it is necessary since `reset-password` endpoint doesn't "
@@ -2388,13 +1993,11 @@ msgstr ""
 "エンドポイントがGETをサポートしていないので必要です。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:791
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a user"
 msgstr "ユーザーに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:796
 msgid ""
 "To list *assigned* realm roles for the user you can specify the target user "
 "by either `username` or `id`."
@@ -2402,51 +2005,43 @@ msgstr ""
 "ユーザーの *割り当てられた* レルム・ロールを一覧表示するには、 `username` か `id` のどちらかで対象ユーザーを指定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:800
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:807
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:810
-#: source/server_admin/topics/admin-cli.adoc:836
 msgid ""
 "To list realm roles that can still be added to the user, use `--available` "
 "option instead."
 msgstr "ユーザーにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:814
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:816
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a user"
 msgstr "ユーザーに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:822
 msgid ""
 "To list *assigned* client roles for the user you can specify the target user"
 " by either `username` (via --uusername option) or `id` (via --uid option), "
 "and client by either `clientId` (via --cclientid option) or `id` (via --cid "
 "option)."
 msgstr ""
-"ユーザに *割り当てられた* クライアント・ロールを一覧表示するには、 `username` （--uusernameオプションで）または ` id` "
-"（--uidオプションで）のいずれかで対象ユーザを指定できます。 `clientId` （--cclientidオプションで）または `id` "
+"ユーザーに *割り当てられた* クライアント・ロールを一覧表示するには、 `username` （--uusernameオプションで）または ` id`"
+" （--uidオプションで）のいずれかで対象ユーザーを指定できます。 `clientId` （--cclientidオプションで）または `id` "
 "（--cidオプションで）のどちらかでクライアントを指定できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:826
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
@@ -2456,7 +2051,6 @@ msgstr ""
 "realm-management\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:833
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
@@ -2466,7 +2060,6 @@ msgstr ""
 "realm-management --effective\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:840
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
@@ -2476,42 +2069,34 @@ msgstr ""
 "realm-management --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:842
 #, no-wrap
 msgid "Adding realm roles to a user"
 msgstr "ユーザーにレルム・ロールを追加する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:845
-#: source/server_admin/topics/admin-cli.adoc:863
 msgid "Use a dedicated `add-roles` command."
 msgstr "専用の `add-roles` コマンドを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:847
 msgid "For example, to add 'user' role to user 'testuser' :"
 msgstr "たとえば、ユーザー 'testuser' に 'user' ロールを追加するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:849
 #, no-wrap
 msgid ""
 "    $ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
 msgstr "$ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:851
 #, no-wrap
 msgid "Removing realm roles from a user"
 msgstr "ユーザーからレルム・ロールを削除する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:856
 msgid "For example, to remove 'user' role from user 'testuser':"
 msgstr "たとえば、ユーザー 'testuser' から 'user' ロールを削除するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:858
 #, no-wrap
 msgid ""
 "    $ kcadm.sh remove-roles --username testuser --rolename user -r "
@@ -2520,13 +2105,11 @@ msgstr ""
 "$ kcadm.sh remove-roles --username testuser --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:860
 #, no-wrap
 msgid "Adding client roles to a user"
 msgstr "ユーザーにクライアント・ロールを追加する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:865
 msgid ""
 "For example, to add to user `testuser` two roles defined on client `realm "
 "management` - `create-client` role and `view-users` role:"
@@ -2535,7 +2118,6 @@ msgstr ""
 "client` ロールと `view-users` ロール）を追加するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:867
 #, no-wrap
 msgid ""
 "    $ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid "
@@ -2545,22 +2127,19 @@ msgstr ""
 "management --rolename create-client --rolename view-users\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:869
 #, no-wrap
 msgid "Removing client roles from a user"
 msgstr "ユーザーからのクライアント・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:874
 msgid ""
 "For example, to remove from user `testuser` two roles defined on client "
 "`realm management` - `create-client` role and `view-users` role:"
 msgstr ""
-"例えば、 `testmy` ユーザから `realm management`  で定義された二つのロール（ `create-client` ロールと "
-"`view-users` ロール）を削除するには："
+"例えば、ユーザー `testuser` からクライアントの `realm management`  で定義された二つのロール（ `create-"
+"client` ロールと `view-users` ロール）を削除するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:876
 #, no-wrap
 msgid ""
 "    $ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid "
@@ -2570,75 +2149,62 @@ msgstr ""
 "management --rolename create-client --rolename view-users\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:878
 #, no-wrap
 msgid "Listing user's sessions"
 msgstr "ユーザーのセッションを一覧表示する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:881
 msgid ""
 "First identify user's `id` then use it to compose an endpoint uri - "
 "`users/ID/sessions`."
-msgstr "最初にユーザの `id` を識別し、エンドポイントuri `users/ID/sessions` を作成するためにそれを使います。"
+msgstr "最初にユーザーの `id` を識別し、エンドポイントuri `users/ID/sessions` を作成するためにそれを使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:883
 msgid "Now use `get` to retrieve a list of user's sessions."
-msgstr "次に、ユーザのセッションの一覧を取得するために `get` を使います。"
+msgstr "次に、ユーザーのセッションの一覧を取得するために `get` を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:887
 #, no-wrap
 msgid "    $kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
 msgstr "$kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:889
 #, no-wrap
 msgid "Logging out user from specific session"
 msgstr "特定のセッションからユーザーをログアウトする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:892
 msgid ""
 "To logout the user's session first get session's `id` as described above."
-msgstr "ユーザーのセッションをログアウトするには、先に説明したように、セッションの `id` を取得します。"
+msgstr "最初にユーザーのセッションをログアウトするには、先に説明したように、セッションの `id` を取得します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:894
 msgid "Use session's `id` to compose an endpoint uri - `sessions/ID`."
 msgstr "ユーザーの `id` を使用してエンドポイントuri `sessions/ID` を作成します。 "
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:896
 msgid "Then use `delete` to invalidate it. For example:"
 msgstr "次に、それを無効にするために `delete` を使います。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:898
 #, no-wrap
 msgid "    $ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
 msgstr "$ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:901
 #, no-wrap
 msgid "Logging out user from all sessions"
 msgstr "すべてのセッションからユーザーをログアウトする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:904
 msgid "You need user's `id` to construct an endpoint uri - `users/ID/logout`."
-msgstr "エンドポイントuri `users/ID/logout` を作成するのにユーザの` id` が必要です。"
+msgstr "エンドポイントuri `users/ID/logout` を作成するのにユーザーの `id` が必要です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:906
 msgid "Use 'create' to perform POST on that endpoint uri:"
-msgstr "POSTをそのエンドポイントuriで実行するには、  'create' を使用します。"
+msgstr "そのエンドポイントuriでPOSTを実行するには、  'create' を使用します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:908
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r "
@@ -2648,58 +2214,48 @@ msgstr ""
 "demorealm -s realm=demorealm -s user=6da5ab89-3397-4205-afaa-e201ff638f9e\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:911
 #, no-wrap
 msgid "Group operations"
 msgstr "グループの操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:913
 #, no-wrap
 msgid "Creating a group"
 msgstr "グループの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:916
 msgid "Use `create` operation on `groups` endpoint to create a new group:"
 msgstr "`group` エンドポイントで `create` 操作を使って新しいグループを作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:918
 #, no-wrap
 msgid "    $ kcadm.sh create groups -r demorealm -s name=Group\n"
 msgstr "$ kcadm.sh create groups -r demorealm -s name=Group\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:920
 #, no-wrap
 msgid "Listing groups"
 msgstr "グループの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:923
 msgid "Use `get` operation on `groups` endpoint to list groups:"
 msgstr "グループを一覧表示するには `groups` エンドポイントで `get` 操作を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:925
 #, no-wrap
 msgid "    $ kcadm.sh get groups -r demorealm\n"
 msgstr "$ kcadm.sh get groups -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:927
 #, no-wrap
 msgid "Getting a specific group"
 msgstr "特定のグループを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:930
 msgid "Use group's `id` to construct an endpoint uri - groups/GROUP_ID:"
 msgstr "グループの `id` を使用してエンドポイントuri `groups/GROUP_ID` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:934
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r "
@@ -2708,20 +2264,17 @@ msgstr ""
 "$ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:936
 #, no-wrap
 msgid "Updating a group"
 msgstr "グループの更新"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:939
 msgid ""
 "Use `update` operation with the same endpoint uri as for getting a specific "
 "group. For example:"
 msgstr "特定のグループを取得する場合と同じエンドポイントuriで `update` 操作を使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:941
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s "
@@ -2731,20 +2284,17 @@ msgstr ""
 "'attributes.email=[\"group@example.com\"]' -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:943
 #, no-wrap
 msgid "Deleting a group"
 msgstr "グループの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:946
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "group. For example:"
 msgstr "特定のグループを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:948
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r "
@@ -2753,13 +2303,11 @@ msgstr ""
 "$ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:950
 #, no-wrap
 msgid "Creating a sub-group"
 msgstr "サブ・グループの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:953
 msgid ""
 "Find 'id' of the parent group - by listing groups for example. Use that `id`"
 " to construct an endpoint uri - groups/GROUP_ID/children:"
@@ -2768,7 +2316,6 @@ msgstr ""
 "`groups/GROUP_ID/children` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:957
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
@@ -2778,13 +2325,11 @@ msgstr ""
 "-r demorealm -s name=SubGroup\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:959
 #, no-wrap
 msgid "Moving a group under another group"
 msgstr "グループを別のグループの下に移動する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:962
 msgid ""
 "Find 'id' of existing parent group, and of existing child group. Use parent "
 "group's `id` to construct and endpoint uri - "
@@ -2794,14 +2339,12 @@ msgstr ""
 "`groups/PARENT_GROUP_ID/children` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:964
 msgid ""
 "Perform 'create' operation on this endpoint, and pass child group `id` as "
 "JSON body. For example:"
 msgstr "このエンドポイントで 'create' 操作を実行し、子グループ `id` をJSON本体として渡します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:966
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
@@ -2811,13 +2354,11 @@ msgstr ""
 "-r demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:968
 #, no-wrap
 msgid "Get groups for specific user"
 msgstr "特定のユーザーのグループを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:971
 msgid ""
 "To get user's membership in groups, use user's `id` to compose an endpoint "
 "URI - `users/USER_ID/groups`"
@@ -2826,7 +2367,6 @@ msgstr ""
 "を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:975
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r "
@@ -2836,13 +2376,11 @@ msgstr ""
 "demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:977
 #, no-wrap
 msgid "Adding user to a group"
 msgstr "ユーザーをグループに追加する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:980
 msgid ""
 "To join user to a group use `update` operation with an endpoint uri composed"
 " from user's `id`, and group's `id` - users/USER_ID/groups/GROUP_ID."
@@ -2851,7 +2389,6 @@ msgstr ""
 "`users/USER_ID/groups/GROUP_ID` で `update` 操作を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:984
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update users/b544f379-5fc4-49e5-8a8d-"
@@ -2865,13 +2402,11 @@ msgstr ""
 "groupId=ce01117a-7426-4670-a29a-5c118056fe20 -n\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:986
 #, no-wrap
 msgid "Removing user from a group"
 msgstr "グループからのユーザーの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:989
 msgid ""
 "To remove user from a group use `delete` operation on the same endpoint uri "
 "as used for adding user to a group - users/USER_ID/groups/GROUP_ID."
@@ -2880,7 +2415,6 @@ msgstr ""
 "`users/USER_ID/groups/GROUP_ID` で `delete` 操作を使用します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:993
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-"
@@ -2890,19 +2424,15 @@ msgstr ""
 "5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:996
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a group"
 msgstr "グループに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:999
-#: source/server_admin/topics/admin-cli.adoc:1025
 msgid "Use a dedicated 'get-roles' command."
 msgstr "専用の `get-roles` コマンドを使用します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1002
 msgid ""
 "To list *assigned* realm roles for the group you can specify the target "
 "group by `name` (via `--gname` option), `path` (via `--gpath` option), or "
@@ -2912,39 +2442,32 @@ msgstr ""
 "`path` （ `--gpath` オプションで）、 `id` （ `--gid` オプションで）のいずれかで指定できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1006
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --gname Group\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --gname Group\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1013
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1016
-#: source/server_admin/topics/admin-cli.adoc:1042
 msgid ""
 "To list realm roles that can still be added to the group, use `--available` "
 "option instead."
 msgstr "グループに追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1020
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1022
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a group"
 msgstr "グループに割り当てられた、利用可能な、有効なクライアントロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1028
 msgid ""
 "To list *assigned* client roles for the user you can specify the target "
 "group by either `name` (via --gname option) or `id` (via `--gid` option), "
@@ -2956,7 +2479,6 @@ msgstr ""
 "`id` （ `--id` オプションで）のどちらかでクライアントを指定できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1032
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
@@ -2966,7 +2488,6 @@ msgstr ""
 "management\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1039
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
@@ -2976,7 +2497,6 @@ msgstr ""
 "management --effective\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1046
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
@@ -2986,25 +2506,21 @@ msgstr ""
 "management --available\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1048
 #, no-wrap
 msgid "Identity Providers operations"
 msgstr "アイデンティティー・プロバイダーの操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1051
 #, no-wrap
 msgid "Listing available identity providers"
 msgstr "使用可能なアイデンティティー・プロバイダー の一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1054
 msgid ""
 "Use `serverinfo` endpoint to list available identity providers. For example:"
 msgstr "使用可能なアイデンティティー・プロバイダーをリストするには、 `serverinfo` エンドポイントを使用します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1056
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
@@ -3012,7 +2528,6 @@ msgstr ""
 "    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1059
 msgid ""
 "Note that `serverinfo` endpoint is handled similarly to `realms` endpoint in"
 " that it is not resolved relative to target realm, because it exists outside"
@@ -3022,18 +2537,15 @@ msgstr ""
 "realms`エンドポイントと同様に扱われる点に注意してください。特定のレルムの外に存在するため、レルムに対して解決されません。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1061
 #, no-wrap
 msgid "Listing configured identity providers"
 msgstr "構成済みアイデンティティー・プロバイダー の一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1064
 msgid "Use `identity-provider/instances` endpoint. For example:"
 msgstr "`identity-provider/instances` エンドポイントを使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1066
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get identity-provider/instances -r demorealm --fields "
@@ -3043,13 +2555,11 @@ msgstr ""
 "alias,providerId,enabled\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1068
 #, no-wrap
 msgid "Getting a specific configured identity provider"
 msgstr "特定の構成済みアイデンティティー・プロバイダーの取得"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1071
 msgid ""
 "To get a specific identity provider use `alias` attribute of identity "
 "provider to construct an endpoint uri - `identity-provider/instances/ALIAS`."
@@ -3058,26 +2568,22 @@ msgstr ""
 "`identity-provider/instances/ALIAS` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1075
 #, no-wrap
 msgid "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
 msgstr "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1077
 #, no-wrap
 msgid "Removing a specific configured identity provider"
 msgstr "特定の構成済みアイデンティティー・プロバイダーの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1080
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "configured identity provider. For example:"
 msgstr "特定の構成済みアイデンティティ・プロバイダーを取得する場合と同じエンドポイントuriで `delete` 操作を使用します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1082
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
@@ -3085,13 +2591,11 @@ msgstr ""
 "    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1084
 #, no-wrap
 msgid "Configuring a Keycloak OpenID Connect identity provider"
 msgstr "Keycloak OpenID Connect アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1087
 msgid ""
 "Use `keycloak-oidc` as `providerId` when creating a new identity provider "
 "instance."
@@ -3099,7 +2603,6 @@ msgstr ""
 "新しいアイデンティティー・プロバイダー・インスタンスを作成するときは、 `keyIdoc` を `providerId` として使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1089
 msgid ""
 "Provide config attributes `authorizationUrl`, `tokenUrl`, `clientId`, and "
 "`clientSecret`."
@@ -3107,7 +2610,6 @@ msgstr ""
 "設定属性 `authorizationUrl` 、 `tokenUrl` 、 `clientId` 、 `clientSecret` を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1093
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias"
@@ -3129,13 +2631,11 @@ msgstr ""
 "config.clientSecret=secret\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1095
 #, no-wrap
 msgid "Configuring an OpenID Connect identity provider"
 msgstr "OpenID Connect アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1099
 msgid ""
 "You configure the generic OpenID Connect provider the same way as Keycloak "
 "OpenID Connect provider, except that you set `providerId` attribute value to"
@@ -3145,13 +2645,11 @@ msgstr ""
 "OpenID Connect プロバイダーと同じ方法で設定します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1101
 #, no-wrap
 msgid "Configuring a SAML 2 identity provider"
 msgstr "SAML 2 アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1104
 msgid ""
 "Use `saml` as `providerId`. Provide `config` attributes - "
 "`singleSignOnServiceUrl`, `nameIDPolicyFormat`, and `signatureAlgorithm`."
@@ -3160,7 +2658,6 @@ msgstr ""
 "`nameIDPolicyFormat` 、および `signatureAlgorithm` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1108
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=saml"
@@ -3176,13 +2673,11 @@ msgstr ""
 ":nameid-format:persistent -s config.signatureAlgorithm=RSA_SHA256\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1110
 #, no-wrap
 msgid "Configuring a Facebook identity provider"
 msgstr "Facebookアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1114
 msgid ""
 "Use `facebook` as `providerId`. Provide `config` attributes - `clientId` and"
 " `clientSecret` as obtained from Facebook Developers application "
@@ -3193,7 +2688,6 @@ msgstr ""
 "）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1116
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3207,13 +2701,11 @@ msgstr ""
 "config.clientSecret=FACEBOOK_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1118
 #, no-wrap
 msgid "Configuring a Google identity provider"
 msgstr "Googleアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1122
 msgid ""
 "Use `google` as `providerId`. Provide `config` attributes - `clientId` and "
 "`clientSecret` as obtained from Google Developers application configuration "
@@ -3224,7 +2716,6 @@ msgstr ""
 "）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1124
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3238,13 +2729,11 @@ msgstr ""
 "config.clientSecret=GOOGLE_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1126
 #, no-wrap
 msgid "Configuring a Twitter identity provider"
 msgstr "Twitterアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1130
 msgid ""
 "Use `twitter` as `providerId`. Provide `config` attributes - `clientId` and "
 "`clientSecret` as obtained from Twitter Application Management application "
@@ -3255,7 +2744,6 @@ msgstr ""
 "`clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1132
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3269,13 +2757,11 @@ msgstr ""
 "config.clientSecret=TWITTER_API_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1134
 #, no-wrap
 msgid "Configuring a GitHub identity provider"
 msgstr "GitHubアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1138
 msgid ""
 "Use `github` as `providerId`. Provide `config` attributes - `clientId` and "
 "`clientSecret` as obtained from GitHub Developer Application Settings page "
@@ -3285,7 +2771,6 @@ msgstr ""
 "`config` 属性（ ` clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1140
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3299,13 +2784,11 @@ msgstr ""
 "config.clientSecret=GITHUB_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1142
 #, no-wrap
 msgid "Configuring a LinkedIn identity provider"
 msgstr "LinkedInアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1146
 msgid ""
 "Use `linkedin` as `providerId`. Provide `config` attributes - `clientId` and"
 " `clientSecret` as obtained from LinkedIn Developer Console application page"
@@ -3316,7 +2799,6 @@ msgstr ""
 "`clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1148
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3330,13 +2812,11 @@ msgstr ""
 "config.clientSecret=LINKEDIN_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1150
 #, no-wrap
 msgid "Configuring a Microsoft Live identity provider"
 msgstr "Microsoft Live アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1154
 msgid ""
 "Use `microsoft` as `providerId`. Provide `config` attributes - `clientId` "
 "and `clientSecret` as obtained from Microsoft Application Registration "
@@ -3346,7 +2826,6 @@ msgstr ""
 " `config` 属性（ `clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1156
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3360,13 +2839,11 @@ msgstr ""
 "config.clientSecret=MICROSOFT_PASSWORD\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1158
 #, no-wrap
 msgid "Configuring a StackOverflow identity provider"
 msgstr "StackOverflowアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1162
 msgid ""
 "Use `stackoverflow` as `providerId`. Provide `config` attributes - "
 "`clientId`, `clientSecret` and `key` as obtained from Stack Apps OAuth page "
@@ -3376,7 +2853,6 @@ msgstr ""
 "OAuthページから取得した `config` 属性（ `--clientId` 、 `clientSecret` 、 `key` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1164
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create identity-provider/instances -r demorealm -s "
@@ -3390,19 +2866,16 @@ msgstr ""
 "config.clientSecret=STACKAPPS_CLIENT_SECRET -s config.key=STACKAPPS_KEY\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1166
 #, no-wrap
 msgid "Storage Providers operations"
 msgstr "ストレージ・プロバイダーの操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1168
 #, no-wrap
 msgid "Configuring a Kerberos storage provider"
 msgstr "Kerberosストレージ・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1171
 msgid ""
 "Use `create` against `user-federation/instances` endpoint. Specify "
 "`kerberos` as a value of `providerName` attribute."
@@ -3411,7 +2884,6 @@ msgstr ""
 "`providerName` 属性の値として指定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1175
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create user-federation/instances -r demorealm -s "
@@ -3431,13 +2903,11 @@ msgstr ""
 "-s 'config.serverPrincipal=\"HTTP/localhost@KEYCLOAK.ORG\"'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1177
 #, no-wrap
 msgid "Configuring an LDAP user storage provider"
 msgstr "LDAPユーザー・ストレージ・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1180
 msgid ""
 "Use `create` against `components` endpoint. Specify `ldap` as a value of "
 "`providerId` attribute, and `org.keycloak.storage.UserStorageProvider` as "
@@ -3449,12 +2919,10 @@ msgstr ""
 "`parentId` 属性の値としてレルム `id` を与えます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1182
 msgid "For example, to create a Kerberos integrated LDAP provider:"
 msgstr "たとえば、Kerberos統合LDAPプロバイダーを作成するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1184
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider"
@@ -3506,25 +2974,21 @@ msgstr ""
 "'config.useKerberosForPasswordAuthentication=[\"true\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1186
 #, no-wrap
 msgid "Removing a user storage provider instance"
 msgstr "ユーザー・ストレージ・プロバイダー・インスタンスの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1189
 msgid ""
 "Use storage provider instance's `id` attribute to compose an endpoint uri - "
 "`components/ID`."
 msgstr "ストレージ・プロバイダー・インスタンスの `id` 属性を使用して、エンドポイントuri  `components/ID` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1191
 msgid "Perform `delete` operation against this endpoint. For example:"
 msgstr "このエンドポイントに対して `delete` 操作を実行します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1193
 #, no-wrap
 msgid ""
 "    $ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r "
@@ -3534,14 +2998,12 @@ msgstr ""
 "demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1195
 #, no-wrap
 msgid ""
 "Triggering synchronization of all users for specific user storage provider"
 msgstr "特定のユーザー・ストレージ・プロバイダーに対してすべてのユーザーの同期をトリガーする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1199
 msgid ""
 "Use storage provider's `id` attribute to compose an endpoint uri - user-"
 "storage/ID_OF_USER_STORAGE_INSTANCE/sync Add `action=triggerFullSync` query "
@@ -3552,7 +3014,6 @@ msgstr ""
 "クエリ・パラメーターを追加し、 `create` コマンドを実行します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1203
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
@@ -3562,7 +3023,6 @@ msgstr ""
 "947d6a09e1ea/sync?action=triggerFullSync\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1205
 #, no-wrap
 msgid ""
 "Triggering synchronization of changed users for specific user storage "
@@ -3570,7 +3030,6 @@ msgid ""
 msgstr "特定のユーザー・ストレージ・プロバイダーの変更されたユーザーの同期をトリガーする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1209
 msgid ""
 "Use storage provider's `id` attribute to compose an endpoint uri - user-"
 "storage/ID_OF_USER_STORAGE_INSTANCE/sync Add "
@@ -3581,7 +3040,6 @@ msgstr ""
 "`action=triggerChangedUsersSync` クエリー・パラメーターを追加し、 `create` コマンドを実行します。 "
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1213
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
@@ -3591,13 +3049,11 @@ msgstr ""
 "947d6a09e1ea/sync?action=triggerChangedUsersSync\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1215
 #, no-wrap
 msgid "Test LDAP user storage connectivity"
 msgstr "LDAPユーザー・ストレージの接続をテストする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1218
 msgid ""
 "Perform `get` operation on `testLDAPConnection` endpoint. Provide query "
 "parameters `bindCredential`, `bindDn`, `connectionUrl`, and "
@@ -3608,7 +3064,6 @@ msgstr ""
 "`testConnection` に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1222
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get testLDAPConnection -q action=testConnection -q "
@@ -3620,13 +3075,11 @@ msgstr ""
 "connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1224
 #, no-wrap
 msgid "Test LDAP user storage authentication"
 msgstr "LDAPユーザー・ストレージ認証をテストする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1227
 msgid ""
 "Perform `get` operation on `testLDAPConnection` endpoint. Provide query "
 "parameters `bindCredential`, `bindDn`, `connectionUrl`, and "
@@ -3638,7 +3091,6 @@ msgstr ""
 "`testAuthentication` に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1231
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
@@ -3650,19 +3102,16 @@ msgstr ""
 "connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1234
 #, no-wrap
 msgid "Adding mappers"
 msgstr "マッパーの追加"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1236
 #, no-wrap
 msgid "Adding a hardcoded role LDAP mapper"
-msgstr "ハードコードされたロールLDAPマッパー"
+msgstr "ハードコードされたロールLDAPマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1240
 msgid ""
 "Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
@@ -3676,7 +3125,6 @@ msgstr ""
 "mapper` を設定してください。必ず `role` 設定パラメーターの値を指定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1244
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=hardcoded-ldap-role-"
@@ -3692,13 +3140,11 @@ msgstr ""
 "management.create-client\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1246
 #, no-wrap
 msgid "Adding a MS Active Directory mapper"
 msgstr "MS Active Directoryマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1250
 msgid ""
 "Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
@@ -3711,7 +3157,6 @@ msgstr ""
 "control-mapper` を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1254
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=msad-user-account-"
@@ -3725,13 +3170,11 @@ msgstr ""
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1256
 #, no-wrap
 msgid "Adding an user attribute LDAP mapper"
 msgstr "ユーザー属性LDAPマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1260
 msgid ""
 "Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
@@ -3744,7 +3187,6 @@ msgstr ""
 "mapper` を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1264
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-"
@@ -3766,13 +3208,11 @@ msgstr ""
 "'config.\"is.mandatory.in.ldap\"=[\"false\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1266
 #, no-wrap
 msgid "Adding a group LDAP mapper"
-msgstr "Adding a group LDAP mapper"
+msgstr "グループLDAPマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1270
 msgid ""
 "Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
@@ -3785,7 +3225,6 @@ msgstr ""
 "に設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1274
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
@@ -3823,13 +3262,11 @@ msgstr ""
 "'config.membership=[\"member\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1276
 #, no-wrap
 msgid "Adding a full name LDAP mapper"
 msgstr "フルネームLDAPマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1280
 msgid ""
 "Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
@@ -3842,7 +3279,6 @@ msgstr ""
 "mapper` を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1284
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper "
@@ -3860,26 +3296,22 @@ msgstr ""
 "'config.\"read.only\"=[\"false\"]' -s 'config.\"write.only\"=[\"true\"]'\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1287
 #, no-wrap
 msgid "Authentication operations"
 msgstr "認証の操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1290
 #, no-wrap
 msgid "Setting a password policy"
 msgstr "パスワード・ポリシーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1293
 msgid ""
 "Set realm's `passwordPolicy` attribute to enumeration expression that "
 "includes the specific policy provider id, and optional configuration."
 msgstr "レルムの `passwordPolicy` 属性を、特定のポリシー・プロバイダー・IDとオプションの設定を含む列挙式に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1296
 msgid ""
 "For example, to set password policy to default values - i.e.: 27500 hashing "
 "iterations, requiring at least one special character, at least one uppercase"
@@ -3890,7 +3322,6 @@ msgstr ""
 " `username` と等しくなく、少なくとも8文字の長さ）に設定するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1298
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations "
@@ -3900,14 +3331,12 @@ msgstr ""
 "and specialChars and upperCase and digits and notUsername and length\"'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1300
 msgid ""
 "If you want want to use values different from defaults, pass configuration "
 "in brackets."
 msgstr "デフォルトと異なる値を使用する場合は、括弧で設定を渡します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1302
 msgid ""
 "For example, to set password policy to 25000 hash iterations, requiring at "
 "least two special characters, at least two uppercase characters, at least "
@@ -3918,7 +3347,6 @@ msgstr ""
 "たとえば、パスワードポリシーを25000ハッシュ反復、少なくとも2つの特殊文字、少なくとも2つ以上の大文字、少なくとも2つ以上の小文字、少なくとも2つ以上の数字、少なくとも9文字の長さ、ユーザー名と等しくなく、過去4回の変更と一致しない、に設定するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1304
 #, no-wrap
 msgid ""
 "    $ kcadm.sh update realms/demorealm -s "
@@ -3932,42 +3360,35 @@ msgstr ""
 "passwordHistory(4)\"'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1306
 #, no-wrap
 msgid "Getting the current password policy"
 msgstr "現在のパスワード・ポリシーの取得"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1309
 msgid ""
 "Get current realm configuration and filter out everything but "
 "`passwordPolicy` attribute."
 msgstr "現在のレルムの設定を取得し、 `passwordPolicy` 属性以外のすべてをフィルタリングします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1311
 msgid "For example, to display `passwordPolicy` for demorealm:"
 msgstr "例えば、demorealmの `passwordPolicy` を表示するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1313
 #, no-wrap
 msgid "    $ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
 msgstr "    $ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1315
 #, no-wrap
 msgid "Listing authentication flows"
 msgstr "認証フローの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1318
 msgid "Use `get` operation on `authentication/flows` endpoint. For example:"
 msgstr "`authentication/flows` エンドポイントで `get` 操作を使います。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1320
 #, no-wrap
 msgid "    $ kcadm.sh get authentication/flows -r demorealm\n"
-msgstr "    $ kcadm.sh get authentication/flows -r demorealm\n"
+msgstr "$ kcadm.sh get authentication/flows -r demorealm\n"

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Hiroshi Katakura <h.katakura@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,20 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-msgid "On Linux:"
-msgstr "Linuxの場合："
+msgid "For example, on:"
+msgstr "例えば"
 
 #. type: Plain text
-msgid "On Windows:"
-msgstr "Windowsの場合："
+msgid "Linux:"
+msgstr "Linuxの場合"
 
 #. type: Plain text
-msgid "For example on Linux:"
-msgstr "例えば、Linux の場合："
-
-#. type: Plain text
-msgid "Or on Windows:"
-msgstr "または、Windowsの場合："
+msgid "Windows:"
+msgstr "Windowsの場合"
 
 #. type: Title ===
 #, no-wrap
@@ -42,150 +38,161 @@ msgstr "例："
 
 #. type: Title ==
 #, no-wrap
-msgid "Admin CLI"
+msgid "The Admin CLI"
 msgstr "管理CLI"
 
 #. type: Plain text
 msgid ""
-"In previous chapters we have described how to use {project_name} Admin "
-"Console to perform administrative tasks.  All those tasks can also be "
-"performed from command line by using Admin CLI command line tool."
+"In previous chapters, we described how to use the {project_name} Admin "
+"Console to perform administrative tasks. You can also perform those tasks "
+"from the command-line interface (CLI) by using the Admin CLI command-line "
+"tool."
 msgstr ""
-"前の章では、{project_name}管理コンソールを使用して管理タスクを実行する方法について説明しました。これらのタスクはすべて、管理CLIコマンドライン・ツールを使用してコマンドラインから実行することもできます。"
+"前の章では、{project_name}管理コンソールを使用して管理タスクを実行する方法について説明しました。管理CLIツールを使用して、コマンドライン・インターフェイス（CLI）からこれらの管理タスクを実行することもできます。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Installing Admin CLI"
+msgid "Installing the Admin CLI"
 msgstr "管理CLIのインストール"
 
 #. type: Plain text
 msgid ""
-"Admin CLI is packaged inside {project_name} Server distribution. You can "
-"find execution scripts inside `bin` directory."
-msgstr "管理CLIは、{project_name}サーバーの配布物に含まれています。 `bin` ディレクトリに実行スクリプトがあります。"
+"The Admin CLI is packaged inside {project_name} Server distribution. You can"
+" find execution scripts inside the [filename]`bin` directory."
+msgstr ""
+"管理CLIは、{project_name}サーバーの配布物に含まれています。実行スクリプトは [filename]`bin` ディレクトリにあります。"
 
 #. type: Plain text
 msgid ""
-"The Linux script is called `kcadm.sh`, and the one for Windows is called "
-"`kcadm.bat`."
-msgstr "Linuxの実行スクリプトは `kcadm.sh` 、Windowsの実行スクリプトは `kcadm.bat` です。"
+"The Linux script is called [filename]`kcadm.sh`, and the script for Windows "
+"is called [filename]`kcadm.bat`."
+msgstr ""
+"Linuxのスクリプトは [filename]`kcadm.sh` と呼ばれ、Windowsのスクリプトは [filename]`kcadm.bat` "
+"と呼ばれます。"
 
 #. type: Plain text
 msgid ""
-"In order to use the client from any location on your filesystem you may want"
-" to add {project_name} server directory to your PATH."
-msgstr "ファイルシステム上の任意の場所からクライアントを使用するには、{project_name}サーバー・ディレクトリをPATHに追加します。"
+"You can add the {project_name} server directory to your [filename]`PATH` to "
+"use the client from any location on your file system."
+msgstr ""
+"{project_name}サーバディレクトリを[filename] `PATH` "
+"に追加することで、ファイルシステム上の任意の場所からクライアントを使用することができます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
-"    $ kcadm.sh\n"
+"$ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
+"$ kcadm.sh\n"
 msgstr ""
 "$ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
-" $ kcadm.sh\n"
+"$ kcadm.sh\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
-"    c:\\> kcadm\n"
+"c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
+"c:\\> kcadm\n"
 msgstr ""
 "c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
-" c:\\> kcadm\n"
+"c:\\> kcadm\n"
 
 #. type: Plain text
 msgid ""
-"We assume KEYCLOAK_HOME env variable is set to the path where you extracted "
-"{project_name} Server distribution."
-msgstr "環境変数KEYCLOAK_HOMEは、{project_name}サーバーの配布物を展開したパスに設定されているものとします。"
+"We assume the `KEYCLOAK_HOME` environment (env) variable is set to the path "
+"where you extracted the {project_name} Server distribution."
+msgstr "`KEYCLOAK_HOME` 環境変数は、{project_name}サーバの配布物を解凍したパスに設定されているものとします。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"To avoid unnecessary repetition the rest of this document will only give "
-"Windows examples in places where difference in command line is more than "
-"just in `kcadm` command name."
+"To avoid repetition, the rest of this document only gives Windows examples "
+"in places where the difference in the CLI is more than just in the "
+"[command]`kcadm` command name."
 msgstr ""
-"不必要な繰り返しを避けるため、この文書の残りの部分でのWindowsの例は、コマンドラインの違いが `kcadm` "
-"コマンド名以外にもある場所でのみ示します。"
+"これ以降、繰り返しの説明を避けるため、CLIの違いが [command]`kcadm` コマンド名だけである場合は、Windowsの例を示しています。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Using Admin CLI"
+msgid "Using the Admin CLI"
 msgstr "管理CLIの利用"
 
 #. type: Plain text
 msgid ""
-"Admin CLI works by making HTTP requests to Admin REST endpoints. Access to "
-"them is protected and requires authentication."
+"The Admin CLI works by making HTTP requests to Admin REST endpoints. Access "
+"to them is protected and requires authentication."
 msgstr ""
-"管理CLIは、管理RESTエンドポイントへのHTTPリクエストを作成することによって機能します。管理RESTエンドポイントへのアクセスは保護されており、認証が必要です。"
+"管理CLIは、管理RESTエンドポイントへのHTTP要求を作成することによって動作します。エンドポイントへのアクセスは保護されており、認証が必要です。"
+
+#. type: delimited block =
+msgid ""
+"Consult the Admin REST API documentation for details about JSON attributes "
+"for specific endpoints."
+msgstr "特定のエンドポイントのJSON属性の詳細については、Admin REST APIのドキュメントを参照してください。"
 
 #. type: Plain text
 msgid ""
-"Consult Admin REST API documentation for details about JSON attributes for "
-"specific endpoints."
-msgstr "エンドポイントのJSON属性の詳細については、Admin REST APIのドキュメントを参照してください。"
+"Start an authenticated session by providing credentials, that is, logging "
+"in. You are ready to perform create, read, update, and delete (CRUD) "
+"operations."
+msgstr ""
+"クレデンシャルを提供すること、つまりログインすることで、認証セッションを開始します。作成、読み取り、更新、および削除（CRUD）操作を実行する準備をします。"
 
 #. type: Plain text
-msgid ""
-"You start an authenticated session by providing credentials (i.e. logging "
-"in), then you are ready to perform some CRUD operations."
-msgstr "クレデンシャルを入力（例えばログイン）することで認証セッションを開始すると、CRUD操作を実行する準備が整います。"
+msgid "For example, on"
+msgstr "例えば"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
-"    $ kcadm.sh create realms -s realm=demorealm -s enabled=true -o\n"
-"    $ CID=$(kcadm.sh create clients -r demorealm -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]' -i)\n"
-"    $ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
+"$ kcadm.sh config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
+"$ kcadm.sh create realms -s realm=demorealm -s enabled=true -o\n"
+"$ C=$(kcadm.sh create clients -r demorealm -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]' -i)\n"
+"$ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
 msgstr ""
 "$ kcadm.sh config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
-" $ kcadm.sh create realms -s realm=demorealm -s enabled=true -o\n"
-" $ CID=$(kcadm.sh create clients -r demorealm -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]' -i)\n"
-" $ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
+"$ kcadm.sh create realms -s realm=demorealm -s enabled=true -o\n"
+"$ C=$(kcadm.sh create clients -r demorealm -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]' -i)\n"
+"$ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
-"    c:\\> kcadm create realms -s realm=demorealm -s enabled=true -o\n"
-"    c:\\> kcadm create clients -r demorealm -s clientId=my_client -s \"redirectUris=[\\\"http://localhost:8980/myapp/*\\\"]\" -i > clientid.txt\n"
-"    c:\\> set /p CID=<clientid.txt\n"
-"    c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
+"c:\\> kcadm config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
+"c:\\> kcadm create realms -s realm=demorealm -s enabled=true -o\n"
+"c:\\> kcadm create clients -r demorealm -s clientId=my_client -s \"redirectUris=[\\\"http://localhost:8980/myapp/*\\\"]\" -i > clientid.txt\n"
+"c:\\> set /p CID=<clientid.txt\n"
+"c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
 msgstr ""
 "c:\\> kcadm config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
-" c:\\> kcadm create realms -s realm=demorealm -s enabled=true -o\n"
-" c:\\> kcadm create clients -r demorealm -s clientId=my_client -s \"redirectUris=[\\\"http://localhost:8980/myapp/*\\\"]\" -i > clientid.txt\n"
-" c:\\> set /p CID=<clientid.txt\n"
-" c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
+"c:\\> kcadm create realms -s realm=demorealm -s enabled=true -o\n"
+"c:\\> kcadm create clients -r demorealm -s clientId=my_client -s \"redirectUris=[\\\"http://localhost:8980/myapp/*\\\"]\" -i > clientid.txt\n"
+"c:\\> set /p CID=<clientid.txt\n"
+"c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
 
 #. type: Plain text
 msgid ""
-"In a production environment {project_name} has to be accessed with `https:` "
-"to avoid exposing tokens to network sniffers. If server's certificate is not"
-" issued by one of the trusted CAs that are included in Java's default "
-"certificate truststore, then you will need to prepare a truststore.jks file,"
-" and instruct `Admin CLI` to use it."
+"In a production environment, you must access {project_name} with `https:` to"
+" avoid exposing tokens to network sniffers. If a server's certificate is not"
+" issued by one of the trusted certificate authorities (CAs) that are "
+"included in Java's default certificate truststore, prepare a "
+"[filename]`truststore.jks` file and instruct the Admin CLI to use it."
 msgstr ""
-"実稼働環境では、ネットワーク・スニファへのトークンの公開を避けるため、{project_name}には `https：` "
-"でアクセスする必要があります。サーバーの証明書が、Javaのデフォルトの証明書トラスト・ストアに含まれている信頼されたCAの1つによって発行されていない場合は、"
-" `truststore.jks` ファイルを準備し、それを使用するように `管理CLI` に指示する必要があります。"
+"プロダクション環境では、ネットワーク解析によりトークンが漏洩しないように、{project_name}に `https：` "
+"でアクセスする必要があります。サーバーの証明書が、Javaのデフォルトの証明書トラストストアに含まれる信頼できる認証局（CA）のいずれかによって発行されていない場合は、"
+" [filename]`truststore.jks` ファイルを準備し、管理CLIに使用するよう指示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh config truststore --trustpass $PASSWORD "
+"$ kcadm.sh config truststore --trustpass $PASSWORD "
 "~/.keycloak/truststore.jks\n"
 msgstr ""
 "$ kcadm.sh config truststore --trustpass $PASSWORD "
 "~/.keycloak/truststore.jks\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm config truststore --trustpass %PASSWORD% "
+"c:\\> kcadm config truststore --trustpass %PASSWORD% "
 "%HOMEPATH%\\.keycloak\\truststore.jks\n"
 msgstr ""
 "c:\\> kcadm config truststore --trustpass %PASSWORD% "
@@ -198,493 +205,499 @@ msgstr "認証"
 
 #. type: Plain text
 msgid ""
-"When logging in with `Admin CLI` you specify a server endpoint url, and a "
-"realm. Then you specify a username, or alternatively you can specify only a "
-"client id, which will result in special, so called 'service account' being "
-"used. In the first case, a password for the specified user has to be used at"
-" login. In the latter case there is no user password - only client secret.  "
-"Alternatively, `Signed JWT` can be used."
+"When you log in with the Admin CLI, you specify a server endpoint URL and a "
+"realm, and then you specify a user name. Another option is to specify only a"
+" clientId, which results in using a special \"service account.\" When you "
+"log in using a user name, you must use a password for the specified user. "
+"When you log in using a clientId, you only need the client secret, not the "
+"user password. You could also use [command]`Signed JWT` instead of the "
+"client secret."
 msgstr ""
-"`管理CLI` "
-"でログインするときに、サーバーのエンドポイントのURLとレルムを指定します。その後、ユーザー名かクライアントIDを指定します。クライアントIDを指定することで、特別な、いわゆる「サービスアカウント」が使用されます。ユーザー名を指定する場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。クライアントIDを指定する場合、ユーザー・パスワードはなく、クライアント・シークレットのみです。"
-" `署名付きJWT` を使用することもできます。"
+"管理CLIでログインするときは、サーバーのエンドポイントURLとレルムを指定してから、ユーザー名を指定します。別の方法としては、特別な「サービスアカウント」を使用するclientIdのみを指定することです。ユーザー名を使用してログインするときは、指定したユーザーのパスワードを使用する必要があります。clientIdを使用してログインする場合、ユーザーのパスワードではなくクライアント・シークレットのみが必要です。また、クライアント・シークレットの代わりに"
+" [command]`Signed JWT` を使用することもできます。"
 
 #. type: Plain text
 msgid ""
-"The account used for the session needs to have proper permissions in order "
-"to be able to invoke Admin REST API operations.  For example, `realm-admin` "
-"role of `realm-management` client allows user to administer the realm within"
-" which the user is defined."
+"Make sure the account used for the session has the proper permissions to "
+"invoke Admin REST API operations. For example, the `realm-admin` role of the"
+" `realm-management` client allows the user to administer the realm within "
+"which the user is defined."
 msgstr ""
-"セッションに使用されるアカウントには、管理REST API操作を呼び出すための適切な権限が必要です。例えば、 `realm-management` "
-"クライアントの `realm-admin` ロールは、ユーザが定義されているレルムを管理することを許可します。"
+"セッションに使用されるアカウントに、管理REST API操作を呼び出すための適切な権限があることを確認します。例えば、 `realm-"
+"management` クライアントの `realm-admin` ロールは、ユーザが定義されているレルムを管理することを許可します。"
 
 #. type: Plain text
 msgid ""
-"There are two primary mechanisms for authentication. One is using `kcadm "
-"config credentials` to start an authenticated session:"
+"There are two primary mechanisms for authentication. One mechanism uses "
+"[command]`kcadm config credentials` to start an authenticated session."
 msgstr ""
-"認証には主に2つのメカニズムがあります。1つは認証されたセッションを開始するために `kcadm config credentials` を使用します。"
+"認証には主に2つの方法があります。 1つ目の方法は、[command]`kcadm config credentials` "
+"を使用して認証セッションを開始します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh config credentials --server http://localhost:8080/auth "
-"--realm master --user admin --password admin\n"
+"$ kcadm.sh config credentials --server http://localhost:8080/auth --realm "
+"master --user admin --password admin\n"
 msgstr ""
 "$ kcadm.sh config credentials --server http://localhost:8080/auth --realm "
 "master --user admin --password admin\n"
 
 #. type: Plain text
 msgid ""
-"This approach maintains an authenticated session between `kcadm` command "
-"invocations by saving the obtained access token, and associated refresh "
-"token, possibly other secrets as well in a private configuration file. See "
-"<<_working_with_alternative_configurations, next chapter>> for more info on "
-"configuration file."
+"This approach maintains an authenticated session between the "
+"[command]`kcadm` command invocations by saving the obtained access token and"
+" the associated refresh token. It may also maintain other secrets in a "
+"private configuration file. See <<_working_with_alternative_configurations, "
+"next chapter>> for more information on the configuration file."
 msgstr ""
-"取得されたアクセストークン、関連付けられたリフレッシュトークン、そしておそらく他のシークレットもプライベートな設定ファイルに保存することで、このアプローチは一連の"
-" `kcadm` "
-"コマンド呼び出しの間の認証されたセッションを維持します。設定ファイルの詳細については<<_working_with_alternative_configurations,"
+"この方法は、取得したアクセストークンと関連するリフレッシュトークンを保存することによって、 [command]`kcadm` "
+"コマンドの呼び出し間で認証されたセッションを維持します。また、プライベート設定ファイルに他のシークレットを保持することもできます。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
 " 次の章>>を参照してください。"
 
 #. type: Plain text
 msgid ""
-"Another approach is to authenticate with each command invocation for the "
-"duration of that invocation only. This approach results in more load on the "
-"server, and more time spent with round-trips obtaining tokens, but has a "
-"benefit of not needing to save any tokens between invocations, thus nothing "
-"is saved to disk. This mode is used when `--no-config` argument is "
-"specified."
+"The second approach only authenticates each command invocation for the "
+"duration of that invocation. This approach increases the load on the server "
+"and the time spent with roundtrips obtaining tokens. The benefit of this "
+"approach is not needing to save any tokens between invocations, which means "
+"nothing is saved to disk. This mode is used when the [command]`--no-config` "
+"argument is specified."
 msgstr ""
-"もう1つの方法は、各コマンドの呼び出しをその呼び出しの間だけ認証することです。この方法では、サーバーに負荷がかかり、トークンを取得する往復時間が長くなりますが、呼び出し間にトークンを保存する必要がないため、ディスクには何も保存されません。このモードは"
-" `--no-config` 引数が指定されている場合に使用されます。"
+"2番目の方法は、各コマンド呼び出しごとに認証する方法です。この方法は、サーバーへの負荷とトークンを取得するやり取りに費やされる時間を増加させます。利点としては、呼び出しの間にトークンを保存する必要がないため、何もディスクに保存されないことです。このモードは、"
+" [command]`--no-config` 引数が指定されている場合に使用されます。"
 
 #. type: Plain text
 msgid ""
-"For example, when performing an operation we specify all the information "
-"required for authentication:"
-msgstr "たとえば、操作を実行するときには、認証に必要なすべての情報を指定します。"
+"For example, when performing an operation, we specify all the information "
+"required for authentication."
+msgstr "操作を実行するときに、認証に必要なすべての情報を指定する例。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get realms --no-config --server http://localhost:8080/auth "
+"$ kcadm.sh get realms --no-config --server http://localhost:8080/auth "
 "--realm master --user admin --password admin\n"
 msgstr ""
 "$ kcadm.sh get realms --no-config --server http://localhost:8080/auth "
 "--realm master --user admin --password admin\n"
 
 #. type: Plain text
-msgid "See built-in help for more information on using `Admin CLI`."
-msgstr "`管理CLI` の使用方法の詳細については、組み込みヘルプを参照してください。"
-
-#. type: Plain text
-#, no-wrap
-msgid "    $ kcadm.sh help\n"
-msgstr "$ kcadm.sh help\n"
+msgid ""
+"Run the [command]`kcadm.sh help` command for more information on using the "
+"Admin CLI."
+msgstr "Admin CLIの使用方法の詳細については、 [command]`kcadm.sh help` コマンドを実行してください。"
 
 #. type: Plain text
 msgid ""
-"See `kcadm.sh config credentials --help` for more information about starting"
-" an authenticated session."
+"Run the [command]`kcadm.sh config credentials --help` command for more "
+"information about starting an authenticated session."
 msgstr ""
-"認証されたセッションの開始の詳細については、 `kcadm.sh config credentials --help` を参照してください。"
+"認証セッションの開始については、[command]`kcadm.sh config credentials --help` コマンドを実行してください。"
 
 #. type: Plain text
 msgid ""
-"By default, `Admin CLI` automatically maintains a configuration file called "
-"`kcadm.config` located under user's home directory - it's full pathname is "
-"`$HOME/.keycloak/kcadm.config` (on Windows it's "
-"`%HOMEPATH%\\.keycloak\\kcadm.config`)."
+"By default, the Admin CLI automatically maintains a configuration file "
+"called [filename]kcadm.config located under the user's home directory. In "
+"Linux-based systems, the full path name is "
+"[filename]$HOME/.keycloak/kcadm.config. On Windows, the full path name is "
+"[filename]%HOMEPATH%\\.keycloak\\kcadm.config. You can use the "
+"[command]`--config` option to point to a different file or location so you "
+"can maintain multiple authenticated sessions in parallel."
 msgstr ""
-"デフォルトで `管理CLI` は、ユーザのホームディレクトリの下にある `kcadm.config` "
-"という設定ファイルを自動的に保持します。フルパス名は `$HOME/.keycloak/kcadm.config` です（Windowsでは "
-"`%HOMEPATH%\\.keycloak\\kcadm.config` ）。"
+"デフォルトでは、管理CLIはユーザーのホームディレクトリにある [filename]kcadm.config "
+"という設定ファイルを自動的に維持します。Linuxベースのシステムでは、フルパス名は[filename]$HOME/.keycloak/kcadm.config"
+" です。 Windowsでは、フルパス名は [filename]%HOMEPATH%\\.keycloak\\kcadm.config です。 "
+"[command]`--config` "
+"オプションを使うと、別のファイルや場所を指し示すことができるので、複数の認証セッションを並行して維持することができます。"
+
+#. type: delimited block =
+msgid ""
+"It is best to perform operations tied to a single configuration file from a "
+"single thread."
+msgstr "単一のスレッドから単一の設定ファイルに結び付けられた操作を実行することが最善の方法です。"
 
 #. type: Plain text
 msgid ""
-"You can use `--config` option to point to a different file / location. This "
-"way you can maintain multiple authenticated sessions in parallel."
+"Make sure you do not make the configuration file visible to other users on "
+"the system. It contains access tokens and secrets that should be kept "
+"private. By default, the [filename]`~/.keycloak` directory and its content "
+"are created automatically with proper access limits. If the directory "
+"already exists, its permissions are not updated."
 msgstr ""
-"`--config` オプションを使うと、別のファイル／場所を指すことができます。これにより、複数の認証済みセッションを並行して維持できます。"
+"システム上の他のユーザーが設定ファイルを参照できないようにしてください。プライベートにしておくべきアクセス・トークンとシークレットが含まれています。デフォルトでは、[filename]`~/.keycloak`"
+" ディレクトリとその内容は適切なアクセス制限で自動的に作成されます。ディレクトリが既に存在する場合、そのアクセス許可は更新されません。"
 
 #. type: Plain text
 msgid ""
-"It's best to perform operations tied to a single config file from a single "
-"thread."
-msgstr "単一のスレッドから単一の設定ファイルに結び付けられた操作を実行するのが最善です。"
-
-#. type: Plain text
-msgid ""
-"Make sure to not make config file visible to other users on the system as it"
-" contains access tokens, and secrets that should be kept private.  By "
-"default the ~/.keycloak directory and its content will be automatically "
-"created with proper access limits. However if directory will exist already "
-"with non-default permissions, those will not be updated."
+"If your unique circumstances require you to avoid storing secrets inside a "
+"configuration file, you can do so. It will be less convenient and you will "
+"have to make more token requests. To not store secrets, use the [command"
+"]`--no-config` option with all your commands and specify all the "
+"authentication information needed by the [command]`config credentials` "
+"command with each [command]`kcadm` invocation."
 msgstr ""
-"非公開とすべきアクセス・トークンとシークレットを含んでいるため、設定ファイルは他のユーザーに見えないようにしてください。デフォルトでは~/.keycloakディレクトリとその内容は、適切なアクセス制限で自動的に作成されます。ただし、デフォルト以外のアクセス権を持つディレクトリがすでに存在する場合、そのアクセス権は更新されません。"
-
-#. type: Plain text
-msgid ""
-"You may want to avoid storing any secrets at all inside a config file for "
-"the price of less convenience and having to do more token requests.  In that"
-" case you can use `--no-config` option with all your commands. In that case "
-"you will have to specify all the authentication info needed by `config "
-"credentials` command with each `kcadm` invocation."
-msgstr ""
-"利便性が低くなり、より多くのトークン要求が必要になることと引き換えに、設定ファイルの中にどんなシークレットも保存することは避けたいかもしれません。その場合、すべてのコマンドで"
-" `--no-config` オプションを使うことができます。その場合、`kcadm` 呼び出しごとに、 `config credentials` "
-"コマンドが必要とするすべての認証情報を指定する必要があります。"
+"固有の要件により、シークレットを設定ファイルに保管しないようにする必要がある場合は、そうすることが可能です。この方法はあまり便利ではなく、トークン要求が多くなります。シークレットを保存しないためには、すべてのコマンドで"
+" [command]`--no-config` オプションを使用し、 [command]`config credentials` "
+"コマンドで必要とされるすべての認証情報を [command]`kcadm` 呼び出しごとに指定します。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Basic operations, and resource URIs"
-msgstr "基本操作、およびリソースURI"
+msgid "Basic operations and resource URIs"
+msgstr "基本操作とリソースURI"
 
 #. type: Plain text
 msgid ""
-"Admin CLI allows you to perform CRUD operations against Admin REST API "
-"endpoints in quite a generic way, with additional commands that simplify "
-"performing certain tasks."
+"The Admin CLI allows you to generically perform CRUD operations against "
+"Admin REST API endpoints with additional commands that simplify performing "
+"certain tasks."
 msgstr ""
-"管理CLIを使用すると、特定のタスクの実行を簡略化する追加のコマンドにより、とても一般的な方法でAdmin REST "
-"APIエンドポイントに対してCRUD操作を実行できます。"
+"管理CLIでは、特定のタスクの実行を簡略化するために追加されたコマンドを使用して、管理REST APIエンドポイントに対してCRUD操作を実行できます。"
 
 #. type: Plain text
-msgid "Main usage pattern is the following:"
-msgstr "主な使用パターンは次のとおりです。"
+msgid ""
+"The main usage pattern is listed below, where the [command]`create`, "
+"[command]`get`, [command]`update`, and [command]`delete` commands are mapped"
+" to the HTTP verbs `POST`, `GET`, `PUT`, and `DELETE`, respectively."
+msgstr ""
+"主な使用パターンを以下に示します。 [command]`create` 、 [command]`get` 、 [command]`update` 、 "
+"[command]`delete` コマンドは、それぞれHTTP動詞の `POST` 、 `GET` 、 `PUT` 、 `DELETE` "
+"に該当します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create ENDPOINT [ARGUMENTS]\n"
-"    $ kcadm.sh get ENDPOINT [ARGUMENTS]\n"
-"    $ kcadm.sh update ENDPOINT [ARGUMENTS]\n"
-"    $ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh create ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh get ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh update ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
 msgstr ""
 "$ kcadm.sh create ENDPOINT [ARGUMENTS]\n"
-" $ kcadm.sh get ENDPOINT [ARGUMENTS]\n"
-" $ kcadm.sh update ENDPOINT [ARGUMENTS]\n"
-" $ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh get ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh update ENDPOINT [ARGUMENTS]\n"
+"$ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
 
 #. type: Plain text
 msgid ""
-"Where operations `create`, `get`, `update`, and `delete` are mapped to HTTP "
-"verbs POST, GET, PUT, and DELETE, respectively.  ENDPOINT is a target "
-"resource URI, and can either be absolute - starting with 'http:' or "
-"'https:', or relative - used to compose an absolute URL of the following "
-"format:"
+"ENDPOINT is a target resource URI and can either be absolute (starting with "
+"`http:` or `https:`) or relative, used to compose an absolute URL of the "
+"following format:"
 msgstr ""
-"`create` 、 ` get` 、 `update` 、および ` delete` "
-"操作はHTTPメソッドのPOST、GET、PUT、DELETEにそれぞれマッピングされます。 ENDPOINTはターゲット・リソースURIであり、 "
-"'http:' または 'https:' で始まる、絶対パスか相対パスです。相対パスは次の形式の絶対URLを作成するために使用されます。"
+"ENDPOINTはターゲット・リソースURIであり、 `http:` または `https:` "
+"で始まる絶対URL、もしくは相対URLで、次の形式の絶対URLを構成するために使用されます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    SERVER_URI/admin/realms/REALM/ENDPOINT\n"
+msgid "SERVER_URI/admin/realms/REALM/ENDPOINT\n"
 msgstr "SERVER_URI/admin/realms/REALM/ENDPOINT\n"
 
 #. type: Plain text
 msgid ""
-"For example, if the server we authenticate against is "
-"`http://localhost:8080/auth`, and realm is `master`, then using `users` as "
-"ENDPOINT will result in the following resource URL: "
-"`http://localhost:8080/auth/admin/realms/master/users`."
+"For example, if you authenticate against the server "
+"http://localhost:8080/auth and realm is [filename]`master`, then using "
+"[filename]`users` as ENDPOINT results in the resource URL "
+"http://localhost:8080/auth/admin/realms/master/users."
 msgstr ""
-"たとえば、認証するサーバが `http://localhost:8080/auth` で、レルムが `master` の場合、 `users` "
-"をENDPOINTとして使用すると、次のようなリソースURLになります。 "
-"`http://localhost:8080/auth/admin/realms/master/users`"
+"たとえば、http://localhost:8080/auth、のサーバーに対してrealmが [filename]`master` 、 "
+"[filename]`users` "
+"をエンドポイントとして認証する場合、リソースURLは、http://localhost:8080/auth/admin/realms/master/usersとなります。"
 
 #. type: Plain text
 msgid ""
-"If we set ENDPOINT to `clients` the effective resource URI would be: "
-"`http://localhost:8080/auth/admin/realms/master/clients`."
+"If you set ENDPOINT to [filename]`clients`, the effective resource URI would"
+" be http://localhost:8080/auth/admin/realms/master/clients."
 msgstr ""
-"ENDPOINTを `clients` に設定すると、有効なリソースURIは次のようになります。 "
-"`http://localhost:8080/auth/admin/realms/master/clients`"
+"エンドポイントに [filename]`clients` "
+"を設定すると、有効なリソースURIはhttp://localhost:8080/auth/admin/realms/master/clientsになります。"
 
 #. type: Plain text
 msgid ""
-"There is `realms` endpoint which is treated slightly differently since it is"
-" the container for realms. It resolves simply to:"
-msgstr "レルムのコンテナであるため、わずかに異なって扱われる `realms` エンドポイントがあり、単純に次のように解決されます。"
+"There is a [filename]`realms` endpoint that is treated slightly differently "
+"because it is the container for realms. It resolves to:"
+msgstr " [filename]`realms` エンドポイントは、レルムのコンテナであるため、少し異なります。それは以下のとおりです。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    SERVER_URI/admin/realms\n"
+msgid "SERVER_URI/admin/realms\n"
 msgstr "SERVER_URI/admin/realms\n"
 
 #. type: Plain text
 msgid ""
-"There is also `serverinfo` which is treated the same way since it is "
-"independent of realms."
-msgstr "レルムから独立している`serverinfo` も同様に扱われます。"
+"There is also a [filename]`serverinfo` endpoint, which is treated the same "
+"way because it is independent of realms."
+msgstr "同様のエンドポイントとして、[filename]`serverinfo` エンドポイントも存在します。"
 
 #. type: Plain text
 msgid ""
-"When authenticating as a user with realm-admin powers you may need to "
-"perform operations on multiple different realms. In that case you can "
-"specify `-r` option to tell explicitly which realm the operation should be "
-"executed against.  Instead of using REALM as specified via `--realm` option "
-"of `kcadm.sh config credentials`, the TARGET_REALM will be used:"
+"When you authenticate as a user with realm-admin powers, you might need to "
+"perform commands on multiple realms. In that case, specify the [command]`-r`"
+" option to tell explicitly which realm the command should be executed "
+"against. Instead of using [filename]`REALM` as specified via the "
+"[command]`--realm` option of [command]`kcadm.sh config credentials`, the "
+"[filename]`TARGET_REALM` is used."
 msgstr ""
-"レルム管理者権限を持つユーザーとして認証する場合、複数の異なるレルムで操作を実行する必要があります。その場合、 `-r` "
-"オプションを指定することで、どのレルムに対して操作が実行されるべきかを明示することができます。 `kcadm.sh config "
-"credentials` の `--realm` オプションで指定されたREALMを使用する代わりに、TARGET_REALMが使用されます。"
+"レルムの管理者権限を持つユーザーとして認証する場合は、複数のレルムでコマンドを実行する必要があります。その場合、 [command]`-r` "
+"オプションを指定して、どのレルムに対してコマンドを実行するかを明示的に指示します。 [command]`kcadm.sh config "
+"credentials` の [command]`--realm` オプションで指定した [filename]`REALM` を使う代わりに "
+"[filename]`TARGET_REALM` が使われます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
+msgid "SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
 msgstr "SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
 
 #. type: Plain text
+msgid "For example,"
+msgstr "例えば"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
-"    $ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
+"$ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
+"$ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
 msgstr ""
 "$ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
-" $ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
+"$ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
 
 #. type: Plain text
 msgid ""
-"In this example we first start a session authenticated as `admin` user in "
-"`master` realm. Then we perform a POST call against the following resource "
-"URL:"
+"In this example, you start a session authenticated as the [filename]`admin` "
+"user in the [filename]`master` realm. You then perform a POST call against "
+"the resource URL "
+"[filename]`http://localhost:8080/auth/admin/realms/demorealm/users`."
 msgstr ""
-"この例では、最初に `master` レルムで `admin` "
-"ユーザーとして認証されたセッションを開始してから、次のリソースURLに対してPOST呼び出しを実行します。"
+"この例では、 [filename]`master` レルムの [filename]`admin` "
+"ユーザーとして認証されたセッションを開始します。その後、リソースURL "
+"[filename]`http://localhost:8080/auth/admin/realms/demorealm/users` "
+"に対してPOST呼び出しを実行します。"
 
 #. type: Plain text
+msgid ""
+"The [command]`create` and [command]`update` commands send a JSON body to the"
+" server by default. You can use [filename]`-f FILENAME` to read a premade "
+"document from a file. When you can use [command]`-f -` option, the message "
+"body is read from standard input. You can also specify individual attributes"
+" and their values as seen in the previous [command]`create users` example. "
+"They are composed into a JSON body and sent to the server."
+msgstr ""
+"[command]`create` と [command]`update` コマンドは、デフォルトでJSONをサーバーに送信します。 "
+"[filename]`-f FILENAME` を使うと、ファイルから作成しておいたJSONを読みこむことができます。 [command]`-f -` "
+"オプションを使うことができる場合、メッセージ本文は標準入力から読み込まれます。前の [command]`create users` "
+"の例に見られるように、個々の属性とその値を指定することもできます。 それらはJSONで構成され、サーバーに送信されます。"
+
+#. type: Plain text
+msgid ""
+"There are several ways to update a resource using the [command]`update` "
+"command. You can first determine the current state of a resource and save it"
+" to a file, and then edit that file and send it to the server for updating."
+msgstr ""
+"[command]`update` "
+"コマンドを使ってリソースを更新する方法はいくつかあります。リソースの現在の状態をファイルに保存し、そのファイルを編集してサーバーに送信することで更新できます。"
+
+#. type: delimited block -
 #, no-wrap
-msgid "    http://localhost:8080/auth/admin/realms/demorealm/users\n"
-msgstr "http://localhost:8080/auth/admin/realms/demorealm/users\n"
-
-#. type: Plain text
 msgid ""
-"Commands `create` and `update` by default send JSON body to the server. You "
-"can use `-f FILENAME` to read a pre-made document from a file.  You can use "
-"`-f -`, and message body will be read from standard input.  But you can also"
-" specify individual attributes and their values as seen in the previous "
-"`create users` example, and they will be composed into a JSON body and sent "
-"to the server."
-msgstr ""
-"コマンド `create` と `update` は、デフォルトでJSONボディをサーバーに送ります。 `-f FILENAME` "
-"を使って、ファイルからあらかじめ作られた文書を読むことができます。 `-f -` を使うと、メッセージ・ボディは標準入力から読み込まれます。前出の "
-"`create users` の例に見られるように、個々の属性とその値を指定することもでき、それらはJSON本体に合成されてサーバーに送られます。"
-
-#. type: Plain text
-msgid ""
-"When using `update` there are several ways to update a resource. You can "
-"first get current state of a resource, and save it into a file, then edit "
-"that file and send it to the server for update. For example:"
-msgstr ""
-"`update` "
-"を使うときは、リソースを更新するいくつかの方法があります。まず、最初にリソースの現在の状態を取得してファイルに保存してから、そのファイルを編集してサーバーに送信して更新する方法があります。例えば："
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"    $ kcadm.sh get realms/demorealm > demorealm.json\n"
-"    $ vi demorealm.json\n"
-"    $ kcadm.sh update realms/demorealm -f demorealm.json\n"
+"$ kcadm.sh get realms/demorealm > demorealm.json\n"
+"$ vi demorealm.json\n"
+"$ kcadm.sh update realms/demorealm -f demorealm.json\n"
 msgstr ""
 "$ kcadm.sh get realms/demorealm > demorealm.json\n"
-" $ vi demorealm.json\n"
-" $ kcadm.sh update realms/demorealm -f demorealm.json\n"
+"$ vi demorealm.json\n"
+"$ kcadm.sh update realms/demorealm -f demorealm.json\n"
 
 #. type: Plain text
 msgid ""
-"This way the resource on the server will be updated with all the attributes "
-"in the sent JSON document."
-msgstr "この方法では、サーバー上のリソースは、送信されたJSONドキュメントのすべての属性で更新されます。"
+"This method updates the resource on the server with all the attributes in "
+"the sent JSON document."
+msgstr "この方法は、送信されたJSONドキュメントのすべての属性を使用してサーバー上のリソースを更新します。"
 
 #. type: Plain text
 msgid ""
-"Another option is to perform an update on-the-fly using `-s, --set` options "
-"to set new values. For example:"
-msgstr "別の選択肢としては `-s、--set` オプションを使ってその場でアップデートを実行して新しい値を設定することです。例えば："
+"Another option is to perform an on-the-fly update using the [command]`-s, "
+"--set` options to set new values."
+msgstr "もう1つの方法は、 [command]`-s, --set` オプションにより、新しい値を設定して更新することです。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh update realms/demorealm -s enabled=false\n"
+msgid "$ kcadm.sh update realms/demorealm -s enabled=false\n"
 msgstr "$ kcadm.sh update realms/demorealm -s enabled=false\n"
 
 #. type: Plain text
-msgid "That would only update `enabled` attribute to `false`."
-msgstr "とすると `enabled` 属性を ` false` に更新するだけです。"
+msgid "That method only updates the [command]`enabled` attribute to `false`."
+msgstr "これは [command]`enabled` 属性を `false` に更新するだけです。"
 
 #. type: Plain text
 msgid ""
-"By default `update` operation first performs a `get`, and then merges new "
-"attribute values with existing.  Mostly this is a preferred behaviour. In "
-"some cases the endpoint may support `PUT` but not `GET`.  You can use `-n` "
-"option to perform a so called 'no-merge' update which performs a PUT, "
-"without first doing a GET."
+"By default, the [commamd]`update` command first performs a [command]`get` "
+"and then merges the new attribute values with existing values. This is the "
+"preferred behavior. In some cases, the endpoint may support the "
+"[command]`PUT` command but not the [command]`GET` command. You can use the "
+"[command]`-n` option to perform a \"no-merge\" update, which performs a "
+"[command]`PUT` command without first running a [command]`GET` command."
 msgstr ""
-"デフォルトでは、 `update` オペレーションはまず `get` "
-"を実行し、新しい属性値を既存のものとマージします。たいていはこれが好ましい動作です。場合によってエンドポイントは `PUT` をサポートしても "
-"`GET` はサポートしないかもしれません。 `-n` オプションを使うと、最初にGETを実行しないでPUTを実行する、いわゆる 'no-merge' "
-"アップデートを実行できます。"
+"デフォルトでは、 [commamd]`update` コマンドは最初に [command]`get` "
+"を実行し、新しい属性値を既存の値とマージします。これが推奨動作です。場合によっては、エンドポイントは [command]`PUT` "
+"コマンドをサポートすることができますが、 [command]`GET` コマンドはサポートしない場合があります。 [command]`-n` "
+"オプションを使用して、 [command]`GET` コマンドを最初に実行することなく [command]`PUT` "
+"コマンドを実行する\"マージしない\"更新を実行することができます。"
 
 #. type: Title ===
 #, no-wrap
 msgid "Realm operations"
 msgstr "レルム操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Creating a new realm"
 msgstr "新しいレルムを作成する"
 
 #. type: Plain text
 msgid ""
-"To create a new enabled realm use `create` operation on `realms` endpoint, "
-"and set attributes `realm` and `enabled`:"
+"Use the [command]`create` command on the `realms` endpoint to create a new "
+"enabled realm, and set the attributes to `realm` and `enabled`."
 msgstr ""
-"新しい有効なレルムを作成するには、 `realms` エンドポイントで `create` 操作を行い、 `realm` 属性と `enabled` "
-"属性を設定してください。"
+"`realms` エンドポイントで [command]`create` コマンドを使用して新しいレルムを作成し、 `realm` と `enabled`"
+" に属性を設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
-msgstr "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
+msgid "$ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
+msgstr "$ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
 
 #. type: Plain text
 msgid ""
-"Realm is not enabled by default. By enabling it, it can be used for "
-"authentication immediately."
-msgstr "レルムはデフォルトでは有効になっていません。有効にすると、すぐに認証に使用できます。"
+"A realm is not enabled by default. By enabling it, you can use a realm "
+"immediately for authentication."
+msgstr "レルムはデフォルトで有効になっていません。有効にすることで、認証用のレルムを使用することができます。"
 
 #. type: Plain text
-msgid "A description for a new object can be in JSON format as well:"
-msgstr "新しいオブジェクトはJSON形式で記述することもできます。"
+msgid "A description for a new object can also be in a JSON format."
+msgstr "新しいオブジェクトの説明は、JSON形式で記述することもできます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh create realms -f demorealm.json\n"
+msgid "$ kcadm.sh create realms -f demorealm.json\n"
 msgstr "$ kcadm.sh create realms -f demorealm.json\n"
 
 #. type: Plain text
 msgid ""
-"JSON document with realm attributes can be sent directly from file or piped "
-"to standard input."
-msgstr "レルム属性を持つJSONドキュメントは、ファイルから直接、またはパイプで標準入力に送信できます。"
+"You can send a JSON document with realm attributes directly from a file or "
+"piped to a standard input."
+msgstr "レルム属性を持つJSONドキュメントをファイルや標準入力のパイプから直接送信することもできます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create realms -f - << EOF\n"
-"    { \"realm\": \"demorealm\", \"enabled\": true }\n"
-"    EOF\n"
+"$ kcadm.sh create realms -f - << EOF\n"
+"{ \"realm\": \"demorealm\", \"enabled\": true }\n"
+"EOF\n"
 msgstr ""
 "$ kcadm.sh create realms -f - << EOF\n"
-" { \"realm\": \"demorealm\", \"enabled\": true }\n"
-" EOF\n"
+"{ \"realm\": \"demorealm\", \"enabled\": true }\n"
+"EOF\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm "
-"create realms -f -\n"
+"c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm create "
+"realms -f -\n"
 msgstr ""
 "c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm create "
 "realms -f -\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing existing realms"
 msgstr "既存レルムの一覧表示"
 
 #. type: Plain text
-msgid "The following will return a list of all realms:"
-msgstr "次の例は、すべてのレルムのリストを返します。"
+msgid "The following command returns a list of all realms."
+msgstr "次のコマンドは、すべてのレルムの一覧を返します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get realms\n"
-msgstr "    $ kcadm.sh get realms\n"
+msgid "$ kcadm.sh get realms\n"
+msgstr "$ kcadm.sh get realms\n"
+
+#. type: delimited block =
+msgid ""
+"A list of realms is additionally filtered on the server to return only "
+"realms a user can see."
+msgstr "レルムの一覧は、サーバー上でフィルターされ、ユーザーが見ることができるレルムだけを返します。"
 
 #. type: Plain text
 msgid ""
-"Note that a list of realms is additionally filtered on the server to only "
-"return realms user is allowed to see."
-msgstr "レルムのリストは、ユーザーが参照できるレルムだけを返すように、サーバー上でさらにフィルタリングされることに注意してください。"
-
-#. type: Plain text
-msgid ""
-"Returning the whole realm description is often too much information as we "
-"are often only interested in a subset of attributes like realm name, and if "
-"realm is enabled or not.  You can specify which attributes to return by "
-"using `--fields` option:"
+"Returning the entire realm description often provides too much information. "
+"Most users are interested only in a subset of attributes, such as realm name"
+" and whether the realm is enabled. You can specify which attributes to "
+"return by using the [command]`--fields` option."
 msgstr ""
-"レルム名や、レルムが有効か否かのように、属性のサブセットだけに興味がある場合がよくありますが、レルムの説明全体を返すと情報が多すぎることがしばしばです。"
-" `fields` オプションを使って返す属性を指定することができます。"
+"レルムの詳細全体を取得することができますが、レルム名やレルムが有効かどうかなど、一部の属性のみ取得したい場合があります。 "
+"[command]`--fields` オプションを使用すると、返す属性を指定することができます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get realms --fields realm,enabled\n"
-msgstr "    $ kcadm.sh get realms --fields realm,enabled\n"
+msgid "$ kcadm.sh get realms --fields realm,enabled\n"
+msgstr "$ kcadm.sh get realms --fields realm,enabled\n"
 
 #. type: Plain text
-msgid "You can even display the result as comma separated values:"
+msgid "You can also display the result as comma separated values."
 msgstr "結果をカンマ区切りの値として表示することもできます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
-msgstr "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
+msgid "$ kcadm.sh get realms --fields realm --format csv --noquotes\n"
+msgstr "$ kcadm.sh get realms --fields realm --format csv --noquotes\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific realm"
 msgstr "特定のレルムを取得する"
 
 #. type: Plain text
 msgid ""
-"As is common for REST web services, in order to get an individual item of a "
-"collection, append an id to collection URI:"
-msgstr "REST Webサービスに共通するように、コレクションの個々の項目を取得するには、コレクションURIにIDを追加します。"
+"You append a realm name to a collection URI to get an individual realm."
+msgstr "コレクションURIにレルム名を指定し、個々のレルムを取得することができます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get realms/master\n"
-msgstr "    $ kcadm.sh get realms/master\n"
+msgid "$ kcadm.sh get realms/master\n"
+msgstr "$ kcadm.sh get realms/master\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Updating a realm"
 msgstr "レルムの更新"
 
 #. type: Plain text
 msgid ""
-"In order to only change some attributes of the realm use `-s` to set new "
-"values for the attributes. For example:"
-msgstr "レルムの一部の属性のみを変更するには、 `-s` を使って属性の新しい値を設定します。例えば："
+"Use the [command]`-s` option to set new values for the attributes when you "
+"want to change only some of the realm's attributes."
+msgstr "レルムの属性の一部だけを変更したい場合は、 [command]`-s` オプションを使用して属性の新しい値を設定します。"
 
 #. type: Plain text
 msgid ""
-"If you want to set all writable attributes with new values, perform a `get` "
-"first, edit current values in JSON file, and resubmit. For example:"
+"If you want to set all writable attributes with new values, run a "
+"[command]`get` command, edit the current values in the JSON file, and "
+"resubmit."
 msgstr ""
-"書き込み可能なすべての属性を新しい値に設定する場合は、最初に `get` を実行し、JSONファイルの現在の値を編集して再送信してください。例えば："
+"書き込み可能なすべての属性を新しい値に設定するには、 [command]`get` コマンドを実行し、JSONファイルの現在の値を編集して送信します。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting a realm"
 msgstr "レルムの削除"
 
 #. type: Plain text
-msgid "Here is how to delete a realm:"
-msgstr "レルムを削除する方法は次のとおりです。"
+msgid "Run the following command to delete a realm."
+msgstr "レルムを削除するには、次のコマンドを実行します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh delete realms/demorealm\n"
-msgstr "    $ kcadm.sh delete realms/demorealm\n"
+msgid "$ kcadm.sh delete realms/demorealm\n"
+msgstr "$ kcadm.sh delete realms/demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Turning on all login page options for the realm"
 msgstr "レルムのすべてのログイン・ページ・オプションを有効にする"
@@ -693,10 +706,10 @@ msgstr "レルムのすべてのログイン・ページ・オプションを有
 msgid "Set the attributes controlling specific capabilities to `true`."
 msgstr "特定の機能を制御する属性を `true` に設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update realms/demorealm -s registrationAllowed=true -s "
+"$ kcadm.sh update realms/demorealm -s registrationAllowed=true -s "
 "registrationEmailAsUsername=true -s rememberMe=true -s verifyEmail=true -s "
 "resetPasswordAllowed=true -s editUsernameAllowed=true\n"
 msgstr ""
@@ -704,49 +717,49 @@ msgstr ""
 "registrationEmailAsUsername=true -s rememberMe=true -s verifyEmail=true -s "
 "resetPasswordAllowed=true -s editUsernameAllowed=true\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing the realm keys"
 msgstr "レルム鍵の一覧表示"
 
 #. type: Plain text
-msgid "Use `get` operation on `keys` endpoint of the target realm:"
-msgstr "対象レルムの `keys` エンドポイントで `get` 操作を使用してください。"
+msgid ""
+"Use the [command]`get` operation on the [filename]`keys` endpoint of the "
+"target realm."
+msgstr "対象レルムの [filename]`keys` エンドポイントで [command]`get` 操作を使用してください。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get keys -r demorealm\n"
+msgid "$ kcadm.sh get keys -r demorealm\n"
 msgstr "$ kcadm.sh get keys -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Generating new realm keys"
 msgstr "新しいレルム鍵の生成"
 
 #. type: Plain text
 msgid ""
-"To add a new RSA generated keypair, first get `id` of the target realm. For "
-"example:"
-msgstr "新たにRSAで生成されたキーペアを追加するには、まず対象レルムの `id` を取得します。例えば："
+"Get the ID of the target realm before adding a new RSA-generated key pair."
+msgstr "新しいRSA生成キーペアを追加する前に、対象レルムのIDを取得します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid ""
-"    $ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
+msgid "$ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
 msgstr "$ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
 
 #. type: Plain text
 msgid ""
-"Then add a new key provider with higher priority than any of the existing "
-"providers as revealed by `kcadm.sh get keys -r demorealm`:"
+"Add a new key provider with a higher priority than the existing providers as"
+" revealed by [command]`kcadm.sh get keys -r demorealm`."
 msgstr ""
-"次に、 `kcadm.sh get keys -r demorealm` "
-"で判明したどの既存のプロバイダーよりも高い優先順位で、新しいキー・プロバイダーを追加します。"
+"[command]`kcadm.sh get keys -r demorealm` "
+"で取得した既存のプロバイダよりも優先度の高い、新しい鍵プロバイダを追加してください。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=rsa-generated -s "
+"$ kcadm.sh create components -r demorealm -s name=rsa-generated -s "
 "providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s "
 "parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]'"
 " -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
@@ -758,10 +771,10 @@ msgstr ""
 " -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
 "'config.keySize=[\"2048\"]'\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm create components -r demorealm -s name=rsa-generated -s "
+"c:\\> kcadm create components -r demorealm -s name=rsa-generated -s "
 "providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s "
 "parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "
 "\"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s "
@@ -774,35 +787,32 @@ msgstr ""
 "\"config.active=[\\\"true\\\"]\" -s \"config.keySize=[\\\"2048\\\"]\"\n"
 
 #. type: Plain text
-msgid ""
-"Attribute `parentId` should be set to the value of target realm's `id`."
-msgstr "`parentId` 属性は対象レルムの `id` の値に設定されなければなりません。"
+msgid "Set the `parentId` attribute to the value of the target realm's ID."
+msgstr "`parentId` 属性を対象レルムのIDの値に設定します。"
 
 #. type: Plain text
 msgid ""
 "The newly added key should now become the active key as revealed by "
-"`kcadm.sh get keys -r demorealm`."
-msgstr "`kcadm.sh get keys -r demorealm` で確認すると、新しく追加した鍵がアクティブな鍵になっているはずです。"
+"[command]`kcadm.sh get keys -r demorealm`."
+msgstr ""
+"新しく追加された鍵は、 [command]`kcadm.sh get keys -r demorealm` "
+"によって取得したとおり、アクティブな鍵になります。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Adding new realm keys from Java Key Store file"
+msgid "Adding new realm keys from a Java Key Store file"
 msgstr "Javaキーストア・ファイルから新しいレルム鍵を追加する"
 
 #. type: Plain text
 msgid ""
-"To add a new keypair already prepared as a JKS file on the server, add a new"
-" key provider as follows:"
-msgstr "すでにサーバー上にJKSファイルとして準備されている新しい鍵ペアを追加するには、次のように新しい鍵プロバイダーを追加します。"
+"Add a new key provider to add a new key pair already prepared as a JKS file "
+"on the server."
+msgstr "新しい鍵プロバイダを追加して、すでにサーバー上にJKSファイルとして用意されている新しい鍵ペアを追加します。"
 
-#. type: Plain text
-msgid "For exmple on Linux:"
-msgstr "例えば、Linux の場合："
-
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=java-keystore -s "
+"$ kcadm.sh create components -r demorealm -s name=java-keystore -s "
 "providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
 "parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]'"
 " -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
@@ -818,10 +828,10 @@ msgstr ""
 "'config.keystorePassword=[\"secret\"]' -s 'config.keyPassword=[\"secret\"]' "
 "-s 'config.alias=[\"localhost\"]'\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm create components -r demorealm -s name=java-keystore -s "
+"c:\\> kcadm create components -r demorealm -s name=java-keystore -s "
 "providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
 "parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "
 "\"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s "
@@ -843,137 +853,146 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Make sure to change attribute values for `keystore`, `keystorePassword`, "
-"`keyPassword`, and `alias` to match your specific keystore."
+"Make sure to change the attribute values for `keystore`, `keystorePassword`,"
+" `keyPassword`, and `alias` to match your specific keystore."
 msgstr ""
-"特定のキーストアに一致するように、 `keystore` 、 `keystorePassword` 、 `keyPassword` 、および "
-"`alias` の属性値を必ず変更してください。"
+"特定のキーストアに一致するように、 `keystore` 、 ` keystorePassword` 、  `keyPassword` 、および "
+"`alias` の属性値を変更してください。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Making key passive or disabling it"
-msgstr "鍵をパッシブにするか無効にする"
+msgid "Making the key passive or disabling the key"
+msgstr "鍵をパッシブにする、または無効にする"
 
 #. type: Plain text
-msgid "Identify the key you wish to make passive:"
-msgstr "パッシブにする鍵を特定します。"
+msgid "Identify the key you want to make passive"
+msgstr "パッシブにしたい鍵を特定する"
 
 #. type: Plain text
 msgid ""
-"Use `providerId` attribute of the key to construct an endpoint uri - "
-"`components/PROVIDER_ID`."
+"Use the key's `providerId` attribute to construct an endpoint URI, such as "
+"[filename]`components/PROVIDER_ID`."
 msgstr ""
-"エンドポイントURI `components/PROVIDER_ID` を構築するのに鍵の `providerId` 属性を使用してください。"
+"鍵の `providerId` 属性を使用して、 [filename]`components/PROVIDER_ID` "
+"のようなエンドポイントURIを構築します。"
 
 #. type: Plain text
-msgid "Then perform an `update`. For example on Linux:"
-msgstr "次に、 `update` を実行します。たとえばLinuxの場合："
+msgid "Perform an [command]`update`."
+msgstr "[command]`update` を実行します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update components/PROVIDER_ID -r demorealm -s "
+"$ kcadm.sh update components/PROVIDER_ID -r demorealm -s "
 "'config.active=[\"false\"]'\n"
 msgstr ""
 "$ kcadm.sh update components/PROVIDER_ID -r demorealm -s "
 "'config.active=[\"false\"]'\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm update components/PROVIDER_ID -r demorealm -s "
+"c:\\> kcadm update components/PROVIDER_ID -r demorealm -s "
 "\"config.active=[\\\"false\\\"]\"\n"
 msgstr ""
 "c:\\> kcadm update components/PROVIDER_ID -r demorealm -s "
 "\"config.active=[\\\"false\\\"]\"\n"
 
 #. type: Plain text
-msgid "Analogously, other key attributes can be updated."
-msgstr "同様に、他の鍵属性も更新できます。"
+msgid "You can update other key attributes."
+msgstr "他のキー属性を更新することができます。"
 
 #. type: Plain text
 msgid ""
-"To disable the key set new `enabled` value, for example: "
-"`'config.enabled=[\"false\"]'`"
-msgstr "鍵を無効にするには、新しい `enabled` 値を設定します。たとえば： `'config.enabled=[\"false\"]'`"
+"Set a new `enabled` value to disable the key, for example, "
+"`config.enabled=[\"false\"]`."
+msgstr "例えば、 `config.enabled=[\"false\"]` のように、鍵を無効にするために `enabled` の値を設定してください。"
 
 #. type: Plain text
 msgid ""
-"To change key's priority set new `priority` value, for example: "
-"`'config.priority=[\"110\"]'`"
-msgstr "鍵の優先度を変更するには、新しい `priority` 値を設定します。たとえば： `'config.priority=[\"110\"]'`"
+"Set a new `priority` value to change the key's priority, for example, "
+"`config.priority=[\"110\"]`."
+msgstr "鍵の優先度を変更するために新しい `priority` 値を設定します。たとえば、 `config.priority=[\"110\"]` です。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting an old key"
 msgstr "古い鍵を削除する"
 
 #. type: Plain text
 msgid ""
-"Make sure that the key you are deleting has been passive for some time, and "
-"then disabled for some time in order to prevent any existing tokens held by "
-"applications and users from abruptly failing to work."
-msgstr ""
-"必ず、削除する鍵がしばらくの間パッシブであることを確認してから、さらにしばらくの間無効にして、アプリケーションやユーザーが保持している既存のトークンが突然動作しなくなることを防止してください。"
+"Make sure the key you are deleting has been passive and disabled to prevent "
+"any existing tokens held by applications and users from abruptly failing to "
+"work."
+msgstr "削除している鍵がパッシブで無効になっていることを確認して、アプリケーションやユーザーが保持している既存のトークンを無効にします。"
 
 #. type: Plain text
-msgid "Use the `providerId` of that key to perform a delete. For example:"
-msgstr "その鍵の `providerId` を使って削除を行います。例えば："
+msgid "Identify the key you want to make passive."
+msgstr "パッシブにする鍵を特定します。"
 
 #. type: Plain text
+msgid "Use the `providerId` of that key to perform a delete."
+msgstr "その鍵の `providerId` を使用して削除を行います。"
+
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
+msgid "$ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
 msgstr "$ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring event logging for a realm"
 msgstr "レルムのイベントログの設定"
 
 #. type: Plain text
-msgid "Use `update` on `events/config` endpoint."
-msgstr "`events/config` エンドポイントで `update` を使います。"
+msgid ""
+"Use the [command]`update` command on the [filename]`events/config` endpoint."
+msgstr "[filename]`events/config` エンドポイントで [command]`update` コマンドを使用してください。"
 
 #. type: Plain text
 msgid ""
-"Attribute `eventsListeners` contains a list of EventListenerProviderFactory "
-"ids, specifying all event listeners receiving events.  Separately, there are"
-" attributes that control a built-in event storage which allows querying past"
-" events via Admin REST API.  There is separate control over logging of "
-"service calls - 'eventsEnabled', and auditing events triggered during Admin "
-"Console or Admin REST API - 'adminEventsEnabled'.  You may want to setup "
-"expiry of old events so that your database doesn't get filled up - "
-"'eventsExpiration' is set to time-to-live expressed in seconds."
+"The `eventsListeners` attribute contains a list of "
+"EventListenerProviderFactory IDs that specify all event listeners receiving "
+"events. Separately, there are attributes that control a built-in event "
+"storage, which allows querying past events via the Admin REST API. There is "
+"separate control over logging of service calls (`eventsEnabled`) and "
+"auditing events triggered during Admin Console or Admin REST API "
+"(`adminEventsEnabled`). You may want to set up expiry of old events so that "
+"your database does not fill up; `eventsExpiration` is set to time-to-live "
+"expressed in seconds."
 msgstr ""
 "`eventsListeners` "
-"属性には、イベントを受け取るすべてのイベント・リスナーを指定するEventListenerProviderFactoryのIDリストが含まれています。これとは別に、Admin"
-" REST APIを介して過去のイベントを照会できる組み込みイベント・ストレージを制御する属性があります。 サービスコール "
-"`eventsEnabled` のログ記録と、管理コンソールの間またはAdmin REST API 'adminEventsEnabled' "
-"にトリガーされた監査イベントについて、個別の制御があります。古いイベントの有効期限を設定してデータベースが満杯にならないようにすることができます。 "
-"'eventsExpiration' は有効期限（秒単位）に設定されています。"
+"属性には、イベントを受け取るすべてのイベントリスナーを指定するEventListenerProviderFactory "
+"IDのリストが含まれています。これとは別に、組み込みイベント記憶域を制御する属性があり、管理REST "
+"APIを介して過去のイベントを照会することができます。`eventsEnabled`と呼ばれるサービス呼び出しログと、`adminEventsEnabled`"
+" と呼ばれるAdmin ConsoleまたはAdmin REST "
+"APIをトリガーとするイベント監査という独立した制御があります。古いイベントの有効期限を設定してデータベースがいっぱいにならないようにすることができます。"
+" `eventsExpiration` は秒で有効期限を表します。"
 
 #. type: Plain text
 msgid ""
-"Here is an example of setting up a built-in event listener that will receive"
-" all the events and log them through jboss-logging (error events are logged "
-"as `WARN`, others as `DEBUG`, using a logger called `org.keycloak.events`):"
+"Here is an example of setting up a built-in event listener that receives all"
+" the events and logs them through jboss-logging. (Using a logger called "
+"`org.keycloak.events`, error events are logged as `WARN`, and others are "
+"logged as `DEBUG`.)"
 msgstr ""
-"次に、すべてのイベントを受け取り、jboss-loggingを通じてそれらを記録するビルトイン・イベントリスナーを設定する例を示します（エラーイベントは"
-" `WARN` として、他は `DEBUG` として `org.keycloak.events` というロガーを使って記録されます）。"
+"ここでは、すべてのイベントを受け取り、jboss-loggingを通じてそれらを記録する組み込みのイベント・リスナーを設定する例を示します。 "
+"`org.keycloak.events` というロガーを使うと、エラー・イベントは `WARN` として記録され、他は  `DEBUG` "
+"として記録されます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update events/config -r demorealm -s 'eventsListeners"
-"=[\"jboss-logging\"]'\n"
+"$ kcadm.sh update events/config -r demorealm -s 'eventsListeners=[\"jboss-"
+"logging\"]'\n"
 msgstr ""
 "$ kcadm.sh update events/config -r demorealm -s 'eventsListeners=[\"jboss-"
 "logging\"]'\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm update events/config -r demorealm -s \"eventsListeners"
+"c:\\> kcadm update events/config -r demorealm -s \"eventsListeners"
 "=[\\\"jboss-logging\\\"]\"\n"
 msgstr ""
 "c:\\> kcadm update events/config -r demorealm -s \"eventsListeners"
@@ -981,15 +1000,16 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Here is an example of turning on storage of all available ERROR events - not"
-" including auditing events - for 2 days so they can be retrieved via Admin "
-"REST:"
-msgstr "次に、利用可能なすべてのERRORイベント（監査イベントを除く）の保管を2日間有効にする例を示します。"
+"Here is an example of turning on storage of all available ERROR "
+"events&#8212;not including auditing events&#8212;for 2 days so they can be "
+"retrieved via Admin REST."
+msgstr ""
+"イベントの監査を除く、利用可能なすべてのERRORイベントのストレージを2日間有効にして、管理REST経由で取得できるようにする例を次に示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update events/config -r demorealm -s eventsEnabled=true -s "
+"$ kcadm.sh update events/config -r demorealm -s eventsEnabled=true -s "
 "'enabledEventTypes=[\"LOGIN_ERROR\",\"REGISTER_ERROR\",\"LOGOUT_ERROR\",\"CODE_TO_TOKEN_ERROR\",\"CLIENT_LOGIN_ERROR\",\"FEDERATED_IDENTITY_LINK_ERROR\",\"REMOVE_FEDERATED_IDENTITY_ERROR\",\"UPDATE_EMAIL_ERROR\",\"UPDATE_PROFILE_ERROR\",\"UPDATE_PASSWORD_ERROR\",\"UPDATE_TOTP_ERROR\",\"VERIFY_EMAIL_ERROR\",\"REMOVE_TOTP_ERROR\",\"SEND_VERIFY_EMAIL_ERROR\",\"SEND_RESET_PASSWORD_ERROR\",\"SEND_IDENTITY_PROVIDER_LINK_ERROR\",\"RESET_PASSWORD_ERROR\",\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\",\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\",\"CUSTOM_REQUIRED_ACTION_ERROR\",\"EXECUTE_ACTIONS_ERROR\",\"CLIENT_REGISTER_ERROR\",\"CLIENT_UPDATE_ERROR\",\"CLIENT_DELETE_ERROR\"]'"
 " -s eventsExpiration=172800\n"
 msgstr ""
@@ -997,147 +1017,142 @@ msgstr ""
 "'enabledEventTypes=[\"LOGIN_ERROR\",\"REGISTER_ERROR\",\"LOGOUT_ERROR\",\"CODE_TO_TOKEN_ERROR\",\"CLIENT_LOGIN_ERROR\",\"FEDERATED_IDENTITY_LINK_ERROR\",\"REMOVE_FEDERATED_IDENTITY_ERROR\",\"UPDATE_EMAIL_ERROR\",\"UPDATE_PROFILE_ERROR\",\"UPDATE_PASSWORD_ERROR\",\"UPDATE_TOTP_ERROR\",\"VERIFY_EMAIL_ERROR\",\"REMOVE_TOTP_ERROR\",\"SEND_VERIFY_EMAIL_ERROR\",\"SEND_RESET_PASSWORD_ERROR\",\"SEND_IDENTITY_PROVIDER_LINK_ERROR\",\"RESET_PASSWORD_ERROR\",\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\",\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\",\"CUSTOM_REQUIRED_ACTION_ERROR\",\"EXECUTE_ACTIONS_ERROR\",\"CLIENT_REGISTER_ERROR\",\"CLIENT_UPDATE_ERROR\",\"CLIENT_DELETE_ERROR\"]'"
 " -s eventsExpiration=172800\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s "
-"\"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\""
-" -s eventsExpiration=172800\n"
-msgstr ""
 "c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s "
 "\"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\""
 " -s eventsExpiration=172800\n"
-
-#. type: Plain text
-msgid ""
-"Here is how you reset stored event types to *all available event types* - "
-"setting to empty list is the same as enumerating all:"
 msgstr ""
-"ここでは、保存されたイベントタイプを *すべての利用可能なイベントタイプ* "
-"にリセットする方法を示します。空のリストに設定することは、すべてを列挙することと同じです。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"    $ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
+"Here is an example of how to reset stored event types to *all available "
+"event types*; setting to empty list is the same as enumerating all."
+msgstr ""
+" *all available event types* "
+"にリセットする方法の例を次に示します。空のリストに設定することはすべてを列挙することを意味します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
 msgstr "$ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
 
 #. type: Plain text
-msgid "And here is how you enable storage of auditing events:"
-msgstr "監査イベントの保管を有効にする方法は次のとおりです。"
+msgid "Here is an example of how to enable storage of auditing events."
+msgstr "次に、監査イベントの格納を有効にする方法の例を示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true "
-"-s adminEventsDetailsEnabled=true\n"
+"$ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true -s "
+"adminEventsDetailsEnabled=true\n"
 msgstr ""
 "$ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true -s "
 "adminEventsDetailsEnabled=true\n"
 
 #. type: Plain text
 msgid ""
-"Here is how you get the last 100 events - they are ordered from newest to "
-"oldest:"
-msgstr "最後の100イベントを取得する方法は次のとおりです。最新のものから古いものまで順番に並べ替えられています。"
+"Here is an example of how to get the last 100 events; they are ordered from "
+"newest to oldest."
+msgstr "最新の100イベントを取得する方法を次に示します。新しいイベントから順番に並んでいます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get events --offset 0 --limit 100\n"
+msgid "$ kcadm.sh get events --offset 0 --limit 100\n"
 msgstr "$ kcadm.sh get events --offset 0 --limit 100\n"
 
 #. type: Plain text
-msgid "Here is how you delete all saved events:"
-msgstr "保存されたすべてのイベントを削除する方法は次のとおりです。"
+msgid "Here is an example of how to delete all saved events."
+msgstr "保存されたすべてのイベントを削除する方法の例を次に示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm delete events\n"
+msgid "$ kcadm delete events\n"
 msgstr "$ kcadm delete events\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Flushing the caches"
 msgstr "キャッシュのフラッシュ"
 
 #. type: Plain text
 msgid ""
-"Use `create` operation, and one of the following endpoints: `clear-realm-"
-"cache`, `clear-user-cache`, `clear-keys-cache`."
+"Use the [command]`create` command and one of the following endpoints: "
+"[filename]`clear-realm-cache`, [filename]`clear-user-cache`, or [filename"
+"]`clear-keys-cache`."
 msgstr ""
-"`create` 操作と 、 `clear-realm-cache` 、 `clear-user-cache` 、 `clear-keys-cache`"
-" エンドポイントのいずれかを使います。"
+"[command]`create` コマンドと、[filename]`clear-realm-cache` 、 [filename]`clear-"
+"user-cache` 、[filename]`clear-keys-cache` のいずれかのエンドポイントを使用します。"
 
 #. type: Plain text
-msgid "Set `realm` to the same value as target realm."
-msgstr "`realm` の値を対象のレルムに設定してください。"
+msgid "Set `realm` to the same value as the target realm."
+msgstr "`realm` を対象レルムと同じ値に設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
-msgstr "$ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
-
-#. type: Plain text
-#, no-wrap
-msgid "    $ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
-msgstr "$ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
-
-#. type: Plain text
-#, no-wrap
-msgid "    $ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
-msgstr "$ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
+"$ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
+"$ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
+"$ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
+msgstr ""
+"$ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
+"$ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
+"$ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Title ===
 #, no-wrap
 msgid "Role operations"
 msgstr "ロール操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Creating a realm role"
 msgstr "レルム・ロールの作成"
 
 #. type: Plain text
-msgid "To create a realm role use `roles` endpoint:"
-msgstr "レルム・ロールを作成するには `roles` エンドポイントを使います。"
+msgid "Use the [filename]`roles` endpoint to create a realm role."
+msgstr "レルム・ロールを作成するには、 [filename]`roles` エンドポイントを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create roles -r demorealm -s name=user -s "
-"'description=Regular user with limited set of permissions'\n"
+"$ kcadm.sh create roles -r demorealm -s name=user -s 'description=Regular "
+"user with limited set of permissions'\n"
 msgstr ""
 "$ kcadm.sh create roles -r demorealm -s name=user -s 'description=Regular "
 "user with limited set of permissions'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Creating a client role"
 msgstr "クライアント・ロールの作成"
 
 #. type: Plain text
 msgid ""
-"To create a client role identify the client first - use `get` to list "
-"available clients:"
-msgstr "クライアント・ロールを作成するには、まずクライアントを確認します。利用可能なクライアントを一覧表示するには `get` を使います。"
+"Identify the client first and then use the [command]`get` command to list "
+"available clients when creating a client role."
+msgstr ""
+"最初にクライアントを特定し、 [command]`get` "
+"コマンドを使用して、クライアント・ロールを作成するときに使用可能なクライアントを一覧表示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get clients -r demorealm --fields id,clientId\n"
+msgid "$ kcadm.sh get clients -r demorealm --fields id,clientId\n"
 msgstr "$ kcadm.sh get clients -r demorealm --fields id,clientId\n"
 
 #. type: Plain text
 msgid ""
-"Then, create a new role by using client's `id` attribute to construct an "
-"endpoint uri - `clients/ID/roles`."
+"Create a new role by using the [command]`clientId` attribute to construct an"
+" endpoint URI, such as [filename]`clients/ID/roles`."
 msgstr ""
-"次に、クライアントの `id` 属性を使用して構築したエンドポイントuri `clients/ID/roles` によって新しいロールを作成します。"
+"[command]`clientId` 属性を使用して、 [filename]`clients/ID/roles` "
+"のようにエンドポイントURIを作成して、新しいロールを作成します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles -r "
+"$ kcadm.sh create clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles -r "
 "demorealm -s name=editor -s 'description=Editor can edit, and publish any "
 "article'\n"
 msgstr ""
@@ -1145,238 +1160,251 @@ msgstr ""
 "demorealm -s name=editor -s 'description=Editor can edit, and publish any "
 "article'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing realm roles"
 msgstr "レルム・ロールの一覧表示"
 
 #. type: Plain text
-msgid "To list existing realm roles use `get` command on `roles` endpoint:"
-msgstr "既存のレルム・ロールを一覧表示するには、 `roles` エンドポイントで `get` コマンドを使います。"
+msgid ""
+"Use the [command]`get` command on the [filename]`roles` endpoint to list "
+"existing realm roles."
+msgstr ""
+"[filename]`roles` エンドポイントで [command]`get` コマンドを使用して、既存のレルム・ロール一覧を取得します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get roles -r demorealm\n"
+msgid "$ kcadm.sh get roles -r demorealm\n"
 msgstr "$ kcadm.sh get roles -r demorealm\n"
 
 #. type: Plain text
-msgid "You can also use `get-roles` command:"
-msgstr "`get-roles` コマンドを使うこともできます。"
+msgid "You can also use the [command]`get-roles` command."
+msgstr "[command]`get-roles` コマンドを使用することもできます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm\n"
+msgid "$ kcadm.sh get-roles -r demorealm\n"
 msgstr "$ kcadm.sh get-roles -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing client roles"
 msgstr "クライアント・ロールの一覧表示"
 
 #. type: Plain text
 msgid ""
-"There is a dedicated `get-roles` command to simplify listing of both realm "
-"and client roles. It is an extension of `get` command and so it behaves the "
-"same with additional semantics for listing roles."
+"There is a dedicated [command]`get-roles` command to simplify listing realm "
+"and client roles. It is an extension of the [command]`get` command and "
+"behaves the same with additional semantics for listing roles."
 msgstr ""
-"レルムとクライアント・ロールの両方の一覧表示を単純化するための専用の `get-roles` コマンドがあります。 `get` "
-"コマンドの拡張であるため、ロールを一覧表示するための追加のセマンティクスで同じように動作します。"
+"レルム・ロールとクライアント・ロールを一覧表示するための専用の [command]`get-roles` コマンドがあります。これは[command] "
+"`get`コマンドの拡張です。"
 
 #. type: Plain text
 msgid ""
-"To list client roles use `get-roles` command, passing it either `clientId` "
-"(via `--cclientid` option) or `id` (via `--cid` option) to identify the "
-"client."
+"Use the [command]`get-roles` command, passing it either the clientId "
+"attribute (via the [command]`--cclientid` option) or [command]`id` (via the "
+"[command]`--cid` option) to identify the client to list client roles."
 msgstr ""
-"クライアント・ロールを一覧表示するには `get-roles` コマンドを使い、 `clientId` （ `--cclientid` "
-"オプションで）または `id` （ `--cid` オプションで）を渡してクライアントを識別します。"
+"[command]`get-roles` コマンドは、 [command]`--cclientid` オプションを利用してclientId属性、または "
+"[command]`--cid` オプションを利用して [command] `id` "
+"を渡すことでクライアント・ロールを一覧表示するクライアントを指定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
+msgid "$ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific realm role"
 msgstr "特定のレルム・ロールを取得する"
 
 #. type: Plain text
 msgid ""
-"Use `get` command, and role `name` to construct an endpoint uri for a "
-"specific realm role - `roles/ROLE_NAME`"
+"Use the [command]`get` command and the role [filename]`name` to construct an"
+" endpoint URI for a specific realm role: [filename]`roles/ROLE_NAME`, where "
+"[filename]`user` is the name of the existing role."
 msgstr ""
-"`get` コマンドとロール ` name` を使用して特定のレルム・ロールのエンドポイントuri `roles/ROLE_NAME` を構築します"
+"特定のレルム・ロールのエンドポイントURIを構築するには、 [command]`get` コマンドと "
+"[filename]`roles/ROLE_NAME` のように、ロール [filename]`name` を使用します。 [filename]` "
+"user`は 既存のロールです。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get roles/user -r demorealm\n"
+msgid "$ kcadm.sh get roles/user -r demorealm\n"
 msgstr "$ kcadm.sh get roles/user -r demorealm\n"
 
 #. type: Plain text
-msgid "Where `user` is the name of existing role."
-msgstr "`user` は既存のロール名です。"
-
-#. type: Plain text
 msgid ""
-"Alternatively, use special `get-roles` command, passing it role `name` (via "
-"`--rolename` option) or `id` (via `--roleid` option)."
+"You can also use the special [command]`get-roles` command, passing it a role"
+" name (via the [command]`--rolename` option) or ID (via the "
+"[command]`--roleid` option)."
 msgstr ""
-"または、特別な `get-roles` コマンドを使用して `name` （ `--rolename` オプションで）または `id` （ "
-"`--roleid` オプションで）を渡してください。"
+"[command]`get-roles` コマンドを使用して、[command]`--rolename` オプションを使用してロール名を渡すか、 "
+"[command]`--roleid` オプションを使用してIDを渡すこともできます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "   $ kcadm.sh get-roles -r demorealm --rolename user\n"
+msgid "$ kcadm.sh get-roles -r demorealm --rolename user\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rolename user\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific client role"
 msgstr "特定のクライアント・ロールを取得する"
 
 #. type: Plain text
 msgid ""
-"Use a dedicated `get-roles` command, passing it either `clientId` (via "
-"`--cclientid` option) or `id` (via `--cid` option) to identify the client, "
-"and passing it either role `name` (via `--rolename` option) or 'id' (via "
-"`--roleid`) to identify a specific client role:"
+"Use a dedicated [command]`get-roles` command, passing it either the clientId"
+" attribute (via the [command]`--cclientid` option) or ID (via the "
+"[command]`--cid` option) to identify the client, and passing it either the "
+"role name (via the [command]`--rolename` option) or ID (via the "
+"[command]`--roleid`) to identify a specific client role."
 msgstr ""
-"専用の `get-roles` コマンドを使って `clientId` （ `--cclientid`オプションで）または `id` （ `--cid`"
-" オプションで）を渡してクライアントを識別し、 `name` （ `--rolename` オプションで）または 'id' （ `--roleid` "
-"オプションで）を使用して特定のクライアント・ロールを識別します。"
+"[command]`get-roles` コマンドでは、[command]`--cclientid` オプションでclientId属性、または "
+"[command]`--cid` オプションでIDを渡して、クライアントを特定します。クライアント・ロールを特定するためには、 [command] "
+"`--rolename` オプションでロール名または [command]`--roleid` オプションでIDを渡します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --cclientid realm-management "
-"--rolename manage-clients\n"
+"$ kcadm.sh get-roles -r demorealm --cclientid realm-management --rolename "
+"manage-clients\n"
 msgstr ""
 "$ kcadm.sh get-roles -r demorealm --cclientid realm-management --rolename "
 "manage-clients\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Updating a realm role"
 msgstr "レルム・ロールの更新"
 
 #. type: Plain text
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"realm role. For example:"
-msgstr "特定のレルム・ロールを取得する場合と同じエンドポイントuriで `update` オペレーションを使用してください。例えば："
+"Use the [command]`update` command with the same endpoint URI that you used "
+"to get a specific realm role."
+msgstr ""
+"特定のレルム・ロールを取得するために使用したものと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update roles/user -r demorealm -s 'description=Role "
-"representing a regular user'\n"
+"$ kcadm.sh update roles/user -r demorealm -s 'description=Role representing "
+"a regular user'\n"
 msgstr ""
 "$ kcadm.sh update roles/user -r demorealm -s 'description=Role representing "
 "a regular user'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Updating a client role"
 msgstr "クライアント・ロールの更新"
 
 #. type: Plain text
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"client role. For example:"
-msgstr "特定のクライアント・ロールを取得する場合と同じエンドポイントuriで `update` オペレーションを使用してください。例えば："
+"Use the [command]`update` command with the same endpoint URI that you used "
+"to get a specific client role."
+msgstr ""
+"特定のクライアント・ロールを取得するために使用したものと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-"
-"6d61a4eca9a0/roles/editor -r demorealm -s 'description=User that can edit, "
-"and publish articles'\n"
+"$ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor "
+"-r demorealm -s 'description=User that can edit, and publish articles'\n"
 msgstr ""
 "$ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor "
 "-r demorealm -s 'description=User that can edit, and publish articles'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting a realm role"
 msgstr "レルム・ロールの削除"
 
 #. type: Plain text
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"realm role. For example:"
-msgstr "特定のレルム・ロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
+"Use the [command]`delete` command with the same endpoint URI that you used "
+"to get a specific realm role."
+msgstr ""
+"特定のレルム・ロールを取得するために使用したのと同じエンドポイントURIを指定して [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh delete roles/user -r demorealm\n"
+msgid "$ kcadm.sh delete roles/user -r demorealm\n"
 msgstr "$ kcadm.sh delete roles/user -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting a client role"
 msgstr "クライアント・ロールの削除"
 
 #. type: Plain text
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"client role. For example:"
-msgstr "特定のクライアント・ロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
+"Use the [command]`delete` command with the same endpoint URI that you used "
+"to get a specific client role."
+msgstr ""
+"特定のクライアントロールを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-"
-"6d61a4eca9a0/roles/editor -r demorealm\n"
+"$ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor "
+"-r demorealm\n"
 msgstr ""
 "$ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor "
 "-r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid ""
-"Listing assigned, available and effective realm roles for a composite role"
-msgstr "複合ロールに割り当てられた、利用可能な、有効なレルム・ロールの一覧表示"
-
-#. type: Plain text
-msgid "Use a dedicated `get-roles` command."
-msgstr "専用の `get-roles` コマンドを使用してください"
+"Listing assigned, available, and effective realm roles for a composite role"
+msgstr "複合ロールに割り当てられた、使用可能な、有効なレルム・ロールの一覧"
 
 #. type: Plain text
 msgid ""
-"To list *assigned* realm roles for the composite role you can specify the "
-"target composite role by either `name` (via --rname option) or `id` (via "
-"--rid option)."
+"Use a dedicated [command]`get-roles` command to list assigned, available, "
+"and effective realm roles for a composite role."
 msgstr ""
-"複合ロールのために *割り当てられた* レルム・ロールを一覧表示するには、 `name` （ `--rname` オプションで）または `id` （ "
-"`--rid` オプションで）のいずれかで対象の複合ロールを指定できます。"
+"専用の [command]`get-roles` コマンドを使用して、複合ロールに割り当てられた、使用可能な、有効なレルムロールを一覧表示します。"
 
 #. type: Plain text
+msgid ""
+"To list *assigned* realm roles for the composite role, you can specify the "
+"target composite role by either name (via the [command]`--rname` option) or "
+"ID (via the [command]`--rid` option)."
+msgstr ""
+"複合ロールの *assigned* レルム・ロールを一覧表示するには、[command]`--rname` オプションを使用して名前を指定するか、 "
+"[command]`--rid` オプションを使用してIDを指定します。"
+
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole\n"
+msgid "$ kcadm.sh get-roles -r demorealm --rname testrole\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole\n"
 
 #. type: Plain text
-msgid "To list *effective* realm roles, use additional `--effective` option."
-msgstr "*有効な* レルム・ロールを一覧表示するには、 `--effective` オプションを追加してください。"
+msgid ""
+"Use the additional [command]`--effective` option to list *effective* realm "
+"roles."
+msgstr "*有効な* レルム・ロールをリストするには、 [command]`--effective` オプションを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
+msgid "$ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
 
 #. type: Plain text
 msgid ""
-"To list realm roles that can still be added to the composite role, use "
-"`--available` option instead."
-msgstr "複合ロールにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+"Use the [command]`--available` option to list realm roles that can still be "
+"added to the composite role."
+msgstr "複合ロールにまだ利用可能なレルム・ロールを一覧表示するには、 [command]`--available` オプションを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
+msgid "$ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid ""
 "Listing assigned, available, and effective client roles for a composite role"
@@ -1384,28 +1412,37 @@ msgstr "複合ロールに割り当てられた、利用可能な、有効なク
 
 #. type: Plain text
 msgid ""
-"To list *assigned* client roles for the composite role you can specify the "
-"target composite role by either `name` (via --rname option)  or `id` (via "
-"--rid option), and client by either `clientId` (via --cclientid option) or "
-"`id` (via --cid option)."
+"Use a dedicated [command]`get-roles` command to list assigned, available, "
+"and effective client roles for a composite role."
 msgstr ""
-"複合ロールの *割り当てられた* クライアント・ロールを一覧表示するには、 `name` （ `--rname` オプションで）または `id` （ "
-"`--rid` オプションで）のいずれかで対象の複合ロールを指定できます。 `clientId` （ `--cclientid` オプションで）または "
-"`id` （ `--cid` オプションで）のどちらかでクライアントを指定できます。"
+"専用の [command]`get-roles` "
+"コマンドを使用して、複合ロールに割り当てられた、利用可能な、有効なクライアント・ロールを一覧表示します。"
 
 #. type: Plain text
+msgid ""
+"To list *assigned* client roles for the composite role, you can specify the "
+"target composite role by either name (via the [command]`--rname` option) or "
+"ID (via the [command]`--rid` option) and client by either the clientId "
+"attribute (via the [command]`--cclientid` option) or ID (via the "
+"[command]`--cid` option)."
+msgstr ""
+"複合ロールの *割り当てられた* クライアント・ロールを一覧表示するには、[command]`--rname` オプションでロール名を指定するか、または"
+" [command]`--rid` オプションでIDを指定します。また、クライアントを特定するために、 [command] `--cclientid` "
+"オプションでclientId属性、または[command]` --cid`オプションでIDのいずれかを使用します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
 "management\n"
 msgstr ""
 "$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
 "management\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
 "management --effective\n"
 msgstr ""
 "$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1413,112 +1450,107 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"To list realm roles that can still be added to the target composite role, "
-"use `--available` option instead."
-msgstr "対象の複合ロールにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+"Use the [command]`--available` option to list realm roles that can still be "
+"added to the target composite role."
+msgstr "対象の複合ロールに利用可能なレルム・ロールを一覧表示するには、 [command]`--available` オプションを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
 "management --available\n"
 msgstr ""
 "$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
 "management --available\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding realm roles to a composite role"
 msgstr "レルム・ロールを複合ロールに追加する"
 
 #. type: Plain text
 msgid ""
-"There is a dedicated `add-roles` command that can be used for adding both "
-"realm roles and client roles."
-msgstr "レルム・ロールとクライアント・ロールの両方を追加するために使用できる専用の `add-roles` コマンドがあります。"
+"There is a dedicated [command]`add-roles` command that can be used for "
+"adding realm roles and client roles."
+msgstr "レルム・ロールとクライアント・ロールを追加するために使用できる専用の [command]`add-roles` コマンドがあります。"
 
 #. type: Plain text
-msgid "For example, to add 'user' role to composite role 'testrole' :"
-msgstr "たとえば、 'user' ロールを複合ロール 'testrole' に追加するには、次のようにします。"
+msgid ""
+"The following example adds the [command]`user` role to the composite role "
+"[command]`testrole`."
+msgstr "[command]`user` ロールを複合ロール [command]`testrole` に追加する例を示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
+msgid "$ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
 msgstr "$ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Removing realm roles from a composite role"
 msgstr "複合ロールからレルム・ロールを削除する"
 
 #. type: Plain text
 msgid ""
-"There is a dedicated `remove-roles` command that can be used to remove both "
-"realm roles and client roles."
-msgstr "レルム・ロールとクライアント・ロールの両方を削除するために使用できる専用の `remove-roles` コマンドがあります。"
+"There is a dedicated [command]`remove-roles` command that can be used to "
+"remove realm roles and client roles."
+msgstr "レルム・ロールとクライアント・ロールを削除するための専用の [command]`remove-roles` コマンドがあります。"
 
 #. type: Plain text
 msgid ""
-"For example, to remove 'user' role from target composite role 'testrole':"
-msgstr "たとえば、対象の複合ロール 'testrole' から 'user' ロールを削除するには、次のようにします。"
+"The following example removes the [command]`user` role from the target "
+"composite role [command]`testrole`."
+msgstr "次の例では、ターゲットの複合ロール [command]`testrole` から [command]`user` ロールを削除します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid ""
-"    $ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
+msgid "$ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
 msgstr "$ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding client roles to a realm role"
 msgstr "レルム・ロールへのクライアント・ロールの追加"
 
 #. type: Plain text
-msgid "This is how you create or modify a composite realm role."
-msgstr "これは、複合レルムロールを作成または変更する方法です。"
+msgid ""
+"Use a dedicated [command]`add-roles` command that can be used for adding "
+"realm roles and client roles."
+msgstr "レルム・ロールとクライアン・トロールを追加するために使用できる専用の [command]`add-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
-"Use a dedicated `add-roles` command that can be used for adding both realm "
-"roles and client roles."
-msgstr "レルム・ロールとクライアント・ロールの両方を追加するために使用できる専用の `add-roles` コマンドを使用してください。"
-
-#. type: Plain text
-msgid ""
-"For example, to add to `testrole` composite role two roles defined on client"
-" `realm-management` - `create-client` role and `view-users` role:"
+"The following example adds the roles defined on the client [command]`realm-"
+"management` - `create-client` role and the [command]`view-users` role to the"
+" [command]`testrole` composite role."
 msgstr ""
-"たとえば、 `testrole` 複合ロールにクライアント `realm-management` で定義された2つのロール（ `create-"
-"client` ロールと `view-users` ロール）を追加するには："
+"次の例では、 [command]`realm-management` - `create-client` クライアントに定義されたロールと "
+"[command]`view-users` ロールを複合ロール [command]`testrole` に追加します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-"
+"$ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-"
 "management --rolename create-client --rolename view-users\n"
 msgstr ""
 "$ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-"
 "management --rolename create-client --rolename view-users\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding client roles to a client role"
 msgstr "クライアント・ロールへのクライアント・ロールの追加"
 
 #. type: Plain text
-msgid "This is how you create or modify a composite client role."
-msgstr "これは、複合クライアントロールを作成または変更する方法です。"
-
-#. type: Plain text
 msgid ""
-"First, find out an `id` of the composite client role - by using `get-roles` "
-"command for example:"
-msgstr "まず、 `get-roles` コマンドを使って複合クライアントロールの `id` を見つけます。例えば："
+"Determine the ID of the composite client role by using the [command]`get-"
+"roles` command."
+msgstr "[command]`get-roles` コマンドを使用して複合クライアント・ロールのIDを特定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --cclientid test-client --rolename "
+"$ kcadm.sh get-roles -r demorealm --cclientid test-client --rolename "
 "operations\n"
 msgstr ""
 "$ kcadm.sh get-roles -r demorealm --cclientid test-client --rolename "
@@ -1526,29 +1558,23 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Let's assume that there exists a client with \"clientId\": 'test-client', a "
-"client role called 'support', and another client role - that will become "
-"composite role - that has an \"id\": \"fc400897-ef6a-4e8c-872b-"
-"1581b7fa8a71\", \"name\":\"operations\"."
+"Assume that there is a client with a clientId attribute of [filename]`test-"
+"client`, a client role called [filename]`support`, and another client role "
+"called [filename]`operations`, which becomes a composite role, that has an "
+"ID of \"fc400897-ef6a-4e8c-872b-1581b7fa8a71\"."
 msgstr ""
-"\"clientId\": 'test-client' "
-"であるクライアント、'support'というクライアント・ロール、複合ロールになるもう1つのクライアント・ロール（\"id\": \"fc400897"
-"-ef6a-4e8c-872b-1581b7fa8a71\", \"name\":\"operations\"）が存在するとします。"
+"[filename]`test-client` のclientId属性、 [filename]`support` というクライアント・ロール、および "
+"[filename]`operations` という別のクライアント・ロールがあり、IDは\"fc400897-ef6a-4e8c-872b-"
+"1581b7fa8a71\"という複合ロールがあると仮定します。"
 
 #. type: Plain text
-msgid ""
-"In this example 'operations' is our target composite role, and we just got "
-"its `id`."
-msgstr "この例では、 'operations' は対象とする複合ロールで、その `id` も取得しています。"
+msgid "Use the following example to add another role to the composite role."
+msgstr "次の例を使用して、複合ロールに別のロールを追加します。"
 
-#. type: Plain text
-msgid "We can now add another role to it:"
-msgstr "これで別のロールを追加できます。"
-
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh add-roles -r demorealm --cclientid test-client --rid fc400897"
+"$ kcadm.sh add-roles -r demorealm --cclientid test-client --rid fc400897"
 "-ef6a-4e8c-872b-1581b7fa8a71 --rolename support\n"
 msgstr ""
 "$ kcadm.sh add-roles -r demorealm --cclientid test-client --rid fc400897"
@@ -1556,37 +1582,39 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Afterwards all the roles of a composite role can be listed by using `get-"
-"roles --all`. For example:"
-msgstr "その後、 `get-roles --all` を使用して複合ロールのすべてのロールを一覧表示することができます。例えば："
+"List the roles of a composite role by using the [command]`get-roles --all` "
+"command."
+msgstr "[command]`get-roles --all` コマンドを使用して、複合ロールのロールを一覧表示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid ""
-"    $ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
+msgid "$ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
 msgstr "$ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Removing client roles from a composite role"
 msgstr "複合ロールからのクライアント・ロールの削除"
 
 #. type: Plain text
-msgid "Use a dedicated `remove-roles` command."
-msgstr "専用の `remove-roles` コマンドを使用してください。"
+msgid ""
+"Use a dedicated [command]`remove-roles` command to remove client roles from "
+"a composite role."
+msgstr "複合ロールからクライアント・ロールを削除するには、専用の [command]`remove-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
-"For example, to remove from `testrole` composite role two roles defined on "
-"client `realm management` - `create-client` role and `view-users` role:"
+"Use the following example to remove two roles defined on the client "
+"[command]`realm management` - `create-client` role and the [command]`view-"
+"users` role from the [command]`testrole` composite role."
 msgstr ""
-"たとえば、 `testrole`  複合ロールからクライアント `realm management`  で定義された2つのロール（ `create-"
-"client` ロールと ` view-users` ロール）を削除するには："
+"次の例を使用して、 [command]`realm management` - `create-client` ロールと [command]`view-"
+"users` ロールで定義された2つのクライアント・ロールを複合ロール [command]`testrole` から削除します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-"
+"$ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-"
 "management --rolename create-client --rolename view-users\n"
 msgstr ""
 "$ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-"
@@ -1597,155 +1625,165 @@ msgstr ""
 msgid "Client operations"
 msgstr "クライアント操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Creating a client"
 msgstr "クライアントの作成"
 
 #. type: Plain text
 msgid ""
-"To create a new client perform `create` command on `clients` endpoint. For "
-"example:"
-msgstr "新しいクライアントを作成するには、 `clients` エンドポイントで `create` コマンドを実行します。例えば："
+"Run the [command]`create` command on a [filename]`clients` endpoint to "
+"create a new client."
+msgstr ""
+"[filename]`clients` エンドポイントで [command]`create` コマンドを実行して、新しいクライアントを作成します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s "
-"enabled=true\n"
+"$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true\n"
 msgstr ""
 "$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true\n"
 
 #. type: Plain text
 msgid ""
-"If you want to set a secret for adapters to authenticate specify a `secret`."
-" For example:"
-msgstr "認証するためのアダプターのシークレットを設定する場合は、 `secret` を指定します。例えば："
+"Specify a secret if you want to set a secret for adapters to authenticate."
+msgstr "認証するアダプターのシークレットを設定する場合は、シークレットを指定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true"
-" -s clientAuthenticatorType=client-secret -s secret=d0b8122f-8dfb-46b7-b68a-"
+"$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true -s "
+"clientAuthenticatorType=client-secret -s secret=d0b8122f-8dfb-46b7-b68a-"
 "f5cc4e25d000\n"
 msgstr ""
 "$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true -s "
 "clientAuthenticatorType=client-secret -s secret=d0b8122f-8dfb-46b7-b68a-"
 "f5cc4e25d000\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing clients"
 msgstr "クライアントの一覧表示"
 
 #. type: Plain text
-msgid "Use `get` operation on `clients` endpoint. For example:"
-msgstr "`clients` エンドポイントで `get` 操作を使います。例えば："
+msgid ""
+"Use the [command]`get` command on the [filename]`clients` endpoint to list "
+"clients."
+msgstr ""
+"クライアントの一覧を表示するには、 [filename]`clients` エンドポイントで [command]`get` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
-"Here we filter the output to only list `id`, and `clientId` attributes."
-msgstr "ここでは、出力を `id` と `clientId` 属性だけにフィルタリングします。"
+"This example filters the output to list only the [filename]`id` and "
+"[filename]`clientId` attributes."
+msgstr ""
+"この例では、 [filename]`id` および [filename]`clientId` 属性のみを一覧出力するようにフィルタリングしています。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific client"
 msgstr "特定のクライアントを取得する"
 
 #. type: Plain text
 msgid ""
-"Use client's `id` to construct an endpoint uri targeting specific client - "
-"`clients/ID`. For example:"
-msgstr "クライアントの `id` を使用して、特定のクライアントを対象とするエンドポイントuri `clients/ID` を構築します。例えば："
+"Use a client's ID to construct an endpoint URI that targets a specific "
+"client, such as [filename]`clients/ID`."
+msgstr ""
+"クライアントのIDを使用して、 [filename]`clients/ID` のような特定のクライアントを対象とするエンドポイントURIを構築します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
-"demorealm\n"
+"$ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm\n"
 msgstr ""
 "$ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Getting current secret for specific client"
-msgstr "特定のクライアントの現在のシークレットを取得する"
+msgid "Getting the current secret for a specific client"
+msgstr "特定のクライアントの現在のシークレットの取得"
 
 #. type: Plain text
 msgid ""
-"Use client's `id` to construct an endpoint uri - `clients/ID/client-secret`."
-" For example"
-msgstr "クライアントの `id` を使ってエンドポイントuri 'clients/ID/client-secret` を構築します。例えば"
+"Use a client's ID to construct an endpoint URI, such as "
+"[filename]`clients/ID/client-secret`."
+msgstr ""
+"クライアントのIDを使用して、 [filename]`clients/ID/client-secret` のようなエンドポイントURIを構築します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get clients/$CID/client-secret\n"
+msgid "$ kcadm.sh get clients/$CID/client-secret\n"
 msgstr "$ kcadm.sh get clients/$CID/client-secret\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Getting adapter configuration file (keycloak.json) for specific client"
-msgstr "特定のクライアント用のアダプター構成ファイル（keycloak.json）の取得"
+msgid ""
+"Getting an adapter configuration file (keycloak.json) for a specific client"
+msgstr "特定のクライアントのアダプター設定ファイル（keycloak.json）の取得"
 
 #. type: Plain text
 msgid ""
-"Use client's `id` to construct an endpoint uri targeting specific client - "
-"`clients/ID/installation/providers/keycloak-oidc-keycloak-json`."
+"Use a client's ID to construct an endpoint URI that targets a specific "
+"client, such as [filename]`clients/ID/installation/providers/keycloak-oidc-"
+"keycloak-json`."
 msgstr ""
-"クライアントの `id` を使用して、特定のクライアントを対象にしたエンドポイントuri "
-"`clients/ID/installation/providers/keycloak-oidc-keycloak-json` を構築します。"
+"クライアントIDを使用して、 [filename]`clients/ID/installation/providers/keycloak-oidc-"
+"keycloak-json` などの特定のクライアントを対象とするエンドポイントURIを構築します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get "
+"$ kcadm.sh get "
 "clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
 "/keycloak-oidc-keycloak-json -r demorealm\n"
 msgstr ""
-"    $ kcadm.sh get "
+"$ kcadm.sh get "
 "clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
 "/keycloak-oidc-keycloak-json -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Getting Wildfly subsystem adapter configuration for specific client"
+msgid ""
+"Getting a Wildfly subsystem adapter configuration for a specific client"
 msgstr "特定のクライアントのためのWildflyサブシステム・アダプタ設定の取得"
 
 #. type: Plain text
 msgid ""
-"Use client's `id` to construct an endpoint uri targeting specific client - "
-"`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem`."
+"Use a client's ID to construct an endpoint URI that targets a specific "
+"client, such as [filename]`clients/ID/installation/providers/keycloak-oidc-"
+"jboss-subsystem`."
 msgstr ""
-"クライアントの` id` を使用して特定のクライアントを対象とするエンドポイントuri "
-"`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem` を構築します。"
+"クライアントIDを使用して、 [filename]`clients/ID/installation/providers/keycloak-oidc-"
+"jboss-subsystem` などの特定のクライアントを対象とするエンドポイントURIを構築します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get "
+"$ kcadm.sh get "
 "clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
 "/keycloak-oidc-jboss-subsystem -r demorealm\n"
 msgstr ""
-"    $ kcadm.sh get "
+"$ kcadm.sh get "
 "clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
 "/keycloak-oidc-jboss-subsystem -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Updating a client"
 msgstr "クライアントの更新"
 
 #. type: Plain text
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"client. For example on Linux:"
-msgstr "特定のクライアントを取得する場合と同じエンドポイントuriで `update` 操作を使用してください。たとえばLinuxの場合："
+"Use the [command]`update` command with the same endpoint URI that you used "
+"to get a specific client."
+msgstr ""
+"特定のクライアントを取得するために使用したのと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
-"demorealm -s enabled=false -s publicClient=true -s "
+"$ kcadm.sh update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm "
+"-s enabled=false -s publicClient=true -s "
 "'redirectUris=[\"http://localhost:8080/myapp/*\"]' -s "
 "baseUrl=http://localhost:8080/myapp -s "
 "adminUrl=http://localhost:8080/myapp\n"
@@ -1756,11 +1794,11 @@ msgstr ""
 "baseUrl=http://localhost:8080/myapp -s "
 "adminUrl=http://localhost:8080/myapp\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
-"demorealm -s enabled=false -s publicClient=true -s "
+"c:\\> kcadm update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm"
+" -s enabled=false -s publicClient=true -s "
 "\"redirectUris=[\\\"http://localhost:8080/myapp/*\\\"]\" -s "
 "baseUrl=http://localhost:8080/myapp -s "
 "adminUrl=http://localhost:8080/myapp\n"
@@ -1771,21 +1809,21 @@ msgstr ""
 "baseUrl=http://localhost:8080/myapp -s "
 "adminUrl=http://localhost:8080/myapp\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting a client"
 msgstr "クライアントの削除"
 
 #. type: Plain text
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"client. For example:"
-msgstr "特定のクライアントを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
+"Use the [command]`delete` command with the same endpoint URI that you used "
+"to get a specific client."
+msgstr "特定のクライアントを取得するのに使用したのと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
+"$ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
 "demorealm\n"
 msgstr ""
 "$ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
@@ -1796,158 +1834,160 @@ msgstr ""
 msgid "User operations"
 msgstr "ユーザー操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Creating a user"
 msgstr "ユーザーの作成"
 
 #. type: Plain text
 msgid ""
-"To create a new user perform `create` operation on `users` endpoint. For "
-"example:"
-msgstr "新しいユーザーを作成するには、 `users` エンドポイントで `create` 操作を実行します。例えば："
+"Run the [command]`create` command on the [filename]`users` endpoint to "
+"create a new user."
+msgstr "[filename]`users` エンドポイントで [command]`create` コマンドを実行して、新しいユーザーを作成します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create users -r demorealm -s username=testuser -s "
-"enabled=true\n"
+"$ kcadm.sh create users -r demorealm -s username=testuser -s enabled=true\n"
 msgstr ""
 "$ kcadm.sh create users -r demorealm -s username=testuser -s enabled=true\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing users"
 msgstr "ユーザーの一覧表示"
 
 #. type: Plain text
 msgid ""
-"Use `users` endpoint to list users. Number of users may be large, and you "
-"may want to limit how many are returned:"
-msgstr "ユーザーを一覧表示するには `users` エンドポイントを使います。ユーザー数が多く、返される数を制限したい場合は："
+"Use the [filename]`users` endpoint to list users. The target user will have "
+"to change the password the next time they log in."
+msgstr ""
+"[filename]`users` "
+"エンドポイントを使用してユーザーをリストします。対象ユーザーは、次回のログイン時にパスワードを変更する必要があります。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
+msgid "$ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
 msgstr "$ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
 
 #. type: Plain text
 msgid ""
-"It's also possible to filter users by `username`, `firstName`, `lastName`, "
-"or `email`. For example:"
+"You can filter users by [filename]`username`, [filename]`firstName`, "
+"[filename]`lastName`, or [filename]`email`."
 msgstr ""
-"`username` 、 `firstName` 、 `lastName` 、または `email` "
-"によってユーザをフィルタすることも可能です。例えば："
+"[filename]`username` 、 [filename]`firstName` 、 [filename]`lastName` 、 "
+"[filename]`email` でユーザーをフィルタリングできます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get users -r demorealm -q email=google.com\n"
-"    $ kcadm.sh get users -r demorealm -q username=testuser\n"
+"$ kcadm.sh get users -r demorealm -q email=google.com\n"
+"$ kcadm.sh get users -r demorealm -q username=testuser\n"
 msgstr ""
 "$ kcadm.sh get users -r demorealm -q email=google.com\n"
-" $ kcadm.sh get users -r demorealm -q username=testuser\n"
+"$ kcadm.sh get users -r demorealm -q username=testuser\n"
+
+#. type: delimited block =
+msgid ""
+"Filtering does not use exact matching. For example, the above example would "
+"match the value of the [filename]`username` attribute against the "
+"[filename]`\\*testuser*`` pattern."
+msgstr ""
+"フィルタリングでは完全一致は使用されません。例えば、上記の例では、[filename]`\\*testuser*`` のパターンと "
+"[filename]`username` 属性の値が一致します。"
 
 #. type: Plain text
 msgid ""
-"Note that filtering doesn't use exact matching. For example, the above would"
-" match the value of `username` attribute against '\\*testuser*' pattern."
+"You can also filter across multiple attributes by specifying multiple "
+"[command]`-q` options, which return only users that match the condition for "
+"all the attributes."
 msgstr ""
-"フィルタリングは完全一致を使用しないことに注意してください。例えば、上記は `username` 属性の値と '\\*testuser*' "
-"パターンを一致させます。"
+"複数の [command]`-q` "
+"オプションを指定することで、複数の属性をフィルタリングすることもできます。このオプションは、すべての属性の条件に一致するユーザーのみを返します。"
 
-#. type: Plain text
-msgid ""
-"You can also filter across multiple attributes by specifying multiple `-q` "
-"options, which would return only users that match condition for all the "
-"attributes."
-msgstr ""
-"`-q` "
-"オプションを複数指定することで、複数の属性をフィルタリングをすることもできます。このオプションは、すべての属性の条件に一致するユーザのみを返します。"
-
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific user"
 msgstr "特定のユーザーを取得する"
 
 #. type: Plain text
-msgid "Use user's `id` to compose an endpoint uri - `users/USER_ID`."
-msgstr "ユーザーの `id` を使用してエンドポイントuri `users/USER_ID` を作成します。"
-
-#. type: Plain text
-#, no-wrap
 msgid ""
-"    $ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
+"Use a user's ID to compose an endpoint URI, such as "
+"[filename]`users/USER_ID`."
+msgstr "[filename]`users/USER_ID` などのエンドポイントURIを作成するには、ユーザーのIDを使用します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 msgstr ""
 "$ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Updating a user"
 msgstr "ユーザーの更新"
 
 #. type: Plain text
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"user. For example on Linux:"
-msgstr "特定のユーザーを取得する場合と同じエンドポイントuriで `update` 操作を使用します。たとえばLinuxの場合："
+"Use the [command]`update` command with the same endpoint URI that you used "
+"to get a specific user."
+msgstr "特定のユーザーを取得するために使用したのと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
-"demorealm -s "
+"$ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm -s"
+" "
 "'requiredActions=[\"VERIFY_EMAIL\",\"UPDATE_PROFILE\",\"CONFIGURE_TOTP\",\"UPDATE_PASSWORD\"]'\n"
 msgstr ""
 "$ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm -s"
 " "
 "'requiredActions=[\"VERIFY_EMAIL\",\"UPDATE_PROFILE\",\"CONFIGURE_TOTP\",\"UPDATE_PASSWORD\"]'\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
-"demorealm -s "
+"c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm "
+"-s "
 "\"requiredActions=[\\\"VERIFY_EMAIL\\\",\\\"UPDATE_PROFILE\\\",\\\"CONFIGURE_TOTP\\\",\\\"UPDATE_PASSWORD\\\"]\"\n"
 msgstr ""
 "c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm "
 "-s "
 "\"requiredActions=[\\\"VERIFY_EMAIL\\\",\\\"UPDATE_PROFILE\\\",\\\"CONFIGURE_TOTP\\\",\\\"UPDATE_PASSWORD\\\"]\"\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting a user"
 msgstr "ユーザーの削除"
 
 #. type: Plain text
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"user. For example:"
-msgstr "特定のユーザーを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
+"Use the [command]`delete` command with the same endpoint URI that you used "
+"to get a specific user."
+msgstr "特定のユーザーを取得するために使用したのと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
-"demorealm\n"
+"$ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 msgstr ""
 "$ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Resetting user's password"
-msgstr "ユーザーのパスワードをリセットする"
+msgid "Resetting a user's password"
+msgstr "ユーザー・パスワードのリセット"
 
 #. type: Plain text
 msgid ""
-"There is a dedicated `set-password` command specifically to reset user's "
-"password. For example:"
-msgstr "ユーザーのパスワードをリセットするための専用コマンド `set-password` があります。例えば："
+"Use the dedicated [command]`set-password` command to reset a user's "
+"password."
+msgstr "専用の [command]`set-password` コマンドを使用して、ユーザーのパスワードをリセットします。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh set-password -r demorealm --username testuser --new-password "
+"$ kcadm.sh set-password -r demorealm --username testuser --new-password "
 "NEWPASSWORD --temporary\n"
 msgstr ""
 "$ kcadm.sh set-password -r demorealm --username testuser --new-password "
@@ -1955,259 +1995,304 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"That will set a temporary password for the user, which they will have to "
-"change the next time they login."
-msgstr "これにより、ユーザーが次回ログイン時に変更を求められる仮パスワードが設定されます。"
+"That command sets a temporary password for the user. The target user will "
+"have to change the password the next time they log in."
+msgstr "このコマンドは、ユーザーの一時パスワードを設定します。対象ユーザーは、次回のログイン時にパスワードを変更する必要があります。"
 
 #. type: Plain text
 msgid ""
-"You can use `--userid` if you want to specify the user by using `id` "
-"attribute."
-msgstr "`id` 属性を使ってユーザを指定したい場合、 `--userid` を使うことができます。"
+"You can use [command]`--userid` if you want to specify the user by using the"
+" [filename]`id` attribute."
+msgstr "[filename]`id` 属性を使用してユーザーを指定する場合は、 [command]`--userid` を使用できます。"
 
 #. type: Plain text
 msgid ""
-"The same can be achieved using `update` operation on an endpoint constructed"
-" from one for getting a specific user - `users/USER_ID/reset-password`."
+"You can achieve the same result using the [command]`update` command on an "
+"endpoint constructed from the one you used to get a specific user, such as "
+"[filename]`users/USER_ID/reset-password`."
 msgstr ""
-"特定のユーザを取得するために構築されたエンドポイント `users/USER_ID/reset-password` に対して `update` "
-"操作を行うことで、同じことができます。"
+"[filename]`users/USER_ID/reset-password` のように、特定のユーザーを取得するために使用したエンドポイントで "
+"[command]`update` コマンドを使用しても同じ結果が得ることができます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-"
-"password -r demorealm -s type=password -s value=NEWPASSWORD -s "
-"temporary=true -n\n"
+"$ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-password "
+"-r demorealm -s type=password -s value=NEWPASSWORD -s temporary=true -n\n"
 msgstr ""
 "$ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-password "
 "-r demorealm -s type=password -s value=NEWPASSWORD -s temporary=true -n\n"
 
 #. type: Plain text
 msgid ""
-"The last parameter (`-n`) ensures that only PUT is performed without a prior"
-" GET. In this case it is necessary since `reset-password` endpoint doesn't "
-"support GET."
+"The last parameter ([command]`-n`) ensures that only the [command]`PUT` "
+"command is performed without a prior [command]`GET` command. It is necessary"
+" in this instance because the [command]`reset-password` endpoint does not "
+"support [command]`GET`."
 msgstr ""
-"最後のパラメータ（ `-n` ）は、更新前のGETなしでPUTだけが実行されることを保証します。このケースでは、 `reset-password` "
-"エンドポイントがGETをサポートしていないので必要です。"
+"最後のパラメータ [command]`-n` は、 [command]`GET` コマンドなしで [command]`PUT` "
+"コマンドだけが実行されるようにします。この場合、 [command]`reset-password` エンドポイントは [command]`GET` "
+"をサポートしていないので指定が必要です。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a user"
 msgstr "ユーザーに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
 msgid ""
-"To list *assigned* realm roles for the user you can specify the target user "
-"by either `username` or `id`."
+"You can use a dedicated [command]`get-roles` command to list assigned, "
+"available, and effective realm roles for a user."
 msgstr ""
-"ユーザーの *割り当てられた* レルム・ロールを一覧表示するには、 `username` か `id` のどちらかで対象ユーザーを指定します。"
+"専用の [command]`get-roles` "
+"コマンドを使用して、ユーザーに割り当てられた、利用可能な、有効なレルム・ロールを一覧表示することができます。"
 
 #. type: Plain text
+msgid ""
+"Specify the target user by either user name or ID to list *assigned* realm "
+"roles for the user."
+msgstr "ユーザーの *割り当てられた* レルム・ロールを一覧表示するには、ユーザー名またはIDのどちらかを使用して対象ユーザーを指定します。"
+
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser\n"
+msgid "$ kcadm.sh get-roles -r demorealm --uusername testuser\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
+msgid "$ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
 
 #. type: Plain text
 msgid ""
-"To list realm roles that can still be added to the user, use `--available` "
-"option instead."
-msgstr "ユーザーにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+"Use the [command]`--available` option to list realm roles that can still be "
+"added to the user."
+msgstr "ユーザーに利用可能なレルム・ロールを一覧表示するには、 [command]`--available` オプションを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
+msgid "$ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a user"
 msgstr "ユーザーに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
 
 #. type: Plain text
 msgid ""
-"To list *assigned* client roles for the user you can specify the target user"
-" by either `username` (via --uusername option) or `id` (via --uid option), "
-"and client by either `clientId` (via --cclientid option) or `id` (via --cid "
-"option)."
+"Use a dedicated [command]`get-roles` command to list assigned, available, "
+"and effective client roles for a user."
 msgstr ""
-"ユーザーに *割り当てられた* クライアント・ロールを一覧表示するには、 `username` （--uusernameオプションで）または ` id`"
-" （--uidオプションで）のいずれかで対象ユーザーを指定できます。 `clientId` （--cclientidオプションで）または `id` "
-"（--cidオプションで）のどちらかでクライアントを指定できます。"
+"専用の [command]`get-roles` コマンドを使用して、ユーザに割り当てられた、利用可能な、有効なクライアント・ロールを一覧表示します。"
 
 #. type: Plain text
+msgid ""
+"Specify the target user by either a user name (via the "
+"[command]`--uusername` option) or an ID (via the [command]`--uid` option) "
+"and client by either a clientId attribute (via the [command]`--cclientid` "
+"option) or an ID (via the [command]`--cid` option) to list *assigned* client"
+" roles for the user."
+msgstr ""
+"[command]`--uusername` オプションを使用してユーザー名を指定する、または [command]`--uid` "
+"オプションを使用してIDを指定することで対象ユーザー特定します。また、 [command]`--cclientid` "
+"オプションでclientId属性を指定する、または [command]`--cid` オプションでIDを指定してクライアントを指定して、ユーザーの "
+"*割り当てられた* クライアント・ロールを一覧表示します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
-"realm-management\n"
+"$ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-"
+"management\n"
 msgstr ""
-"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
-"realm-management\n"
+"$ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-"
+"management\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
-"realm-management --effective\n"
+"$ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --effective\n"
 msgstr ""
-"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
-"realm-management --effective\n"
+"$ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --effective\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
-"realm-management --available\n"
+"$ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --available\n"
 msgstr ""
-"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
-"realm-management --available\n"
+"$ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --available\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding realm roles to a user"
 msgstr "ユーザーにレルム・ロールを追加する"
 
 #. type: Plain text
-msgid "Use a dedicated `add-roles` command."
-msgstr "専用の `add-roles` コマンドを使用してください。"
-
-#. type: Plain text
-msgid "For example, to add 'user' role to user 'testuser' :"
-msgstr "たとえば、ユーザー 'testuser' に 'user' ロールを追加するには、次のようにします。"
-
-#. type: Plain text
-#, no-wrap
 msgid ""
-"    $ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
+"Use a dedicated [command]`add-roles` command to add realm roles to a user."
+msgstr "レルム・ロールをユーザーに追加するには、専用の [command]`add-roles` コマンドを使用します。"
+
+#. type: Plain text
+msgid ""
+"Use the following example to add the [command]`user` role to user "
+"[command]`testuser`."
+msgstr "次の例を使用して、 [command]`user` ロールをユーザー [command]`testuser` に追加します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
 msgstr "$ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Removing realm roles from a user"
 msgstr "ユーザーからレルム・ロールを削除する"
 
 #. type: Plain text
-msgid "For example, to remove 'user' role from user 'testuser':"
-msgstr "たとえば、ユーザー 'testuser' から 'user' ロールを削除するには、次のようにします。"
+msgid ""
+"Use a dedicated [command]`remove-roles` command to remove realm roles from a"
+" user."
+msgstr "ユーザーからレルム・ロールを削除するには、専用の [command]`remove-roles` コマンドを使用します。"
 
 #. type: Plain text
+msgid ""
+"Use the following example to remove the [command]`user` role from the user "
+"[command]`testuser`."
+msgstr "以下の例を使用して、 ユーザー[command]`testuser` から [command]`user` ロールを削除します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh remove-roles --username testuser --rolename user -r "
-"demorealm\n"
+"$ kcadm.sh remove-roles --username testuser --rolename user -r demorealm\n"
 msgstr ""
 "$ kcadm.sh remove-roles --username testuser --rolename user -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding client roles to a user"
 msgstr "ユーザーにクライアント・ロールを追加する"
 
 #. type: Plain text
 msgid ""
-"For example, to add to user `testuser` two roles defined on client `realm "
-"management` - `create-client` role and `view-users` role:"
-msgstr ""
-"たとえば、ユーザー `testuser` にクライアント `realm management` で定義された2つのロール（ `create-"
-"client` ロールと `view-users` ロール）を追加するには："
+"Use a dedicated [command]`add-roles` command to add client roles to a user."
+msgstr "クライアント・ロールをユーザーに追加するには、専用の [command]`add-roles` コマンドを使用します。"
 
 #. type: Plain text
+msgid ""
+"Use the following example to add two roles defined on the client "
+"[command]`realm management` - `create-client` role and the [command]`view-"
+"users` role to the user `testuser`."
+msgstr ""
+"次の例を使用して、 [command]`realm management` - `create-client` ロールと [command]`view-"
+"users` ロールのクライアントに定義された2つのロールを `testuser` ユーザーに追加します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid "
-"realm-management --rolename create-client --rolename view-users\n"
+"$ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
 msgstr ""
 "$ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid realm-"
 "management --rolename create-client --rolename view-users\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Removing client roles from a user"
 msgstr "ユーザーからのクライアント・ロールの削除"
 
 #. type: Plain text
 msgid ""
-"For example, to remove from user `testuser` two roles defined on client "
-"`realm management` - `create-client` role and `view-users` role:"
-msgstr ""
-"例えば、ユーザー `testuser` からクライアントの `realm management`  で定義された二つのロール（ `create-"
-"client` ロールと `view-users` ロール）を削除するには："
+"Use a dedicated [command]`remove-roles` command to remove client roles from "
+"a user."
+msgstr "専用の [command]`remove-roles` コマンドを使用して、クライアント・ロールをユーザーから削除します。"
 
 #. type: Plain text
+msgid ""
+"Use the following example to remove two roles defined on the realm "
+"management client."
+msgstr "次の例を使用して、レルム管理クライアントで定義されている2つのロールを削除します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid "
-"realm-management --rolename create-client --rolename view-users\n"
+"$ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
 msgstr ""
 "$ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid realm-"
 "management --rolename create-client --rolename view-users\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Listing user's sessions"
-msgstr "ユーザーのセッションを一覧表示する"
+msgid "Listing a user's sessions"
+msgstr "ユーザー・セッションの一覧表示"
 
 #. type: Plain text
 msgid ""
-"First identify user's `id` then use it to compose an endpoint uri - "
-"`users/ID/sessions`."
-msgstr "最初にユーザーの `id` を識別し、エンドポイントuri `users/ID/sessions` を作成するためにそれを使います。"
+"Identify the user's ID, and then use it to compose an endpoint URI, such as "
+"[filename]`users/ID/sessions`."
+msgstr ""
+"ユーザーのIDを特定し、それを利用して [filename]`users/ID/sessions` などのエンドポイントURIを作成します。"
 
 #. type: Plain text
-msgid "Now use `get` to retrieve a list of user's sessions."
-msgstr "次に、ユーザーのセッションの一覧を取得するために `get` を使います。"
+msgid ""
+"Use the [command]`get` command to retrieve a list of the user's sessions."
+msgstr "ユーザーのセッションの一覧を取得するには、 [command]`get` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
+msgid "$kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
 msgstr "$kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Logging out user from specific session"
+msgid "Logging out a user from a specific session"
 msgstr "特定のセッションからユーザーをログアウトする"
 
 #. type: Plain text
+msgid "Determine the session's ID as described above."
+msgstr "上記のようにセッションのIDを決定します。"
+
+#. type: Plain text
 msgid ""
-"To logout the user's session first get session's `id` as described above."
-msgstr "最初にユーザーのセッションをログアウトするには、先に説明したように、セッションの `id` を取得します。"
+"Use the session's ID to compose an endpoint URI, such as "
+"[filename]`sessions/ID`."
+msgstr "セッションIDを使用して、 [filename]`sessions/ID` のようなエンドポイントURIを作成します。"
 
 #. type: Plain text
-msgid "Use session's `id` to compose an endpoint uri - `sessions/ID`."
-msgstr "ユーザーの `id` を使用してエンドポイントuri `sessions/ID` を作成します。 "
+msgid "Use the [command]`delete` command to invalidate the session."
+msgstr "セッションを無効にするには、 [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
-msgid "Then use `delete` to invalidate it. For example:"
-msgstr "次に、それを無効にするために `delete` を使います。例えば："
-
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
+msgid "$ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
 msgstr "$ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Logging out user from all sessions"
+msgid "Logging out a user from all sessions"
 msgstr "すべてのセッションからユーザーをログアウトする"
 
 #. type: Plain text
-msgid "You need user's `id` to construct an endpoint uri - `users/ID/logout`."
-msgstr "エンドポイントuri `users/ID/logout` を作成するのにユーザーの `id` が必要です。"
+msgid ""
+"You need a user's ID to construct an endpoint URI, such as "
+"[filename]`users/ID/logout`."
+msgstr "[filename]`users/ID/logout` のようなエンドポイントURIを構築するには、ユーザーのIDが必要です。"
 
 #. type: Plain text
-msgid "Use 'create' to perform POST on that endpoint uri:"
-msgstr "そのエンドポイントuriでPOSTを実行するには、  'create' を使用します。"
+msgid ""
+"Use the [command]`create` command to perform [command]`POST` on that "
+"endpoint URI."
+msgstr ""
+"その [command]`create` コマンドを使って、そのエンドポイントURIに対して [command]`POST` を実行します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r "
+"$ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r "
 "demorealm -s realm=demorealm -s user=6da5ab89-3397-4205-afaa-e201ff638f9e\n"
 msgstr ""
 "$ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r "
@@ -2218,180 +2303,189 @@ msgstr ""
 msgid "Group operations"
 msgstr "グループの操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Creating a group"
 msgstr "グループの作成"
 
 #. type: Plain text
-msgid "Use `create` operation on `groups` endpoint to create a new group:"
-msgstr "`group` エンドポイントで `create` 操作を使って新しいグループを作成します。"
+msgid ""
+"Use the [command]`create` command on the [filename]`groups` endpoint to "
+"create a new group."
+msgstr ""
+"新しいグループを作成するには、 [filename]`groups` エンドポイントで [command]`create` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh create groups -r demorealm -s name=Group\n"
+msgid "$ kcadm.sh create groups -r demorealm -s name=Group\n"
 msgstr "$ kcadm.sh create groups -r demorealm -s name=Group\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing groups"
 msgstr "グループの一覧表示"
 
 #. type: Plain text
-msgid "Use `get` operation on `groups` endpoint to list groups:"
-msgstr "グループを一覧表示するには `groups` エンドポイントで `get` 操作を使います。"
+msgid ""
+"Use the [command]`get` command on the [filename]`groups` endpoint to list "
+"groups."
+msgstr "グループを一覧表示するには、 [filename]`groups` エンドポイントで [command]`get` コマンドを使います。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get groups -r demorealm\n"
+msgid "$ kcadm.sh get groups -r demorealm\n"
 msgstr "$ kcadm.sh get groups -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific group"
 msgstr "特定のグループを取得する"
 
 #. type: Plain text
-msgid "Use group's `id` to construct an endpoint uri - groups/GROUP_ID:"
-msgstr "グループの `id` を使用してエンドポイントuri `groups/GROUP_ID` を作成します。"
+msgid ""
+"Use the group's ID to construct an endpoint URI, such as `groups/GROUP_ID`."
+msgstr "グループのIDを使用して、 `groups/GROUP_ID` のようなのエンドポイントURIを作成します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r "
-"demorealm\n"
+"$ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
 msgstr ""
 "$ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Updating a group"
 msgstr "グループの更新"
 
 #. type: Plain text
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"group. For example:"
-msgstr "特定のグループを取得する場合と同じエンドポイントuriで `update` 操作を使用してください。例えば："
+"Use the [command]`update` command with the same endpoint URI that you used "
+"to get a specific group."
+msgstr "特定のグループを取得するために使用したものと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s "
+"$ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s "
 "'attributes.email=[\"group@example.com\"]' -r demorealm\n"
 msgstr ""
 "$ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s "
 "'attributes.email=[\"group@example.com\"]' -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Deleting a group"
 msgstr "グループの削除"
 
 #. type: Plain text
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"group. For example:"
-msgstr "特定のグループを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
+"Use the [command]`delete` command with the same endpoint URI that you used "
+"to get a specific group."
+msgstr "特定のグループを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r "
-"demorealm\n"
+"$ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
 msgstr ""
 "$ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Creating a sub-group"
-msgstr "サブ・グループの作成"
+msgid "Creating a subgroup"
+msgstr "サブグループの作成"
 
 #. type: Plain text
 msgid ""
-"Find 'id' of the parent group - by listing groups for example. Use that `id`"
-" to construct an endpoint uri - groups/GROUP_ID/children:"
+"Find the ID of the parent group by listing groups, and then use that ID to "
+"construct an endpoint URI, such as [filename]`groups/GROUP_ID/children`."
 msgstr ""
-"グループを一覧表示するなどして、親グループの 'id' を検索します。その `id`を私用してエンドポイントuri "
-"`groups/GROUP_ID/children` を作成します。"
+"グループを一覧表示して親グループのIDを探し、そのIDを使用して [filename]`groups/GROUP_ID/children` "
+"のようなエンドポイントURIを構築します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
-"-r demorealm -s name=SubGroup\n"
+"$ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children -r "
+"demorealm -s name=SubGroup\n"
 msgstr ""
-"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
-"-r demorealm -s name=SubGroup\n"
+"$ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children -r "
+"demorealm -s name=SubGroup\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Moving a group under another group"
 msgstr "グループを別のグループの下に移動する"
 
 #. type: Plain text
 msgid ""
-"Find 'id' of existing parent group, and of existing child group. Use parent "
-"group's `id` to construct and endpoint uri - "
-"groups/PARENT_GROUP_ID/children."
-msgstr ""
-"既存の親グループと既存の子グループの 'id' を検索します。 親グループの `id` を使用してエンドポイントuri "
-"`groups/PARENT_GROUP_ID/children` を作成します。"
+"Find the ID of an existing parent group and of an existing child group."
+msgstr "既存の親グループと既存の子グループのIDを検索します。"
 
 #. type: Plain text
 msgid ""
-"Perform 'create' operation on this endpoint, and pass child group `id` as "
-"JSON body. For example:"
-msgstr "このエンドポイントで 'create' 操作を実行し、子グループ `id` をJSON本体として渡します。例えば："
+"Use the parent group's ID to construct an endpoint URI, such as "
+"[filename]`groups/PARENT_GROUP_ID/children`."
+msgstr ""
+"親グループのIDを使用して、 [filename]`groups/PARENT_GROUP_ID/children` "
+"のようなエンドポイントURIを作成します。"
 
 #. type: Plain text
+msgid ""
+"Run the [command]`create` command on this endpoint and pass the child "
+"group's ID as a JSON body."
+msgstr "このエンドポイントで [command]`create` コマンドを実行し、子グループのIDをJSONとして渡します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
-"-r demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
+"$ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children -r "
+"demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
 msgstr ""
-"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
-"-r demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
+"$ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children -r "
+"demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Get groups for specific user"
+msgid "Get groups for a specific user"
 msgstr "特定のユーザーのグループを取得する"
 
 #. type: Plain text
 msgid ""
-"To get user's membership in groups, use user's `id` to compose an endpoint "
-"URI - `users/USER_ID/groups`"
+"Use a user's ID to determine a user's membership in groups to compose an "
+"endpoint URI, such as [filename]`users/USER_ID/groups`."
 msgstr ""
-"ユーザーが構成員となっているグループを取得するには、ユーザーの `id` を使用してエンドポイントURI `users/USER_ID/groups` "
-"を作成します。"
+"グループ内のユーザーのメンバーシップを判断するため、ユーザーのIDを使用して、 [filename]`users/USER_ID/groups` "
+"のようなエンドポイントURIを構成します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r "
+"$ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r "
 "demorealm\n"
 msgstr ""
 "$ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r "
 "demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Adding user to a group"
-msgstr "ユーザーをグループに追加する"
+msgid "Adding a user to a group"
+msgstr "グループにユーザーを追加する"
 
 #. type: Plain text
 msgid ""
-"To join user to a group use `update` operation with an endpoint uri composed"
-" from user's `id`, and group's `id` - users/USER_ID/groups/GROUP_ID."
+"Use the [command]`update` command with an endpoint URI composed from user's "
+"ID and a group's ID, such as [filename]`users/USER_ID/groups/GROUP_ID`, to "
+"add a user to a group."
 msgstr ""
-"ユーザーをグループに参加させるには、ユーザーの `id` とグループの `id` から構成されたエンドポイントuri "
-"`users/USER_ID/groups/GROUP_ID` で `update` 操作を使います。"
+"グループにユーザーを追加するには、ユーザのIDと、[filename]`users/USER_ID/groups/GROUP_ID` "
+"から構成されるエンドポイントURIを利用して[command]`update` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update users/b544f379-5fc4-49e5-8a8d-"
+"$ kcadm.sh update users/b544f379-5fc4-49e5-8a8d-"
 "5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm -s "
 "realm=demorealm -s userId=b544f379-5fc4-49e5-8a8d-5cfb71f46f53 -s "
 "groupId=ce01117a-7426-4670-a29a-5c118056fe20 -n\n"
@@ -2401,218 +2495,236 @@ msgstr ""
 "realm=demorealm -s userId=b544f379-5fc4-49e5-8a8d-5cfb71f46f53 -s "
 "groupId=ce01117a-7426-4670-a29a-5c118056fe20 -n\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Removing user from a group"
-msgstr "グループからのユーザーの削除"
+msgid "Removing a user from a group"
+msgstr "グループからユーザーを削除する"
 
 #. type: Plain text
 msgid ""
-"To remove user from a group use `delete` operation on the same endpoint uri "
-"as used for adding user to a group - users/USER_ID/groups/GROUP_ID."
+"Use the [command]`delete` command on the same endpoint URI as used for "
+"adding a user to a group, such as [filename]`users/USER_ID/groups/GROUP_ID`,"
+" to remove a user from a group."
 msgstr ""
-"ユーザーをグループから削除するには、ユーザーをグループに追加するのと同じエンドポイントuri "
-"`users/USER_ID/groups/GROUP_ID` で `delete` 操作を使用します。"
+"グループからユーザーを削除するには、 [filename]`users/USER_ID/groups/GROUP_ID` "
+"のように、ユーザーをグループに追加するときに使用したのと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-"
+"$ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-"
 "5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm\n"
 msgstr ""
 "$ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-"
 "5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a group"
 msgstr "グループに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
-msgid "Use a dedicated 'get-roles' command."
-msgstr "専用の `get-roles` コマンドを使用します。"
+msgid ""
+"Use a dedicated [command]`get-roles` command to list assigned, available, "
+"and effective realm roles for a group."
+msgstr ""
+"グループに割り当てられた、使用可能な、有効なレルム・ロールを一覧表示するには、専用の [command]`get-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
-"To list *assigned* realm roles for the group you can specify the target "
-"group by `name` (via `--gname` option), `path` (via `--gpath` option), or "
-"`id` (via `--gid` option)."
+"Specify the target group by name (via the [command]`--gname` option), path "
+"(via the [command] `--gpath` option), or ID (via the [command]`--gid` "
+"option) to list *assigned* realm roles for the group."
 msgstr ""
-"グループの *割り当てられた* レルム・ロールを一覧表示するには、対象のグループを `name` （ ` --gname` オプションで）、 "
-"`path` （ `--gpath` オプションで）、 `id` （ `--gid` オプションで）のいずれかで指定できます。"
+"対象グループを、 [command]`--gname` オプションで名前を指定するか、 [command] `--gpath` "
+"オプションでパスをを指定する、または [command]`--gid` オプションでIDを指定することにとり、そのグループの *割り当てられた* "
+"レルム・ロールを一覧表示します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group\n"
+msgid "$ kcadm.sh get-roles -r demorealm --gname Group\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --gname Group\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
+msgid "$ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
 
 #. type: Plain text
 msgid ""
-"To list realm roles that can still be added to the group, use `--available` "
-"option instead."
-msgstr "グループに追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+"Use the [command]`--available` option to list realm roles that can still be "
+"added to the group."
+msgstr "グループに追加できるレルム・ロールを表示するには、 [command]`--available` オプションを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --available\n"
+msgid "$ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a group"
 msgstr "グループに割り当てられた、利用可能な、有効なクライアントロールの一覧表示"
 
 #. type: Plain text
 msgid ""
-"To list *assigned* client roles for the user you can specify the target "
-"group by either `name` (via --gname option) or `id` (via `--gid` option), "
-"and client by either `clientId` (via `--cclientid` option) or `id` (via "
-"`--id` option)."
+"Use a dedicated [command]`get-roles` command to list assigned, available, "
+"and effective client roles for a group."
 msgstr ""
-"ユーザに *割り当てられた* クライアント・ロールを一覧表示するには、 `name` （ `--gname` オプションで）または `id` （ "
-"`--gid` オプションで）のいずれかで対象のグループを指定できます。 `clientId` （ `--cclientid`オプションで）または "
-"`id` （ `--id` オプションで）のどちらかでクライアントを指定できます。"
+"グループに割り当てられた、利用可能な、有効なクライアント・ロールを一覧表示するには、専用の [command]`get-roles` "
+"コマンドを使用します。"
 
 #. type: Plain text
+msgid ""
+"Specify the target group by either name (via the [command]`--gname` option) "
+"or ID (via the [command]`--gid` option), and client by either the clientId "
+"attribute (via the [command] `--cclientid` option) or ID (via the "
+"[command]`--id` option) to list *assigned* client roles for the user."
+msgstr ""
+"[command]`--gname` オプションで名前指定する、 [command]`--gid` "
+"オプションでIDを指定することでグループを指定します。また、 [command] `--cclientid` オプションでclientId属性を指定、 "
+"[command]`--id` オプションでIDを指定することでクライアントを特定し、ユーザーの *割り当てられた* "
+"クライアント・ロールを一覧表示します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"$ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
 "management\n"
 msgstr ""
-"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"$ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
 "management\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
-"management --effective\n"
+"$ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management"
+" --effective\n"
 msgstr ""
-"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
-"management --effective\n"
+"$ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management"
+" --effective\n"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
-"management --available\n"
+"$ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management"
+" --available\n"
 msgstr ""
-"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
-"management --available\n"
+"$ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management"
+" --available\n"
 
 #. type: Title ===
 #, no-wrap
-msgid "Identity Providers operations"
-msgstr "アイデンティティー・プロバイダーの操作"
+msgid "Identity provider operations"
+msgstr " アイデンティティー・プロバイダーの操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing available identity providers"
 msgstr "使用可能なアイデンティティー・プロバイダー の一覧表示"
 
 #. type: Plain text
 msgid ""
-"Use `serverinfo` endpoint to list available identity providers. For example:"
-msgstr "使用可能なアイデンティティー・プロバイダーをリストするには、 `serverinfo` エンドポイントを使用します。例えば："
+"Use the [filename]`serverinfo` endpoint to list available identity "
+"providers."
+msgstr "使用可能なアイデンティティー・プロバイダーを一覧表示するには、 [filename]`serverinfo` エンドポイントを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid ""
-"    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
+msgid "$ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
 msgstr ""
-"    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
+"$ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"Note that `serverinfo` endpoint is handled similarly to `realms` endpoint in"
-" that it is not resolved relative to target realm, because it exists outside"
-" any specific realm."
+"The [filename]`serverinfo` endpoint is handled similarly to the "
+"[filename]`realms` endpoint in that it is not resolved relative to a target "
+"realm because it exists outside any specific realm."
 msgstr ""
-"`serverinfo`エンドポイントは` "
-"realms`エンドポイントと同様に扱われる点に注意してください。特定のレルムの外に存在するため、レルムに対して解決されません。"
+" [filename]`serverinfo` エンドポイントは、特定のレルムの外に存在するため、対象レルムに対して関連がないという点において "
+"[filename]`realms` エンドポイントと同様に扱われます。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing configured identity providers"
-msgstr "構成済みアイデンティティー・プロバイダー の一覧表示"
+msgstr "設定済みアイデンティティー・プロバイダー の一覧表示"
 
 #. type: Plain text
-msgid "Use `identity-provider/instances` endpoint. For example:"
-msgstr "`identity-provider/instances` エンドポイントを使用してください。例えば："
+msgid "Use the [filename]`identity-provider/instances` endpoint."
+msgstr "[filename]`identity-provider/instances` エンドポイントを使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get identity-provider/instances -r demorealm --fields "
+"$ kcadm.sh get identity-provider/instances -r demorealm --fields "
 "alias,providerId,enabled\n"
 msgstr ""
 "$ kcadm.sh get identity-provider/instances -r demorealm --fields "
 "alias,providerId,enabled\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting a specific configured identity provider"
-msgstr "特定の構成済みアイデンティティー・プロバイダーの取得"
+msgstr "特定の設定済みアイデンティティー・プロバイダーの取得"
 
 #. type: Plain text
 msgid ""
-"To get a specific identity provider use `alias` attribute of identity "
-"provider to construct an endpoint uri - `identity-provider/instances/ALIAS`."
+"Use the [command]`alias` attribute of the identity provider to construct an "
+"endpoint URI, such as [filename]`identity-provider/instances/ALIAS`, to get "
+"a specific identity provider."
 msgstr ""
-"特定のアイデンティティー・プロバイダーを取得するには、アイデンティティー・プロバイダーの `alias` 属性を使用して、エンドポイントuri  "
-"`identity-provider/instances/ALIAS` を作成します。"
+"アイデンティティー・プロバイダーの [command]`alias` 属性を使用して、  [filename]`identity-"
+"provider/instances/ALIAS` などのエンドポイントURIを構築し、特定のアイデンティティー・プロバイダーを取得します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
-msgstr "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
+msgid "$ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
+msgstr "$ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Removing a specific configured identity provider"
-msgstr "特定の構成済みアイデンティティー・プロバイダーの削除"
+msgstr "特定の設定済みアイデンティティー・プロバイダーの削除"
 
 #. type: Plain text
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"configured identity provider. For example:"
-msgstr "特定の構成済みアイデンティティ・プロバイダーを取得する場合と同じエンドポイントuriで `delete` 操作を使用します。例えば："
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
+"Use the [command]`delete` command with the same endpoint URI that you used "
+"to get a specific configured identity provider to remove a specific "
+"configured identity provider."
 msgstr ""
-"    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
+"特定の設定済みのアイデンティティー・プロバイダーを取得して、特定の設定済みのアイデンティティー・プロバイダーを取得するために使用したものと同じエンドポイントURIで"
+" [command]`delete` コマンドを使用します。"
 
-#. type: Labeled list
+#. type: delimited block -
+#, no-wrap
+msgid "$ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
+msgstr "$ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
+
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a Keycloak OpenID Connect identity provider"
 msgstr "Keycloak OpenID Connect アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
 msgid ""
-"Use `keycloak-oidc` as `providerId` when creating a new identity provider "
-"instance."
+"Use [command]`keycloak-oidc` as the [command]`providerId` when creating a "
+"new identity provider instance."
 msgstr ""
-"新しいアイデンティティー・プロバイダー・インスタンスを作成するときは、 `keyIdoc` を `providerId` として使用してください。"
+"新しいアイデンティティー・プロバイダー・インスタンスを作成するときは、 [command]`providerId` として [command"
+"]`keycloak-oidc` を使用してください。"
 
 #. type: Plain text
 msgid ""
-"Provide config attributes `authorizationUrl`, `tokenUrl`, `clientId`, and "
-"`clientSecret`."
+"Provide the [command]`config` attributes: [command]`authorizationUrl`, "
+"[command]`tokenUrl`, [command]`clientId`, and [command]`clientSecret`."
 msgstr ""
-"設定属性 `authorizationUrl` 、 `tokenUrl` 、 `clientId` 、 `clientSecret` を提供します。"
+"[command]`authorizationUrl` 、 [command]`tokenUrl` 、 [command]`clientId` 、  "
+"[command]`clientSecret` の [command]`config` 属性として指定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s alias"
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias"
 "=keycloak-oidc -s providerId=keycloak-oidc -s enabled=true -s "
 "'config.useJwksUrl=\"true\"' -s "
 "config.authorizationUrl=http://localhost:8180/auth/realms/demorealm/protocol"
@@ -2621,7 +2733,7 @@ msgid ""
 "connect/token -s config.clientId=demo-oidc-provider -s "
 "config.clientSecret=secret\n"
 msgstr ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s alias"
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias"
 "=keycloak-oidc -s providerId=keycloak-oidc -s enabled=true -s "
 "'config.useJwksUrl=\"true\"' -s "
 "config.authorizationUrl=http://localhost:8180/auth/realms/demorealm/protocol"
@@ -2630,38 +2742,42 @@ msgstr ""
 "connect/token -s config.clientId=demo-oidc-provider -s "
 "config.clientSecret=secret\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring an OpenID Connect identity provider"
 msgstr "OpenID Connect アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
 msgid ""
-"You configure the generic OpenID Connect provider the same way as Keycloak "
-"OpenID Connect provider, except that you set `providerId` attribute value to"
-" `oidc`."
+"Configure the generic OpenID Connect provider the same way you configure the"
+" Keycloak OpenID Connect provider, except that you set the "
+"[command]`providerId` attribute value to [command]`oidc`."
 msgstr ""
-"一般的なOpenID Connect プロバイダーは、 `providerId` 属性値を `oidc` に設定する点を除いて、Keycloak "
-"OpenID Connect プロバイダーと同じ方法で設定します。"
+"[command]`providerId` 属性値を [command]`oidc` に設定することを除いて、Keycloak OpenID "
+"Connectプロバイダーを設定するのと同じ方法で、汎用OpenID Connectプロバイダーを設定します。"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a SAML 2 identity provider"
 msgstr "SAML 2 アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `saml` as `providerId`. Provide `config` attributes - "
-"`singleSignOnServiceUrl`, `nameIDPolicyFormat`, and `signatureAlgorithm`."
-msgstr ""
-"`saml` を `providerId` として使用してください。 `config` 属性（ ` singleSignOnServiceUrl` 、 "
-"`nameIDPolicyFormat` 、および `signatureAlgorithm` ）を提供します。"
+msgid "Use [command]`saml` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`saml` を使います。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes: [command]`singleSignOnServiceUrl`,"
+" [command]`nameIDPolicyFormat`, and [command]`signatureAlgorithm`."
+msgstr ""
+"[command]`singleSignOnServiceUrl` 、 [command]`nameIDPolicyFormat` 、  "
+"[command]`signatureAlgorithm` を [command]`config` 属性として指定します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=saml"
-" -s providerId=saml -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=saml -s "
+"providerId=saml -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
 "config.singleSignOnServiceUrl=http://localhost:8180/auth/realms/saml-broker-"
 "realm/protocol/saml -s config.nameIDPolicyFormat=urn:oasis:names:tc:SAML:2.0"
 ":nameid-format:persistent -s config.signatureAlgorithm=RSA_SHA256\n"
@@ -2672,221 +2788,249 @@ msgstr ""
 "realm/protocol/saml -s config.nameIDPolicyFormat=urn:oasis:names:tc:SAML:2.0"
 ":nameid-format:persistent -s config.signatureAlgorithm=RSA_SHA256\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a Facebook identity provider"
 msgstr "Facebookアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `facebook` as `providerId`. Provide `config` attributes - `clientId` and"
-" `clientSecret` as obtained from Facebook Developers application "
-"configuration page for your application."
-msgstr ""
-"`facebook` を `providerId` として使います。アプリケーションのFacebook "
-"Developersアプリケーション設定ページから取得した `config` 属性（ `clientId` と `clientSecret` "
-"）を提供します。"
+msgid "Use [command]`facebook` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`facebook` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes: [command]`clientId` and "
+"[command]`clientSecret`. You can find these attributes in the Facebook "
+"Developers application configuration page for your application."
+msgstr ""
+"[command]`clientId` と [command]`clientSecret` の[command]`config` "
+"属性をして指定します。これらの属性は、アプリケーションのFacebook Developersアプリケーション設定ページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=facebook -s providerId=facebook -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=FACEBOOK_CLIENT_ID -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=facebook"
+" -s providerId=facebook -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=FACEBOOK_CLIENT_ID -s "
 "config.clientSecret=FACEBOOK_CLIENT_SECRET\n"
 msgstr ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=facebook -s providerId=facebook -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=FACEBOOK_CLIENT_ID -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=facebook"
+" -s providerId=facebook -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=FACEBOOK_CLIENT_ID -s "
 "config.clientSecret=FACEBOOK_CLIENT_SECRET\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a Google identity provider"
 msgstr "Googleアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `google` as `providerId`. Provide `config` attributes - `clientId` and "
-"`clientSecret` as obtained from Google Developers application configuration "
-"page for your application."
-msgstr ""
-"`google` を `providerId` として使います。アプリケーションのGoogle "
-"Developersアプリケーション設定ページから取得した `config` 属性（ `clientId` と `clientSecret` "
-"）を提供します。"
+msgid "Use [command]`google` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`google` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes: [command]`clientId` and "
+"[command]`clientSecret`. You can find these attributes in the Google "
+"Developers application configuration page for your application."
+msgstr ""
+"[command]`clientId` と [command]`clientSecret` を [command]`config` "
+"属性として指定します。これらの属性は、アプリケーションのGoogle Developersアプリケーション設定ページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=google -s providerId=google -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=GOOGLE_CLIENT_ID -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=google "
+"-s providerId=google -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=GOOGLE_CLIENT_ID -s "
 "config.clientSecret=GOOGLE_CLIENT_SECRET\n"
 msgstr ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=google -s providerId=google -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=GOOGLE_CLIENT_ID -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=google "
+"-s providerId=google -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=GOOGLE_CLIENT_ID -s "
 "config.clientSecret=GOOGLE_CLIENT_SECRET\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a Twitter identity provider"
 msgstr "Twitterアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `twitter` as `providerId`. Provide `config` attributes - `clientId` and "
-"`clientSecret` as obtained from Twitter Application Management application "
-"configuration page for your application."
-msgstr ""
-"`twitter` を `providerId` "
-"として使います。アプリケーションのTwitterアプリケーション管理アプリケーション設定ページから取得した `config` 属性（ "
-"`clientId` と `clientSecret` ）を提供します。"
+msgid "Use [command]`twitter` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`twitter` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes [command]`clientId` and "
+"[command]`clientSecret`. You can find these attributes in the Twitter "
+"Application Management application configuration page for your application."
+msgstr ""
+"[command]`clientId` と [command]`clientSecret` を [command]`config` "
+"属性として指定します。これらの属性は、アプリケーションのTwitterアプリケーション管理アプリケーション設定ページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=google -s providerId=google -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=TWITTER_API_KEY -s "
-"config.clientSecret=TWITTER_API_SECRET\n"
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=google "
+"-s providerId=google -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=TWITTER_API_KEY -s config.clientSecret=TWITTER_API_SECRET\n"
 msgstr ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=google -s providerId=google -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=TWITTER_API_KEY -s "
-"config.clientSecret=TWITTER_API_SECRET\n"
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=google "
+"-s providerId=google -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=TWITTER_API_KEY -s config.clientSecret=TWITTER_API_SECRET\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a GitHub identity provider"
 msgstr "GitHubアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `github` as `providerId`. Provide `config` attributes - `clientId` and "
-"`clientSecret` as obtained from GitHub Developer Application Settings page "
-"for your application."
-msgstr ""
-"`github` を `providerId` として使います。アプリケーションのGitHub開発者アプリケーション設定ページから取得した "
-"`config` 属性（ ` clientId` と `clientSecret` ）を提供します。"
+msgid "Use [command]`github` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`github` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes [command]`clientId` and "
+"[command]`clientSecret`. You can find these attributes in the GitHub "
+"Developer Application Settings page for your application."
+msgstr ""
+"[command]`clientId` と [command]`clientSecret` を [command]`config` "
+"属性として指定します。これらの属性は、アプリケーションのGitHub開発者アプリケーション設定ページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=github -s providerId=github -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=GITHUB_CLIENT_ID -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=github "
+"-s providerId=github -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=GITHUB_CLIENT_ID -s "
 "config.clientSecret=GITHUB_CLIENT_SECRET\n"
 msgstr ""
 "$ kcadm.sh create identity-provider/instances -r demorealm -s alias=github "
-"-s providerId=github -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+"-s providerId=github -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
 "config.clientId=GITHUB_CLIENT_ID -s "
 "config.clientSecret=GITHUB_CLIENT_SECRET\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a LinkedIn identity provider"
 msgstr "LinkedInアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `linkedin` as `providerId`. Provide `config` attributes - `clientId` and"
-" `clientSecret` as obtained from LinkedIn Developer Console application page"
-" for your application."
-msgstr ""
-"`linkedin` を `providerId` "
-"として使用してください。アプリケーションのLinkedIn開発者コンソール・アプリケーション・ページから取得した `config` 属性（ "
-"`clientId` と `clientSecret` ）を提供します。"
+msgid "Use [command]`linkedin` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`linkedin` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes [command]`clientId` and "
+"[command]`clientSecret`. You can find these attributes in the LinkedIn "
+"Developer Console application page for your application."
+msgstr ""
+"[command]`clientId` と [command]`clientSecret` を [command]`config` "
+"属性として指定します。これらの属性は、アプリケーションのLinkedInデベロッパーコンソールアプリケーションページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=linkedin -s providerId=linkedin -s enabled=true  -s "
-"'config.useJwksUrl=\"true\"' -s config.clientId=LINKEDIN_CLIENT_ID -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=linkedin"
+" -s providerId=linkedin -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=LINKEDIN_CLIENT_ID -s "
 "config.clientSecret=LINKEDIN_CLIENT_SECRET\n"
 msgstr ""
 "$ kcadm.sh create identity-provider/instances -r demorealm -s alias=linkedin"
-" -s providerId=linkedin -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+" -s providerId=linkedin -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s "
 "config.clientId=LINKEDIN_CLIENT_ID -s "
 "config.clientSecret=LINKEDIN_CLIENT_SECRET\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a Microsoft Live identity provider"
 msgstr "Microsoft Live アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `microsoft` as `providerId`. Provide `config` attributes - `clientId` "
-"and `clientSecret` as obtained from Microsoft Application Registration "
-"Portal page for your application."
-msgstr ""
-"`microsoft` を `providerId` として使います。アプリケーションのMicrosoftアプリケーション登録ポータルページから取得した"
-" `config` 属性（ `clientId` と `clientSecret` ）を提供します。"
+msgid "Use [command]`microsoft` as the [command]`providerId`."
+msgstr "[command]`providerId` として [command]`microsoft` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes `clientId` and `clientSecret`. You "
+"can find these attributes in the Microsoft Application Registration Portal "
+"page for your application."
+msgstr ""
+"`clientId` and `clientSecret` を [command]`config` "
+"属性として指定します。これらの属性は、アプリケーションのMicrosoftアプリケーション登録ポータルページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s "
 "alias=microsoft -s providerId=microsoft -s enabled=true  -s "
 "'config.useJwksUrl=\"true\"' -s config.clientId=MICROSOFT_APP_ID -s "
 "config.clientSecret=MICROSOFT_PASSWORD\n"
 msgstr ""
 "$ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=microsoft -s providerId=microsoft -s enabled=true -s "
+"alias=microsoft -s providerId=microsoft -s enabled=true  -s "
 "'config.useJwksUrl=\"true\"' -s config.clientId=MICROSOFT_APP_ID -s "
 "config.clientSecret=MICROSOFT_PASSWORD\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a StackOverflow identity provider"
 msgstr "StackOverflowアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-msgid ""
-"Use `stackoverflow` as `providerId`. Provide `config` attributes - "
-"`clientId`, `clientSecret` and `key` as obtained from Stack Apps OAuth page "
-"for your application."
-msgstr ""
-"`stackoverflow` を `providerId` として使用してください。アプリケーションのStack Apps "
-"OAuthページから取得した `config` 属性（ `--clientId` 、 `clientSecret` 、 `key` ）を提供します。"
+msgid "Use `stackoverflow` command as the [command]`providerId`."
+msgstr "[command]`providerId` として `stackoverflow` を使用します。"
 
 #. type: Plain text
+msgid ""
+"Provide the [command]`config` attributes [command]`clientId`, "
+"[command]`clientSecret`, and [command]`key`. You can find these attributes "
+"in the Stack Apps OAuth page for your application."
+msgstr ""
+"[command]`clientId` 、 [command]`clientSecret` 、 [command]`key` を "
+"[command]`config` として提供します。これらの属性は、アプリケーションのStack Apps OAuthページで確認できます。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"$ kcadm.sh create identity-provider/instances -r demorealm -s "
 "alias=stackoverflow -s providerId=stackoverflow -s enabled=true  -s "
 "'config.useJwksUrl=\"true\"' -s config.clientId=STACKAPPS_CLIENT_ID -s "
 "config.clientSecret=STACKAPPS_CLIENT_SECRET -s config.key=STACKAPPS_KEY\n"
 msgstr ""
 "$ kcadm.sh create identity-provider/instances -r demorealm -s "
-"alias=stackoverflow -s providerId=stackoverflow -s enabled=true -s "
+"alias=stackoverflow -s providerId=stackoverflow -s enabled=true  -s "
 "'config.useJwksUrl=\"true\"' -s config.clientId=STACKAPPS_CLIENT_ID -s "
 "config.clientSecret=STACKAPPS_CLIENT_SECRET -s config.key=STACKAPPS_KEY\n"
 
 #. type: Title ===
 #, no-wrap
-msgid "Storage Providers operations"
+msgid "Storage provider operations"
 msgstr "ストレージ・プロバイダーの操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring a Kerberos storage provider"
 msgstr "Kerberosストレージ・プロバイダーの設定"
 
 #. type: Plain text
 msgid ""
-"Use `create` against `user-federation/instances` endpoint. Specify "
-"`kerberos` as a value of `providerName` attribute."
+"Use the [command]`create` command against the [filename]`user-"
+"federation/instances` endpoint."
 msgstr ""
-"`user-federation/instances` エンドポイントに対して `create` を使います。 `kerberos` を "
-"`providerName` 属性の値として指定してください。"
+"[filename]`user-federation/instances` エンドポイントに対して [command]`create` "
+"コマンドを使用します。"
 
 #. type: Plain text
+msgid ""
+"Specify [command]`kerberos` as a value of the [command]`providerName` "
+"attribute."
+msgstr "[command]`providerName` 属性の値として [command]`kerberos` を指定します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create user-federation/instances -r demorealm -s "
+"$ kcadm.sh create user-federation/instances -r demorealm -s "
 "providerName=kerberos -s priority=0 -s config.debug=false -s "
 "config.allowPasswordAuthentication=true -s 'config.editMode=\"UNSYNCED\"' -s"
 " config.updateProfileFirstLogin=true -s "
@@ -2902,39 +3046,49 @@ msgstr ""
 "'config.kerberosRealm=\"KEYCLOAK.ORG\"' -s 'config.keyTab=\"http.keytab\"' "
 "-s 'config.serverPrincipal=\"HTTP/localhost@KEYCLOAK.ORG\"'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Configuring an LDAP user storage provider"
 msgstr "LDAPユーザー・ストレージ・プロバイダーの設定"
 
 #. type: Plain text
 msgid ""
-"Use `create` against `components` endpoint. Specify `ldap` as a value of "
-"`providerId` attribute, and `org.keycloak.storage.UserStorageProvider` as "
-"value of `providerType` attribute. Provide realm `id` as value of `parentId`"
-" attribute."
+"Use the [command]`create` command against the [filename]`components` "
+"endpoint."
+msgstr "[filename]`components` エンドポイントに対して [command]`create` コマンドを使用します。"
+
+#. type: Plain text
+msgid ""
+"Specify [command]`ldap` as a value of the [command]`providerId` attribute, "
+"and [command]`org.keycloak.storage.UserStorageProvider` as the value of the "
+"[command]`providerType` attribute."
 msgstr ""
-"`components` エンドポイントに対して `create` を使います。 `providerId` 属性の値として `ldap` を指定し、 "
-"`providerType` 属性の値として `org.keycloak.storage.UserStorageProvider` を指定します。 "
-"`parentId` 属性の値としてレルム `id` を与えます。"
+"[command]`providerId` 属性の値として [command]`ldap` を指定し、 [command]`providerType` "
+"属性の値として [command]`org.keycloak.storage.UserStorageProvider` を指定します。"
 
 #. type: Plain text
-msgid "For example, to create a Kerberos integrated LDAP provider:"
-msgstr "たとえば、Kerberos統合LDAPプロバイダーを作成するには、次のようにします。"
+msgid ""
+"Provide the realm ID as the value of the [command]`parentId` attribute."
+msgstr "レルムIDを [command]`parentId` 属性の値として指定します。"
 
 #. type: Plain text
+msgid ""
+"Use the following example to create a Kerberos-integrated LDAP provider."
+msgstr "次の例を使用して、Kerberos統合LDAPプロバイダーを作成します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider"
-" -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider"
-" -s parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s "
-"'config.priority=[\"1\"]' -s 'config.fullSyncPeriod=[\"-1\"]' -s "
-"'config.changedSyncPeriod=[\"-1\"]' -s 'config.cachePolicy=[\"DEFAULT\"]' -s"
-" config.evictionDay=[] -s config.evictionHour=[] -s config.evictionMinute=[]"
-" -s config.maxLifespan=[] -s 'config.batchSizeForSync=[\"1000\"]' -s "
-"'config.editMode=[\"WRITABLE\"]' -s 'config.syncRegistrations=[\"false\"]' "
-"-s 'config.vendor=[\"other\"]' -s 'config.usernameLDAPAttribute=[\"uid\"]' "
-"-s 'config.rdnLDAPAttribute=[\"uid\"]' -s "
+"$ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider -s "
+"providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s "
+"parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s 'config.priority=[\"1\"]' "
+"-s 'config.fullSyncPeriod=[\"-1\"]' -s 'config.changedSyncPeriod=[\"-1\"]' "
+"-s 'config.cachePolicy=[\"DEFAULT\"]' -s config.evictionDay=[] -s "
+"config.evictionHour=[] -s config.evictionMinute=[] -s config.maxLifespan=[] "
+"-s 'config.batchSizeForSync=[\"1000\"]' -s 'config.editMode=[\"WRITABLE\"]' "
+"-s 'config.syncRegistrations=[\"false\"]' -s 'config.vendor=[\"other\"]' -s "
+"'config.usernameLDAPAttribute=[\"uid\"]' -s "
+"'config.rdnLDAPAttribute=[\"uid\"]' -s "
 "'config.uuidLDAPAttribute=[\"entryUUID\"]' -s "
 "'config.userObjectClasses=[\"inetOrgPerson, organizationalPerson\"]' -s "
 "'config.connectionUrl=[\"ldap://localhost:10389\"]'  -s "
@@ -2951,7 +3105,7 @@ msgid ""
 msgstr ""
 "$ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider -s "
 "providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s "
-"parentId=3d9c572b-8f33-483f-98a6-8bb421667867 -s 'config.priority=[\"1\"]' "
+"parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s 'config.priority=[\"1\"]' "
 "-s 'config.fullSyncPeriod=[\"-1\"]' -s 'config.changedSyncPeriod=[\"-1\"]' "
 "-s 'config.cachePolicy=[\"DEFAULT\"]' -s config.evictionDay=[] -s "
 "config.evictionHour=[] -s config.evictionMinute=[] -s config.maxLifespan=[] "
@@ -2961,7 +3115,7 @@ msgstr ""
 "'config.rdnLDAPAttribute=[\"uid\"]' -s "
 "'config.uuidLDAPAttribute=[\"entryUUID\"]' -s "
 "'config.userObjectClasses=[\"inetOrgPerson, organizationalPerson\"]' -s "
-"'config.connectionUrl=[\"ldap://localhost:10389\"]' -s "
+"'config.connectionUrl=[\"ldap://localhost:10389\"]'  -s "
 "'config.usersDn=[\"ou=People,dc=keycloak,dc=org\"]' -s "
 "'config.authType=[\"simple\"]' -s 'config.bindDn=[\"uid=admin,ou=system\"]' "
 "-s 'config.bindCredential=[\"secret\"]' -s 'config.searchScope=[\"1\"]' -s "
@@ -2973,100 +3127,112 @@ msgstr ""
 "'config.kerberosRealm=[\"KEYCLOAK.ORG\"]' -s 'config.debug=[\"true\"]' -s "
 "'config.useKerberosForPasswordAuthentication=[\"true\"]'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Removing a user storage provider instance"
 msgstr "ユーザー・ストレージ・プロバイダー・インスタンスの削除"
 
 #. type: Plain text
 msgid ""
-"Use storage provider instance's `id` attribute to compose an endpoint uri - "
-"`components/ID`."
-msgstr "ストレージ・プロバイダー・インスタンスの `id` 属性を使用して、エンドポイントuri  `components/ID` を作成します。"
+"Use the storage provider instance's [command]`id` attribute to compose an "
+"endpoint URI, such as [filename]`components/ID`."
+msgstr ""
+"ストレージ・プロバイダー・インスタンスの [command]`id` 属性を使用して、 [filename]`components/ID` "
+"のようなエンドポイントURIを作成します。"
 
 #. type: Plain text
-msgid "Perform `delete` operation against this endpoint. For example:"
-msgstr "このエンドポイントに対して `delete` 操作を実行します。例えば："
+msgid "Run the [command]`delete` command against this endpoint."
+msgstr "このエンドポイントに対して [command]`delete` コマンドを実行します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r "
+"$ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r "
 "demorealm\n"
 msgstr ""
 "$ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r "
 "demorealm\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid ""
-"Triggering synchronization of all users for specific user storage provider"
-msgstr "特定のユーザー・ストレージ・プロバイダーに対してすべてのユーザーの同期をトリガーする"
+"Triggering synchronization of all users for a specific user storage provider"
+msgstr "特定のユーザー・ストレージ・プロバイダーのすべてのユーザーの同期をトリガーする"
 
 #. type: Plain text
 msgid ""
-"Use storage provider's `id` attribute to compose an endpoint uri - user-"
-"storage/ID_OF_USER_STORAGE_INSTANCE/sync Add `action=triggerFullSync` query "
-"parameter and perform `create` command."
+"Use the storage provider's [command]`id` attribute to compose an endpoint "
+"URI, such as [filename]`user-storage/ID_OF_USER_STORAGE_INSTANCE/sync`."
 msgstr ""
-"ストレージ・プロバイダーの `id` 属性を使用してエンドポイントuri `user-"
-"storage/ID_OF_USER_STORAGE_INSTANCE/sync` を作成します。 `action=triggerFullSync` "
-"クエリ・パラメーターを追加し、 `create` コマンドを実行します。"
+"ストレージ・プロバイダーの [command]`id` 属性を使用して、 [filename]`user-"
+"storage/ID_OF_USER_STORAGE_INSTANCE/sync` のようなエンドポイントURIを作成します。"
 
 #. type: Plain text
+msgid ""
+"Add the [command]`action=triggerFullSync` query parameter and run the "
+"[command]`create` command."
+msgstr ""
+"[command]`action=triggerFullSync` クエリパラメータを追加し、 [command]`create` "
+"コマンドを実行します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
+"$ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
 "947d6a09e1ea/sync?action=triggerFullSync\n"
 msgstr ""
 "$ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
 "947d6a09e1ea/sync?action=triggerFullSync\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid ""
-"Triggering synchronization of changed users for specific user storage "
+"Triggering synchronization of changed users for a specific user storage "
 "provider"
 msgstr "特定のユーザー・ストレージ・プロバイダーの変更されたユーザーの同期をトリガーする"
 
 #. type: Plain text
 msgid ""
-"Use storage provider's `id` attribute to compose an endpoint uri - user-"
-"storage/ID_OF_USER_STORAGE_INSTANCE/sync Add "
-"`action=triggerChangedUsersSync` query parameter and use `create`."
+"Add the [command]`action=triggerChangedUsersSync` query parameter and run "
+"the [command]`create` command."
 msgstr ""
-"ストレージ・プロバイダーの `id` 属性を使用してエンドポイントuri `user-"
-"storage/ID_OF_USER_STORAGE_INSTANCE/sync` を作成します。 "
-"`action=triggerChangedUsersSync` クエリー・パラメーターを追加し、 `create` コマンドを実行します。 "
+"[command]`action=triggerChangedUsersSync` クエリパラメータを追加し、 [command]`create` "
+"コマンドを実行します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
+"$ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
 "947d6a09e1ea/sync?action=triggerChangedUsersSync\n"
 msgstr ""
 "$ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
 "947d6a09e1ea/sync?action=triggerChangedUsersSync\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Test LDAP user storage connectivity"
 msgstr "LDAPユーザー・ストレージの接続をテストする"
 
 #. type: Plain text
 msgid ""
-"Perform `get` operation on `testLDAPConnection` endpoint. Provide query "
-"parameters `bindCredential`, `bindDn`, `connectionUrl`, and "
-"`useTruststoreSpi`, and set `action` query parameter to `testConnection`."
-msgstr ""
-"`testLDAPConnection` エンドポイントで `get` 操作を行います。クエリー・パラメータ ー `bindCredential` 、 "
-"`bindDn` 、 `connectionUrl` 、 `useTruststoreSpi` を指定し、 `action` クエリー・パラメーターを "
-"`testConnection` に設定します。"
+"Run the [command]`get` command on the [filename]`testLDAPConnection` "
+"endpoint."
+msgstr "[filename]`testLDAPConnection` エンドポイントで [command]`get` コマンドを実行します。"
 
 #. type: Plain text
+msgid ""
+"Provide query parameters [command]`bindCredential`, [command]`bindDn`, "
+"[command]`connectionUrl`, and [command]`useTruststoreSpi`, and then set the "
+"[command]`action` query parameter to [command]`testConnection`."
+msgstr ""
+"[command]`bindCredential`, [command]`bindDn`, [command]`connectionUrl`, and "
+"[command]`useTruststoreSpi` をクエリ・パラメーターとして指定します。[command]`action` "
+"クエリ・パラメーターに [command]`testConnection` を設定します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get testLDAPConnection -q action=testConnection -q "
+"$ kcadm.sh get testLDAPConnection -q action=testConnection -q "
 "bindCredential=secret -q bindDn=uid=admin,ou=system -q "
 "connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 msgstr ""
@@ -3074,30 +3240,29 @@ msgstr ""
 "bindCredential=secret -q bindDn=uid=admin,ou=system -q "
 "connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Test LDAP user storage authentication"
 msgstr "LDAPユーザー・ストレージ認証をテストする"
 
 #. type: Plain text
 msgid ""
-"Perform `get` operation on `testLDAPConnection` endpoint. Provide query "
-"parameters `bindCredential`, `bindDn`, `connectionUrl`, and "
-"`useTruststoreSpi`, and set `action` query parameter to "
-"`testAuthentication`."
+"Provide the query parameters [command]`bindCredential`, [command]`bindDn`, "
+"[command]`connectionUrl`, and [command]`useTruststoreSpi`, and then set the "
+"[command]`action` query parameter to [command]`testAuthentication`."
 msgstr ""
-"`testLDAPConnection` エンドポイントで `get` 操作を行います。クエリー・パラメーター `bindCredential` 、 "
-"`bindDn` 、 `connectionUrl` 、 `useTruststoreSpi` を指定し、 `action` クエリー・パラメーターを "
-"`testAuthentication` に設定します。"
+"[command]`bindCredential` 、 [command]`bindDn` 、  [command]`connectionUrl` 、 "
+"[command]`useTruststoreSpi` をクエリ・パラメーターに指定します。[command]`action` クエリ・パラメーターに "
+"[command]`testAuthentication` を指定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
+"$ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
 "bindCredential=secret -q bindDn=uid=admin,ou=system -q "
 "connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 msgstr ""
-"    $ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
+"$ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
 "bindCredential=secret -q bindDn=uid=admin,ou=system -q "
 "connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 
@@ -3106,29 +3271,44 @@ msgstr ""
 msgid "Adding mappers"
 msgstr "マッパーの追加"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding a hardcoded role LDAP mapper"
 msgstr "ハードコードされたロールLDAPマッパーの追加"
 
 #. type: Plain text
 msgid ""
-"Use `create` on `components` endpoint. Set `providerType` attribute to "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
-"attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
-"`hardcoded-ldap-role-mapper`. Make sure to provide a value of `role` config "
-"parameter."
-msgstr ""
-"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
-"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `hardcoded-ldap-role-"
-"mapper` を設定してください。必ず `role` 設定パラメーターの値を指定してください。"
+"Run the [command]`create` command on the [filename]`components` endpoint."
+msgstr "[filename]`components` エンドポイントで [command]`create` コマンドを実行します。"
 
 #. type: Plain text
+msgid ""
+"Set the [command]`providerType` attribute to "
+"[filename]`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`."
+msgstr ""
+"[command]`providerType` 属性を "
+"[filename]`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` に設定します。"
+
+#. type: Plain text
+msgid ""
+"Set the [command]`parentId` attribute to the ID of the LDAP provider "
+"instance."
+msgstr "[command]`parentId` 属性にLDAPプロバイダー・インスタンスのIDを設定します。"
+
+#. type: Plain text
+msgid ""
+"Set the [command]`providerId` attribute to [command]`hardcoded-ldap-role-"
+"mapper`. Make sure to provide a value of [command]`role` configuration "
+"parameter."
+msgstr ""
+"[command]`providerId` 属性に [command]`hardcoded-ldap-role-mapper` を設定します。 "
+"[command]`role` 設定パラメータの値を指定します。"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=hardcoded-ldap-role-"
-"mapper -s providerId=hardcoded-ldap-role-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=hardcoded-ldap-role-mapper"
+" -s providerId=hardcoded-ldap-role-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.role=[\"realm-"
 "management.create-client\"]'\n"
@@ -3139,28 +3319,24 @@ msgstr ""
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.role=[\"realm-"
 "management.create-client\"]'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
-msgid "Adding a MS Active Directory mapper"
+msgid "Adding an MS Active Directory mapper"
 msgstr "MS Active Directoryマッパーの追加"
 
 #. type: Plain text
 msgid ""
-"Use `create` on `components` endpoint. Set `providerType` attribute to "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
-"attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
-"`msad-user-account-control-mapper`."
+"Set the [command]`providerId` attribute to [filename]`msad-user-account-"
+"control-mapper`."
 msgstr ""
-"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
-"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `msad-user-account-"
-"control-mapper` を設定してください。"
+"[command]`providerId` 属性を [filename]`msad-user-account-control-mapper` "
+"に設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=msad-user-account-"
-"control-mapper -s providerId=msad-user-account-control-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=msad-user-account-control-"
+"mapper -s providerId=msad-user-account-control-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea\n"
 msgstr ""
@@ -3169,28 +3345,23 @@ msgstr ""
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding an user attribute LDAP mapper"
 msgstr "ユーザー属性LDAPマッパーの追加"
 
 #. type: Plain text
 msgid ""
-"Use `create` on `components` endpoint. Set `providerType` attribute to "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
-"attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
-"`user-attribute-ldap-mapper`."
+"Set the [command]`providerId` attribute to [filename]`user-attribute-ldap-"
+"mapper`."
 msgstr ""
-"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
-"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `user-attribute-ldap-"
-"mapper` を設定してください。"
+"[command]`providerId` 属性を [filename]`user-attribute-ldap-mapper`に設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-"
-"mapper -s providerId=user-attribute-ldap-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-mapper"
+" -s providerId=user-attribute-ldap-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
 "'config.\"user.model.attribute\"=[\"email\"]' -s "
@@ -3198,8 +3369,8 @@ msgid ""
 " -s 'config.\"always.read.value.from.ldap\"=[\"false\"]' -s "
 "'config.\"is.mandatory.in.ldap\"=[\"false\"]'\n"
 msgstr ""
-"    $ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-"
-"mapper -s providerId=user-attribute-ldap-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-mapper"
+" -s providerId=user-attribute-ldap-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
 "'config.\"user.model.attribute\"=[\"email\"]' -s "
@@ -3207,27 +3378,20 @@ msgstr ""
 " -s 'config.\"always.read.value.from.ldap\"=[\"false\"]' -s "
 "'config.\"is.mandatory.in.ldap\"=[\"false\"]'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding a group LDAP mapper"
 msgstr "グループLDAPマッパーの追加"
 
 #. type: Plain text
 msgid ""
-"Use `create` on `components` endpoint. Set `providerType` attribute to "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
-"attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
-"`group-ldap-mapper`."
-msgstr ""
-"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
-"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性を `group-ldap-mapper` "
-"に設定してください。"
+"Set the [command]`providerId` attribute to [filename]`group-ldap-mapper`."
+msgstr "[command]`providerId` 属性を [filename]`group-ldap-mapper` に設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
 "providerId=group-ldap-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"groups.dn\"=[]' "
@@ -3244,7 +3408,7 @@ msgid ""
 "'config.group=[]' -s 'config.preserve=[\"true\"]' -s "
 "'config.membership=[\"member\"]'\n"
 msgstr ""
-"    $ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
 "providerId=group-ldap-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"groups.dn\"=[]' "
@@ -3261,35 +3425,29 @@ msgstr ""
 "'config.group=[]' -s 'config.preserve=[\"true\"]' -s "
 "'config.membership=[\"member\"]'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Adding a full name LDAP mapper"
 msgstr "フルネームLDAPマッパーの追加"
 
 #. type: Plain text
 msgid ""
-"Use `create` on `components` endpoint. Set `providerType` attribute to "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
-"attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
-"`full-name-ldap-mapper`."
-msgstr ""
-"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
-"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
-"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `full-name-ldap-"
-"mapper` を設定してください。"
+"Set the [command]`providerId` attribute to [filename]`full-name-ldap-"
+"mapper`."
+msgstr "[command]`providerId` 属性を [filename]`full-name-ldap-mapper` に設定します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper "
-"-s providerId=full-name-ldap-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper -s "
+"providerId=full-name-ldap-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
 "'config.\"ldap.full.name.attribute\"=[\"cn\"]' -s "
 "'config.\"read.only\"=[\"false\"]' -s 'config.\"write.only\"=[\"true\"]'\n"
 msgstr ""
-"    $ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper "
-"-s providerId=full-name-ldap-mapper -s "
+"$ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper -s "
+"providerId=full-name-ldap-mapper -s "
 "providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
 "parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
 "'config.\"ldap.full.name.attribute\"=[\"cn\"]' -s "
@@ -3300,95 +3458,144 @@ msgstr ""
 msgid "Authentication operations"
 msgstr "認証の操作"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Setting a password policy"
 msgstr "パスワード・ポリシーの設定"
 
 #. type: Plain text
 msgid ""
-"Set realm's `passwordPolicy` attribute to enumeration expression that "
-"includes the specific policy provider id, and optional configuration."
-msgstr "レルムの `passwordPolicy` 属性を、特定のポリシー・プロバイダー・IDとオプションの設定を含む列挙式に設定します。"
+"Set the realm's [command]`passwordPolicy` attribute to an enumeration "
+"expression that includes the specific policy provider ID and optional "
+"configuration."
+msgstr ""
+"レルムの [command]`passwordPolicy` 属性を、特定のポリシー・プロバイダーIDとオプション設定を含む列挙表現で設定します。"
 
 #. type: Plain text
 msgid ""
-"For example, to set password policy to default values - i.e.: 27500 hashing "
-"iterations, requiring at least one special character, at least one uppercase"
-" character, at least one digit character, not be equal to user's `username`,"
-" and be at least 8 characters long you would use the following:"
-msgstr ""
-"たとえば、パスワード・ポリシーをデフォルト値（27500ハッシュ反復、少なくとも1つの特殊文字、少なくとも1つの大文字、少なくとも1つの数字文字、ユーザーの"
-" `username` と等しくなく、少なくとも8文字の長さ）に設定するには、次のようにします。"
+"Use the following example to set a password policy to default values. The "
+"default values include:"
+msgstr "次の例を使用して、パスワード・ポリシーをデフォルト値に設定します。デフォルト値は次のとおりです。"
 
 #. type: Plain text
+msgid "27,500 hashing iterations"
+msgstr "27,500ハッシュ反復"
+
+#. type: Plain text
+msgid "at least one special character"
+msgstr "少なくとも1つの特殊文字"
+
+#. type: Plain text
+msgid "at least one uppercase character"
+msgstr "少なくとも1つの大文字"
+
+#. type: Plain text
+msgid "at least one digit character"
+msgstr "少なくとも1つの数字"
+
+#. type: Plain text
+msgid "not be equal to a user's [filename]`username`"
+msgstr "ユーザーの [filename]`username` と等しくないこと"
+
+#. type: Plain text
+msgid "be at least eight characters long"
+msgstr "8文字以上の長さ"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations "
-"and specialChars and upperCase and digits and notUsername and length\"'\n"
+"$ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations and "
+"specialChars and upperCase and digits and notUsername and length\"'\n"
 msgstr ""
-"    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations "
-"and specialChars and upperCase and digits and notUsername and length\"'\n"
+"$ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations and "
+"specialChars and upperCase and digits and notUsername and length\"'\n"
 
 #. type: Plain text
 msgid ""
-"If you want want to use values different from defaults, pass configuration "
-"in brackets."
-msgstr "デフォルトと異なる値を使用する場合は、括弧で設定を渡します。"
+"If you want to use values different from defaults, pass the configuration in"
+" brackets."
+msgstr "デフォルトと異なる値を使用する場合は、設定を大括弧で囲みます。"
 
 #. type: Plain text
-msgid ""
-"For example, to set password policy to 25000 hash iterations, requiring at "
-"least two special characters, at least two uppercase characters, at least "
-"two lowercase characters, at least two digits, be at least nine characters "
-"long, not be equal to user's username, and not repeat for at least four "
-"changes back:"
-msgstr ""
-"たとえば、パスワードポリシーを25000ハッシュ反復、少なくとも2つの特殊文字、少なくとも2つ以上の大文字、少なくとも2つ以上の小文字、少なくとも2つ以上の数字、少なくとも9文字の長さ、ユーザー名と等しくなく、過去4回の変更と一致しない、に設定するには、次のようにします。"
+msgid "Use the following example to set a password policy to:"
+msgstr "パスワードポリシーを次のように設定するには、以下の例を使用します。"
 
 #. type: Plain text
+msgid "25,000 hash iterations"
+msgstr "25,000ハッシュ反復"
+
+#. type: Plain text
+msgid "at least two special characters"
+msgstr "少なくとも2つの特殊文字"
+
+#. type: Plain text
+msgid "at least two uppercase characters"
+msgstr "少なくとも2つの大文字"
+
+#. type: Plain text
+msgid "at least two lowercase characters"
+msgstr "少なくとも2つの小文字"
+
+#. type: Plain text
+msgid "at least two digits"
+msgstr "少なくとも2つの数字"
+
+#. type: Plain text
+msgid "be at least nine characters long"
+msgstr "9文字以上の長さ"
+
+#. type: Plain text
+msgid "not repeat for at least four changes back"
+msgstr "過去4回の変更履歴の重複を許可しない"
+
+#. type: delimited block -
 #, no-wrap
 msgid ""
-"    $ kcadm.sh update realms/demorealm -s "
+"$ kcadm.sh update realms/demorealm -s "
 "'passwordPolicy=\"hashIterations(25000) and specialChars(2) and upperCase(2)"
 " and lowerCase(2) and digits(2) and length(9) and notUsername and "
 "passwordHistory(4)\"'\n"
 msgstr ""
-"    $ kcadm.sh update realms/demorealm -s "
+"$ kcadm.sh update realms/demorealm -s "
 "'passwordPolicy=\"hashIterations(25000) and specialChars(2) and upperCase(2)"
 " and lowerCase(2) and digits(2) and length(9) and notUsername and "
 "passwordHistory(4)\"'\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Getting the current password policy"
 msgstr "現在のパスワード・ポリシーの取得"
 
 #. type: Plain text
 msgid ""
-"Get current realm configuration and filter out everything but "
-"`passwordPolicy` attribute."
-msgstr "現在のレルムの設定を取得し、 `passwordPolicy` 属性以外のすべてをフィルタリングします。"
+"Get the current realm configuration and filter everything but the "
+"[command]`passwordPolicy` attribute."
+msgstr "現在のレルム設定を取得し、 [command]`passwordPolicy` 属性以外のすべてをフィルタリングします。"
 
 #. type: Plain text
-msgid "For example, to display `passwordPolicy` for demorealm:"
-msgstr "例えば、demorealmの `passwordPolicy` を表示するには："
+msgid ""
+"Use the following example to display [command]`passwordPolicy` for "
+"[filename]`demorealm`."
+msgstr ""
+"[filename]`demorealm` に対して [command]`passwordPolicy` を表示するには、次の例を使用します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
-msgstr "    $ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
+msgid "$ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
+msgstr "$ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
 
-#. type: Labeled list
+#. type: Title ====
 #, no-wrap
 msgid "Listing authentication flows"
 msgstr "認証フローの一覧表示"
 
 #. type: Plain text
-msgid "Use `get` operation on `authentication/flows` endpoint. For example:"
-msgstr "`authentication/flows` エンドポイントで `get` 操作を使います。例えば："
+msgid ""
+"Run the [command]`get` command on the [filename]`authentication/flows` "
+"endpoint."
+msgstr "[filename]`authentication/flows` エンドポイントで [command]`get` コマンドを実行します。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
-msgid "    $ kcadm.sh get authentication/flows -r demorealm\n"
-msgstr "$ kcadm.sh get authentication/flows -r demorealm\n"
+msgid "$ kcadm.sh get authentication/flows -r demorealm\n"
+msgstr ""

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroshi Katakura <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,15 +17,15 @@ msgstr ""
 
 #. type: Plain text
 msgid "For example, on:"
-msgstr "例えば"
+msgstr "以下に例を示します。"
 
 #. type: Plain text
 msgid "Linux:"
-msgstr "Linuxの場合"
+msgstr "Linuxの場合："
 
 #. type: Plain text
 msgid "Windows:"
-msgstr "Windowsの場合"
+msgstr "Windowsの場合："
 
 #. type: Title ===
 #, no-wrap
@@ -60,23 +60,22 @@ msgid ""
 "The Admin CLI is packaged inside {project_name} Server distribution. You can"
 " find execution scripts inside the [filename]`bin` directory."
 msgstr ""
-"管理CLIは、{project_name}サーバーの配布物に含まれています。実行スクリプトは [filename]`bin` ディレクトリにあります。"
+"管理CLIは、{project_name}サーバーの配布物に含まれています。実行スクリプトは [filename]`bin` ディレクトリーにあります。"
 
 #. type: Plain text
 msgid ""
 "The Linux script is called [filename]`kcadm.sh`, and the script for Windows "
 "is called [filename]`kcadm.bat`."
 msgstr ""
-"Linuxのスクリプトは [filename]`kcadm.sh` と呼ばれ、Windowsのスクリプトは [filename]`kcadm.bat` "
-"と呼ばれます。"
+"Linuxのスクリプトは [filename]`kcadm.sh` 、Windowsのスクリプトは [filename]`kcadm.bat` です。"
 
 #. type: Plain text
 msgid ""
 "You can add the {project_name} server directory to your [filename]`PATH` to "
 "use the client from any location on your file system."
 msgstr ""
-"{project_name}サーバディレクトリを[filename] `PATH` "
-"に追加することで、ファイルシステム上の任意の場所からクライアントを使用することができます。"
+"{project_name}サーバー・ディレクトリーを [filename]`PATH` "
+"に追加することで、ファイル・システム上の任意の場所からクライアントを使用することができます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -100,7 +99,7 @@ msgstr ""
 msgid ""
 "We assume the `KEYCLOAK_HOME` environment (env) variable is set to the path "
 "where you extracted the {project_name} Server distribution."
-msgstr "`KEYCLOAK_HOME` 環境変数は、{project_name}サーバの配布物を解凍したパスに設定されているものとします。"
+msgstr "`KEYCLOAK_HOME` 環境変数は、{project_name}サーバーの配布物を解凍したパスに設定されているものとします。"
 
 #. type: delimited block =
 msgid ""
@@ -120,7 +119,7 @@ msgid ""
 "The Admin CLI works by making HTTP requests to Admin REST endpoints. Access "
 "to them is protected and requires authentication."
 msgstr ""
-"管理CLIは、管理RESTエンドポイントへのHTTP要求を作成することによって動作します。エンドポイントへのアクセスは保護されており、認証が必要です。"
+"管理CLIは、管理RESTエンドポイントへのHTTPリクエストを作成することによって動作します。エンドポイントへのアクセスは保護されており、認証が必要です。"
 
 #. type: delimited block =
 msgid ""
@@ -134,7 +133,7 @@ msgid ""
 "in. You are ready to perform create, read, update, and delete (CRUD) "
 "operations."
 msgstr ""
-"クレデンシャルを提供すること、つまりログインすることで、認証セッションを開始します。作成、読み取り、更新、および削除（CRUD）操作を実行する準備をします。"
+"クレデンシャルを提供すること、つまりログインすることで、認証セッションを開始します。作成、読み取り、更新、および削除（CRUD）操作を実行する準備ができました。"
 
 #. type: Plain text
 msgid "For example, on"
@@ -176,7 +175,7 @@ msgid ""
 "included in Java's default certificate truststore, prepare a "
 "[filename]`truststore.jks` file and instruct the Admin CLI to use it."
 msgstr ""
-"プロダクション環境では、ネットワーク解析によりトークンが漏洩しないように、{project_name}に `https：` "
+"プロダクション環境では、ネットワーク・スニファーによりトークンが漏洩しないように、{project_name}に `https:` "
 "でアクセスする必要があります。サーバーの証明書が、Javaのデフォルトの証明書トラストストアに含まれる信頼できる認証局（CA）のいずれかによって発行されていない場合は、"
 " [filename]`truststore.jks` ファイルを準備し、管理CLIに使用するよう指示します。"
 
@@ -213,7 +212,7 @@ msgid ""
 "user password. You could also use [command]`Signed JWT` instead of the "
 "client secret."
 msgstr ""
-"管理CLIでログインするときは、サーバーのエンドポイントURLとレルムを指定してから、ユーザー名を指定します。別の方法としては、特別な「サービスアカウント」を使用するclientIdのみを指定することです。ユーザー名を使用してログインするときは、指定したユーザーのパスワードを使用する必要があります。clientIdを使用してログインする場合、ユーザーのパスワードではなくクライアント・シークレットのみが必要です。また、クライアント・シークレットの代わりに"
+"管理CLIでログインするときは、サーバーのエンドポイントURLとレルムを指定してから、ユーザー名を指定します。別のオプションはclientIdのみを指定することで、特別な「サービスアカウント」を使用することになります。ユーザー名を使用してログインするときは、指定したユーザーのパスワードを使用する必要があります。clientIdを使用してログインする場合、ユーザーのパスワードではなくクライアント・シークレットのみが必要です。また、クライアント・シークレットの代わりに"
 " [command]`Signed JWT` を使用することもできます。"
 
 #. type: Plain text
@@ -224,14 +223,14 @@ msgid ""
 "which the user is defined."
 msgstr ""
 "セッションに使用されるアカウントに、管理REST API操作を呼び出すための適切な権限があることを確認します。例えば、 `realm-"
-"management` クライアントの `realm-admin` ロールは、ユーザが定義されているレルムを管理することを許可します。"
+"management` クライアントの `realm-admin` ロールは、ユーザーが定義されているレルムを管理することを許可します。"
 
 #. type: Plain text
 msgid ""
 "There are two primary mechanisms for authentication. One mechanism uses "
 "[command]`kcadm config credentials` to start an authenticated session."
 msgstr ""
-"認証には主に2つの方法があります。 1つ目の方法は、[command]`kcadm config credentials` "
+"認証には主に2つの機構があります。1つ目の機構は、[command]`kcadm config credentials` "
 "を使用して認証セッションを開始します。"
 
 #. type: delimited block -
@@ -251,7 +250,7 @@ msgid ""
 "private configuration file. See <<_working_with_alternative_configurations, "
 "next chapter>> for more information on the configuration file."
 msgstr ""
-"この方法は、取得したアクセストークンと関連するリフレッシュトークンを保存することによって、 [command]`kcadm` "
+"このアプローチは、取得したアクセス・トークンと関連するリフレッシュ・トークンを保存することによって、 [command]`kcadm` "
 "コマンドの呼び出し間で認証されたセッションを維持します。また、プライベート設定ファイルに他のシークレットを保持することもできます。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
 " 次の章>>を参照してください。"
 
@@ -264,14 +263,14 @@ msgid ""
 "nothing is saved to disk. This mode is used when the [command]`--no-config` "
 "argument is specified."
 msgstr ""
-"2番目の方法は、各コマンド呼び出しごとに認証する方法です。この方法は、サーバーへの負荷とトークンを取得するやり取りに費やされる時間を増加させます。利点としては、呼び出しの間にトークンを保存する必要がないため、何もディスクに保存されないことです。このモードは、"
+"2番目のアプローチは、各コマンド呼び出しごとに認証する方法です。この方法は、サーバーへの負荷とトークンを取得するやり取りに費やされる時間を増加させます。利点としては、呼び出しの間にトークンを保存する必要がないため、何もディスクに保存されないことです。このモードは、"
 " [command]`--no-config` 引数が指定されている場合に使用されます。"
 
 #. type: Plain text
 msgid ""
 "For example, when performing an operation, we specify all the information "
 "required for authentication."
-msgstr "操作を実行するときに、認証に必要なすべての情報を指定する例。"
+msgstr "たとえば、操作を実行するときに、認証に必要なすべての情報を指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -286,14 +285,15 @@ msgstr ""
 msgid ""
 "Run the [command]`kcadm.sh help` command for more information on using the "
 "Admin CLI."
-msgstr "Admin CLIの使用方法の詳細については、 [command]`kcadm.sh help` コマンドを実行してください。"
+msgstr "管理CLIの使用方法の詳細については、 [command]`kcadm.sh help` コマンドを実行してください。"
 
 #. type: Plain text
 msgid ""
 "Run the [command]`kcadm.sh config credentials --help` command for more "
 "information about starting an authenticated session."
 msgstr ""
-"認証セッションの開始については、[command]`kcadm.sh config credentials --help` コマンドを実行してください。"
+"認証されたセッションの開始については、[command]`kcadm.sh config credentials --help` "
+"コマンドを実行してください。"
 
 #. type: Plain text
 msgid ""
@@ -305,11 +305,11 @@ msgid ""
 "[command]`--config` option to point to a different file or location so you "
 "can maintain multiple authenticated sessions in parallel."
 msgstr ""
-"デフォルトでは、管理CLIはユーザーのホームディレクトリにある [filename]kcadm.config "
-"という設定ファイルを自動的に維持します。Linuxベースのシステムでは、フルパス名は[filename]$HOME/.keycloak/kcadm.config"
-" です。 Windowsでは、フルパス名は [filename]%HOMEPATH%\\.keycloak\\kcadm.config です。 "
+"デフォルトでは、管理CLIはユーザーのホーム・ディレクトリーにある [filename]`kcadm.config` "
+"という設定ファイルを自動的に維持します。Linuxベースのシステムでは、フルパス名は[filename]`$HOME/.keycloak/kcadm.config`"
+" です。 Windowsでは、フルパス名は [filename]`%HOMEPATH%\\.keycloak\\kcadm.config` です。 "
 "[command]`--config` "
-"オプションを使うと、別のファイルや場所を指し示すことができるので、複数の認証セッションを並行して維持することができます。"
+"オプションを使うと、別のファイルや場所を指し示すことができるので、複数の認証されたセッションを並行して維持することができます。"
 
 #. type: delimited block =
 msgid ""
@@ -326,7 +326,7 @@ msgid ""
 "already exists, its permissions are not updated."
 msgstr ""
 "システム上の他のユーザーが設定ファイルを参照できないようにしてください。プライベートにしておくべきアクセス・トークンとシークレットが含まれています。デフォルトでは、[filename]`~/.keycloak`"
-" ディレクトリとその内容は適切なアクセス制限で自動的に作成されます。ディレクトリが既に存在する場合、そのアクセス許可は更新されません。"
+" ディレクトリーとその内容は適切なアクセス制限で自動的に作成されます。ディレクトリーが既に存在する場合、そのパーミッションは更新されません。"
 
 #. type: Plain text
 msgid ""
@@ -337,7 +337,7 @@ msgid ""
 "authentication information needed by the [command]`config credentials` "
 "command with each [command]`kcadm` invocation."
 msgstr ""
-"固有の要件により、シークレットを設定ファイルに保管しないようにする必要がある場合は、そうすることが可能です。この方法はあまり便利ではなく、トークン要求が多くなります。シークレットを保存しないためには、すべてのコマンドで"
+"特殊な状況で、シークレットを設定ファイルに保管しないようにする必要がある場合は、そうすることが可能です。この方法はあまり便利ではなく、トークン・リクエストが多くなります。シークレットを保存しないためには、すべてのコマンドで"
 " [command]`--no-config` オプションを使用し、 [command]`config credentials` "
 "コマンドで必要とされるすべての認証情報を [command]`kcadm` 呼び出しごとに指定します。"
 
@@ -398,9 +398,9 @@ msgid ""
 "[filename]`users` as ENDPOINT results in the resource URL "
 "http://localhost:8080/auth/admin/realms/master/users."
 msgstr ""
-"たとえば、http://localhost:8080/auth、のサーバーに対してrealmが [filename]`master` 、 "
-"[filename]`users` "
-"をエンドポイントとして認証する場合、リソースURLは、http://localhost:8080/auth/admin/realms/master/usersとなります。"
+"たとえば、http://localhost:8080/authのサーバーに対して認証し、レルムが [filename]`master` "
+"の場合、エンドポイントとして [filename]`users` "
+"を使用すると、リソースURLはhttp://localhost:8080/auth/admin/realms/master/usersとなります。"
 
 #. type: Plain text
 msgid ""
@@ -414,7 +414,9 @@ msgstr ""
 msgid ""
 "There is a [filename]`realms` endpoint that is treated slightly differently "
 "because it is the container for realms. It resolves to:"
-msgstr " [filename]`realms` エンドポイントは、レルムのコンテナであるため、少し異なります。それは以下のとおりです。"
+msgstr ""
+"レルムのコンテナーであるため、少し異なる方法で扱われる [filename]`realms` "
+"エンドポイントがあります。このエンドポイントは次のようになります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -480,10 +482,10 @@ msgid ""
 " and their values as seen in the previous [command]`create users` example. "
 "They are composed into a JSON body and sent to the server."
 msgstr ""
-"[command]`create` と [command]`update` コマンドは、デフォルトでJSONをサーバーに送信します。 "
+"[command]`create` と [command]`update` コマンドは、デフォルトでJSON本体をサーバーに送信します。 "
 "[filename]`-f FILENAME` を使うと、ファイルから作成しておいたJSONを読みこむことができます。 [command]`-f -` "
 "オプションを使うことができる場合、メッセージ本文は標準入力から読み込まれます。前の [command]`create users` "
-"の例に見られるように、個々の属性とその値を指定することもできます。 それらはJSONで構成され、サーバーに送信されます。"
+"の例に見られるように、個々の属性とその値を指定することもできます。それらはJSONで構成され、サーバーに送信されます。"
 
 #. type: Plain text
 msgid ""
@@ -568,7 +570,7 @@ msgstr "$ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
 msgid ""
 "A realm is not enabled by default. By enabling it, you can use a realm "
 "immediately for authentication."
-msgstr "レルムはデフォルトで有効になっていません。有効にすることで、認証用のレルムを使用することができます。"
+msgstr "レルムはデフォルトで有効になっていません。有効にすることで、認証のためにレルムをすぐに使用できます。"
 
 #. type: Plain text
 msgid "A description for a new object can also be in a JSON format."
@@ -754,7 +756,7 @@ msgid ""
 " revealed by [command]`kcadm.sh get keys -r demorealm`."
 msgstr ""
 "[command]`kcadm.sh get keys -r demorealm` "
-"で取得した既存のプロバイダよりも優先度の高い、新しい鍵プロバイダを追加してください。"
+"で取得した既存のプロバイダーよりも優先度の高い、新しい鍵プロバイダーを追加してください。"
 
 #. type: delimited block -
 #, no-wrap
@@ -807,7 +809,7 @@ msgstr "Javaキーストア・ファイルから新しいレルム鍵を追加�
 msgid ""
 "Add a new key provider to add a new key pair already prepared as a JKS file "
 "on the server."
-msgstr "新しい鍵プロバイダを追加して、すでにサーバー上にJKSファイルとして用意されている新しい鍵ペアを追加します。"
+msgstr "新しい鍵プロバイダーを追加して、すでにサーバー上にJKSファイルとして用意されている新しい鍵ペアを追加します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -856,7 +858,7 @@ msgid ""
 "Make sure to change the attribute values for `keystore`, `keystorePassword`,"
 " `keyPassword`, and `alias` to match your specific keystore."
 msgstr ""
-"特定のキーストアに一致するように、 `keystore` 、 ` keystorePassword` 、  `keyPassword` 、および "
+"特定のキーストアに一致するように、 `keystore` 、 ` keystorePassword` 、`keyPassword` 、および "
 "`alias` の属性値を変更してください。"
 
 #. type: Title ====
@@ -963,11 +965,11 @@ msgid ""
 msgstr ""
 "`eventsListeners` "
 "属性には、イベントを受け取るすべてのイベントリスナーを指定するEventListenerProviderFactory "
-"IDのリストが含まれています。これとは別に、組み込みイベント記憶域を制御する属性があり、管理REST "
+"IDのリストが含まれています。これとは別に、組み込みイベント・ストレージを制御する属性があり、管理REST "
 "APIを介して過去のイベントを照会することができます。`eventsEnabled`と呼ばれるサービス呼び出しログと、`adminEventsEnabled`"
-" と呼ばれるAdmin ConsoleまたはAdmin REST "
+" と呼ばれる管理コンソールまたは管理REST "
 "APIをトリガーとするイベント監査という独立した制御があります。古いイベントの有効期限を設定してデータベースがいっぱいにならないようにすることができます。"
-" `eventsExpiration` は秒で有効期限を表します。"
+" `eventsExpiration` は有効期限を秒で表します。"
 
 #. type: Plain text
 msgid ""
@@ -977,7 +979,7 @@ msgid ""
 "logged as `DEBUG`.)"
 msgstr ""
 "ここでは、すべてのイベントを受け取り、jboss-loggingを通じてそれらを記録する組み込みのイベント・リスナーを設定する例を示します。 "
-"`org.keycloak.events` というロガーを使うと、エラー・イベントは `WARN` として記録され、他は  `DEBUG` "
+"`org.keycloak.events` というロガーを使うと、エラー・イベントは `WARN` として記録され、他は`DEBUG` "
 "として記録されます。"
 
 #. type: delimited block -
@@ -1003,8 +1005,7 @@ msgid ""
 "Here is an example of turning on storage of all available ERROR "
 "events&#8212;not including auditing events&#8212;for 2 days so they can be "
 "retrieved via Admin REST."
-msgstr ""
-"イベントの監査を除く、利用可能なすべてのERRORイベントのストレージを2日間有効にして、管理REST経由で取得できるようにする例を次に示します。"
+msgstr "次に、利用可能なすべてのERRORイベント（監査イベントを除く）の保管を2日間有効にする例を示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1024,14 +1025,17 @@ msgid ""
 "\"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\""
 " -s eventsExpiration=172800\n"
 msgstr ""
+"c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s "
+"\"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\""
+" -s eventsExpiration=172800\n"
 
 #. type: Plain text
 msgid ""
 "Here is an example of how to reset stored event types to *all available "
 "event types*; setting to empty list is the same as enumerating all."
 msgstr ""
-" *all available event types* "
-"にリセットする方法の例を次に示します。空のリストに設定することはすべてを列挙することを意味します。"
+"保存されているイベントタイプを *すべての利用可能なイベントタイプ* "
+"にリセットする方法の例を次に示します。空のリストに設定することは、すべてを列挙することを意味します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1040,7 +1044,7 @@ msgstr "$ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
 
 #. type: Plain text
 msgid "Here is an example of how to enable storage of auditing events."
-msgstr "次に、監査イベントの格納を有効にする方法の例を示します。"
+msgstr "次に、監査イベントの保存を有効にする方法の例を示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1055,7 +1059,7 @@ msgstr ""
 msgid ""
 "Here is an example of how to get the last 100 events; they are ordered from "
 "newest to oldest."
-msgstr "最新の100イベントを取得する方法を次に示します。新しいイベントから順番に並んでいます。"
+msgstr "最新の100個のイベントを取得する方法を次に示します。新しいイベントから順番に並んでいます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1082,12 +1086,12 @@ msgid ""
 "[filename]`clear-realm-cache`, [filename]`clear-user-cache`, or [filename"
 "]`clear-keys-cache`."
 msgstr ""
-"[command]`create` コマンドと、[filename]`clear-realm-cache` 、 [filename]`clear-"
-"user-cache` 、[filename]`clear-keys-cache` のいずれかのエンドポイントを使用します。"
+"[command]`create` コマンドと、 [filename]`clear-realm-cache` 、 [filename]`clear-"
+"user-cache` 、 [filename]`clear-keys-cache` のいずれかのエンドポイントを使用します。"
 
 #. type: Plain text
 msgid "Set `realm` to the same value as the target realm."
-msgstr "`realm` を対象レルムと同じ値に設定します。"
+msgstr "`realm` を対象のレルムと同じ値に設定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1133,8 +1137,8 @@ msgid ""
 "Identify the client first and then use the [command]`get` command to list "
 "available clients when creating a client role."
 msgstr ""
-"最初にクライアントを特定し、 [command]`get` "
-"コマンドを使用して、クライアント・ロールを作成するときに使用可能なクライアントを一覧表示します。"
+"クライアント・ロールを作成するときは、最初にクライアントを特定し、 [command]`get` "
+"コマンドを使用して使用可能なクライアントを一覧表示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1146,8 +1150,8 @@ msgid ""
 "Create a new role by using the [command]`clientId` attribute to construct an"
 " endpoint URI, such as [filename]`clients/ID/roles`."
 msgstr ""
-"[command]`clientId` 属性を使用して、 [filename]`clients/ID/roles` "
-"のようにエンドポイントURIを作成して、新しいロールを作成します。"
+"[filename]`clients/ID/roles` のようなエンドポイントURIを構築するには、 [command]`clientId` "
+"属性を使用して新しいロールを作成します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1206,9 +1210,9 @@ msgid ""
 "attribute (via the [command]`--cclientid` option) or [command]`id` (via the "
 "[command]`--cid` option) to identify the client to list client roles."
 msgstr ""
-"[command]`get-roles` コマンドは、 [command]`--cclientid` オプションを利用してclientId属性、または "
-"[command]`--cid` オプションを利用して [command] `id` "
-"を渡すことでクライアント・ロールを一覧表示するクライアントを指定します。"
+"クライアント・ロールを一覧表示するには、[command]`get-roles` コマンドを使用します。 [command] `clientId` "
+"または [command] `id` 属性を渡すことで（ [command]`--cclientid` または [command]`--cid` "
+"オプションを介して）、クライアントを指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1226,9 +1230,8 @@ msgid ""
 " endpoint URI for a specific realm role: [filename]`roles/ROLE_NAME`, where "
 "[filename]`user` is the name of the existing role."
 msgstr ""
-"特定のレルム・ロールのエンドポイントURIを構築するには、 [command]`get` コマンドと "
-"[filename]`roles/ROLE_NAME` のように、ロール [filename]`name` を使用します。 [filename]` "
-"user`は 既存のロールです。"
+"[filename]`roles/ROLE_NAME` のように特定のレルム・ロールのエンドポイントURIを構築するには、 [command]`get`"
+" コマンドとロール [filename]`name` を使用します。ここで、 [filename]`user`は既存のロールです。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1241,8 +1244,8 @@ msgid ""
 " name (via the [command]`--rolename` option) or ID (via the "
 "[command]`--roleid` option)."
 msgstr ""
-"[command]`get-roles` コマンドを使用して、[command]`--rolename` オプションを使用してロール名を渡すか、 "
-"[command]`--roleid` オプションを使用してIDを渡すこともできます。"
+"[command]`get-roles` コマンドを使用することもできます。 [command]`--rolename` オプションでロール名を渡すか、"
+" [command]`--roleid` オプションでIDを渡します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1262,9 +1265,8 @@ msgid ""
 "role name (via the [command]`--rolename` option) or ID (via the "
 "[command]`--roleid`) to identify a specific client role."
 msgstr ""
-"[command]`get-roles` コマンドでは、[command]`--cclientid` オプションでclientId属性、または "
-"[command]`--cid` オプションでIDを渡して、クライアントを特定します。クライアント・ロールを特定するためには、 [command] "
-"`--rolename` オプションでロール名または [command]`--roleid` オプションでIDを渡します。"
+"専用の[command]`get-roles` "
+"コマンドを使用します。クライアントを識別するためにclientId属性（[command]`--cclientid`オプションで）またはID（[command]`--cid`オプションで）を渡し、クライアント・ロールを識別するためにロール名（[command]`--rolename`オプションで）またはID（[command]`--roleid`で）を渡します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1305,8 +1307,7 @@ msgstr "クライアント・ロールの更新"
 msgid ""
 "Use the [command]`update` command with the same endpoint URI that you used "
 "to get a specific client role."
-msgstr ""
-"特定のクライアント・ロールを取得するために使用したものと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
+msgstr "特定のロールを取得するために使用したのと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1327,7 +1328,7 @@ msgid ""
 "Use the [command]`delete` command with the same endpoint URI that you used "
 "to get a specific realm role."
 msgstr ""
-"特定のレルム・ロールを取得するために使用したのと同じエンドポイントURIを指定して [command]`delete` コマンドを使用します。"
+"特定のレルムロールを取得するために使用したものと同じエンドポイントURIを指定して [command]`delete` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1344,7 +1345,7 @@ msgid ""
 "Use the [command]`delete` command with the same endpoint URI that you used "
 "to get a specific client role."
 msgstr ""
-"特定のクライアントロールを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
+"特定のクライアント・ロールを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1359,14 +1360,14 @@ msgstr ""
 #, no-wrap
 msgid ""
 "Listing assigned, available, and effective realm roles for a composite role"
-msgstr "複合ロールに割り当てられた、使用可能な、有効なレルム・ロールの一覧"
+msgstr "複合ロールに割り当てられた、利用可能な、有効なレルムロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective realm roles for a composite role."
 msgstr ""
-"専用の [command]`get-roles` コマンドを使用して、複合ロールに割り当てられた、使用可能な、有効なレルムロールを一覧表示します。"
+"専用の [command]`get-roles` コマンドを使用して、複合ロールに割り当てられた、利用可能な、有効なレルムロールを一覧表示します。"
 
 #. type: Plain text
 msgid ""
@@ -1374,8 +1375,8 @@ msgid ""
 "target composite role by either name (via the [command]`--rname` option) or "
 "ID (via the [command]`--rid` option)."
 msgstr ""
-"複合ロールの *assigned* レルム・ロールを一覧表示するには、[command]`--rname` オプションを使用して名前を指定するか、 "
-"[command]`--rid` オプションを使用してIDを指定します。"
+"複合ロールに *割り当てられた* レルムロールを一覧表示するには、name（ [command]`--rname` オプションで）またはID（  "
+"[command]`--rid` オプションで）のいずれかで対象の複合ロールを指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1386,7 +1387,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole\n"
 msgid ""
 "Use the additional [command]`--effective` option to list *effective* realm "
 "roles."
-msgstr "*有効な* レルム・ロールをリストするには、 [command]`--effective` オプションを使用します。"
+msgstr "*有効な* レルムロールをリストするには、 [command]`--effective` オプションを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1397,7 +1398,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
 msgid ""
 "Use the [command]`--available` option to list realm roles that can still be "
 "added to the composite role."
-msgstr "複合ロールにまだ利用可能なレルム・ロールを一覧表示するには、 [command]`--available` オプションを使用します。"
+msgstr "複合ロールにまだ利用可能なレルムロールを一覧表示するには、 [command]`--available` オプションを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1408,15 +1409,14 @@ msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
 #, no-wrap
 msgid ""
 "Listing assigned, available, and effective client roles for a composite role"
-msgstr "複合ロールに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
+msgstr "複合ロールに割り当てられた、利用可能な、有効なクライアントロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective client roles for a composite role."
 msgstr ""
-"専用の [command]`get-roles` "
-"コマンドを使用して、複合ロールに割り当てられた、利用可能な、有効なクライアント・ロールを一覧表示します。"
+"専用の [command]`get-roles` コマンドを使用して、複合ロールに割り当てられた、利用可能な、有効なクライアントロールを一覧表示します。"
 
 #. type: Plain text
 msgid ""
@@ -1426,9 +1426,9 @@ msgid ""
 "attribute (via the [command]`--cclientid` option) or ID (via the "
 "[command]`--cid` option)."
 msgstr ""
-"複合ロールの *割り当てられた* クライアント・ロールを一覧表示するには、[command]`--rname` オプションでロール名を指定するか、または"
+"複合ロールの *割り当てられた* クライアントロールを一覧表示するには、 [command]`--rname` オプションでロール名を指定するか、または"
 " [command]`--rid` オプションでIDを指定します。また、クライアントを特定するために、 [command] `--cclientid` "
-"オプションでclientId属性、または[command]` --cid`オプションでIDのいずれかを使用します。"
+"オプションでclientId属性、または [command]` --cid` オプションでIDのいずれかを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid ""
 "Use the [command]`--available` option to list realm roles that can still be "
 "added to the target composite role."
-msgstr "対象の複合ロールに利用可能なレルム・ロールを一覧表示するには、 [command]`--available` オプションを使用します。"
+msgstr "対象の複合ロールにまだ追加できるレルムロールを一覧表示するには、 [command]`--available` オプションを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1472,7 +1472,7 @@ msgstr "レルム・ロールを複合ロールに追加する"
 msgid ""
 "There is a dedicated [command]`add-roles` command that can be used for "
 "adding realm roles and client roles."
-msgstr "レルム・ロールとクライアント・ロールを追加するために使用できる専用の [command]`add-roles` コマンドがあります。"
+msgstr "レルムロールとクライアント・ロールを追加するために使用できる専用の [command]`add-roles` コマンドがあります。"
 
 #. type: Plain text
 msgid ""
@@ -1494,7 +1494,7 @@ msgstr "複合ロールからレルム・ロールを削除する"
 msgid ""
 "There is a dedicated [command]`remove-roles` command that can be used to "
 "remove realm roles and client roles."
-msgstr "レルム・ロールとクライアント・ロールを削除するための専用の [command]`remove-roles` コマンドがあります。"
+msgstr "レルムロールとクライアント・ロールを削除するための専用の [command]`remove-roles` コマンドがあります。"
 
 #. type: Plain text
 msgid ""
@@ -1563,9 +1563,9 @@ msgid ""
 "called [filename]`operations`, which becomes a composite role, that has an "
 "ID of \"fc400897-ef6a-4e8c-872b-1581b7fa8a71\"."
 msgstr ""
-"[filename]`test-client` のclientId属性、 [filename]`support` というクライアント・ロール、および "
-"[filename]`operations` という別のクライアント・ロールがあり、IDは\"fc400897-ef6a-4e8c-872b-"
-"1581b7fa8a71\"という複合ロールがあると仮定します。"
+"[filename]`test-client` のclientId属性をもつクライアントと、 [filename]`support` "
+"というクライアント・ロール、および [filename]`operations` という別のクライアント・ロールがあり、IDが\"fc400897"
+"-ef6a-4e8c-872b-1581b7fa8a71\"という複合ロールになると仮定します。"
 
 #. type: Plain text
 msgid "Use the following example to add another role to the composite role."
@@ -1647,7 +1647,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Specify a secret if you want to set a secret for adapters to authenticate."
-msgstr "認証するアダプターのシークレットを設定する場合は、シークレットを指定します。"
+msgstr "認証するアダプターのシークレットを設定したい場合は、シークレットを指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1677,7 +1677,8 @@ msgid ""
 "This example filters the output to list only the [filename]`id` and "
 "[filename]`clientId` attributes."
 msgstr ""
-"この例では、 [filename]`id` および [filename]`clientId` 属性のみを一覧出力するようにフィルタリングしています。"
+"この例では、 [filename]`id` および [filename]`clientId` "
+"属性のみを一覧出力するように、出力をフィルタリングしています。"
 
 #. type: Title ====
 #, no-wrap
@@ -1728,7 +1729,7 @@ msgid ""
 "keycloak-json`."
 msgstr ""
 "クライアントIDを使用して、 [filename]`clients/ID/installation/providers/keycloak-oidc-"
-"keycloak-json` などの特定のクライアントを対象とするエンドポイントURIを構築します。"
+"keycloak-json` のような特定のクライアントを対象とするエンドポイントURIを構築します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1745,7 +1746,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "Getting a Wildfly subsystem adapter configuration for a specific client"
-msgstr "特定のクライアントのためのWildflyサブシステム・アダプタ設定の取得"
+msgstr "特定のクライアントのためのWildFlyサブシステム・アダプター設定の取得"
 
 #. type: Plain text
 msgid ""
@@ -1754,7 +1755,7 @@ msgid ""
 "jboss-subsystem`."
 msgstr ""
 "クライアントIDを使用して、 [filename]`clients/ID/installation/providers/keycloak-oidc-"
-"jboss-subsystem` などの特定のクライアントを対象とするエンドポイントURIを構築します。"
+"jboss-subsystem` のような特定のクライアントを対象とするエンドポイントURIを構築します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1776,8 +1777,7 @@ msgstr "クライアントの更新"
 msgid ""
 "Use the [command]`update` command with the same endpoint URI that you used "
 "to get a specific client."
-msgstr ""
-"特定のクライアントを取得するために使用したのと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
+msgstr "特定のクライアントを取得するために使用したURIと同じエンドポイントURIで、 [command]`update` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1818,7 +1818,7 @@ msgstr "クライアントの削除"
 msgid ""
 "Use the [command]`delete` command with the same endpoint URI that you used "
 "to get a specific client."
-msgstr "特定のクライアントを取得するのに使用したのと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
+msgstr "特定のクライアントを取得するのに使用したURIと同じエンドポイントURIで、 [command]`delete` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1931,7 +1931,7 @@ msgstr "ユーザーの更新"
 msgid ""
 "Use the [command]`update` command with the same endpoint URI that you used "
 "to get a specific user."
-msgstr "特定のユーザーを取得するために使用したのと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
+msgstr "特定のユーザーを取得するために使用したURIと同じエンドポイントURIで、 [command]`update` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1964,7 +1964,7 @@ msgstr "ユーザーの削除"
 msgid ""
 "Use the [command]`delete` command with the same endpoint URI that you used "
 "to get a specific user."
-msgstr "特定のユーザーを取得するために使用したのと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
+msgstr "特定のユーザーを取得するために使用したURIと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2011,8 +2011,9 @@ msgid ""
 "endpoint constructed from the one you used to get a specific user, such as "
 "[filename]`users/USER_ID/reset-password`."
 msgstr ""
-"[filename]`users/USER_ID/reset-password` のように、特定のユーザーを取得するために使用したエンドポイントで "
-"[command]`update` コマンドを使用しても同じ結果が得ることができます。"
+"[filename]`users/USER_ID/reset-password` "
+"のように、特定のユーザーを取得するために使用したユーザーIDで構築されたエンドポイントで [command]`update` "
+"コマンドを使用しても同じ結果が得ることができます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2030,7 +2031,7 @@ msgid ""
 " in this instance because the [command]`reset-password` endpoint does not "
 "support [command]`GET`."
 msgstr ""
-"最後のパラメータ [command]`-n` は、 [command]`GET` コマンドなしで [command]`PUT` "
+"最後のパラメーター [command]`-n` は、 [command]`GET` コマンドなしで [command]`PUT` "
 "コマンドだけが実行されるようにします。この場合、 [command]`reset-password` エンドポイントは [command]`GET` "
 "をサポートしていないので指定が必要です。"
 
@@ -2045,7 +2046,7 @@ msgid ""
 "available, and effective realm roles for a user."
 msgstr ""
 "専用の [command]`get-roles` "
-"コマンドを使用して、ユーザーに割り当てられた、利用可能な、有効なレルム・ロールを一覧表示することができます。"
+"コマンドを使用して、ユーザーに割り当てられた、利用可能で、有効なレルム・ロールを一覧表示することができます。"
 
 #. type: Plain text
 msgid ""
@@ -2084,7 +2085,7 @@ msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective client roles for a user."
 msgstr ""
-"専用の [command]`get-roles` コマンドを使用して、ユーザに割り当てられた、利用可能な、有効なクライアント・ロールを一覧表示します。"
+"専用の [command]`get-roles` コマンドを使用して、ユーザーに割り当てられた、利用可能で、有効なクライアント・ロールを一覧表示します。"
 
 #. type: Plain text
 msgid ""
@@ -2094,10 +2095,10 @@ msgid ""
 "option) or an ID (via the [command]`--cid` option) to list *assigned* client"
 " roles for the user."
 msgstr ""
-"[command]`--uusername` オプションを使用してユーザー名を指定する、または [command]`--uid` "
-"オプションを使用してIDを指定することで対象ユーザー特定します。また、 [command]`--cclientid` "
-"オプションでclientId属性を指定する、または [command]`--cid` オプションでIDを指定してクライアントを指定して、ユーザーの "
-"*割り当てられた* クライアント・ロールを一覧表示します。"
+"ユーザーに *割り当てられた* クライアント・ロールを一覧表示するには、[command]`--uusername` "
+"オプションでユーザー名を指定するか、 [command]`--uid` オプションでIDを指定して対象ユーザー特定し、 "
+"[command]`--cclientid` オプションでclientId属性を指定するか、 [command]`--cid` "
+"オプションでIDを指定して対象クライアントを特定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2162,7 +2163,7 @@ msgstr "ユーザーからレルム・ロールを削除するには、専用の
 msgid ""
 "Use the following example to remove the [command]`user` role from the user "
 "[command]`testuser`."
-msgstr "以下の例を使用して、 ユーザー[command]`testuser` から [command]`user` ロールを削除します。"
+msgstr "以下の例を使用して、ユーザー [command]`testuser` から [command]`user` ロールを削除します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2187,8 +2188,8 @@ msgid ""
 "[command]`realm management` - `create-client` role and the [command]`view-"
 "users` role to the user `testuser`."
 msgstr ""
-"次の例を使用して、 [command]`realm management` - `create-client` ロールと [command]`view-"
-"users` ロールのクライアントに定義された2つのロールを `testuser` ユーザーに追加します。"
+"次の例を使用して、クライアント[command]`realm management` に定義された2つのロール（ [command]`create-"
+"client` ロールと [command]`view-users` ロール）を `testuser` ユーザーに追加します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2286,8 +2287,7 @@ msgstr "[filename]`users/ID/logout` のようなエンドポイントURIを構�
 msgid ""
 "Use the [command]`create` command to perform [command]`POST` on that "
 "endpoint URI."
-msgstr ""
-"その [command]`create` コマンドを使って、そのエンドポイントURIに対して [command]`POST` を実行します。"
+msgstr "そのエンドポイントURIに対して、 [command]`create` コマンドを使って [command]`POST` を実行します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2382,7 +2382,7 @@ msgstr "グループの削除"
 msgid ""
 "Use the [command]`delete` command with the same endpoint URI that you used "
 "to get a specific group."
-msgstr "特定のグループを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
+msgstr "特定のグループを取得するために使用したものと同じエンドポイントURIで [command]`delete` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2479,8 +2479,8 @@ msgid ""
 "ID and a group's ID, such as [filename]`users/USER_ID/groups/GROUP_ID`, to "
 "add a user to a group."
 msgstr ""
-"グループにユーザーを追加するには、ユーザのIDと、[filename]`users/USER_ID/groups/GROUP_ID` "
-"から構成されるエンドポイントURIを利用して[command]`update` コマンドを使用します。"
+"グループにユーザーを追加するには、ユーザーのIDとグループのID（ [filename]`users/USER_ID/groups/GROUP_ID` "
+"のような）から構成されるエンドポイントURIで、 [command]`update` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2521,14 +2521,14 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a group"
-msgstr "グループに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
+msgstr "グループに割り当てられた、使用可能で、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective realm roles for a group."
 msgstr ""
-"グループに割り当てられた、使用可能な、有効なレルム・ロールを一覧表示するには、専用の [command]`get-roles` コマンドを使用します。"
+"グループに割り当てられた、使用可能で、有効なレルム・ロールを一覧表示するには、専用の [command]`get-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -2564,14 +2564,14 @@ msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 #. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a group"
-msgstr "グループに割り当てられた、利用可能な、有効なクライアントロールの一覧表示"
+msgstr "グループに割り当てられた、利用可能で、有効なクライアント・ロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective client roles for a group."
 msgstr ""
-"グループに割り当てられた、利用可能な、有効なクライアント・ロールを一覧表示するには、専用の [command]`get-roles` "
+"グループに割り当てられた、利用可能で、有効なクライアント・ロールを一覧表示するには、専用の [command]`get-roles` "
 "コマンドを使用します。"
 
 #. type: Plain text
@@ -2581,10 +2581,10 @@ msgid ""
 "attribute (via the [command] `--cclientid` option) or ID (via the "
 "[command]`--id` option) to list *assigned* client roles for the user."
 msgstr ""
-"[command]`--gname` オプションで名前指定する、 [command]`--gid` "
-"オプションでIDを指定することでグループを指定します。また、 [command] `--cclientid` オプションでclientId属性を指定、 "
-"[command]`--id` オプションでIDを指定することでクライアントを特定し、ユーザーの *割り当てられた* "
-"クライアント・ロールを一覧表示します。"
+"[command]`--gname` オプションで名前指定するか、 [command]`--gid` "
+"オプションでIDを指定することでグループを指定します。また、 [command] `--cclientid` "
+"オプションでclientId属性を指定するか、 [command]`--id` オプションでIDを指定することでクライアントを特定し、ユーザーの "
+"*割り当てられた* クライアント・ロールを一覧表示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2641,7 +2641,7 @@ msgid ""
 "[filename]`realms` endpoint in that it is not resolved relative to a target "
 "realm because it exists outside any specific realm."
 msgstr ""
-" [filename]`serverinfo` エンドポイントは、特定のレルムの外に存在するため、対象レルムに対して関連がないという点において "
+"[filename]`serverinfo` エンドポイントは、特定のレルムの外に存在するため、対象レルムに対して関連がないという点において "
 "[filename]`realms` エンドポイントと同様に扱われます。"
 
 #. type: Title ====
@@ -2692,8 +2692,8 @@ msgid ""
 "to get a specific configured identity provider to remove a specific "
 "configured identity provider."
 msgstr ""
-"特定の設定済みのアイデンティティー・プロバイダーを取得して、特定の設定済みのアイデンティティー・プロバイダーを取得するために使用したものと同じエンドポイントURIで"
-" [command]`delete` コマンドを使用します。"
+"特定の設定済みのアイデンティティー・プロバイダーを取得するために使用したものと同じエンドポイントURIで、 [command]`delete` "
+"コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2866,7 +2866,7 @@ msgid ""
 "Application Management application configuration page for your application."
 msgstr ""
 "[command]`clientId` と [command]`clientSecret` を [command]`config` "
-"属性として指定します。これらの属性は、アプリケーションのTwitterアプリケーション管理アプリケーション設定ページで確認できます。"
+"属性として指定します。これらの属性は、アプリケーションのTwitterアプリケーション管理のアプリケーション設定ページで確認できます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2926,7 +2926,7 @@ msgid ""
 "Developer Console application page for your application."
 msgstr ""
 "[command]`clientId` と [command]`clientSecret` を [command]`config` "
-"属性として指定します。これらの属性は、アプリケーションのLinkedInデベロッパーコンソールアプリケーションページで確認できます。"
+"属性として指定します。これらの属性は、アプリケーションのLinkedInデベロッパー・コンソールのアプリケーション・ページで確認できます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -3172,7 +3172,7 @@ msgid ""
 "Add the [command]`action=triggerFullSync` query parameter and run the "
 "[command]`create` command."
 msgstr ""
-"[command]`action=triggerFullSync` クエリパラメータを追加し、 [command]`create` "
+"[command]`action=triggerFullSync` クエリー・パラメーターを追加し、 [command]`create` "
 "コマンドを実行します。"
 
 #. type: delimited block -
@@ -3189,15 +3189,15 @@ msgstr ""
 msgid ""
 "Triggering synchronization of changed users for a specific user storage "
 "provider"
-msgstr "特定のユーザー・ストレージ・プロバイダーの変更されたユーザーの同期をトリガーする"
+msgstr "特定のユーザー・ストレージ・プロバイダーに対して、変更されたユーザーの同期をトリガーする"
 
 #. type: Plain text
 msgid ""
 "Add the [command]`action=triggerChangedUsersSync` query parameter and run "
 "the [command]`create` command."
 msgstr ""
-"[command]`action=triggerChangedUsersSync` クエリパラメータを追加し、 [command]`create` "
-"コマンドを実行します。"
+"[command]`action=triggerChangedUsersSync` クエリー・パラメーターを追加し、 [command]`create`"
+" コマンドを実行します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -3225,9 +3225,9 @@ msgid ""
 "[command]`connectionUrl`, and [command]`useTruststoreSpi`, and then set the "
 "[command]`action` query parameter to [command]`testConnection`."
 msgstr ""
-"[command]`bindCredential`, [command]`bindDn`, [command]`connectionUrl`, and "
-"[command]`useTruststoreSpi` をクエリ・パラメーターとして指定します。[command]`action` "
-"クエリ・パラメーターに [command]`testConnection` を設定します。"
+"[command]`bindCredential` 、 [command]`bindDn` 、 [command]`connectionUrl` 、 "
+"[command]`useTruststoreSpi` をクエリー・パラメーターとして指定します。[command]`action` "
+"クエリー・パラメーターに [command]`testConnection` を設定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -3252,8 +3252,8 @@ msgid ""
 "[command]`action` query parameter to [command]`testAuthentication`."
 msgstr ""
 "[command]`bindCredential` 、 [command]`bindDn` 、  [command]`connectionUrl` 、 "
-"[command]`useTruststoreSpi` をクエリ・パラメーターに指定します。[command]`action` クエリ・パラメーターに "
-"[command]`testAuthentication` を指定します。"
+"[command]`useTruststoreSpi` をクエリー・パラメーターに指定します。 [command]`action` "
+"クエリー・パラメーターに [command]`testAuthentication` を指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -3302,7 +3302,7 @@ msgid ""
 "parameter."
 msgstr ""
 "[command]`providerId` 属性に [command]`hardcoded-ldap-role-mapper` を設定します。 "
-"[command]`role` 設定パラメータの値を指定します。"
+"[command]`role` 設定パラメーターの値を指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -3355,7 +3355,7 @@ msgid ""
 "Set the [command]`providerId` attribute to [filename]`user-attribute-ldap-"
 "mapper`."
 msgstr ""
-"[command]`providerId` 属性を [filename]`user-attribute-ldap-mapper`に設定します。"
+"[command]`providerId` 属性を [filename]`user-attribute-ldap-mapper` に設定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -3469,7 +3469,7 @@ msgid ""
 "expression that includes the specific policy provider ID and optional "
 "configuration."
 msgstr ""
-"レルムの [command]`passwordPolicy` 属性を、特定のポリシー・プロバイダーIDとオプション設定を含む列挙表現で設定します。"
+"レルムの [command]`passwordPolicy` 属性に、特定のポリシー・プロバイダーIDとオプション設定を含む列挙表現を設定します。"
 
 #. type: Plain text
 msgid ""
@@ -3598,4 +3598,4 @@ msgstr "[filename]`authentication/flows` エンドポイントで [command]`get`
 #. type: delimited block -
 #, no-wrap
 msgid "$ kcadm.sh get authentication/flows -r demorealm\n"
-msgstr ""
+msgstr "$ kcadm.sh get authentication/flows -r demorealm\n"

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -2,236 +2,251 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:65
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:243
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:266
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:281
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:300
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:319
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:337
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:354
-#: source/server_admin/topics/admin-cli.adoc:21
-#: source/server_admin/topics/admin-cli.adoc:362
-#: source/server_admin/topics/admin-cli.adoc:373
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:63
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:244
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:304
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:341
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:359
+#: source/server_admin/topics/admin-cli.adoc:17
+#: source/server_admin/topics/admin-cli.adoc:381
+#: source/server_admin/topics/admin-cli.adoc:392
 msgid "On Linux:"
-msgstr "Linuxの場合:"
+msgstr "Linuxの場合："
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:72
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:203
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:249
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:272
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:287
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:308
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:325
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:343
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:360
-#: source/server_admin/topics/admin-cli.adoc:26
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:70
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:206
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:250
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:275
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:290
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:312
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:329
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:347
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:365
+#: source/server_admin/topics/admin-cli.adoc:22
 msgid "On Windows:"
-msgstr "Windowsの場合:"
+msgstr "Windowsの場合："
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:82
-#: source/server_admin/topics/admin-cli.adoc:37
-msgid ""
-"Usually a user will first start an authenticated session by providing "
-"credentials, then perform some CRUD operations."
-msgstr ""
-
-#. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:84
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:107
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:142
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:188
-#: source/server_admin/topics/admin-cli.adoc:39
-#: source/server_admin/topics/admin-cli.adoc:59
-#: source/server_admin/topics/admin-cli.adoc:197
-#: source/server_admin/topics/admin-cli.adoc:282
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:85
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:108
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:144
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:191
+#: source/server_admin/topics/admin-cli.adoc:42
+#: source/server_admin/topics/admin-cli.adoc:62
+#: source/server_admin/topics/admin-cli.adoc:221
+#: source/server_admin/topics/admin-cli.adoc:301
 msgid "For example on Linux:"
-msgstr "例えば、Linux の場合:"
+msgstr "例えば、Linux の場合："
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:93
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:113
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:149
-#: source/server_admin/topics/admin-cli.adoc:47
-#: source/server_admin/topics/admin-cli.adoc:63
-#: source/server_admin/topics/admin-cli.adoc:203
-#: source/server_admin/topics/admin-cli.adoc:286
-#: source/server_admin/topics/admin-cli.adoc:303
-#: source/server_admin/topics/admin-cli.adoc:324
-#: source/server_admin/topics/admin-cli.adoc:366
-#: source/server_admin/topics/admin-cli.adoc:377
-#: source/server_admin/topics/admin-cli.adoc:652
-#: source/server_admin/topics/admin-cli.adoc:704
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:94
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:114
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:151
+#: source/server_admin/topics/admin-cli.adoc:50
+#: source/server_admin/topics/admin-cli.adoc:66
+#: source/server_admin/topics/admin-cli.adoc:227
+#: source/server_admin/topics/admin-cli.adoc:305
+#: source/server_admin/topics/admin-cli.adoc:322
+#: source/server_admin/topics/admin-cli.adoc:343
+#: source/server_admin/topics/admin-cli.adoc:385
+#: source/server_admin/topics/admin-cli.adoc:396
+#: source/server_admin/topics/admin-cli.adoc:708
+#: source/server_admin/topics/admin-cli.adoc:760
 msgid "Or on Windows:"
-msgstr "またはWindowsの場合:"
+msgstr "または、Windowsの場合："
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:159
-#: source/server_admin/topics/admin-cli.adoc:113
+#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:161
+#: source/server_admin/topics/admin-cli.adoc:110
 #, no-wrap
 msgid "Working with alternative configurations"
-msgstr ""
+msgstr "代替設定の使用"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:168
-#: source/server_admin/topics/admin-cli.adoc:122
-msgid ""
-"Make sure to not make a config file visible to other users on the system as "
-"it contains access tokens, and secrets that should be kept private."
-msgstr ""
-
-#. type: Plain text
+#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:22
 #: source/securing_apps/topics/oidc/java/fuse/camel.adoc:8
 #: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:13
 #: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:55
-#: source/server_admin/topics/admin-cli.adoc:104
-#: source/server_admin/topics/admin-cli.adoc:168
-#: source/server_admin/topics/admin-cli.adoc:262
-#: source/server_admin/topics/admin-cli.adoc:407
-#: source/server_admin/topics/admin-cli.adoc:433
-#: source/server_admin/topics/admin-cli.adoc:453
-#: source/server_admin/topics/admin-cli.adoc:463
-#: source/server_admin/topics/admin-cli.adoc:471
-#: source/server_admin/topics/admin-cli.adoc:482
-#: source/server_admin/topics/admin-cli.adoc:522
-#: source/server_admin/topics/admin-cli.adoc:529
-#: source/server_admin/topics/admin-cli.adoc:536
-#: source/server_admin/topics/admin-cli.adoc:548
-#: source/server_admin/topics/admin-cli.adoc:555
-#: source/server_admin/topics/admin-cli.adoc:562
-#: source/server_admin/topics/admin-cli.adoc:632
-#: source/server_admin/topics/admin-cli.adoc:641
-#: source/server_admin/topics/admin-cli.adoc:693
-#: source/server_admin/topics/admin-cli.adoc:728
-#: source/server_admin/topics/admin-cli.adoc:744
-#: source/server_admin/topics/admin-cli.adoc:751
-#: source/server_admin/topics/admin-cli.adoc:758
-#: source/server_admin/topics/admin-cli.adoc:770
-#: source/server_admin/topics/admin-cli.adoc:777
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:321
+#: source/securing_apps/topics/oidc/javascript-adapter.adoc:368
+#: source/server_admin/topics/admin-cli.adoc:101
+#: source/server_admin/topics/admin-cli.adoc:169
+#: source/server_admin/topics/admin-cli.adoc:281
+#: source/server_admin/topics/admin-cli.adoc:426
+#: source/server_admin/topics/admin-cli.adoc:452
+#: source/server_admin/topics/admin-cli.adoc:475
+#: source/server_admin/topics/admin-cli.adoc:485
+#: source/server_admin/topics/admin-cli.adoc:493
+#: source/server_admin/topics/admin-cli.adoc:504
+#: source/server_admin/topics/admin-cli.adoc:543
+#: source/server_admin/topics/admin-cli.adoc:550
+#: source/server_admin/topics/admin-cli.adoc:557
+#: source/server_admin/topics/admin-cli.adoc:569
+#: source/server_admin/topics/admin-cli.adoc:576
+#: source/server_admin/topics/admin-cli.adoc:583
+#: source/server_admin/topics/admin-cli.adoc:688
+#: source/server_admin/topics/admin-cli.adoc:697
+#: source/server_admin/topics/admin-cli.adoc:749
 #: source/server_admin/topics/admin-cli.adoc:784
+#: source/server_admin/topics/admin-cli.adoc:798
+#: source/server_admin/topics/admin-cli.adoc:805
+#: source/server_admin/topics/admin-cli.adoc:812
+#: source/server_admin/topics/admin-cli.adoc:824
 #: source/server_admin/topics/admin-cli.adoc:831
-#: source/server_admin/topics/admin-cli.adoc:878
-#: source/server_admin/topics/admin-cli.adoc:901
-#: source/server_admin/topics/admin-cli.adoc:919
-#: source/server_admin/topics/admin-cli.adoc:928
-#: source/server_admin/topics/admin-cli.adoc:937
-#: source/server_admin/topics/admin-cli.adoc:951
-#: source/server_admin/topics/admin-cli.adoc:958
-#: source/server_admin/topics/admin-cli.adoc:965
-#: source/server_admin/topics/admin-cli.adoc:977
-#: source/server_admin/topics/admin-cli.adoc:984
+#: source/server_admin/topics/admin-cli.adoc:838
+#: source/server_admin/topics/admin-cli.adoc:885
+#: source/server_admin/topics/admin-cli.adoc:932
+#: source/server_admin/topics/admin-cli.adoc:955
+#: source/server_admin/topics/admin-cli.adoc:973
+#: source/server_admin/topics/admin-cli.adoc:982
 #: source/server_admin/topics/admin-cli.adoc:991
-#: source/server_admin/topics/admin-cli.adoc:1020
-#: source/server_admin/topics/admin-cli.adoc:1038
-#: source/server_admin/topics/admin-cli.adoc:1053
-#: source/server_admin/topics/admin-cli.adoc:1120
-#: source/server_admin/topics/admin-cli.adoc:1148
-#: source/server_admin/topics/admin-cli.adoc:1158
-#: source/server_admin/topics/admin-cli.adoc:1167
-#: source/server_admin/topics/admin-cli.adoc:1176
-#: source/server_admin/topics/admin-cli.adoc:1189
-#: source/server_admin/topics/admin-cli.adoc:1199
-#: source/server_admin/topics/admin-cli.adoc:1209
-#: source/server_admin/topics/admin-cli.adoc:1219
+#: source/server_admin/topics/admin-cli.adoc:1004
+#: source/server_admin/topics/admin-cli.adoc:1011
+#: source/server_admin/topics/admin-cli.adoc:1018
+#: source/server_admin/topics/admin-cli.adoc:1030
+#: source/server_admin/topics/admin-cli.adoc:1037
+#: source/server_admin/topics/admin-cli.adoc:1044
+#: source/server_admin/topics/admin-cli.adoc:1073
+#: source/server_admin/topics/admin-cli.adoc:1091
+#: source/server_admin/topics/admin-cli.adoc:1106
+#: source/server_admin/topics/admin-cli.adoc:1173
+#: source/server_admin/topics/admin-cli.adoc:1201
+#: source/server_admin/topics/admin-cli.adoc:1211
+#: source/server_admin/topics/admin-cli.adoc:1220
 #: source/server_admin/topics/admin-cli.adoc:1229
+#: source/server_admin/topics/admin-cli.adoc:1242
+#: source/server_admin/topics/admin-cli.adoc:1252
+#: source/server_admin/topics/admin-cli.adoc:1262
+#: source/server_admin/topics/admin-cli.adoc:1272
+#: source/server_admin/topics/admin-cli.adoc:1282
 msgid "For example:"
-msgstr ""
+msgstr "例："
 
 #. type: Title ==
 #: source/server_admin/topics/admin-cli.adoc:2
 #, no-wrap
 msgid "Admin CLI"
-msgstr ""
+msgstr "管理CLI"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:6
-msgid "Admin CLI is a Technology Preview feature and is not fully supported."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:10
 msgid ""
-"In previous chapters we have described how to use the {project_name} Admin "
+"In previous chapters we have described how to use {project_name} Admin "
 "Console to perform administrative tasks.  All those tasks can also be "
 "performed from command line by using Admin CLI command line tool."
 msgstr ""
+"前の章では、{project_name} "
+"管理コンソールを使用して管理タスクを実行する方法について説明しました。これらのタスクはすべて、管理CLIコマンドライン・ツールを使用してコマンドラインから実行することもできます。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:12
+#: source/server_admin/topics/admin-cli.adoc:8
 #, no-wrap
 msgid "Installing Admin CLI"
-msgstr ""
+msgstr "管理CLIのインストール"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:11
+msgid ""
+"Admin CLI is packaged inside {project_name} Server distribution. You can "
+"find execution scripts inside `bin` directory."
+msgstr "管理CLIは、{project_name}サーバーの配布物に含まれています。 `bin` ディレクトリに実行スクリプトがあります。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:13
+msgid ""
+"The Linux script is called `kcadm.sh`, and the one for Windows is called "
+"`kcadm.bat`."
+msgstr "Linuxの実行スクリプトは `kcadm.sh` 、Windowsの実行スクリプトは ` kcadm.bat` です。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:15
 msgid ""
-"Admin CLI is packaged inside {project_name} Server distribution. You can "
-"find execution scripts inside `bin` directory."
-msgstr ""
+"In order to use the client from any location on your filesystem you may want"
+" to add {project_name} server directory to your PATH."
+msgstr "ファイルシステム上の任意の場所からクライアントを使用するには、{project_name}サーバー・ディレクトリをPATHに追加します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:17
-msgid ""
-"The Linux script is called `kcadm.sh`, and the one for Windows is called "
-"`kcadm.bat`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:19
-msgid ""
-"In order to setup the client to be used from any location on the filesystem "
-"you may want to add {project_name} server directory to your PATH."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:24
+#: source/server_admin/topics/admin-cli.adoc:20
 #, no-wrap
 msgid ""
 "    $ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
 "    $ kcadm.sh\n"
 msgstr ""
+"$ export PATH=$PATH:$KEYCLOAK_HOME/bin\n"
+" $ kcadm.sh\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:29
+#: source/server_admin/topics/admin-cli.adoc:25
 #, no-wrap
 msgid ""
 "    c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
 "    c:\\> kcadm\n"
 msgstr ""
+"c:\\> set PATH=%PATH%;%KEYCLOAK_HOME%\\bin\n"
+" c:\\> kcadm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:32
+#: source/server_admin/topics/admin-cli.adoc:28
+msgid ""
+"We assume KEYCLOAK_HOME env variable is set to the path where you extracted "
+"{project_name} Server distribution."
+msgstr "環境変数KEYCLOAK_HOMEは、{project_name}サーバーの配布物を展開したパスに設定されているものとします。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:31
 msgid ""
 "To avoid unnecessary repetition the rest of this document will only give "
 "Windows examples in places where difference in command line is more than "
 "just in `kcadm` command name."
 msgstr ""
+"不必要な繰り返しを避けるため、この文書の残りの部分でのWindowsの例は、コマンドラインの違いが `kcadm` "
+"コマンド名以外にもある場所でのみ示します。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:34
+#: source/server_admin/topics/admin-cli.adoc:33
 #, no-wrap
 msgid "Using Admin CLI"
-msgstr ""
+msgstr "管理CLIの利用"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:44
+#: source/server_admin/topics/admin-cli.adoc:36
+msgid ""
+"Admin CLI works by making HTTP requests to Admin REST endpoints. Access to "
+"them is protected and requires authentication."
+msgstr ""
+"管理CLIは、管理RESTエンドポイントへのHTTP要求を作成することによって機能します。管理RESTエンドポイントへのアクセスは保護されており、認証が必要です。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:38
+msgid ""
+"Consult Admin REST API documentation for details about JSON attributes for "
+"specific endpoints."
+msgstr "エンドポイントのJSON属性の詳細については、Admin REST APIのドキュメントを参照してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:40
+msgid ""
+"You start an authenticated session by providing credentials (i.e. logging "
+"in), then you are ready to perform some CRUD operations."
+msgstr "クレデンシャルを入力（例えばログイン）することで認証セッションを開始すると、CRUD操作を実行する準備が整います。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:47
 #, no-wrap
 msgid ""
 "    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
@@ -239,9 +254,13 @@ msgid ""
 "    $ CID=$(kcadm.sh create clients -r demorealm -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]' -i)\n"
 "    $ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
 msgstr ""
+"$ kcadm.sh config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
+" $ kcadm.sh create realms -s realm=demorealm -s enabled=true -o\n"
+" $ CID=$(kcadm.sh create clients -r demorealm -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]' -i)\n"
+" $ kcadm.sh get clients/$CID/installation/providers/keycloak-oidc-keycloak-json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:53
+#: source/server_admin/topics/admin-cli.adoc:56
 #, no-wrap
 msgid ""
 "    c:\\> kcadm config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
@@ -250,181 +269,231 @@ msgid ""
 "    c:\\> set /p CID=<clientid.txt\n"
 "    c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
 msgstr ""
+"c:\\> kcadm config credentials --server http://localhost:8080/auth --realm demo --user admin --client admin\n"
+" c:\\> kcadm create realms -s realm=demorealm -s enabled=true -o\n"
+" c:\\> kcadm create clients -r demorealm -s clientId=my_client -s \"redirectUris=[\\\"http://localhost:8980/myapp/*\\\"]\" -i > clientid.txt\n"
+" c:\\> set /p CID=<clientid.txt\n"
+" c:\\> kcadm get clients/%CID%/installation/providers/keycloak-oidc-keycloak-json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:57
+#: source/server_admin/topics/admin-cli.adoc:60
 msgid ""
 "In a production environment {project_name} has to be accessed with `https:` "
-"to avoid exposing tokens to network sniffers. If server's certificate is not "
-"issued by one of the trusted CAs that are included in Java's default "
-"certificate truststore, then you will need to prepare a truststore.jks file, "
-"and instruct `Admin CLI` to use it."
+"to avoid exposing tokens to network sniffers. If server's certificate is not"
+" issued by one of the trusted CAs that are included in Java's default "
+"certificate truststore, then you will need to prepare a truststore.jks file,"
+" and instruct `Admin CLI` to use it."
 msgstr ""
+"実稼働環境では、ネットワーク・スニファへのトークンの公開を避けるため、{project_name}には `https：` "
+"でアクセスする必要があります。サーバーの証明書が、Javaのデフォルトの証明書トラスト・ストアに含まれている信頼されたCAの1つによって発行されていない場合は、"
+" `truststore.jks` ファイルを準備し、それを使用するように `管理CLI` に指示する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:61
+#: source/server_admin/topics/admin-cli.adoc:64
 #, no-wrap
-msgid "    $ kcadm.sh config truststore --trustpass $PASSWORD ~/.keycloak/truststore.jks\n"
+msgid ""
+"    $ kcadm.sh config truststore --trustpass $PASSWORD "
+"~/.keycloak/truststore.jks\n"
 msgstr ""
+"$ kcadm.sh config truststore --trustpass $PASSWORD "
+"~/.keycloak/truststore.jks\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:65
+#: source/server_admin/topics/admin-cli.adoc:68
 #, no-wrap
-msgid "    c:\\> kcadm config truststore --trustpass %PASSWORD% %HOMEPATH%\\.keycloak\\truststore.jks\n"
+msgid ""
+"    c:\\> kcadm config truststore --trustpass %PASSWORD% "
+"%HOMEPATH%\\.keycloak\\truststore.jks\n"
 msgstr ""
+"c:\\> kcadm config truststore --trustpass %PASSWORD% "
+"%HOMEPATH%\\.keycloak\\truststore.jks\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:67
+#: source/server_admin/topics/admin-cli.adoc:70
 #, no-wrap
 msgid "Authenticating"
-msgstr ""
+msgstr "認証する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:70
-msgid ""
-"Admin CLI works by making HTTP requests to Admin REST endpoints. Access to "
-"them is protected and requires authentication."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:75
+#: source/server_admin/topics/admin-cli.adoc:76
 msgid ""
 "When logging in with `Admin CLI` you specify a server endpoint url, and a "
-"realm. Then you specify a username, or alternatively you can only specify a "
-"client id, which will result in special service account being used. In the "
-"first case, a password for the specified user has to be used at login. In "
-"the latter case there is no user password - only client secret or a `Signed "
-"JWT` is used."
+"realm. Then you specify a username, or alternatively you can specify only a "
+"client id, which will result in special, so called 'service account' being "
+"used. In the first case, a password for the specified user has to be used at"
+" login. In the latter case there is no user password - only client secret.  "
+"Alternatively, `Signed JWT` can be used."
 msgstr ""
+"`管理CLI` "
+"でログインするときに、サーバーのエンドポイントのURLとレルムを指定します。その後、ユーザー名かクライアントIDを指定します。クライアントIDを指定することで、特別な、いわゆる「サービスアカウント」が使用されます。ユーザー名を指定する場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。クライアントIDを指定する場合、ユーザー・パスワードはなく、クライアント・シークレットのみです。"
+" '署名付きJWT' を使用することもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:78
+#: source/server_admin/topics/admin-cli.adoc:79
 msgid ""
-"The account that logs in needs to have proper permissions in order to be "
-"able to invoke Admin REST API operations.  Specifically - `realm-admin` role "
-"of `realm-management` client is required for user to administer the realm "
-"within which the user is defined."
+"The account used for the session needs to have proper permissions in order "
+"to be able to invoke Admin REST API operations.  For example, `realm-admin` "
+"role of `realm-management` client allows user to administer the realm within"
+" which the user is defined."
 msgstr ""
+"セッションに使用されるアカウントには、管理REST API操作を呼び出すための適切な権限が必要です。例えば、 `realm-management` "
+"クライアントの `realm-admin` ロールは、ユーザが定義されているレルムを管理することを許可します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:81
+#: source/server_admin/topics/admin-cli.adoc:82
 msgid ""
-"There are two primary mechanisms to authenticate. One is by using `kcadm "
+"There are two primary mechanisms for authentication. One is using `kcadm "
 "config credentials` to start an authenticated session:"
 msgstr ""
+"認証には主に2つのメカニズムがあります。1つは認証されたセッションを開始するために `kcadm config credentials` を使用します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:83
+#: source/server_admin/topics/admin-cli.adoc:84
 #, no-wrap
-msgid "    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
+msgid ""
+"    $ kcadm.sh config credentials --server http://localhost:8080/auth "
+"--realm master --user admin --password admin\n"
 msgstr ""
+"$ kcadm.sh config credentials --server http://localhost:8080/auth --realm "
+"master --user admin --password admin\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:88
+#: source/server_admin/topics/admin-cli.adoc:87
 msgid ""
 "This approach maintains an authenticated session between `kcadm` command "
 "invocations by saving the obtained access token, and associated refresh "
-"token, possibly other secrets as well in a private configuration file. By "
-"default this file is called `kcadm.config` and is located under user's home "
-"directory - it's full pathname is `$HOME/.keycloak/kcadm.config` (on Windows "
-"it's `%HOMEPATH%\\.keycloak\\kcadm.config`).  The file can be named "
-"something else by using `-c, --config` option."
+"token, possibly other secrets as well in a private configuration file. See "
+"<<_working_with_alternative_configurations, next chapter>> for more info on "
+"configuration file."
 msgstr ""
+"取得されたアクセストークン、関連付けられたリフレッシュトークン、そしておそらく他のシークレットもプライベートな設定ファイルに保存することで、このアプローチは一連の"
+" `kcadm` "
+"コマンド呼び出しの間の認証されたセッションを維持します。設定ファイルの詳細については<<_working_with_alternative_configurations,"
+" 次の章>>を参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:90
-msgid ""
-"See <<_working_with_alternative_configurations, next chapter>> for more info "
-"on configuration file."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:94
+#: source/server_admin/topics/admin-cli.adoc:91
 msgid ""
 "Another approach is to authenticate with each command invocation for the "
 "duration of that invocation only. This approach results in more load on the "
 "server, and more time spent with round-trips obtaining tokens, but has a "
 "benefit of not needing to save any tokens between invocations, thus nothing "
-"is saved to disk."
+"is saved to disk. This mode is used when `--no-config` argument is "
+"specified."
 msgstr ""
+"もう1つの方法は、各コマンドの呼び出しをその呼び出しの間だけ認証することです。この方法では、サーバーに負荷がかかり、トークンを取得する往復時間が長くなりますが、呼び出し間にトークンを保存する必要がないため、ディスクには何も保存されません。このモードは"
+" `--no-config` 引数が指定されている場合に使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:96
+#: source/server_admin/topics/admin-cli.adoc:93
 msgid ""
 "For example, when performing an operation we specify all the information "
 "required for authentication:"
+msgstr "たとえば、操作を実行するときには、認証に必要なすべての情報を指定します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:95
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get realms --no-config --server http://localhost:8080/auth "
+"--realm master --user admin --password admin\n"
 msgstr ""
+"$ kcadm.sh get realms --no-config --server http://localhost:8080/auth "
+"--realm master --user admin --password admin\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:98
-#, no-wrap
-msgid "    $ kcadm.sh get realms --no-config --server http://localhost:8080/auth --realm master --user admin --password admin\n"
-msgstr ""
+msgid "See built-in help for more information on using `Admin CLI`."
+msgstr "`管理CLI` の使用方法の詳細については、組み込みヘルプを参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:101
-msgid "See built-in help for more information on using `Admin CLI`."
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:103
+#, no-wrap
+msgid "    $ kcadm.sh help\n"
+msgstr "$ kcadm.sh help\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:106
-#, no-wrap
-msgid "    $ kcadm.sh help\n"
+msgid ""
+"See `kcadm.sh config credentials --help` for more information about starting"
+" an authenticated session."
 msgstr ""
+"認証されたセッションの開始の詳細については、 `kcadm.sh config credentials --help` を参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:109
+#: source/server_admin/topics/admin-cli.adoc:114
 msgid ""
-"See `kcadm.sh config credentials --help` for more information about starting "
-"an authenticated session."
+"By default, `Admin CLI` automatically maintains a configuration file called "
+"`kcadm.config` located under user's home directory - it's full pathname is "
+"`$HOME/.keycloak/kcadm.config` (on Windows it's "
+"`%HOMEPATH%\\.keycloak\\kcadm.config`)."
 msgstr ""
+"デフォルトで `管理CLI` は、ユーザのホームディレクトリの下にある `kcadm.config` "
+"という設定ファイルを自動的に保持します。フルパス名は `$HOME/.keycloak/kcadm.config` です（Windowsでは "
+"`%HOMEPATH%\\.keycloak\\kcadm.config` ）。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:117
 msgid ""
-"By default, `Admin CLI` automatically maintains a configuration file at a "
-"default location - `.keycloak/kcadm.config` under user's home directory."
+"You can use `--config` option to point to a different file / location. This "
+"way you can maintain multiple authenticated sessions in parallel."
 msgstr ""
+"`--config` オプションを使うと、別のファイル／場所を指すことができます。これにより、複数の認証済みセッションを並行して維持できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:120
+#: source/server_admin/topics/admin-cli.adoc:119
 msgid ""
-"You can use `--config` option at any time to point to a different file / "
-"location. This way you can maintain multiple authenticated sessions in "
-"parallel. It is safest to perform operations tied to a single config file "
-"from a single thread."
-msgstr ""
+"It's best to perform operations tied to a single config file from a single "
+"thread."
+msgstr "単一のスレッドから単一の設定ファイルに結び付けられた操作を実行するのが最善です。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:126
+#: source/server_admin/topics/admin-cli.adoc:123
+msgid ""
+"Make sure to not make config file visible to other users on the system as it"
+" contains access tokens, and secrets that should be kept private.  By "
+"default the ~/.keycloak directory and its content will be automatically "
+"created with proper access limits. However if directory will exist already "
+"with non-default permissions, those will not be updated."
+msgstr ""
+"非公開とすべきアクセス・トークンとシークレットを含んでいるため、設定ファイルは他のユーザーに見えないようにしてください。デフォルトでは~/.keycloakディレクトリとその内容は、適切なアクセス制限で自動的に作成されます。ただし、デフォルト以外のアクセス権を持つディレクトリがすでに存在する場合、そのアクセス権は更新されません。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:127
 msgid ""
 "You may want to avoid storing any secrets at all inside a config file for "
-"the price of less convenience and having to do more token requests.  In that "
-"case you can use `--no-config` option with all your commands. You will have "
-"to specify all authentication info with each `kcadm` invocation."
+"the price of less convenience and having to do more token requests.  In that"
+" case you can use `--no-config` option with all your commands. In that case "
+"you will have to specify all the authentication info needed by `config "
+"credentials` command with each `kcadm` invocation."
 msgstr ""
+"利便性が低くなり、より多くのトークン要求が必要になることと引き換えに、設定ファイルの中にどんなシークレットも保存することは避けたいかもしれません。その場合、すべてのコマンドで"
+" `--no-config` オプションを使うことができます。その場合、`kcadm` 呼び出しごとに、 `config credentials` "
+"コマンドが必要とするすべての認証情報を指定する必要があります。"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:129
+#: source/server_admin/topics/admin-cli.adoc:130
 #, no-wrap
 msgid "Basic operations, and resource URIs"
-msgstr ""
+msgstr "基本操作、およびリソースURI"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:133
+#: source/server_admin/topics/admin-cli.adoc:134
 msgid ""
 "Admin CLI allows you to perform CRUD operations against Admin REST API "
 "endpoints in quite a generic way, with additional commands that simplify "
-"performing certain actions."
+"performing certain tasks."
 msgstr ""
+"管理CLIを使用すると、特定のタスクの実行を簡略化する追加のコマンドにより、とても一般的な方法でAdmin REST "
+"APIエンドポイントに対してCRUD操作を実行できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:135
+#: source/server_admin/topics/admin-cli.adoc:136
 msgid "Main usage pattern is the following:"
-msgstr ""
+msgstr "主な使用パターンは次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:140
+#: source/server_admin/topics/admin-cli.adoc:141
 #, no-wrap
 msgid ""
 "    $ kcadm.sh create ENDPOINT [ARGUMENTS]\n"
@@ -432,9 +501,13 @@ msgid ""
 "    $ kcadm.sh update ENDPOINT [ARGUMENTS]\n"
 "    $ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
 msgstr ""
+"$ kcadm.sh create ENDPOINT [ARGUMENTS]\n"
+" $ kcadm.sh get ENDPOINT [ARGUMENTS]\n"
+" $ kcadm.sh update ENDPOINT [ARGUMENTS]\n"
+" $ kcadm.sh delete ENDPOINT [ARGUMENTS]\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:144
+#: source/server_admin/topics/admin-cli.adoc:145
 msgid ""
 "Where operations `create`, `get`, `update`, and `delete` are mapped to HTTP "
 "verbs POST, GET, PUT, and DELETE, respectively.  ENDPOINT is a target "
@@ -442,2523 +515,3399 @@ msgid ""
 "'https:', or relative - used to compose an absolute URL of the following "
 "format:"
 msgstr ""
+"`create` 、 ` get` 、 `update` 、および ` delete` "
+"操作はHTTPメソッドのPOST、GET、PUT、DELETEにそれぞれマッピングされます。 ENDPOINTはターゲット・リソースURIであり、 "
+"'http:' または 'https:' で始まる、絶対パスか相対パスです。相対パスは次の形式の絶対URLを作成するために使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:146
+#: source/server_admin/topics/admin-cli.adoc:147
 #, no-wrap
 msgid "    SERVER_URI/admin/realms/REALM/ENDPOINT\n"
-msgstr ""
+msgstr "SERVER_URI/admin/realms/REALM/ENDPOINT\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:150
+#: source/server_admin/topics/admin-cli.adoc:151
 msgid ""
-"For example, if the server we authenticate against is `http://localhost:8080/"
-"auth`, and realm is `master`, then using `users` as ENDPOINT will result in "
-"the following resource URL: `http://localhost:8080/auth/admin/realms/master/"
-"users`."
+"For example, if the server we authenticate against is "
+"`http://localhost:8080/auth`, and realm is `master`, then using `users` as "
+"ENDPOINT will result in the following resource URL: "
+"`http://localhost:8080/auth/admin/realms/master/users`."
 msgstr ""
+"たとえば、認証するサーバが `http://localhost:8080/auth` で、レルムが `master` の場合、 `users` "
+"をENDPOINTとして使用すると、次のようなリソースURLになります。 "
+"`http://localhost:8080/auth/admin/realms/master/users`"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:152
+#: source/server_admin/topics/admin-cli.adoc:153
 msgid ""
-"If we set ENDPOINT to `clients` the effective resource URI would be: `http://"
-"localhost:8080/auth/admin/realms/master/clients`."
+"If we set ENDPOINT to `clients` the effective resource URI would be: "
+"`http://localhost:8080/auth/admin/realms/master/clients`."
 msgstr ""
+"ENDPOINTを `clients` に設定すると、有効なリソースURIは次のようになります。 "
+"`http://localhost:8080/auth/admin/realms/master/clients`"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:154
+#: source/server_admin/topics/admin-cli.adoc:155
 msgid ""
-"There is `realms` endpoint which is treated slightly differently since it is "
-"the container for realms. It resolves simply to:"
-msgstr ""
+"There is `realms` endpoint which is treated slightly differently since it is"
+" the container for realms. It resolves simply to:"
+msgstr "レルムのコンテナであるため、わずかに異なって扱われる `realms` エンドポイントがあり、単純に次のように解決されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:156
+#: source/server_admin/topics/admin-cli.adoc:157
 #, no-wrap
 msgid "    SERVER_URI/admin/realms\n"
-msgstr ""
+msgstr "SERVER_URI/admin/realms\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:159
+#: source/server_admin/topics/admin-cli.adoc:160
 msgid ""
 "There is also `serverinfo` which is treated the same way since it is "
 "independent of realms."
-msgstr ""
+msgstr "レルムから独立している`serverinfo` も同様に扱われます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:163
+#: source/server_admin/topics/admin-cli.adoc:164
 msgid ""
 "When authenticating as a user with realm-admin powers you may need to "
 "perform operations on multiple different realms. In that case you can "
-"specify `-r, --target-realm` option to tell explicitly which realm the "
-"operation should be executed against.  Instead of using REALM as specified "
-"via `--realm` option of `kcadm.sh config credentials`, the TARGET_REALM will "
-"be used:"
+"specify `-r` option to tell explicitly which realm the operation should be "
+"executed against.  Instead of using REALM as specified via `--realm` option "
+"of `kcadm.sh config credentials`, the TARGET_REALM will be used:"
 msgstr ""
+"レルム管理者権限を持つユーザーとして認証する場合、複数の異なるレルムで操作を実行する必要があります。その場合、 `-r` "
+"オプションを指定することで、どのレルムに対して操作が実行されるべきかを明示することができます。 `kcadm.sh config "
+"credentials` の `--realm` オプションで指定されたREALMを使用する代わりに、TARGET_REALMが使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:165
+#: source/server_admin/topics/admin-cli.adoc:166
 #, no-wrap
 msgid "    SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
-msgstr ""
+msgstr "SERVER_URI/admin/realms/TARGET_REALM/ENDPOINT\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:171
+#: source/server_admin/topics/admin-cli.adoc:172
 #, no-wrap
 msgid ""
 "    $ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
 "    $ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
 msgstr ""
+"$ kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin\n"
+" $ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:174
+#: source/server_admin/topics/admin-cli.adoc:175
 msgid ""
 "In this example we first start a session authenticated as `admin` user in "
 "`master` realm. Then we perform a POST call against the following resource "
 "URL:"
 msgstr ""
+"この例では、最初に `master` レルムで `admin` "
+"ユーザとして認証されたセッションを開始してから、次のリソースURLに対してPOST呼び出しを実行します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:176
+#: source/server_admin/topics/admin-cli.adoc:177
 #, no-wrap
 msgid "    http://localhost:8080/auth/admin/realms/demorealm/users\n"
-msgstr ""
-
-#. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:179
-#, no-wrap
-msgid "Realm operations"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:181
-#, no-wrap
-msgid "Creating a new realm"
-msgstr ""
+msgstr "http://localhost:8080/auth/admin/realms/demorealm/users\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:185
+#: source/server_admin/topics/admin-cli.adoc:182
 msgid ""
-"A new realm can be created by specifying individual attributes on command "
-"line. They will be converted into a JSON document and sent to the server:"
+"Commands `create` and `update` by default send JSON body to the server. You "
+"can use `-f FILENAME` to read a pre-made document from a file.  You can use "
+"`-f -`, and message body will be read from standard input.  But you can also"
+" specify individual attributes and their values as seen in the previous "
+"`create users` example, and they will be composed into a JSON body and sent "
+"to the server."
 msgstr ""
+"コマンド `create` と `update` は、デフォルトでJSONボディをサーバーに送ります。 `-f FILENAME` "
+"を使って、ファイルからあらかじめ作られた文書を読むことができます。 `-f -` を使うと、メッセージ・ボディは標準入力から読み込まれます。前出の "
+"`create users` の例に見られるように、個々の属性とその値を指定することもでき、それらはJSON本体に合成されてサーバーに送られます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:187
-#, no-wrap
-msgid "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:189
+#: source/server_admin/topics/admin-cli.adoc:186
 msgid ""
-"Realm is not enabled by default. By enabling it, it can be used for "
-"authentication immediately."
+"When using `update` there are several ways to update a resource. You can "
+"first get current state of a resource, and save it into a file, then edit "
+"that file and send it to the server for update. For example:"
 msgstr ""
+"`update` "
+"を使うときは、リソースを更新するいくつかの方法があります。まず、最初にリソースの現在の状態を取得してファイルに保存してから、そのファイルを編集してサーバーに送信して更新する方法があります。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:191
-msgid "A description for a new object can be in JSON format as well:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:193
-#, no-wrap
-msgid "    $ kcadm.sh create realms -f demorealm.json\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:195
-msgid ""
-"JSON document with realm attributes can be sent directly from file or piped "
-"to standard input."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:201
-#, no-wrap
-msgid ""
-"    $ kcadm.sh create realms -f - << EOF\n"
-"    { \"realm\": \"demorealm\", \"enabled\": true }\n"
-"    EOF\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:205
-#, no-wrap
-msgid "    c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm create realms -f -\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:207
-#, no-wrap
-msgid "Listing existing realms"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:210
-msgid "The following will return a list of all the realms:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:212
-#, no-wrap
-msgid "    $ kcadm.sh get realms\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:214
-msgid ""
-"Note, that the list of realms returned is additionally filtered on the "
-"server to only return realms the user has permissions for."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:217
-msgid ""
-"Often that is too much information as we may only be interested in realm "
-"name, or - for example - if it is enabled or not.  You can specify the "
-"attributes to return by using `--fields` option:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:219
-#, no-wrap
-msgid "    $ kcadm.sh get realms --fields realm,enabled\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:221
-msgid "You may even display the result as comma separated values:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:223
-#, no-wrap
-msgid "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:225
-#, no-wrap
-msgid "Getting a specific realm"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:228
-msgid ""
-"As is common for REST web services, in order to get an individual item of a "
-"collection, append an id to collection URI:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:230
-#, no-wrap
-msgid "    $ kcadm.sh get realms/master\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:232
-#, no-wrap
-msgid "Updating a realm"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:236
-msgid ""
-"There are several options when updating any resource. You can first get "
-"current state of resource, and save it into a file, then edit that file, and "
-"send it to server for update. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:240
+#: source/server_admin/topics/admin-cli.adoc:190
+#: source/server_admin/topics/admin-cli.adoc:267
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get realms/demorealm > demorealm.json\n"
 "    $ vi demorealm.json\n"
 "    $ kcadm.sh update realms/demorealm -f demorealm.json\n"
 msgstr ""
+"$ kcadm.sh get realms/demorealm > demorealm.json\n"
+" $ vi demorealm.json\n"
+" $ kcadm.sh update realms/demorealm -f demorealm.json\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:242
+#: source/server_admin/topics/admin-cli.adoc:192
 msgid ""
 "This way the resource on the server will be updated with all the attributes "
 "in the sent JSON document."
-msgstr ""
+msgstr "この方法では、サーバー上のリソースは、送信されたJSONドキュメントのすべての属性で更新されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:244
+#: source/server_admin/topics/admin-cli.adoc:194
 msgid ""
-"Another option is to perform the update on-the-fly using `-s, --set` options "
-"to set new values:"
-msgstr ""
+"Another option is to perform an update on-the-fly using `-s, --set` options "
+"to set new values. For example:"
+msgstr "別の選択肢としては `-s、--set` オプションを使ってその場でアップデートを実行して新しい値を設定することです。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:246
+#: source/server_admin/topics/admin-cli.adoc:196
+#: source/server_admin/topics/admin-cli.adoc:261
 #, no-wrap
 msgid "    $ kcadm.sh update realms/demorealm -s enabled=false\n"
-msgstr ""
+msgstr "$ kcadm.sh update realms/demorealm -s enabled=false\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:248
+#: source/server_admin/topics/admin-cli.adoc:198
 msgid "That would only update `enabled` attribute to `false`."
+msgstr "とすると `enabled` 属性を ` false` に更新するだけです。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:202
+msgid ""
+"By default `update` operation first performs a `get`, and then merges new "
+"attribute values with existing.  Mostly this is a preferred behaviour. In "
+"some cases the endpoint may support `PUT` but not `GET`.  You can use `-n` "
+"option to perform a so called 'no-merge' update which performs a PUT, "
+"without first doing a GET."
 msgstr ""
+"デフォルトでは、 `update` オペレーションはまず `get` "
+"を実行し、新しい属性値を既存のものとマージします。たいていはこれが好ましい動作です。場合によってエンドポイントは `PUT` をサポートしても "
+"`GET` はサポートしないかもしれません。 `-n` オプションを使うと、最初にGETを実行しないでPUTを実行する、いわゆる 'no-merge' "
+"アップデートを実行できます。"
+
+#. type: Title ===
+#: source/server_admin/topics/admin-cli.adoc:204
+#, no-wrap
+msgid "Realm operations"
+msgstr "レルム操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:250
+#: source/server_admin/topics/admin-cli.adoc:206
+#, no-wrap
+msgid "Creating a new realm"
+msgstr "新しいレルムを作成する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:209
+msgid ""
+"To create a new enabled realm use `create` operation on `realms` endpoint, "
+"and set attributes `realm` and `enabled`:"
+msgstr ""
+"新しい有効なレルムを作成するには、 `realms` エンドポイントで `create` 操作を行い、 `realm` 属性と `enabled` "
+"属性を設定してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:211
+#, no-wrap
+msgid "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
+msgstr "    $ kcadm.sh create realms -s realm=demorealm -s enabled=true\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:213
+msgid ""
+"Realm is not enabled by default. By enabling it, it can be used for "
+"authentication immediately."
+msgstr "レルムはデフォルトでは有効になっていません。有効にすると、すぐに認証に使用できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:215
+msgid "A description for a new object can be in JSON format as well:"
+msgstr "新しいオブジェクトはJSON形式で記述することもできます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:217
+#, no-wrap
+msgid "    $ kcadm.sh create realms -f demorealm.json\n"
+msgstr "$ kcadm.sh create realms -f demorealm.json\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:219
+msgid ""
+"JSON document with realm attributes can be sent directly from file or piped "
+"to standard input."
+msgstr "レルム属性を持つJSONドキュメントは、ファイルから直接、またはパイプで標準入力に送信できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:225
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create realms -f - << EOF\n"
+"    { \"realm\": \"demorealm\", \"enabled\": true }\n"
+"    EOF\n"
+msgstr ""
+"$ kcadm.sh create realms -f - << EOF\n"
+" { \"realm\": \"demorealm\", \"enabled\": true }\n"
+" EOF\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:229
+#, no-wrap
+msgid ""
+"    c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm "
+"create realms -f -\n"
+msgstr ""
+"c:\\> echo { \"realm\": \"demorealm\", \"enabled\": true } | kcadm create "
+"realms -f -\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:231
+#, no-wrap
+msgid "Listing existing realms"
+msgstr "既存レルムの一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:234
+msgid "The following will return a list of all realms:"
+msgstr "次の例は、すべてのレルムのリストを返します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:236
+#, no-wrap
+msgid "    $ kcadm.sh get realms\n"
+msgstr "    $ kcadm.sh get realms\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:238
+msgid ""
+"Note that a list of realms is additionally filtered on the server to only "
+"return realms user is allowed to see."
+msgstr "レルムのリストは、ユーザが見ることができるレルムだけを返すために、サーバ上でさらにフィルタリングされることに注意してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:241
+msgid ""
+"Returning the whole realm description is often too much information as we "
+"are often only interested in a subset of attributes like realm name, and if "
+"realm is enabled or not.  You can specify which attributes to return by "
+"using `--fields` option:"
+msgstr ""
+"レルム名や、レルムが有効か否かのように、属性のサブセットだけに興味がある場合がよくありますが、レルムの説明全体を返すと情報が多すぎることがしばしばです。"
+" `fields` オプションを使って返す属性を指定することができます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:243
+#, no-wrap
+msgid "    $ kcadm.sh get realms --fields realm,enabled\n"
+msgstr "    $ kcadm.sh get realms --fields realm,enabled\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:245
+msgid "You can even display the result as comma separated values:"
+msgstr "結果をカンマ区切りの値として表示することもできます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:247
+#, no-wrap
+msgid "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
+msgstr "    $ kcadm.sh get realms --fields realm --format csv --noquotes\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:249
+#, no-wrap
+msgid "Getting a specific realm"
+msgstr "特定のレルムを取得する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:252
+msgid ""
+"As is common for REST web services, in order to get an individual item of a "
+"collection, append an id to collection URI:"
+msgstr "REST Webサービスに共通するように、コレクションの個々の項目を取得するには、コレクションURIにIDを追加します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:254
+#, no-wrap
+msgid "    $ kcadm.sh get realms/master\n"
+msgstr "    $ kcadm.sh get realms/master\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:256
+#, no-wrap
+msgid "Updating a realm"
+msgstr "レルムの更新"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:259
+msgid ""
+"In order to only change some attributes of the realm use `-s` to set new "
+"values for the attributes. For example:"
+msgstr "レルムの一部の属性のみを変更するには、 `-s` を使って属性の新しい値を設定します。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:263
+msgid ""
+"If you want to set all writable attributes with new values, perform a `get` "
+"first, edit current values in JSON file, and resubmit. For example:"
+msgstr ""
+"書き込み可能なすべての属性を新しい値に設定する場合は、最初に `get` を実行し、JSONファイルの現在の値を編集して再送信してください。例えば："
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:269
 #, no-wrap
 msgid "Deleting a realm"
-msgstr ""
+msgstr "レルムの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:253
-msgid "It's very simple to delete a realm:"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:272
+msgid "Here is how to delete a realm:"
+msgstr "レルムを削除する方法は次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:255
+#: source/server_admin/topics/admin-cli.adoc:274
 #, no-wrap
 msgid "    $ kcadm.sh delete realms/demorealm\n"
-msgstr ""
+msgstr "    $ kcadm.sh delete realms/demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:257
+#: source/server_admin/topics/admin-cli.adoc:276
 #, no-wrap
 msgid "Turning on all login page options for the realm"
-msgstr ""
+msgstr "レルムのすべてのログイン・ページ・オプションを有効にする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:260
+#: source/server_admin/topics/admin-cli.adoc:279
 msgid "Set the attributes controlling specific capabilities to `true`."
-msgstr ""
+msgstr "特定の機能を制御する属性を `true` に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:264
+#: source/server_admin/topics/admin-cli.adoc:283
 #, no-wrap
-msgid "    $ kcadm.sh update realms/demorealm -s registrationAllowed=true -s registrationEmailAsUsername=true -s rememberMe=true -s verifyEmail=true -s resetPasswordAllowed=true -s editUsernameAllowed=true\n"
+msgid ""
+"    $ kcadm.sh update realms/demorealm -s registrationAllowed=true -s "
+"registrationEmailAsUsername=true -s rememberMe=true -s verifyEmail=true -s "
+"resetPasswordAllowed=true -s editUsernameAllowed=true\n"
 msgstr ""
+"$ kcadm.sh update realms/demorealm -s registrationAllowed=true -s "
+"registrationEmailAsUsername=true -s rememberMe=true -s verifyEmail=true -s "
+"resetPasswordAllowed=true -s editUsernameAllowed=true\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:266
+#: source/server_admin/topics/admin-cli.adoc:285
 #, no-wrap
 msgid "Listing the realm keys"
-msgstr ""
+msgstr "レルム鍵の一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:269
-msgid "It's very simple to list the realm keys for a specific realm:"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:288
+msgid "Use `get` operation on `keys` endpoint of the target realm:"
+msgstr "対象レルムの `keys` エンドポイントで `get` 操作を使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:271
-#: source/server_admin/topics/admin-cli.adoc:316
-#: source/server_admin/topics/admin-cli.adoc:343
+#: source/server_admin/topics/admin-cli.adoc:290
+#: source/server_admin/topics/admin-cli.adoc:335
+#: source/server_admin/topics/admin-cli.adoc:362
 #, no-wrap
 msgid "    $ kcadm.sh get keys -r demorealm\n"
-msgstr ""
+msgstr "$ kcadm.sh get keys -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:273
+#: source/server_admin/topics/admin-cli.adoc:292
 #, no-wrap
 msgid "Generating new realm keys"
-msgstr ""
+msgstr "新しいレルム鍵の生成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:276
+#: source/server_admin/topics/admin-cli.adoc:295
 msgid ""
 "To add a new RSA generated keypair, first get `id` of the target realm. For "
-"example, to get `id` for a realm whose `realm` attribute is 'demorealm':"
-msgstr ""
+"example:"
+msgstr "新しいRSAキーペアを追加するには、まず対象レルムの `id` を取得します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:278
+#: source/server_admin/topics/admin-cli.adoc:297
 #, no-wrap
-msgid "    $ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
-msgstr ""
+msgid ""
+"    $ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
+msgstr "$ kcadm.sh get realms/demorealm --fields id --format csv --noquotes\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:280
+#: source/server_admin/topics/admin-cli.adoc:299
 msgid ""
 "Then add a new key provider with higher priority than any of the existing "
 "providers as revealed by `kcadm.sh get keys -r demorealm`:"
 msgstr ""
+"次に、 `kcadm.sh get keys -r demorealm` "
+"で判明したどの既存のプロバイダーよりも高い優先順位で、新しいキー・プロバイダーを追加します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:284
+#: source/server_admin/topics/admin-cli.adoc:303
 #, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=rsa-generated -s providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]' -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s 'config.keySize=[\"2048\"]'\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:288
-#, no-wrap
-msgid "    c:\\> kcadm create components -r demorealm -s name=rsa-generated -s providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s \"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s \"config.active=[\\\"true\\\"]\" -s \"config.keySize=[\\\"2048\\\"]\"\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:290
-#: source/server_admin/topics/admin-cli.adoc:309
-msgid "Attribute `parentId` should be set to the value of target realm's `id`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:292
 msgid ""
-"The newly added key should now become the active key as revealed by `kcadm."
-"sh get keys -r demorealm`."
+"    $ kcadm.sh create components -r demorealm -s name=rsa-generated -s "
+"providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]'"
+" -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
+"'config.keySize=[\"2048\"]'\n"
 msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:294
-#, no-wrap
-msgid "Adding new realm keys from Java Key Store file"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:297
-msgid ""
-"To add a new keypair already prepared as a JKS file on the server, add a new "
-"key provider as follows:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:299
-msgid "For exmple on Linux:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:301
-#, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=java-keystore -s providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]' -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s 'config.keystore=[\"/opt/keycloak/keystore.jks\"]' -s 'config.keystorePassword=[\"secret\"]' -s 'config.keyPassword=[\"secret\"]' -s 'config.alias=[\"localhost\"]'\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:305
-#, no-wrap
-msgid "    c:\\> kcadm create components -r demorealm -s name=java-keystore -s providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s \"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s \"config.active=[\\\"true\\\"]\" -s \"config.keystore=[\\\"/opt/keycloak/keystore.jks\\\"]\" -s \"config.keystorePassword=[\\\"secret\\\"]\" -s \"config.keyPassword=[\\\"secret\\\"]\" -s \"config.alias=[\\\"localhost\\\"]\"\n"
-msgstr ""
+"$ kcadm.sh create components -r demorealm -s name=rsa-generated -s "
+"providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]'"
+" -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
+"'config.keySize=[\"2048\"]'\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:307
-msgid ""
-"And change attribute values for `keystore`, `keystorePassword`, "
-"`keyPassword`, and `alias` to match your specific keystore."
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:311
 #, no-wrap
-msgid "Making key passive or disabling it"
+msgid ""
+"    c:\\> kcadm create components -r demorealm -s name=rsa-generated -s "
+"providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "
+"\"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s "
+"\"config.active=[\\\"true\\\"]\" -s \"config.keySize=[\\\"2048\\\"]\"\n"
 msgstr ""
+"c:\\> kcadm create components -r demorealm -s name=rsa-generated -s "
+"providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "
+"\"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s "
+"\"config.active=[\\\"true\\\"]\" -s \"config.keySize=[\\\"2048\\\"]\"\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:314
-#: source/server_admin/topics/admin-cli.adoc:341
-msgid "Identify the key you wish to make passive:"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:309
+#: source/server_admin/topics/admin-cli.adoc:328
+msgid ""
+"Attribute `parentId` should be set to the value of target realm's `id`."
+msgstr "`parentId` 属性は対象レルムの `id` の値に設定されなければなりません。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:311
+msgid ""
+"The newly added key should now become the active key as revealed by "
+"`kcadm.sh get keys -r demorealm`."
+msgstr "`kcadm.sh get keys -r demorealm` で確認すると、新しく追加した鍵がアクティブな鍵になっているはずです。"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:313
+#, no-wrap
+msgid "Adding new realm keys from Java Key Store file"
+msgstr "Javaキーストア・ファイルから新しいレルム鍵を追加する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:316
+msgid ""
+"To add a new keypair already prepared as a JKS file on the server, add a new"
+" key provider as follows:"
+msgstr "すでにサーバー上にJKSファイルとして準備されている新しい鍵ペアを追加するには、次のように新しい鍵プロバイダーを追加します。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:318
+msgid "For exmple on Linux:"
+msgstr "例えば、Linux の場合："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:320
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=java-keystore -s "
+"providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]'"
+" -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
+"'config.keystore=[\"/opt/keycloak/keystore.jks\"]' -s "
+"'config.keystorePassword=[\"secret\"]' -s 'config.keyPassword=[\"secret\"]' "
+"-s 'config.alias=[\"localhost\"]'\n"
+msgstr ""
+"$ kcadm.sh create components -r demorealm -s name=java-keystore -s "
+"providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=[\"101\"]'"
+" -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
+"'config.keystore=[\"/opt/keycloak/keystore.jks\"]' -s "
+"'config.keystorePassword=[\"secret\"]' -s 'config.keyPassword=[\"secret\"]' "
+"-s 'config.alias=[\"localhost\"]'\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:324
+#, no-wrap
+msgid ""
+"    c:\\> kcadm create components -r demorealm -s name=java-keystore -s "
+"providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "
+"\"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s "
+"\"config.active=[\\\"true\\\"]\" -s "
+"\"config.keystore=[\\\"/opt/keycloak/keystore.jks\\\"]\" -s "
+"\"config.keystorePassword=[\\\"secret\\\"]\" -s "
+"\"config.keyPassword=[\\\"secret\\\"]\" -s "
+"\"config.alias=[\\\"localhost\\\"]\"\n"
+msgstr ""
+"c:\\> kcadm create components -r demorealm -s name=java-keystore -s "
+"providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
+"parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "
+"\"config.priority=[\\\"101\\\"]\" -s \"config.enabled=[\\\"true\\\"]\" -s "
+"\"config.active=[\\\"true\\\"]\" -s "
+"\"config.keystore=[\\\"/opt/keycloak/keystore.jks\\\"]\" -s "
+"\"config.keystorePassword=[\\\"secret\\\"]\" -s "
+"\"config.keyPassword=[\\\"secret\\\"]\" -s "
+"\"config.alias=[\\\"localhost\\\"]\"\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:326
+msgid ""
+"Make sure to change attribute values for `keystore`, `keystorePassword`, "
+"`keyPassword`, and `alias` to match your specific keystore."
+msgstr ""
+"特定のキーストアに一致するように、 `keystore` 、 `keystorePassword` 、 `keyPassword` 、および "
+"`alias` の属性値を必ず変更してください。"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:330
+#, no-wrap
+msgid "Making key passive or disabling it"
+msgstr "鍵をパッシブにするか無効にする"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:333
+#: source/server_admin/topics/admin-cli.adoc:360
+msgid "Identify the key you wish to make passive:"
+msgstr "パッシブにする鍵を特定します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:337
 msgid ""
 "Use `providerId` attribute of the key to construct an endpoint uri - "
 "`components/PROVIDER_ID`."
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:320
-msgid "Then perform an `update`. For example on Linux:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:322
-#, no-wrap
-msgid "    $ kcadm.sh update components/PROVIDER_ID -r demorealm -s 'config.active=[\"false\"]'\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:326
-#, no-wrap
-msgid "    c:\\> kcadm update components/PROVIDER_ID -r demorealm -s \"config.active=[\\\"false\\\"]\"\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:329
-msgid "Analogously, other key attributes can be updated."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:331
-msgid ""
-"To disable the key set new `enabled` value, for example: `'config."
-"enabled=[\"false\"]'`"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:333
-msgid ""
-"To change key's priority set new `priority` value, for example: `'config."
-"priority=[\"110\"]'`"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:335
-#, no-wrap
-msgid "Deleting an old key"
-msgstr ""
+"エンドポイントURI `components/PROVIDER_ID` を構築するのに鍵の `providerId` 属性を使用してください。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:339
+msgid "Then perform an `update`. For example on Linux:"
+msgstr "次に、 `update` を実行します。たとえばLinuxの場合："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:341
+#, no-wrap
+msgid ""
+"    $ kcadm.sh update components/PROVIDER_ID -r demorealm -s "
+"'config.active=[\"false\"]'\n"
+msgstr ""
+"$ kcadm.sh update components/PROVIDER_ID -r demorealm -s "
+"'config.active=[\"false\"]'\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:345
+#, no-wrap
+msgid ""
+"    c:\\> kcadm update components/PROVIDER_ID -r demorealm -s "
+"\"config.active=[\\\"false\\\"]\"\n"
+msgstr ""
+"c:\\> kcadm update components/PROVIDER_ID -r demorealm -s "
+"\"config.active=[\\\"false\\\"]\"\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:348
+msgid "Analogously, other key attributes can be updated."
+msgstr "同様に、他の鍵属性も更新できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:350
+msgid ""
+"To disable the key set new `enabled` value, for example: "
+"`'config.enabled=[\"false\"]'`"
+msgstr "鍵を無効にするには、新しい `enabled` 値を設定します。たとえば： `'config.enabled=[\"false\"]'`"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:352
+msgid ""
+"To change key's priority set new `priority` value, for example: "
+"`'config.priority=[\"110\"]'`"
+msgstr "鍵の優先度を変更するには、新しい `priority` 値を設定します。たとえば： `'config.priority=[\"110\"]'`"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:354
+#, no-wrap
+msgid "Deleting an old key"
+msgstr "古い鍵を削除する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:358
 msgid ""
 "Make sure that the key you are deleting has been passive for some time, and "
 "then disabled for some time in order to prevent any existing tokens held by "
 "applications and users from abruptly failing to work."
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:345
-msgid "Use the `providerId` of that key to perform a delete. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:347
-#, no-wrap
-msgid "    $ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:349
-#, no-wrap
-msgid "Configuring event logging for a realm"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:352
-msgid "Use `update` against `events/config` endpoint."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:357
-msgid ""
-"Attribute 'eventsListeners' sets the list of EventListenerProviderFactory "
-"'id's specifying all the event listeners receiving events.  Separately from "
-"that there are attributes that control a built-in event storage which allows "
-"querying of past events via Admin REST API.  There is separate control over "
-"logging of service calls - 'eventsEnabled', and auditing events triggered "
-"during Admin Console or Admin REST API - 'adminEventsEnabled'.  You may want "
-"to limit the time when old events expire so that your database doesn't get "
-"filled up - 'eventsExpiration' is set to time-to-live expressed in seconds."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:360
-msgid ""
-"For example, this is how you set a built-in event listener that will receive "
-"all the events and log them through jboss-logging (error events are logged "
-"as `WARN`, others as `DEBUG`, using a logger called `org.keycloak.events`):"
-msgstr ""
+"必ず、削除する鍵がしばらくの間パッシブであることを確認してから、さらにしばらくの間無効にして、アプリケーションやユーザーが保持している既存のトークンが突然動作しなくなることを防止してください。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:364
-#, no-wrap
-msgid "    $ kcadm.sh update events/config -r demorealm -s 'eventsListeners=[\"jboss-logging\"]'\n"
-msgstr ""
+msgid "Use the `providerId` of that key to perform a delete. For example:"
+msgstr "その鍵の `providerId` を使って削除を行います。例えば："
 
 #. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:366
+#, no-wrap
+msgid "    $ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
+msgstr "$ kcadm.sh delete components/PROVIDER_ID -r demorealm\n"
+
+#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:368
 #, no-wrap
-msgid "    c:\\> kcadm update events/config -r demorealm -s \"eventsListeners=[\\\"jboss-logging\\\"]\"\n"
-msgstr ""
+msgid "Configuring event logging for a realm"
+msgstr "レルムのイベントログの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:371
-msgid ""
-"This is how you turn on storage of all available ERROR events - not auditing "
-"events - for 2 days so they can be retrieved via Admin REST:"
-msgstr ""
+msgid "Use `update` on `events/config` endpoint."
+msgstr "`events/config` エンドポイントで `update` を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:375
-#, no-wrap
-msgid "    $ kcadm.sh update events/config -r demorealm -s eventsEnabled=true -s 'enabledEventTypes=[\"LOGIN_ERROR\",\"REGISTER_ERROR\",\"LOGOUT_ERROR\",\"CODE_TO_TOKEN_ERROR\",\"CLIENT_LOGIN_ERROR\",\"FEDERATED_IDENTITY_LINK_ERROR\",\"REMOVE_FEDERATED_IDENTITY_ERROR\",\"UPDATE_EMAIL_ERROR\",\"UPDATE_PROFILE_ERROR\",\"UPDATE_PASSWORD_ERROR\",\"UPDATE_TOTP_ERROR\",\"VERIFY_EMAIL_ERROR\",\"REMOVE_TOTP_ERROR\",\"SEND_VERIFY_EMAIL_ERROR\",\"SEND_RESET_PASSWORD_ERROR\",\"SEND_IDENTITY_PROVIDER_LINK_ERROR\",\"RESET_PASSWORD_ERROR\",\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\",\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\",\"CUSTOM_REQUIRED_ACTION_ERROR\",\"EXECUTE_ACTIONS_ERROR\",\"CLIENT_REGISTER_ERROR\",\"CLIENT_UPDATE_ERROR\",\"CLIENT_DELETE_ERROR\"]' -s eventsExpiration=172800\n"
+#: source/server_admin/topics/admin-cli.adoc:376
+msgid ""
+"Attribute `eventsListeners` contains a list of EventListenerProviderFactory "
+"ids, specifying all event listeners receiving events.  Separately, there are"
+" attributes that control a built-in event storage which allows querying past"
+" events via Admin REST API.  There is separate control over logging of "
+"service calls - 'eventsEnabled', and auditing events triggered during Admin "
+"Console or Admin REST API - 'adminEventsEnabled'.  You may want to setup "
+"expiry of old events so that your database doesn't get filled up - "
+"'eventsExpiration' is set to time-to-live expressed in seconds."
 msgstr ""
+"`eventsListeners` "
+"属性には、イベントを受け取るすべてのイベント・リスナーを指定するEventListenerProviderFactoryのIDリストが含まれています。これとは別に、Admin"
+" REST APIを介して過去のイベントを照会できる組み込みイベント・ストレージを制御する属性があります。 サービスコール "
+"`eventsEnabled` のログ記録と、管理コンソールの間またはAdmin REST API 'adminEventsEnabled' "
+"にトリガーされた監査イベントについて、個別の制御があります。古いイベントの有効期限を設定してデータベースが満杯にならないようにすることができます。 "
+"'eventsExpiration' は有効期限（秒単位）に設定されています。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:379
-#, no-wrap
-msgid "    c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s \"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\" -s eventsExpiration=172800\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:381
 msgid ""
-"This is how you reset stored event types to `all available event types` - "
-"setting to empty list is the same as enumerating all:"
+"Here is an example of setting up a built-in event listener that will receive"
+" all the events and log them through jboss-logging (error events are logged "
+"as `WARN`, others as `DEBUG`, using a logger called `org.keycloak.events`):"
 msgstr ""
+"次に、すべてのイベントを受け取り、jboss-loggingを通じてそれらを記録するビルトイン・イベントリスナーを設定する例を示します（エラーイベントは"
+" `WARN` として、他は `DEBUG` として `org.keycloak.events` というロガーを使って記録されます）。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:383
 #, no-wrap
-msgid "    $ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:386
-msgid "And this is how you turn on auditing events:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:388
-#, no-wrap
-msgid "    $ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true -s adminEventsDetailsEnabled=true\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:391
 msgid ""
-"Here is how you get the last 100 events - they are ordered from newest to "
-"oldest:"
+"    $ kcadm.sh update events/config -r demorealm -s 'eventsListeners"
+"=[\"jboss-logging\"]'\n"
 msgstr ""
+"$ kcadm.sh update events/config -r demorealm -s 'eventsListeners=[\"jboss-"
+"logging\"]'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:393
+#: source/server_admin/topics/admin-cli.adoc:387
 #, no-wrap
-msgid "    $ kcadm.sh get events --offset 0 --limit 100\n"
+msgid ""
+"    c:\\> kcadm update events/config -r demorealm -s \"eventsListeners"
+"=[\\\"jboss-logging\\\"]\"\n"
 msgstr ""
+"c:\\> kcadm update events/config -r demorealm -s \"eventsListeners"
+"=[\\\"jboss-logging\\\"]\"\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:396
-msgid "Here is how you delete all saved events:"
+#: source/server_admin/topics/admin-cli.adoc:390
+msgid ""
+"Here is an example of turning on storage of all available ERROR events - not"
+" including auditing events - for 2 days so they can be retrieved via Admin "
+"REST:"
+msgstr "次に、利用可能なすべてのERRORイベント（監査イベントを除く）の保管を2日間有効にする例を示します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:394
+#, no-wrap
+msgid ""
+"    $ kcadm.sh update events/config -r demorealm -s eventsEnabled=true -s "
+"'enabledEventTypes=[\"LOGIN_ERROR\",\"REGISTER_ERROR\",\"LOGOUT_ERROR\",\"CODE_TO_TOKEN_ERROR\",\"CLIENT_LOGIN_ERROR\",\"FEDERATED_IDENTITY_LINK_ERROR\",\"REMOVE_FEDERATED_IDENTITY_ERROR\",\"UPDATE_EMAIL_ERROR\",\"UPDATE_PROFILE_ERROR\",\"UPDATE_PASSWORD_ERROR\",\"UPDATE_TOTP_ERROR\",\"VERIFY_EMAIL_ERROR\",\"REMOVE_TOTP_ERROR\",\"SEND_VERIFY_EMAIL_ERROR\",\"SEND_RESET_PASSWORD_ERROR\",\"SEND_IDENTITY_PROVIDER_LINK_ERROR\",\"RESET_PASSWORD_ERROR\",\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\",\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\",\"CUSTOM_REQUIRED_ACTION_ERROR\",\"EXECUTE_ACTIONS_ERROR\",\"CLIENT_REGISTER_ERROR\",\"CLIENT_UPDATE_ERROR\",\"CLIENT_DELETE_ERROR\"]'"
+" -s eventsExpiration=172800\n"
 msgstr ""
+"$ kcadm.sh update events/config -r demorealm -s eventsEnabled=true -s "
+"'enabledEventTypes=[\"LOGIN_ERROR\",\"REGISTER_ERROR\",\"LOGOUT_ERROR\",\"CODE_TO_TOKEN_ERROR\",\"CLIENT_LOGIN_ERROR\",\"FEDERATED_IDENTITY_LINK_ERROR\",\"REMOVE_FEDERATED_IDENTITY_ERROR\",\"UPDATE_EMAIL_ERROR\",\"UPDATE_PROFILE_ERROR\",\"UPDATE_PASSWORD_ERROR\",\"UPDATE_TOTP_ERROR\",\"VERIFY_EMAIL_ERROR\",\"REMOVE_TOTP_ERROR\",\"SEND_VERIFY_EMAIL_ERROR\",\"SEND_RESET_PASSWORD_ERROR\",\"SEND_IDENTITY_PROVIDER_LINK_ERROR\",\"RESET_PASSWORD_ERROR\",\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\",\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\",\"CUSTOM_REQUIRED_ACTION_ERROR\",\"EXECUTE_ACTIONS_ERROR\",\"CLIENT_REGISTER_ERROR\",\"CLIENT_UPDATE_ERROR\",\"CLIENT_DELETE_ERROR\"]'"
+" -s eventsExpiration=172800\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:398
 #, no-wrap
-msgid "    $ kcadm delete events\n"
+msgid ""
+"    c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s "
+"\"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\""
+" -s eventsExpiration=172800\n"
 msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:400
-#, no-wrap
-msgid "Flushing the caches"
-msgstr ""
+"c:\\> kcadm update events/config -r demorealm -s eventsEnabled=true -s "
+"\"enabledEventTypes=[\\\"LOGIN_ERROR\\\",\\\"REGISTER_ERROR\\\",\\\"LOGOUT_ERROR\\\",\\\"CODE_TO_TOKEN_ERROR\\\",\\\"CLIENT_LOGIN_ERROR\\\",\\\"FEDERATED_IDENTITY_LINK_ERROR\\\",\\\"REMOVE_FEDERATED_IDENTITY_ERROR\\\",\\\"UPDATE_EMAIL_ERROR\\\",\\\"UPDATE_PROFILE_ERROR\\\",\\\"UPDATE_PASSWORD_ERROR\\\",\\\"UPDATE_TOTP_ERROR\\\",\\\"VERIFY_EMAIL_ERROR\\\",\\\"REMOVE_TOTP_ERROR\\\",\\\"SEND_VERIFY_EMAIL_ERROR\\\",\\\"SEND_RESET_PASSWORD_ERROR\\\",\\\"SEND_IDENTITY_PROVIDER_LINK_ERROR\\\",\\\"RESET_PASSWORD_ERROR\\\",\\\"IDENTITY_PROVIDER_FIRST_LOGIN_ERROR\\\",\\\"IDENTITY_PROVIDER_POST_LOGIN_ERROR\\\",\\\"CUSTOM_REQUIRED_ACTION_ERROR\\\",\\\"EXECUTE_ACTIONS_ERROR\\\",\\\"CLIENT_REGISTER_ERROR\\\",\\\"CLIENT_UPDATE_ERROR\\\",\\\"CLIENT_DELETE_ERROR\\\"]\""
+" -s eventsExpiration=172800\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:403
+#: source/server_admin/topics/admin-cli.adoc:400
+msgid ""
+"Here is how you reset stored event types to *all available event types* - "
+"setting to empty list is the same as enumerating all:"
+msgstr ""
+"ここでは、保存されたイベントタイプを *すべての利用可能なイベントタイプ* "
+"にリセットする方法を示します。空のリストに設定することは、すべてを列挙することと同じです。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:402
+#, no-wrap
+msgid ""
+"    $ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
+msgstr "$ kcadm.sh update events/config -r demorealm -s enabledEventTypes=[]\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:405
+msgid "And here is how you enable storage of auditing events:"
+msgstr "監査イベントの保管を有効にする方法は次のとおりです。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:407
+#, no-wrap
+msgid ""
+"    $ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true "
+"-s adminEventsDetailsEnabled=true\n"
+msgstr ""
+"$ kcadm.sh update events/config -r demorealm -s adminEventsEnabled=true -s "
+"adminEventsDetailsEnabled=true\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:410
+msgid ""
+"Here is how you get the last 100 events - they are ordered from newest to "
+"oldest:"
+msgstr "最後の100イベントを取得する方法は次のとおりです。最新のものから古いものまで順番に並べ替えられています。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:412
+#, no-wrap
+msgid "    $ kcadm.sh get events --offset 0 --limit 100\n"
+msgstr "$ kcadm.sh get events --offset 0 --limit 100\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:415
+msgid "Here is how you delete all saved events:"
+msgstr "保存されたすべてのイベントを削除する方法は次のとおりです。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:417
+#, no-wrap
+msgid "    $ kcadm delete events\n"
+msgstr "$ kcadm delete events\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:419
+#, no-wrap
+msgid "Flushing the caches"
+msgstr "キャッシュのフラッシュ"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:422
 msgid ""
 "Use `create` operation, and one of the following endpoints: `clear-realm-"
 "cache`, `clear-user-cache`, `clear-keys-cache`."
 msgstr ""
+"`create` 操作と 、 `clear-realm-cache` 、 `clear-user-cache` 、 `clear-keys-cache`"
+" エンドポイントのいずれかを使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:405
+#: source/server_admin/topics/admin-cli.adoc:424
 msgid "Set `realm` to the same value as target realm."
-msgstr ""
+msgstr "`realm` の値を対象のレルムに設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:409
+#: source/server_admin/topics/admin-cli.adoc:428
 #, no-wrap
-msgid "    $ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
-msgstr ""
+msgid ""
+"    $ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
+msgstr "$ kcadm.sh create clear-realm-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:411
+#: source/server_admin/topics/admin-cli.adoc:430
 #, no-wrap
 msgid "    $ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
-msgstr ""
+msgstr "$ kcadm.sh create clear-user-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:413
+#: source/server_admin/topics/admin-cli.adoc:432
 #, no-wrap
 msgid "    $ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
-msgstr ""
+msgstr "$ kcadm.sh create clear-keys-cache -r demorealm -s realm=demorealm\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:415
+#: source/server_admin/topics/admin-cli.adoc:434
 #, no-wrap
 msgid "Role operations"
-msgstr ""
+msgstr "ロール操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:417
+#: source/server_admin/topics/admin-cli.adoc:436
 #, no-wrap
 msgid "Creating a realm role"
-msgstr ""
+msgstr "レルム・ロールの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:420
+#: source/server_admin/topics/admin-cli.adoc:439
 msgid "To create a realm role use `roles` endpoint:"
-msgstr ""
+msgstr "レルム・ロールを作成するには `roles` エンドポイントを使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:422
+#: source/server_admin/topics/admin-cli.adoc:441
 #, no-wrap
-msgid "    $ kcadm.sh create roles -r demorealm -s name=user -s 'description=Regular user with limited set of permissions'\n"
+msgid ""
+"    $ kcadm.sh create roles -r demorealm -s name=user -s "
+"'description=Regular user with limited set of permissions'\n"
 msgstr ""
+"$ kcadm.sh create roles -r demorealm -s name=user -s 'description=Regular "
+"user with limited set of permissions'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:424
+#: source/server_admin/topics/admin-cli.adoc:443
 #, no-wrap
 msgid "Creating a client role"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:427
-msgid ""
-"To create a client role identify the client first - use `get` to list "
-"available clients:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:429
-#: source/server_admin/topics/admin-cli.adoc:616
-#, no-wrap
-msgid "    $ kcadm.sh get clients -r demorealm --fields id,clientId\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:431
-msgid ""
-"Then create a new role by using client's `id` attribute to construct an "
-"endpoint uri - `clients/ID/roles`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:435
-#, no-wrap
-msgid "    $ kcadm.sh create clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles -r demorealm -s name=editor -s 'description=Editor can edit, and publish any article'\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:437
-#, no-wrap
-msgid "Listing realm roles"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:440
-msgid "To list existing realm roles use `get` command:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:442
-#, no-wrap
-msgid "    $ kcadm.sh get roles -r demorealm\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:444
-msgid "You can also use `get-roles` command:"
-msgstr ""
+msgstr "クライアント・ロールの作成"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:446
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:448
-#, no-wrap
-msgid "Listing client roles"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:451
 msgid ""
-"Use special `get-roles` command, passing it either `clientId` (via `--"
-"cclientid` option) or `id` (via `--cid` option) to identify the client, and "
-"list defined roles:"
-msgstr ""
+"To create a client role identify the client first - use `get` to list "
+"available clients:"
+msgstr "クライアント・ロールを作成するには、まずクライアントを確認します。利用可能なクライアントを一覧表示するには `get` を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:455
+#: source/server_admin/topics/admin-cli.adoc:448
+#: source/server_admin/topics/admin-cli.adoc:665
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
+msgid "    $ kcadm.sh get clients -r demorealm --fields id,clientId\n"
+msgstr "$ kcadm.sh get clients -r demorealm --fields id,clientId\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:450
+msgid ""
+"Then, create a new role by using client's `id` attribute to construct an "
+"endpoint uri - `clients/ID/roles`."
 msgstr ""
+"次に、クライアントの `id` 属性を使用して構築したエンドポイントuri `clients/ID/roles` によって新しいロールを作成します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:454
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles -r "
+"demorealm -s name=editor -s 'description=Editor can edit, and publish any "
+"article'\n"
+msgstr ""
+"$ kcadm.sh create clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles -r "
+"demorealm -s name=editor -s 'description=Editor can edit, and publish any "
+"article'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:458
+#: source/server_admin/topics/admin-cli.adoc:456
 #, no-wrap
-msgid "Getting a specific realm role"
-msgstr ""
+msgid "Listing realm roles"
+msgstr "レルム・ロールの一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:459
+msgid "To list existing realm roles use `get` command on `roles` endpoint:"
+msgstr "既存のレルム・ロールを一覧表示するには、 `roles` エンドポイントで `get` コマンドを使います。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:461
-msgid ""
-"Use `get` command, and role `name` to construct an endpoint uri for a "
-"specific realm role - `roles/ROLE_NAME`"
-msgstr ""
+#, no-wrap
+msgid "    $ kcadm.sh get roles -r demorealm\n"
+msgstr "$ kcadm.sh get roles -r demorealm\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:463
+msgid "You can also use `get-roles` command:"
+msgstr "`get-roles` コマンドを使うこともできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:465
 #, no-wrap
-msgid "    $ kcadm.sh get roles/user -r demorealm\n"
-msgstr ""
+msgid "    $ kcadm.sh get-roles -r demorealm\n"
+msgstr "$ kcadm.sh get-roles -r demorealm\n"
 
-#. type: Plain text
+#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:467
-msgid "Where `user` is the name of existing role."
-msgstr ""
+#, no-wrap
+msgid "Listing client roles"
+msgstr "クライアント・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:469
+#: source/server_admin/topics/admin-cli.adoc:471
+msgid ""
+"There is a dedicated `get-roles` command to simplify listing of both realm "
+"and client roles. It is an extension of `get` command and so it behaves the "
+"same with additional semantics for listing roles."
+msgstr ""
+"レルムとクライアント・ロールの両方の一覧表示を単純化するための専用の `get-roles` コマンドがあります。 `get` "
+"コマンドの拡張であるため、ロールを一覧表示するための追加のセマンティクスで同じように動作します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:473
+msgid ""
+"To list client roles use `get-roles` command, passing it either `clientId` "
+"(via `--cclientid` option) or `id` (via `--cid` option) to identify the "
+"client."
+msgstr ""
+"クライアント・ロールを一覧表示するには `get-roles` コマンドを使い、 `clientId` （ `--cclientid` "
+"オプションで）または `id` （ `--cid` オプションで）を渡してクライアントを識別します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:477
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:480
+#, no-wrap
+msgid "Getting a specific realm role"
+msgstr "特定のレルム・ロールを取得する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:483
+msgid ""
+"Use `get` command, and role `name` to construct an endpoint uri for a "
+"specific realm role - `roles/ROLE_NAME`"
+msgstr ""
+"`get` コマンドとロール ` name` を使用して特定のレルム・ロールのエンドポイントuri `roles/ROLE_NAME` を構築します"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:487
+#, no-wrap
+msgid "    $ kcadm.sh get roles/user -r demorealm\n"
+msgstr "$ kcadm.sh get roles/user -r demorealm\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:489
+msgid "Where `user` is the name of existing role."
+msgstr "`user` は既存のロール名です。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:491
 msgid ""
 "Alternatively, use special `get-roles` command, passing it role `name` (via "
 "`--rolename` option) or `id` (via `--roleid` option)."
 msgstr ""
+"または、特別な `get-roles` コマンドを使用して `name` （ `--rolename` オプションで）または `id` （ "
+"`--roleid` オプションで）を渡してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:473
+#: source/server_admin/topics/admin-cli.adoc:495
 #, no-wrap
 msgid "   $ kcadm.sh get-roles -r demorealm --rolename user\n"
-msgstr ""
+msgstr "$ kcadm.sh get-roles -r demorealm --rolename user\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:476
-#, no-wrap
-msgid "Getting a specific client role"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:480
-msgid ""
-"Use special `get-roles` command, passing it either `clientId` (via `--"
-"cclientid` option) or `id` (via `--cid` option) to identify the client, and "
-"passing it either role `name` (via `--rolename` option) or 'id' (via --"
-"roleid) to identify a specific client role:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:484
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --cclientid realm-management --rolename manage-clients\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:486
-#, no-wrap
-msgid "Updating a realm role"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:489
-msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"realm role. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:491
-#, no-wrap
-msgid "    $ kcadm.sh update roles/user -r demorealm -s 'description=Role representing a regular user'\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:493
-#, no-wrap
-msgid "Updating a client role"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:496
-msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"client role. For example:"
-msgstr ""
-
-#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:498
 #, no-wrap
-msgid "    $ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor -r demorealm -s 'description=User that can edit, and publish articles'\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:500
-#, no-wrap
-msgid "Deleting a realm role"
-msgstr ""
+msgid "Getting a specific client role"
+msgstr "特定のクライアント・ロールを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:503
+#: source/server_admin/topics/admin-cli.adoc:502
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
+"Use a dedicated `get-roles` command, passing it either `clientId` (via "
+"`--cclientid` option) or `id` (via `--cid` option) to identify the client, "
+"and passing it either role `name` (via `--rolename` option) or 'id' (via "
+"`--roleid`) to identify a specific client role:"
+msgstr ""
+"専用の `get-roles` コマンドを使って `clientId` （ `--cclientid`オプションで）または `id` （ `--cid`"
+" オプションで）を渡してクライアントを識別し、 `name` （ `--rolename` オプションで）または 'id' （ `--roleid` "
+"オプションで）を使用して特定のクライアント・ロールを識別します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:506
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --cclientid realm-management "
+"--rolename manage-clients\n"
+msgstr ""
+"$ kcadm.sh get-roles -r demorealm --cclientid realm-management --rolename "
+"manage-clients\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:508
+#, no-wrap
+msgid "Updating a realm role"
+msgstr "レルム・ロールの更新"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:511
+msgid ""
+"Use `update` operation with the same endpoint uri as for getting a specific "
 "realm role. For example:"
-msgstr ""
+msgstr "特定のレルム・ロールを取得する場合と同じエンドポイントuriで `update` オペレーションを使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:505
+#: source/server_admin/topics/admin-cli.adoc:513
 #, no-wrap
-msgid "    $ kcadm.sh delete roles/user -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:507
-#, no-wrap
-msgid "Deleting a client role"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:510
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"client role. For example:"
+"    $ kcadm.sh update roles/user -r demorealm -s 'description=Role "
+"representing a regular user'\n"
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:512
-#, no-wrap
-msgid "    $ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor -r demorealm\n"
-msgstr ""
+"$ kcadm.sh update roles/user -r demorealm -s 'description=Role representing "
+"a regular user'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:514
+#: source/server_admin/topics/admin-cli.adoc:515
 #, no-wrap
-msgid "Listing assigned, available and effective realm roles for a composite role"
-msgstr ""
+msgid "Updating a client role"
+msgstr "クライアント・ロールの更新"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:518
-#: source/server_admin/topics/admin-cli.adoc:740
 msgid ""
-"There is a dedicated `get-roles` command to simplify listing of both realm "
-"and client roles. It is an extension of `get` command thus it behaves like "
-"`get` command with additional semantics for listing roles."
-msgstr ""
+"Use `update` operation with the same endpoint uri as for getting a specific "
+"client role. For example:"
+msgstr "特定のクライアント・ロールを取得する場合と同じエンドポイントuriで `update` オペレーションを使用してください。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:520
+#, no-wrap
 msgid ""
-"To list *assigned* realm roles for the composite role you can specify the "
-"target composite role by either `name` (via --rname option) or `id` (via --"
-"rid option)."
+"    $ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-"
+"6d61a4eca9a0/roles/editor -r demorealm -s 'description=User that can edit, "
+"and publish articles'\n"
 msgstr ""
+"$ kcadm.sh update clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor "
+"-r demorealm -s 'description=User that can edit, and publish articles'\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:522
+#, no-wrap
+msgid "Deleting a realm role"
+msgstr "レルム・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:524
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole\n"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:525
+msgid ""
+"Use `delete` operation with the same endpoint uri as for getting a specific "
+"realm role. For example:"
+msgstr "特定のレルム・ロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:527
-#: source/server_admin/topics/admin-cli.adoc:553
-#: source/server_admin/topics/admin-cli.adoc:749
-#: source/server_admin/topics/admin-cli.adoc:775
-#: source/server_admin/topics/admin-cli.adoc:956
-#: source/server_admin/topics/admin-cli.adoc:982
-msgid "To list *effective* realm roles, use additional `--effective` option."
-msgstr ""
+#, no-wrap
+msgid "    $ kcadm.sh delete roles/user -r demorealm\n"
+msgstr "$ kcadm.sh delete roles/user -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:529
+#, no-wrap
+msgid "Deleting a client role"
+msgstr "クライアント・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:531
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:532
+msgid ""
+"Use `delete` operation with the same endpoint uri as for getting a specific "
+"client role. For example:"
+msgstr "特定のクライアントロールを取得する場合と同じエンドポイントuriで `delete` オペレーションを使用してください。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:534
+#, no-wrap
 msgid ""
-"To list realm roles that can still be added to the composite role, use `--"
-"available` option instead."
+"    $ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-"
+"6d61a4eca9a0/roles/editor -r demorealm\n"
 msgstr ""
+"$ kcadm.sh delete clients/a95b6af3-0bdc-4878-ae2e-6d61a4eca9a0/roles/editor "
+"-r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:536
+#, no-wrap
+msgid ""
+"Listing assigned, available and effective realm roles for a composite role"
+msgstr "複合ロールに割り当てられた、利用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:538
+#: source/server_admin/topics/admin-cli.adoc:539
+#: source/server_admin/topics/admin-cli.adoc:564
+#: source/server_admin/topics/admin-cli.adoc:794
+#: source/server_admin/topics/admin-cli.adoc:819
+msgid "Use a dedicated `get-roles` command."
+msgstr "専用の `get-roles` コマンドを使用してください"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:541
+msgid ""
+"To list *assigned* realm roles for the composite role you can specify the "
+"target composite role by either `name` (via --rname option) or `id` (via "
+"--rid option)."
+msgstr ""
+"複合ロールのために *割り当てられた* レルム・ロールを一覧表示するには、 `name` （ `--rname` オプションで）または `id` （ "
+"`--rid` オプションで）のいずれかで対象の複合ロールを指定できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:545
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:548
+#: source/server_admin/topics/admin-cli.adoc:574
+#: source/server_admin/topics/admin-cli.adoc:803
+#: source/server_admin/topics/admin-cli.adoc:829
+#: source/server_admin/topics/admin-cli.adoc:1009
+#: source/server_admin/topics/admin-cli.adoc:1035
+msgid "To list *effective* realm roles, use additional `--effective` option."
+msgstr "*有効な* レルム・ロールを一覧表示するには、 `--effective` オプションを追加してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:552
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --effective\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:555
+msgid ""
+"To list realm roles that can still be added to the composite role, use "
+"`--available` option instead."
+msgstr "複合ロールにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:559
 #, no-wrap
 msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
-msgstr ""
+msgstr "$ kcadm.sh get-roles -r demorealm --rname testrole --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:540
+#: source/server_admin/topics/admin-cli.adoc:561
 #, no-wrap
-msgid "Listing assigned, available, and effective client roles for a composite role"
-msgstr ""
+msgid ""
+"Listing assigned, available, and effective client roles for a composite role"
+msgstr "複合ロールに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:543
-#: source/server_admin/topics/admin-cli.adoc:765
-msgid "You can again use `get-roles` command to simplify listing of roles."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:546
+#: source/server_admin/topics/admin-cli.adoc:567
 msgid ""
 "To list *assigned* client roles for the composite role you can specify the "
-"target composite role by either `name` (via --rname option)  or `id` (via --"
-"rid option), and client by either `clientId` (via --cclientid option) or "
+"target composite role by either `name` (via --rname option)  or `id` (via "
+"--rid option), and client by either `clientId` (via --cclientid option) or "
 "`id` (via --cid option)."
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:550
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-management\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:557
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-management --effective\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:560
-msgid ""
-"To list realm roles that can still be added to the target composite role, "
-"use `--available` option instead."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:564
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-management --available\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:566
-#, no-wrap
-msgid "Adding realm roles to a composite role"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:569
-#: source/server_admin/topics/admin-cli.adoc:791
-msgid ""
-"There is a dedicated `add-roles` command that can be used for adding both "
-"realm roles and client roles."
-msgstr ""
+"複合ロールの *割り当てられた* クライアント・ロールを一覧表示するには、 `name` （ `--rname` オプションで）または `id` （ "
+"`--rid` オプションで）のいずれかで対象の複合ロールを指定できます。 `clientId` （ `--cclientid` オプションで）または "
+"`id` （ `--cid` オプションで）のどちらかでクライアントを指定できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:571
-msgid "For example, to add 'user' role to composite role 'testrole' :"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:573
 #, no-wrap
-msgid "    $ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"management\n"
 msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:575
-#, no-wrap
-msgid "Removing realm roles from a composite role"
-msgstr ""
+"$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"management\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:578
-#: source/server_admin/topics/admin-cli.adoc:800
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"management --effective\n"
+msgstr ""
+"$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"management --effective\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:581
+msgid ""
+"To list realm roles that can still be added to the target composite role, "
+"use `--available` option instead."
+msgstr "対象の複合ロールにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:585
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"management --available\n"
+msgstr ""
+"$ kcadm.sh get-roles -r demorealm --rname testrole --cclientid realm-"
+"management --available\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:587
+#, no-wrap
+msgid "Adding realm roles to a composite role"
+msgstr "レルム・ロールを複合ロールに追加する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:590
+msgid ""
+"There is a dedicated `add-roles` command that can be used for adding both "
+"realm roles and client roles."
+msgstr "レルム・ロールとクライアント・ロールの両方を追加するために使用できる専用の `add-roles` コマンドがあります。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:592
+msgid "For example, to add 'user' role to composite role 'testrole' :"
+msgstr "たとえば、 'user' ロールを複合ロール 'testrole' に追加するには、次のようにします。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:594
+#, no-wrap
+msgid "    $ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
+msgstr "$ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:596
+#, no-wrap
+msgid "Removing realm roles from a composite role"
+msgstr "複合ロールからレルム・ロールを削除する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:599
 msgid ""
 "There is a dedicated `remove-roles` command that can be used to remove both "
 "realm roles and client roles."
-msgstr ""
+msgstr "レルム・ロールとクライアント・ロールの両方を削除するために使用できる専用の `remove-roles` コマンドがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:580
+#: source/server_admin/topics/admin-cli.adoc:601
 msgid ""
 "For example, to remove 'user' role from target composite role 'testrole':"
-msgstr ""
+msgstr "たとえば、対象の複合ロール 'testrole' から 'user' ロールを削除するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:582
+#: source/server_admin/topics/admin-cli.adoc:603
 #, no-wrap
-msgid "    $ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
-msgstr ""
+msgid ""
+"    $ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
+msgstr "$ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:584
+#: source/server_admin/topics/admin-cli.adoc:605
 #, no-wrap
-msgid "Adding client roles to a composite role"
-msgstr ""
+msgid "Adding client roles to a realm role"
+msgstr "レルム・ロールへのクライアント・ロールの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:587
-#: source/server_admin/topics/admin-cli.adoc:809
+#: source/server_admin/topics/admin-cli.adoc:608
+msgid "This is how you create or modify a composite realm role."
+msgstr "これは、複合レルムロールを作成または変更する方法です。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:610
 msgid ""
-"There is a dedicated `add-roles` operation that can be used for adding both "
-"realm roles and client roles."
-msgstr ""
+"Use a dedicated `add-roles` command that can be used for adding both realm "
+"roles and client roles."
+msgstr "レルム・ロールとクライアント・ロールの両方を追加するために使用できる専用の `add-roles` コマンドを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:589
+#: source/server_admin/topics/admin-cli.adoc:612
 msgid ""
-"For example, to add to `testrole` composite role two roles defined on client "
-"`realm-management` - `create-client` role and `view-users` role:"
+"For example, to add to `testrole` composite role two roles defined on client"
+" `realm-management` - `create-client` role and `view-users` role:"
 msgstr ""
+"たとえば、 `testrole` 複合ロールにクライアント `realm-management` で定義された2つのロール（ `create-"
+"client` ロールと `view-users` ロール）を追加するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:591
+#: source/server_admin/topics/admin-cli.adoc:614
 #, no-wrap
-msgid "    $ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-management --rolename create-client --rolename view-users\n"
+msgid ""
+"    $ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
 msgstr ""
+"$ kcadm.sh add-roles -r demorealm --rname testrole --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:593
+#: source/server_admin/topics/admin-cli.adoc:616
+#, no-wrap
+msgid "Adding client roles to a client role"
+msgstr "クライアント・ロールへのクライアント・ロールの追加"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:619
+msgid "This is how you create or modify a composite client role."
+msgstr "これは、複合クライアントロールを作成または変更する方法です。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:621
+msgid ""
+"First, find out an `id` of the composite client role - by using `get-roles` "
+"command for example:"
+msgstr "まず、 `get-roles` コマンドを使って複合クライアントロールの `id` を見つけます。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:623
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --cclientid test-client --rolename "
+"operations\n"
+msgstr ""
+"$ kcadm.sh get-roles -r demorealm --cclientid test-client --rolename "
+"operations\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:625
+msgid ""
+"Let's assume that there exists a client with \"clientId\": 'test-client', a "
+"client role called 'support', and another client role - that will become "
+"composite role - that has an \"id\": \"fc400897-ef6a-4e8c-872b-"
+"1581b7fa8a71\", \"name\":\"operations\"."
+msgstr ""
+"\"clientId\": 'test-client' "
+"であるクライアント、'support'というクライアント・ロール、複合ロールになるもう1つのクライアント・ロール（\"id\": \"fc400897"
+"-ef6a-4e8c-872b-1581b7fa8a71\", \"name\":\"operations\"）が存在するとしましょう。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:627
+msgid ""
+"In this example 'operations' is our target composite role, and we just got "
+"its `id`."
+msgstr "この例では、 'operations'　は目標とする複合ロールで、その `id` も得ています。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:629
+msgid "We can now add another role to it:"
+msgstr "これで別のロールを追加できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:631
+#, no-wrap
+msgid ""
+"    $ kcadm.sh add-roles -r demorealm --cclientid test-client --rid fc400897"
+"-ef6a-4e8c-872b-1581b7fa8a71 --rolename support\n"
+msgstr ""
+"$ kcadm.sh add-roles -r demorealm --cclientid test-client --rid fc400897"
+"-ef6a-4e8c-872b-1581b7fa8a71 --rolename support\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:634
+msgid ""
+"Afterwards all the roles of a composite role can be listed by using `get-"
+"roles --all`. For example:"
+msgstr "その後、 `get-roles --all` を使用して複合ロールのすべてのロールを一覧表示することができます。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:636
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
+msgstr "$ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:638
 #, no-wrap
 msgid "Removing client roles from a composite role"
-msgstr ""
+msgstr "複合ロールからのクライアント・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:596
-#: source/server_admin/topics/admin-cli.adoc:818
-msgid ""
-"There is a dedicated `remove-roles` operation that can be used for removing "
-"both realm roles and client roles."
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:641
+#: source/server_admin/topics/admin-cli.adoc:854
+#: source/server_admin/topics/admin-cli.adoc:872
+msgid "Use a dedicated `remove-roles` command."
+msgstr "専用の `remove-roles` コマンドを使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:598
+#: source/server_admin/topics/admin-cli.adoc:643
 msgid ""
 "For example, to remove from `testrole` composite role two roles defined on "
 "client `realm management` - `create-client` role and `view-users` role:"
 msgstr ""
+"たとえば、 `testrole`  複合ロールからクライアント `realm management`  で定義された2つのロール（ `create-"
+"client` ロールと ` view-users` ロール）を削除するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:600
-#, no-wrap
-msgid "    $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-management --rolename create-client --rolename view-users\n"
-msgstr ""
-
-#. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:602
-#, no-wrap
-msgid "Client operations"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:604
-#, no-wrap
-msgid "Creating a client"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:607
-msgid ""
-"A new client can be created by using `create` command against `clients` "
-"endpoint. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:609
-#, no-wrap
-msgid "    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:611
-#, no-wrap
-msgid "Listing clients"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:614
-msgid "It's very easy to list existing clients. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:618
-msgid "Here we filter the output to only list `id`, and `clientId` attributes."
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:620
-#, no-wrap
-msgid "Getting a specific client"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:623
-msgid ""
-"Use client's `id` to construct an endpoint uri targeting specific client - "
-"`clients/ID`. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:625
-#, no-wrap
-msgid "    $ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:627
-#, no-wrap
-msgid "Getting adapter configuration file (keycloak.json) for specific client"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:630
-msgid ""
-"Use client's `id` to construct an endpoint uri targeting specific client - "
-"`clients/ID/installation/providers/keycloak-oidc-keycloak-json`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:634
-#, no-wrap
-msgid "    $ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers/keycloak-oidc-keycloak-json -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:636
-#, no-wrap
-msgid "Getting Wildfly subsystem adapter configuration for specific client"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:639
-msgid ""
-"Use client's `id` to construct an endpoint uri targeting specific client - "
-"`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:643
-#, no-wrap
-msgid "    $ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers/keycloak-oidc-jboss-subsystem -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:645
 #, no-wrap
-msgid "Updating a client"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:648
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"client. For example on Linux:"
+"    $ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
 msgstr ""
+"$ kcadm.sh remove-roles -r demorealm --rname testrole --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
+
+#. type: Title ===
+#: source/server_admin/topics/admin-cli.adoc:647
+#, no-wrap
+msgid "Client operations"
+msgstr "クライアント操作"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:649
+#, no-wrap
+msgid "Creating a client"
+msgstr "クライアントの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:650
-#, no-wrap
-msgid "    $ kcadm.sh update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm -s enabled=false -s publicClient=true -s 'redirectUris=[\"http://localhost:8080/myapp/*\"]' -s baseUrl=http://localhost:8080/myapp -s adminUrl=http://localhost:8080/myapp\n"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:652
+msgid ""
+"To create a new client perform `create` command on `clients` endpoint. For "
+"example:"
+msgstr "新しいクライアントを作成するには、 `clients` エンドポイントで `create` コマンドを実行します。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:654
 #, no-wrap
-msgid "    c:\\> kcadm update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm -s enabled=false -s publicClient=true -s \"redirectUris=[\\\"http://localhost:8080/myapp/*\\\"]\" -s baseUrl=http://localhost:8080/myapp -s adminUrl=http://localhost:8080/myapp\n"
+msgid ""
+"    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s "
+"enabled=true\n"
 msgstr ""
+"$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true\n"
 
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:655
-#, no-wrap
-msgid "Deleting a client"
-msgstr ""
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:656
+msgid ""
+"If you want to set a secret for adapters to authenticate specify a `secret`."
+" For example:"
+msgstr "認証するためのアダプターのシークレットを設定する場合は、 `secret` を指定します。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:658
+#, no-wrap
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"client. For example:"
+"    $ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true"
+" -s clientAuthenticatorType=client-secret -s secret=d0b8122f-8dfb-46b7-b68a-"
+"f5cc4e25d000\n"
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:660
-#, no-wrap
-msgid "    $ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm\n"
-msgstr ""
-
-#. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:662
-#, no-wrap
-msgid "User operations"
-msgstr ""
+"$ kcadm.sh create clients -r demorealm -s clientId=myapp -s enabled=true -s "
+"clientAuthenticatorType=client-secret -s secret=d0b8122f-8dfb-46b7-b68a-"
+"f5cc4e25d000\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:664
+#: source/server_admin/topics/admin-cli.adoc:660
 #, no-wrap
-msgid "Creating a user"
-msgstr ""
+msgid "Listing clients"
+msgstr "クライアントの一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:663
+msgid "Use `get` operation on `clients` endpoint. For example:"
+msgstr "`clients` エンドポイントで `get` 操作を使います。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:667
 msgid ""
-"A new user can be created using the `create` command against the `users` "
-"endpoint. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:669
-#, no-wrap
-msgid "    $ kcadm.sh create users -r demorealm -s username=testuser -s enabled=true\n"
-msgstr ""
+"Here we filter the output to only list `id`, and `clientId` attributes."
+msgstr "ここでは、出力を `id` と `clientId` 属性だけにフィルタリングします。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:671
+#: source/server_admin/topics/admin-cli.adoc:669
 #, no-wrap
-msgid "Listing users"
-msgstr ""
+msgid "Getting a specific client"
+msgstr "特定のクライアントを取得する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:672
+msgid ""
+"Use client's `id` to construct an endpoint uri targeting specific client - "
+"`clients/ID`. For example:"
+msgstr "クライアントの `id` を使用して、特定のクライアントを対象とするエンドポイントuri `clients/ID` を構築します。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:674
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
+"demorealm\n"
+msgstr ""
+"$ kcadm.sh get clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:676
+#, no-wrap
+msgid "Getting current secret for specific client"
+msgstr "特定のクライアントの現在のシークレットを取得する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:679
+msgid ""
+"Use client's `id` to construct an endpoint uri - `clients/ID/client-secret`."
+" For example"
+msgstr "クライアントの `id` を使ってエンドポイントuri 'clients/ID/client-secret` を構築します。例えば"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:681
+#, no-wrap
+msgid "    $ kcadm.sh get clients/$CID/client-secret\n"
+msgstr "$ kcadm.sh get clients/$CID/client-secret\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:683
+#, no-wrap
+msgid "Getting adapter configuration file (keycloak.json) for specific client"
+msgstr "特定のクライアント用のアダプター構成ファイル（keycloak.json）の取得"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:686
+msgid ""
+"Use client's `id` to construct an endpoint uri targeting specific client - "
+"`clients/ID/installation/providers/keycloak-oidc-keycloak-json`."
+msgstr ""
+"クライアントの `id` を使用して、特定のクライアントを対象にしたエンドポイントuri "
+"`clients/ID/installation/providers/keycloak-oidc-keycloak-json` を構築します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:690
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get "
+"clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
+"/keycloak-oidc-keycloak-json -r demorealm\n"
+msgstr ""
+"    $ kcadm.sh get "
+"clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
+"/keycloak-oidc-keycloak-json -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:692
+#, no-wrap
+msgid "Getting Wildfly subsystem adapter configuration for specific client"
+msgstr "特定のクライアントのためのWildflyサブシステム・アダプタ設定の取得"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:695
+msgid ""
+"Use client's `id` to construct an endpoint uri targeting specific client - "
+"`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem`."
+msgstr ""
+"クライアントの` id` を使用して特定のクライアントを対象とするエンドポイントuri "
+"`clients/ID/installation/providers/keycloak-oidc-jboss-subsystem` を構築します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:699
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get "
+"clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
+"/keycloak-oidc-jboss-subsystem -r demorealm\n"
+msgstr ""
+"    $ kcadm.sh get "
+"clients/c7b8547f-e748-4333-95d0-410b76b3f4a3/installation/providers"
+"/keycloak-oidc-jboss-subsystem -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:701
+#, no-wrap
+msgid "Updating a client"
+msgstr "クライアントの更新"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:704
+msgid ""
+"Use `update` operation with the same endpoint uri as for getting a specific "
+"client. For example on Linux:"
+msgstr "特定のクライアントを取得する場合と同じエンドポイントuriで `update` 操作を使用してください。たとえばLinuxの場合："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:706
+#, no-wrap
+msgid ""
+"    $ kcadm.sh update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
+"demorealm -s enabled=false -s publicClient=true -s "
+"'redirectUris=[\"http://localhost:8080/myapp/*\"]' -s "
+"baseUrl=http://localhost:8080/myapp -s "
+"adminUrl=http://localhost:8080/myapp\n"
+msgstr ""
+"$ kcadm.sh update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm "
+"-s enabled=false -s publicClient=true -s "
+"'redirectUris=[\"http://localhost:8080/myapp/*\"]' -s "
+"baseUrl=http://localhost:8080/myapp -s "
+"adminUrl=http://localhost:8080/myapp\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:710
+#, no-wrap
+msgid ""
+"    c:\\> kcadm update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
+"demorealm -s enabled=false -s publicClient=true -s "
+"\"redirectUris=[\\\"http://localhost:8080/myapp/*\\\"]\" -s "
+"baseUrl=http://localhost:8080/myapp -s "
+"adminUrl=http://localhost:8080/myapp\n"
+msgstr ""
+"c:\\> kcadm update clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r demorealm"
+" -s enabled=false -s publicClient=true -s "
+"\"redirectUris=[\\\"http://localhost:8080/myapp/*\\\"]\" -s "
+"baseUrl=http://localhost:8080/myapp -s "
+"adminUrl=http://localhost:8080/myapp\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:711
+#, no-wrap
+msgid "Deleting a client"
+msgstr "クライアントの削除"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:714
+msgid ""
+"Use `delete` operation with the same endpoint uri as for getting a specific "
+"client. For example:"
+msgstr "特定のクライアントを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:716
+#, no-wrap
+msgid ""
+"    $ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
+"demorealm\n"
+msgstr ""
+"$ kcadm.sh delete clients/c7b8547f-e748-4333-95d0-410b76b3f4a3 -r "
+"demorealm\n"
+
+#. type: Title ===
+#: source/server_admin/topics/admin-cli.adoc:718
+#, no-wrap
+msgid "User operations"
+msgstr "ユーザー操作"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:720
+#, no-wrap
+msgid "Creating a user"
+msgstr "ユーザーの作成"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:723
+msgid ""
+"To create a new user perform `create` operation on `users` endpoint. For "
+"example:"
+msgstr "新しいユーザーを作成するには、 `users` エンドポイントで `create` 操作を実行します。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:725
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create users -r demorealm -s username=testuser -s "
+"enabled=true\n"
+msgstr ""
+"$ kcadm.sh create users -r demorealm -s username=testuser -s enabled=true\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:727
+#, no-wrap
+msgid "Listing users"
+msgstr "ユーザーの一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:730
 msgid ""
 "Use `users` endpoint to list users. Number of users may be large, and you "
 "may want to limit how many are returned:"
-msgstr ""
+msgstr "ユーザーを一覧表示するには `users` エンドポイントを使います。ユーザー数が多く、返される数を制限したい場合は："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:676
+#: source/server_admin/topics/admin-cli.adoc:732
 #, no-wrap
 msgid "    $ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
-msgstr ""
+msgstr "$ kcadm.sh get users -r demorealm --offset 0 --limit 1000\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:678
+#: source/server_admin/topics/admin-cli.adoc:734
 msgid ""
 "It's also possible to filter users by `username`, `firstName`, `lastName`, "
 "or `email`. For example:"
 msgstr ""
+"`username` 、 `firstName` 、 `lastName` 、または `email` "
+"によってユーザをフィルタすることも可能です。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:681
+#: source/server_admin/topics/admin-cli.adoc:737
 #, no-wrap
 msgid ""
 "    $ kcadm.sh get users -r demorealm -q email=google.com\n"
 "    $ kcadm.sh get users -r demorealm -q username=testuser\n"
 msgstr ""
+"$ kcadm.sh get users -r demorealm -q email=google.com\n"
+" $ kcadm.sh get users -r demorealm -q username=testuser\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:683
+#: source/server_admin/topics/admin-cli.adoc:739
 msgid ""
-"Note that filtering doesn't use exact matching. For example, the above would "
-"match the value of `username` attribute against '\\*testuser*' pattern."
+"Note that filtering doesn't use exact matching. For example, the above would"
+" match the value of `username` attribute against '\\*testuser*' pattern."
 msgstr ""
+"フィルタリングは完全一致を使用しないことに注意してください。例えば、上記は `username` 属性の値と '\\*testuser*' "
+"パターンを一致させます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:686
+#: source/server_admin/topics/admin-cli.adoc:742
 msgid ""
 "You can also filter across multiple attributes by specifying multiple `-q` "
 "options, which would return only users that match condition for all the "
 "attributes."
 msgstr ""
+"`-q` "
+"オプションを複数指定することで、複数の属性をフィルタリングをすることもできます。このオプションは、すべての属性の条件に一致するユーザのみを返します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:688
+#: source/server_admin/topics/admin-cli.adoc:744
 #, no-wrap
 msgid "Getting a specific user"
-msgstr ""
+msgstr "特定のユーザーを取得する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:691
-msgid ""
-"Use user `id` to compose an endpoint uri matching a specific user - `users/"
-"USER_ID`."
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:747
+msgid "Use user's `id` to compose an endpoint uri - `users/USER_ID`."
+msgstr "ユーザーの `id` を使用してエンドポイントuri `users/USER_ID` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:695
+#: source/server_admin/topics/admin-cli.adoc:751
 #, no-wrap
-msgid "    $ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
+msgid ""
+"    $ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 msgstr ""
+"$ kcadm.sh get users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:697
-#, no-wrap
-msgid "Updating a user"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:700
-msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"user. For example on Linux:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:702
-#, no-wrap
-msgid "    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm -s 'requiredActions=[\"VERIFY_EMAIL\",\"UPDATE_PROFILE\",\"CONFIGURE_TOTP\",\"UPDATE_PASSWORD\"]'\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:706
-#, no-wrap
-msgid "    c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm -s \"requiredActions=[\\\"VERIFY_EMAIL\\\",\\\"UPDATE_PROFILE\\\",\\\"CONFIGURE_TOTP\\\",\\\"UPDATE_PASSWORD\\\"]\"\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:707
-#, no-wrap
-msgid "Deleting a user"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:710
-msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"user. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:712
-#, no-wrap
-msgid "    $ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:714
-#, no-wrap
-msgid "Resetting user's password"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:717
-msgid ""
-"There is a dedicated `set-password` command specifically to reset user's "
-"password. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:719
-#, no-wrap
-msgid "    $ kcadm.sh set-password -r demorealm --username testuser --password NEWPASSWORD --temporary\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:721
-msgid ""
-"That will set a temporary password for the user, which they will have to "
-"change the next time they login."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:723
-msgid ""
-"You can use `--userid` if you want to specify the user by using `id` "
-"attribute."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:726
-msgid ""
-"The same can be achieved using the `update` operation against an endpoint "
-"constructed from one for getting a specific user - `users/USER_ID/reset-"
-"password`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:730
-#, no-wrap
-msgid "    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-password -r demorealm -s type=password -s value=NEWPASSWORD -s temporary=true -n\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:733
-msgid ""
-"The last parameter (`-n`) forces a so called 'no-merge' update which "
-"performs a PUT only, without first doing a GET to retrieve current state of "
-"the resource. In this case it is necessary since `reset-password` endpoint "
-"doesn't support GET."
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:736
-#, no-wrap
-msgid "Listing assigned, available, and effective realm roles for a user"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:742
-msgid ""
-"To list *assigned* realm roles for the user you can specify the target user "
-"by either `username` or `id`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:746
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser\n"
-msgstr ""
-
-#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:753
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
-msgstr ""
+msgid "Updating a user"
+msgstr "ユーザーの更新"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:756
-#: source/server_admin/topics/admin-cli.adoc:782
 msgid ""
-"To list realm roles that can still be added to the user, use `--available` "
-"option instead."
-msgstr ""
+"Use `update` operation with the same endpoint uri as for getting a specific "
+"user. For example on Linux:"
+msgstr "特定のユーザーを取得する場合と同じエンドポイントuriで `update` 操作を使用します。たとえばLinuxの場合："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:760
+#: source/server_admin/topics/admin-cli.adoc:758
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
+msgid ""
+"    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
+"demorealm -s "
+"'requiredActions=[\"VERIFY_EMAIL\",\"UPDATE_PROFILE\",\"CONFIGURE_TOTP\",\"UPDATE_PASSWORD\"]'\n"
 msgstr ""
+"$ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm -s"
+" "
+"'requiredActions=[\"VERIFY_EMAIL\",\"UPDATE_PROFILE\",\"CONFIGURE_TOTP\",\"UPDATE_PASSWORD\"]'\n"
 
-#. type: Labeled list
+#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:762
 #, no-wrap
-msgid "Listing assigned, available, and effective client roles for a user"
+msgid ""
+"    c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
+"demorealm -s "
+"\"requiredActions=[\\\"VERIFY_EMAIL\\\",\\\"UPDATE_PROFILE\\\",\\\"CONFIGURE_TOTP\\\",\\\"UPDATE_PASSWORD\\\"]\"\n"
 msgstr ""
+"c:\\> kcadm update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm "
+"-s "
+"\"requiredActions=[\\\"VERIFY_EMAIL\\\",\\\"UPDATE_PROFILE\\\",\\\"CONFIGURE_TOTP\\\",\\\"UPDATE_PASSWORD\\\"]\"\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:763
+#, no-wrap
+msgid "Deleting a user"
+msgstr "ユーザーの削除"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:766
+msgid ""
+"Use `delete` operation with the same endpoint uri as for getting a specific "
+"user. For example:"
+msgstr "特定のユーザーを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:768
+#, no-wrap
 msgid ""
-"To list *assigned* client roles for the user you can specify the target user "
-"by either `username` (via --uusername option) or `id` (via --uid option), "
-"and client by either `clientId` (via --cclientid option) or `id` (via --cid "
-"option)."
+"    $ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r "
+"demorealm\n"
 msgstr ""
+"$ kcadm.sh delete users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2 -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:770
+#, no-wrap
+msgid "Resetting user's password"
+msgstr "ユーザーのパスワードをリセットする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:772
+#: source/server_admin/topics/admin-cli.adoc:773
+msgid ""
+"There is a dedicated `set-password` command specifically to reset user's "
+"password. For example:"
+msgstr "ユーザーのパスワードをリセットするための専用コマンド `set-password` があります。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:775
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-management\n"
+msgid ""
+"    $ kcadm.sh set-password -r demorealm --username testuser --new-password "
+"NEWPASSWORD --temporary\n"
 msgstr ""
+"$ kcadm.sh set-password -r demorealm --username testuser --new-password "
+"NEWPASSWORD --temporary\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:777
+msgid ""
+"That will set a temporary password for the user, which they will have to "
+"change the next time they login."
+msgstr "これにより、ユーザーの次回のログイン時に変更が必要となる仮パスワードが設定されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:779
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-management --effective\n"
+msgid ""
+"You can use `--userid` if you want to specify the user by using `id` "
+"attribute."
+msgstr "`id` 属性を使ってユーザを指定したい場合、 `--userid` を使うことができます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:782
+msgid ""
+"The same can be achieved using `update` operation on an endpoint constructed"
+" from one for getting a specific user - `users/USER_ID/reset-password`."
 msgstr ""
+"特定のユーザを取得するために構築されたエンドポイント `users/USER_ID/reset-password` に対して `update` "
+"操作を行うことで、同じことができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:786
 #, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid realm-management --available\n"
+msgid ""
+"    $ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-"
+"password -r demorealm -s type=password -s value=NEWPASSWORD -s "
+"temporary=true -n\n"
 msgstr ""
+"$ kcadm.sh update users/0ba7a3fd-6fd8-48cd-a60b-2e8fd82d56e2/reset-password "
+"-r demorealm -s type=password -s value=NEWPASSWORD -s temporary=true -n\n"
 
-#. type: Labeled list
+#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:788
-#, no-wrap
-msgid "Adding realm roles to a user"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:793
-msgid "For example, to add 'user' role to user 'testuser' :"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:795
-#, no-wrap
-msgid "    $ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:797
-#, no-wrap
-msgid "Removing realm roles from a user"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:802
-msgid "For example, to remove 'user' role from user 'testuser':"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:804
-#, no-wrap
-msgid "    $ kcadm.sh remove-roles --username testuser --rolename user -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:806
-#, no-wrap
-msgid "Adding client roles to a user"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:811
 msgid ""
-"For example, to add to user `testuser` two roles defined on client `realm "
-"management` - `create-client` role and `view-users` role:"
+"The last parameter (`-n`) ensures that only PUT is performed without a prior"
+" GET. In this case it is necessary since `reset-password` endpoint doesn't "
+"support GET."
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:813
-#, no-wrap
-msgid "    $ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid realm-management --rolename create-client --rolename view-users\n"
-msgstr ""
+"最後のパラメータ（ `-n` ）は、更新前のGETなしでPUTだけが実行されることを保証します。このケースでは、 `reset-password` "
+"エンドポイントがGETをサポートしていないので必要です。"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:815
+#: source/server_admin/topics/admin-cli.adoc:791
 #, no-wrap
-msgid "Removing client roles from a user"
-msgstr ""
+msgid "Listing assigned, available, and effective realm roles for a user"
+msgstr "ユーザーに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:820
+#: source/server_admin/topics/admin-cli.adoc:796
 msgid ""
-"For example, to remove from user `testuser` two roles defined on client "
-"`realm management` - `create-client` role and `view-users` role:"
+"To list *assigned* realm roles for the user you can specify the target user "
+"by either `username` or `id`."
 msgstr ""
+"ユーザーの *割り当てられた* レルム・ロールを一覧表示するには、 `username` か `id` のどちらかで対象ユーザーを指定します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:800
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:807
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:810
+#: source/server_admin/topics/admin-cli.adoc:836
+msgid ""
+"To list realm roles that can still be added to the user, use `--available` "
+"option instead."
+msgstr "ユーザーにまだ追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:814
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:816
+#, no-wrap
+msgid "Listing assigned, available, and effective client roles for a user"
+msgstr "ユーザーに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:822
-#, no-wrap
-msgid "    $ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid realm-management --rolename create-client --rolename view-users\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:824
-#, no-wrap
-msgid "Listing user's sessions"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:827
 msgid ""
-"First identify user's `id` then use it to compose an endpoint uri - `users/"
-"ID/sessions`."
+"To list *assigned* client roles for the user you can specify the target user"
+" by either `username` (via --uusername option) or `id` (via --uid option), "
+"and client by either `clientId` (via --cclientid option) or `id` (via --cid "
+"option)."
 msgstr ""
+"ユーザに *割り当てられた* クライアント・ロールを一覧表示するには、 `username` （--uusernameオプションで）または ` id` "
+"（--uidオプションで）のいずれかで対象ユーザを指定できます。 `clientId` （--cclientidオプションで）または `id` "
+"（--cidオプションで）のどちらかでクライアントを指定できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:829
-msgid "Now use `get` to retrieve a list of user's sessions."
+#: source/server_admin/topics/admin-cli.adoc:826
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
+"realm-management\n"
 msgstr ""
+"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
+"realm-management\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:833
 #, no-wrap
-msgid "    $kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:835
-#, no-wrap
-msgid "Logging out user from specific session"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:838
 msgid ""
-"To invalidate a session you only need session's `id`. You can get it by "
-"listing user's sessions."
+"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
+"realm-management --effective\n"
 msgstr ""
+"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
+"realm-management --effective\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:840
-msgid "Use session's `id` to compose an endpoint uri - `sessions/ID`."
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
+"realm-management --available\n"
 msgstr ""
+"    $ kcadm.sh get-roles -r demorealm --uusername testuser --cclientid "
+"realm-management --available\n"
 
-#. type: Plain text
+#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:842
-msgid "The use `delete` to invalidate it. For example:"
-msgstr ""
+#, no-wrap
+msgid "Adding realm roles to a user"
+msgstr "ユーザーにレルム・ロールを追加する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:844
-#, no-wrap
-msgid "    $ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:845
+#: source/server_admin/topics/admin-cli.adoc:863
+msgid "Use a dedicated `add-roles` command."
+msgstr "専用の `add-roles` コマンドを使用してください。"
 
-#. type: Labeled list
+#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:847
-#, no-wrap
-msgid "Logging out user from all sessions"
-msgstr ""
+msgid "For example, to add 'user' role to user 'testuser' :"
+msgstr "たとえば、ユーザー 'testuser' に 'user' ロールを追加するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:850
-msgid "You need user's `id` to construct an endpoint uri - `users/ID/logout`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:852
-msgid "Use 'create' to send logout-from-all-sessions request:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:854
+#: source/server_admin/topics/admin-cli.adoc:849
 #, no-wrap
-msgid "    $ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r demorealm -s realm=demorealm -s user=6da5ab89-3397-4205-afaa-e201ff638f9e\n"
-msgstr ""
-
-#. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:857
-#, no-wrap
-msgid "Group operations"
-msgstr ""
+msgid ""
+"    $ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
+msgstr "$ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:859
+#: source/server_admin/topics/admin-cli.adoc:851
 #, no-wrap
-msgid "Creating a group"
-msgstr ""
+msgid "Removing realm roles from a user"
+msgstr "ユーザーからレルム・ロールを削除する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:862
-msgid "Use `create` operation, and `groups` endpoint to create a new group:"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:856
+msgid "For example, to remove 'user' role from user 'testuser':"
+msgstr "たとえば、ユーザー 'testuser' から 'user' ロールを削除するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:864
+#: source/server_admin/topics/admin-cli.adoc:858
 #, no-wrap
-msgid "    $ kcadm.sh create groups -r demorealm -s name=Group\n"
+msgid ""
+"    $ kcadm.sh remove-roles --username testuser --rolename user -r "
+"demorealm\n"
 msgstr ""
+"$ kcadm.sh remove-roles --username testuser --rolename user -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:866
+#: source/server_admin/topics/admin-cli.adoc:860
 #, no-wrap
-msgid "Listing groups"
-msgstr ""
+msgid "Adding client roles to a user"
+msgstr "ユーザーにクライアント・ロールを追加する"
 
 #. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:865
+msgid ""
+"For example, to add to user `testuser` two roles defined on client `realm "
+"management` - `create-client` role and `view-users` role:"
+msgstr ""
+"たとえば、ユーザー `testuser` にクライアント `realm management` で定義された2つのロール（ `create-"
+"client` ロールと `view-users` ロール）を追加するには："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:867
+#, no-wrap
+msgid ""
+"    $ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid "
+"realm-management --rolename create-client --rolename view-users\n"
+msgstr ""
+"$ kcadm.sh add-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
+
+#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:869
-msgid "Use `get` operation, and `groups` endpoint to list groups:"
-msgstr ""
+#, no-wrap
+msgid "Removing client roles from a user"
+msgstr "ユーザーからのクライアント・ロールの削除"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:871
-#, no-wrap
-msgid "    $ kcadm.sh get groups -r demorealm\n"
+#: source/server_admin/topics/admin-cli.adoc:874
+msgid ""
+"For example, to remove from user `testuser` two roles defined on client "
+"`realm management` - `create-client` role and `view-users` role:"
 msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:873
-#, no-wrap
-msgid "Getting a specific group"
-msgstr ""
+"例えば、 `testmy` ユーザから `realm management`  で定義された二つのロール（ `create-client` ロールと "
+"`view-users` ロール）を削除するには："
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:876
-msgid "Use group's `id` to construct an endpoint uri - groups/GROUP_ID:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:880
 #, no-wrap
-msgid "    $ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
+msgid ""
+"    $ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid "
+"realm-management --rolename create-client --rolename view-users\n"
 msgstr ""
+"$ kcadm.sh remove-roles -r demorealm --uusername testuser --cclientid realm-"
+"management --rolename create-client --rolename view-users\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:882
+#: source/server_admin/topics/admin-cli.adoc:878
 #, no-wrap
-msgid "Updating a group"
-msgstr ""
+msgid "Listing user's sessions"
+msgstr "ユーザーのセッションを一覧表示する"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:885
+#: source/server_admin/topics/admin-cli.adoc:881
 msgid ""
-"Use `update` operation with the same endpoint uri as for getting a specific "
-"group. For example:"
-msgstr ""
+"First identify user's `id` then use it to compose an endpoint uri - "
+"`users/ID/sessions`."
+msgstr "最初にユーザの `id` を識別し、エンドポイントuri `users/ID/sessions` を作成するためにそれを使います。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:883
+msgid "Now use `get` to retrieve a list of user's sessions."
+msgstr "次に、ユーザのセッションの一覧を取得するために `get` を使います。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:887
 #, no-wrap
-msgid "    $ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s 'attributes.email=[\"group@example.com\"]' -r demorealm\n"
-msgstr ""
+msgid "    $kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
+msgstr "$kcadm get users/6da5ab89-3397-4205-afaa-e201ff638f9e/sessions\n"
 
 #. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:889
 #, no-wrap
-msgid "Deleting a group"
-msgstr ""
+msgid "Logging out user from specific session"
+msgstr "特定のセッションからユーザーをログアウトする"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:892
 msgid ""
-"Use `delete` operation with the same endpoint uri as for getting a specific "
-"group. For example:"
-msgstr ""
+"To logout the user's session first get session's `id` as described above."
+msgstr "ユーザーのセッションをログアウトするには、先に説明したように、セッションの `id` を取得します。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:894
-#, no-wrap
-msgid "    $ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
-msgstr ""
+msgid "Use session's `id` to compose an endpoint uri - `sessions/ID`."
+msgstr "ユーザーの `id` を使用してエンドポイントuri `sessions/ID` を作成します。 "
 
-#. type: Labeled list
+#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:896
-#, no-wrap
-msgid "Creating a sub-group"
-msgstr ""
+msgid "Then use `delete` to invalidate it. For example:"
+msgstr "次に、それを無効にするために `delete` を使います。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:899
-msgid ""
-"Find 'id' of the parent group - by listing groups for example. Use that `id` "
-"to construct an endpoint uri - groups/GROUP_ID/children:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:903
+#: source/server_admin/topics/admin-cli.adoc:898
 #, no-wrap
-msgid "    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children -r demorealm -s name=SubGroup\n"
-msgstr ""
+msgid "    $ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
+msgstr "$ kcadm.sh delete sessions/d0eaa7cc-8c5d-489d-811a-69d3c4ec84d1\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:905
+#: source/server_admin/topics/admin-cli.adoc:901
 #, no-wrap
-msgid "Moving a group under another group"
-msgstr ""
+msgid "Logging out user from all sessions"
+msgstr "すべてのセッションからユーザーをログアウトする"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:904
+msgid "You need user's `id` to construct an endpoint uri - `users/ID/logout`."
+msgstr "エンドポイントuri `users/ID/logout` を作成するのにユーザの` id` が必要です。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:906
+msgid "Use 'create' to perform POST on that endpoint uri:"
+msgstr "POSTをそのエンドポイントuriで実行するには、  'create' を使用します。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:908
-msgid ""
-"Find 'id' of existing parent group, and of existing child group. Use parent "
-"group's `id` to construct and endpoint uri - groups/PARENT_GROUP_ID/children."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:910
-msgid ""
-"Make 'create' operation against this endpoint, and pass child group `id` as "
-"JSON body. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:912
 #, no-wrap
-msgid "    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children -r demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
+msgid ""
+"    $ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r "
+"demorealm -s realm=demorealm -s user=6da5ab89-3397-4205-afaa-e201ff638f9e\n"
 msgstr ""
+"$ kcadm.sh create users/6da5ab89-3397-4205-afaa-e201ff638f9e/logout -r "
+"demorealm -s realm=demorealm -s user=6da5ab89-3397-4205-afaa-e201ff638f9e\n"
+
+#. type: Title ===
+#: source/server_admin/topics/admin-cli.adoc:911
+#, no-wrap
+msgid "Group operations"
+msgstr "グループの操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:914
+#: source/server_admin/topics/admin-cli.adoc:913
 #, no-wrap
-msgid "Get groups for specific user"
-msgstr ""
+msgid "Creating a group"
+msgstr "グループの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:917
-msgid ""
-"To get user's membership in groups, use user's `id` to compose a resource "
-"URI - `users/USER_ID/groups`"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:916
+msgid "Use `create` operation on `groups` endpoint to create a new group:"
+msgstr "`group` エンドポイントで `create` 操作を使って新しいグループを作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:921
+#: source/server_admin/topics/admin-cli.adoc:918
 #, no-wrap
-msgid "    $ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r demorealm\n"
-msgstr ""
+msgid "    $ kcadm.sh create groups -r demorealm -s name=Group\n"
+msgstr "$ kcadm.sh create groups -r demorealm -s name=Group\n"
 
 #. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:920
+#, no-wrap
+msgid "Listing groups"
+msgstr "グループの一覧表示"
+
+#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:923
-#, no-wrap
-msgid "Adding user to a group"
-msgstr ""
+msgid "Use `get` operation on `groups` endpoint to list groups:"
+msgstr "グループを一覧表示するには `groups` エンドポイントで `get` 操作を使います。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:926
-msgid ""
-"To join user to a group use `update` operation against a resource uri "
-"composed from user's `id`, and group's `id` - users/USER_ID/groups/GROUP_ID."
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:925
+#, no-wrap
+msgid "    $ kcadm.sh get groups -r demorealm\n"
+msgstr "$ kcadm.sh get groups -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:927
+#, no-wrap
+msgid "Getting a specific group"
+msgstr "特定のグループを取得する"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:930
-#, no-wrap
-msgid "    $ kcadm.sh update users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm -s realm=demorealm -s userId=b544f379-5fc4-49e5-8a8d-5cfb71f46f53 -s groupId=ce01117a-7426-4670-a29a-5c118056fe20 -n\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:932
-#, no-wrap
-msgid "Removing user from a group"
-msgstr ""
+msgid "Use group's `id` to construct an endpoint uri - groups/GROUP_ID:"
+msgstr "グループの `id` を使用してエンドポイントuri `groups/GROUP_ID` を作成します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:935
+#: source/server_admin/topics/admin-cli.adoc:934
+#, no-wrap
 msgid ""
-"To remove user from a group use `delete` operation against the same resource "
-"uri as used for adding user to a group - users/USER_ID/groups/GROUP_ID."
+"    $ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r "
+"demorealm\n"
 msgstr ""
+"$ kcadm.sh get groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:936
+#, no-wrap
+msgid "Updating a group"
+msgstr "グループの更新"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:939
+msgid ""
+"Use `update` operation with the same endpoint uri as for getting a specific "
+"group. For example:"
+msgstr "特定のグループを取得する場合と同じエンドポイントuriで `update` 操作を使用してください。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:941
 #, no-wrap
-msgid "    $ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm\n"
+msgid ""
+"    $ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s "
+"'attributes.email=[\"group@example.com\"]' -r demorealm\n"
 msgstr ""
+"$ kcadm.sh update groups/51204821-0580-46db-8f2d-27106c6b5ded -s "
+"'attributes.email=[\"group@example.com\"]' -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:942
+#: source/server_admin/topics/admin-cli.adoc:943
 #, no-wrap
-msgid "Listing assigned, available, and effective realm roles for a group"
-msgstr ""
+msgid "Deleting a group"
+msgstr "グループの削除"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:946
 msgid ""
-"There is a dedicated 'get-roles' command to simplify listing of roles. It is "
-"an extension of `get` command thus it behaves like `get` command with "
-"additional semantics for listing roles."
-msgstr ""
+"Use `delete` operation with the same endpoint uri as for getting a specific "
+"group. For example:"
+msgstr "特定のグループを取得する場合と同じエンドポイントuriで `delete` 操作を使用してください。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:949
+#: source/server_admin/topics/admin-cli.adoc:948
+#, no-wrap
+msgid ""
+"    $ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r "
+"demorealm\n"
+msgstr ""
+"$ kcadm.sh delete groups/51204821-0580-46db-8f2d-27106c6b5ded -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:950
+#, no-wrap
+msgid "Creating a sub-group"
+msgstr "サブ・グループの作成"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:953
+msgid ""
+"Find 'id' of the parent group - by listing groups for example. Use that `id`"
+" to construct an endpoint uri - groups/GROUP_ID/children:"
+msgstr ""
+"グループを一覧表示するなどして、親グループの 'id' を検索します。その `id`を私用してエンドポイントuri "
+"`groups/GROUP_ID/children` を作成します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:957
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
+"-r demorealm -s name=SubGroup\n"
+msgstr ""
+"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
+"-r demorealm -s name=SubGroup\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:959
+#, no-wrap
+msgid "Moving a group under another group"
+msgstr "グループを別のグループの下に移動する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:962
+msgid ""
+"Find 'id' of existing parent group, and of existing child group. Use parent "
+"group's `id` to construct and endpoint uri - "
+"groups/PARENT_GROUP_ID/children."
+msgstr ""
+"既存の親グループと既存の子グループの 'id' を検索します。 親グループの `id` を使用してエンドポイントuri "
+"`groups/PARENT_GROUP_ID/children` を作成します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:964
+msgid ""
+"Perform 'create' operation on this endpoint, and pass child group `id` as "
+"JSON body. For example:"
+msgstr "このエンドポイントで 'create' 操作を実行し、子グループ `id` をJSON本体として渡します。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:966
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
+"-r demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
+msgstr ""
+"    $ kcadm.sh create groups/51204821-0580-46db-8f2d-27106c6b5ded/children "
+"-r demorealm -s id=08d410c6-d585-4059-bb07-54dcb92c5094\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:968
+#, no-wrap
+msgid "Get groups for specific user"
+msgstr "特定のユーザーのグループを取得する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:971
+msgid ""
+"To get user's membership in groups, use user's `id` to compose an endpoint "
+"URI - `users/USER_ID/groups`"
+msgstr ""
+"ユーザーが構成員となっているグループを取得するには、ユーザーの `id` を使用してエンドポイントURI `users/USER_ID/groups` "
+"を作成します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:975
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r "
+"demorealm\n"
+msgstr ""
+"$ kcadm.sh get users/b544f379-5fc4-49e5-8a8d-5cfb71f46f53/groups -r "
+"demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:977
+#, no-wrap
+msgid "Adding user to a group"
+msgstr "ユーザーをグループに追加する"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:980
+msgid ""
+"To join user to a group use `update` operation with an endpoint uri composed"
+" from user's `id`, and group's `id` - users/USER_ID/groups/GROUP_ID."
+msgstr ""
+"ユーザーをグループに参加させるには、ユーザーの `id` とグループの `id` から構成されたエンドポイントuri "
+"`users/USER_ID/groups/GROUP_ID` で `update` 操作を使います。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:984
+#, no-wrap
+msgid ""
+"    $ kcadm.sh update users/b544f379-5fc4-49e5-8a8d-"
+"5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm -s "
+"realm=demorealm -s userId=b544f379-5fc4-49e5-8a8d-5cfb71f46f53 -s "
+"groupId=ce01117a-7426-4670-a29a-5c118056fe20 -n\n"
+msgstr ""
+"$ kcadm.sh update users/b544f379-5fc4-49e5-8a8d-"
+"5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm -s "
+"realm=demorealm -s userId=b544f379-5fc4-49e5-8a8d-5cfb71f46f53 -s "
+"groupId=ce01117a-7426-4670-a29a-5c118056fe20 -n\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:986
+#, no-wrap
+msgid "Removing user from a group"
+msgstr "グループからのユーザーの削除"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:989
+msgid ""
+"To remove user from a group use `delete` operation on the same endpoint uri "
+"as used for adding user to a group - users/USER_ID/groups/GROUP_ID."
+msgstr ""
+"ユーザーをグループから削除するには、ユーザーをグループに追加するのと同じエンドポイントuri "
+"`users/USER_ID/groups/GROUP_ID` で `delete` 操作を使用します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:993
+#, no-wrap
+msgid ""
+"    $ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-"
+"5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm\n"
+msgstr ""
+"$ kcadm.sh delete users/b544f379-5fc4-49e5-8a8d-"
+"5cfb71f46f53/groups/ce01117a-7426-4670-a29a-5c118056fe20 -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:996
+#, no-wrap
+msgid "Listing assigned, available, and effective realm roles for a group"
+msgstr "グループに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:999
+#: source/server_admin/topics/admin-cli.adoc:1025
+msgid "Use a dedicated 'get-roles' command."
+msgstr "専用の `get-roles` コマンドを使用します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1002
 msgid ""
 "To list *assigned* realm roles for the group you can specify the target "
 "group by `name` (via `--gname` option), `path` (via `--gpath` option), or "
 "`id` (via `--gid` option)."
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:953
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:960
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:963
-#: source/server_admin/topics/admin-cli.adoc:989
-msgid ""
-"To list realm roles that can still be added to the group, use `--available` "
-"option instead."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:967
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --available\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:969
-#, no-wrap
-msgid "Listing assigned, available, and effective client roles for a group"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:972
-msgid ""
-"A dedicated 'get-roles' command can be used to list for both realm roles and "
-"client roles."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:975
-msgid ""
-"To list *assigned* client roles for the user you can specify the target "
-"group by either `name` (via --gname option) or `id` (via `--gid` option), "
-"and client by either `clientId` (via `--cclientid` option) or `id` (via `--"
-"id` option)."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:979
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:986
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management --effective\n"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:993
-#, no-wrap
-msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-management --available\n"
-msgstr ""
-
-#. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:995
-#, no-wrap
-msgid "Identity Providers operations"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:998
-#, no-wrap
-msgid "Listing available identity providers"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1001
-msgid ""
-"Use `serverinfo` endpoint to list available identity providers. For example:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1003
-#, no-wrap
-msgid "    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
-msgstr ""
+"グループの *割り当てられた* レルム・ロールを一覧表示するには、対象のグループを `name` （ ` --gname` オプションで）、 "
+"`path` （ `--gpath` オプションで）、 `id` （ `--gid` オプションで）のいずれかで指定できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1006
-msgid ""
-"Note that `serverinfo` endpoint is handled similarly to `realms` endpoint in "
-"that it is not resolved into resource URI as relative to target realm."
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1008
 #, no-wrap
-msgid "Listing configured identity providers"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1011
-msgid "Use `identity-provider/instances` endpoint. For example:"
-msgstr ""
+msgid "    $ kcadm.sh get-roles -r demorealm --gname Group\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --gname Group\n"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1013
 #, no-wrap
-msgid "    $ kcadm.sh get identity-provider/instances -r demorealm --fields alias,providerId,enabled\n"
-msgstr ""
+msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1016
+#: source/server_admin/topics/admin-cli.adoc:1042
+msgid ""
+"To list realm roles that can still be added to the group, use `--available` "
+"option instead."
+msgstr "グループに追加できるレルム・ロールを一覧表示するには、代わりに `--available` オプションを使用してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1020
+#, no-wrap
+msgid "    $ kcadm.sh get-roles -r demorealm --gname Group --available\n"
+msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1015
-#, no-wrap
-msgid "Getting a specific configured identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1018
-msgid ""
-"To get a specific identity provider use an `alias` attribute of identity "
-"provider to construct an endpoint uri - `identity-provider/instances/ALIAS`."
-msgstr ""
-
-#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1022
 #, no-wrap
-msgid "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1024
-#, no-wrap
-msgid "Removing a specific configured identity provider"
-msgstr ""
+msgid "Listing assigned, available, and effective client roles for a group"
+msgstr "グループに割り当てられた、利用可能な、有効なクライアントロールの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1027
+#: source/server_admin/topics/admin-cli.adoc:1028
+msgid ""
+"To list *assigned* client roles for the user you can specify the target "
+"group by either `name` (via --gname option) or `id` (via `--gid` option), "
+"and client by either `clientId` (via `--cclientid` option) or `id` (via "
+"`--id` option)."
+msgstr ""
+"ユーザに *割り当てられた* クライアント・ロールを一覧表示するには、 `name` （ `--gname` オプションで）または `id` （ "
+"`--gid` オプションで）のいずれかで対象のグループを指定できます。 `clientId` （ `--cclientid`オプションで）または "
+"`id` （ `--id` オプションで）のどちらかでクライアントを指定できます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1032
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"management\n"
+msgstr ""
+"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"management\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1039
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"management --effective\n"
+msgstr ""
+"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"management --effective\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1046
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"management --available\n"
+msgstr ""
+"    $ kcadm.sh get-roles -r demorealm --gname Group --cclientid realm-"
+"management --available\n"
+
+#. type: Title ===
+#: source/server_admin/topics/admin-cli.adoc:1048
+#, no-wrap
+msgid "Identity Providers operations"
+msgstr "アイデンティティー・プロバイダーの操作"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1051
+#, no-wrap
+msgid "Listing available identity providers"
+msgstr "使用可能なアイデンティティー・プロバイダー の一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1054
+msgid ""
+"Use `serverinfo` endpoint to list available identity providers. For example:"
+msgstr "使用可能なアイデンティティー・プロバイダーをリストするには、 `serverinfo` エンドポイントを使用します。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1056
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
+msgstr ""
+"    $ kcadm.sh get serverinfo -r demorealm --fields 'identityProviders(*)'\n"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1059
+msgid ""
+"Note that `serverinfo` endpoint is handled similarly to `realms` endpoint in"
+" that it is not resolved relative to target realm, because it exists outside"
+" any specific realm."
+msgstr ""
+"`serverinfo`エンドポイントは` "
+"realms`エンドポイントと同様に扱われる点に注意してください。特定のレルムの外に存在するため、レルムに対して解決されません。"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1061
+#, no-wrap
+msgid "Listing configured identity providers"
+msgstr "構成済みアイデンティティー・プロバイダー の一覧表示"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1064
+msgid "Use `identity-provider/instances` endpoint. For example:"
+msgstr "`identity-provider/instances` エンドポイントを使用してください。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1066
+#, no-wrap
+msgid ""
+"    $ kcadm.sh get identity-provider/instances -r demorealm --fields "
+"alias,providerId,enabled\n"
+msgstr ""
+"$ kcadm.sh get identity-provider/instances -r demorealm --fields "
+"alias,providerId,enabled\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1068
+#, no-wrap
+msgid "Getting a specific configured identity provider"
+msgstr "特定の構成済みアイデンティティー・プロバイダーの取得"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1071
+msgid ""
+"To get a specific identity provider use `alias` attribute of identity "
+"provider to construct an endpoint uri - `identity-provider/instances/ALIAS`."
+msgstr ""
+"特定のアイデンティティー・プロバイダーを取得するには、アイデンティティー・プロバイダーの `alias` 属性を使用して、エンドポイントuri  "
+"`identity-provider/instances/ALIAS` を作成します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1075
+#, no-wrap
+msgid "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
+msgstr "    $ kcadm.sh get identity-provider/instances/facebook -r demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1077
+#, no-wrap
+msgid "Removing a specific configured identity provider"
+msgstr "特定の構成済みアイデンティティー・プロバイダーの削除"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1080
 msgid ""
 "Use `delete` operation with the same endpoint uri as for getting a specific "
 "configured identity provider. For example:"
-msgstr ""
+msgstr "特定の構成済みアイデンティティ・プロバイダーを取得する場合と同じエンドポイントuriで `delete` 操作を使用します。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1029
+#: source/server_admin/topics/admin-cli.adoc:1082
 #, no-wrap
-msgid "    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
+msgid ""
+"    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
 msgstr ""
+"    $ kcadm.sh delete identity-provider/instances/facebook -r demorealm\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1031
+#: source/server_admin/topics/admin-cli.adoc:1084
 #, no-wrap
 msgid "Configuring a Keycloak OpenID Connect identity provider"
-msgstr ""
+msgstr "Keycloak OpenID Connect アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1034
+#: source/server_admin/topics/admin-cli.adoc:1087
 msgid ""
-"For Keycloak OpenID Connect use `keycloak-oidc` as `providerId` when "
-"creating a new identity provider instance."
+"Use `keycloak-oidc` as `providerId` when creating a new identity provider "
+"instance."
 msgstr ""
+"新しいアイデンティティー・プロバイダー・インスタンスを作成するときは、 `keyIdoc` を `providerId` として使用してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1036
+#: source/server_admin/topics/admin-cli.adoc:1089
 msgid ""
 "Provide config attributes `authorizationUrl`, `tokenUrl`, `clientId`, and "
 "`clientSecret`."
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1040
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=keycloak-oidc -s providerId=keycloak-oidc -s enabled=true -s 'config.useJwksUrl=\"true\"' -s config.authorizationUrl=http://localhost:8180/auth/realms/demorealm/protocol/openid-connect/auth -s config.tokenUrl=http://localhost:8180/auth/realms/demorealm/protocol/openid-connect/token -s config.clientId=demo-oidc-provider -s config.clientSecret=secret\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1042
-#, no-wrap
-msgid "Configuring an OpenID Connect identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1046
-msgid ""
-"You configure the generic OpenID Connect provider the same way as Keycloak "
-"OpenID Connect provider, except that you set `providerId` attribute value to "
-"`oidc`."
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1048
-#, no-wrap
-msgid "Configuring a SAML 2 identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1051
-msgid ""
-"Use `saml` as `providerId` when creating a new identity provider instance. "
-"Provide `config` attributes - `singleSignOnServiceUrl`, "
-"`nameIDPolicyFormat`, and `signatureAlgorithm`."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1055
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=saml -s providerId=saml -s enabled=true -s 'config.useJwksUrl=\"true\"' -s config.singleSignOnServiceUrl=http://localhost:8180/auth/realms/saml-broker-realm/protocol/saml -s config.nameIDPolicyFormat=urn:oasis:names:tc:SAML:2.0:nameid-format:persistent -s config.signatureAlgorithm=RSA_SHA256\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1057
-#, no-wrap
-msgid "Configuring a Facebook identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1061
-msgid ""
-"Use `facebook` as `providerId` when creating a new identity provider "
-"instance. Provide `config` attributes - `clientId` and `clientSecret` as "
-"obtained from Facebook Developers application configuration page for your "
-"application."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1063
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=facebook -s providerId=facebook -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=FACEBOOK_CLIENT_ID -s config.clientSecret=FACEBOOK_CLIENT_SECRET\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1065
-#, no-wrap
-msgid "Configuring a Google identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1069
-msgid ""
-"Use `google` as `providerId` when creating a new identity provider instance. "
-"Provide `config` attributes - `clientId` and `clientSecret` as obtained from "
-"Google Developers application configuration page for your application."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1071
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=google -s providerId=google -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=GOOGLE_CLIENT_ID -s config.clientSecret=GOOGLE_CLIENT_SECRET\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1073
-#, no-wrap
-msgid "Configuring a Twitter identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1077
-msgid ""
-"Use `twitter` as `providerId` when creating a new identity provider "
-"instance. Provide `config` attributes - `clientId` and `clientSecret` as "
-"obtained from Twitter Application Management application configuration page "
-"for your application."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1079
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=google -s providerId=google -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=TWITTER_API_KEY -s config.clientSecret=TWITTER_API_SECRET\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1081
-#, no-wrap
-msgid "Configuring a GitHub identity provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1085
-msgid ""
-"Use `github` as `providerId` when creating a new identity provider instance. "
-"Provide `config` attributes - `clientId` and `clientSecret` as obtained from "
-"GitHub Developer Application Settings page for your application."
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1087
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=github -s providerId=github -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=GITHUB_CLIENT_ID -s config.clientSecret=GITHUB_CLIENT_SECRET\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1089
-#, no-wrap
-msgid "Configuring a LinkedIn identity provider"
-msgstr ""
+"設定属性 `authorizationUrl` 、 `tokenUrl` 、 `clientId` 、 `clientSecret` を提供します。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1093
+#, no-wrap
 msgid ""
-"Use `linkedin` as `providerId` when creating a new identity provider "
-"instance. Provide `config` attributes - `clientId` and `clientSecret` as "
-"obtained from LinkedIn Developer Console application page for your "
-"application."
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s alias"
+"=keycloak-oidc -s providerId=keycloak-oidc -s enabled=true -s "
+"'config.useJwksUrl=\"true\"' -s "
+"config.authorizationUrl=http://localhost:8180/auth/realms/demorealm/protocol"
+"/openid-connect/auth -s "
+"config.tokenUrl=http://localhost:8180/auth/realms/demorealm/protocol/openid-"
+"connect/token -s config.clientId=demo-oidc-provider -s "
+"config.clientSecret=secret\n"
 msgstr ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s alias"
+"=keycloak-oidc -s providerId=keycloak-oidc -s enabled=true -s "
+"'config.useJwksUrl=\"true\"' -s "
+"config.authorizationUrl=http://localhost:8180/auth/realms/demorealm/protocol"
+"/openid-connect/auth -s "
+"config.tokenUrl=http://localhost:8180/auth/realms/demorealm/protocol/openid-"
+"connect/token -s config.clientId=demo-oidc-provider -s "
+"config.clientSecret=secret\n"
 
-#. type: Plain text
+#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:1095
 #, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=linkedin -s providerId=linkedin -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=LINKEDIN_CLIENT_ID -s config.clientSecret=LINKEDIN_CLIENT_SECRET\n"
-msgstr ""
-
-#. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1097
-#, no-wrap
-msgid "Configuring a Microsoft Live identity provider"
-msgstr ""
+msgid "Configuring an OpenID Connect identity provider"
+msgstr "OpenID Connect アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1099
+msgid ""
+"You configure the generic OpenID Connect provider the same way as Keycloak "
+"OpenID Connect provider, except that you set `providerId` attribute value to"
+" `oidc`."
+msgstr ""
+"一般的なOpenID Connect プロバイダーは、 `providerId` 属性値を `oidc` に設定する点を除いて、Keycloak "
+"OpenID Connect プロバイダーと同じ方法で設定します。"
+
+#. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:1101
-msgid ""
-"Use `microsoft` as `providerId` when creating a new identity provider "
-"instance. Provide `config` attributes - `clientId` and `clientSecret` as "
-"obtained from Microsoft Application Registration Portal page for your "
-"application."
-msgstr ""
+#, no-wrap
+msgid "Configuring a SAML 2 identity provider"
+msgstr "SAML 2 アイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1103
-#, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=microsoft -s providerId=microsoft -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=MICROSOFT_APP_ID -s config.clientSecret=MICROSOFT_PASSWORD\n"
+#: source/server_admin/topics/admin-cli.adoc:1104
+msgid ""
+"Use `saml` as `providerId`. Provide `config` attributes - "
+"`singleSignOnServiceUrl`, `nameIDPolicyFormat`, and `signatureAlgorithm`."
 msgstr ""
+"`saml` を `providerId` として使用してください。 `config` 属性（ ` singleSignOnServiceUrl` 、 "
+"`nameIDPolicyFormat` 、および `signatureAlgorithm` ）を提供します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1108
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=saml"
+" -s providerId=saml -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+"config.singleSignOnServiceUrl=http://localhost:8180/auth/realms/saml-broker-"
+"realm/protocol/saml -s config.nameIDPolicyFormat=urn:oasis:names:tc:SAML:2.0"
+":nameid-format:persistent -s config.signatureAlgorithm=RSA_SHA256\n"
+msgstr ""
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=saml -s "
+"providerId=saml -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+"config.singleSignOnServiceUrl=http://localhost:8180/auth/realms/saml-broker-"
+"realm/protocol/saml -s config.nameIDPolicyFormat=urn:oasis:names:tc:SAML:2.0"
+":nameid-format:persistent -s config.signatureAlgorithm=RSA_SHA256\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1105
+#: source/server_admin/topics/admin-cli.adoc:1110
 #, no-wrap
-msgid "Configuring a StackOverflow identity provider"
-msgstr ""
+msgid "Configuring a Facebook identity provider"
+msgstr "Facebookアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1109
+#: source/server_admin/topics/admin-cli.adoc:1114
 msgid ""
-"Use `stackoverflow` as `providerId` when creating a new identity provider "
-"instance. Provide `config` attributes - `clientId`, `clientSecret` and `key` "
-"as obtained from Stack Apps OAuth page for your application."
+"Use `facebook` as `providerId`. Provide `config` attributes - `clientId` and"
+" `clientSecret` as obtained from Facebook Developers application "
+"configuration page for your application."
 msgstr ""
+"`facebook` を `providerId` として使います。アプリケーションのFacebook "
+"Developersアプリケーション設定ページから取得した `config` 属性（ `clientId` と `clientSecret` "
+"）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1111
+#: source/server_admin/topics/admin-cli.adoc:1116
 #, no-wrap
-msgid "    $ kcadm.sh create identity-provider/instances -r demorealm -s alias=stackoverflow -s providerId=stackoverflow -s enabled=true  -s 'config.useJwksUrl=\"true\"' -s config.clientId=STACKAPPS_CLIENT_ID -s config.clientSecret=STACKAPPS_CLIENT_SECRET -s config.key=STACKAPPS_KEY\n"
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=facebook -s providerId=facebook -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=FACEBOOK_CLIENT_ID -s "
+"config.clientSecret=FACEBOOK_CLIENT_SECRET\n"
 msgstr ""
-
-#. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1113
-#, no-wrap
-msgid "Storage Providers operations"
-msgstr ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=facebook -s providerId=facebook -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=FACEBOOK_CLIENT_ID -s "
+"config.clientSecret=FACEBOOK_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1115
-#, no-wrap
-msgid "Configuring a Kerberos storage provider"
-msgstr ""
-
-#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1118
-msgid ""
-"Use `create` against `user-federation/instances` endpoint. Specify "
-"`kerberos` as a value of `providerName` attribute."
-msgstr ""
+#, no-wrap
+msgid "Configuring a Google identity provider"
+msgstr "Googleアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1122
-#, no-wrap
-msgid "    $ kcadm.sh create user-federation/instances -r demorealm -s providerName=kerberos -s priority=0 -s config.debug=false -s config.allowPasswordAuthentication=true -s 'config.editMode=\"UNSYNCED\"' -s config.updateProfileFirstLogin=true -s config.allowKerberosAuthentication=true -s 'config.kerberosRealm=\"KEYCLOAK.ORG\"' -s 'config.keyTab=\"http.keytab\"' -s 'config.serverPrincipal=\"HTTP/localhost@KEYCLOAK.ORG\"'\n"
+msgid ""
+"Use `google` as `providerId`. Provide `config` attributes - `clientId` and "
+"`clientSecret` as obtained from Google Developers application configuration "
+"page for your application."
 msgstr ""
+"`google` を `providerId` として使います。アプリケーションのGoogle "
+"Developersアプリケーション設定ページから取得した `config` 属性（ `clientId` と `clientSecret` "
+"）を提供します。"
 
-#. type: Labeled list
+#. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1124
 #, no-wrap
-msgid "Configuring an LDAP user storage provider"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1127
 msgid ""
-"Use `create` against `components` endpoint. Specify `ldap` as a value of "
-"`providerId` attribute, and `org.keycloak.storage.UserStorageProvider` as "
-"value of `providerType` attribute. Provide realm `id` as value of `parentId` "
-"attribute."
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=google -s providerId=google -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=GOOGLE_CLIENT_ID -s "
+"config.clientSecret=GOOGLE_CLIENT_SECRET\n"
 msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1129
-msgid "For example, to create a Kerberos integrated LDAP provider:"
-msgstr ""
-
-#. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1131
-#, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s 'config.priority=[\"1\"]' -s 'config.fullSyncPeriod=[\"-1\"]' -s 'config.changedSyncPeriod=[\"-1\"]' -s 'config.cachePolicy=[\"DEFAULT\"]' -s config.evictionDay=[] -s config.evictionHour=[] -s config.evictionMinute=[] -s config.maxLifespan=[] -s 'config.batchSizeForSync=[\"1000\"]' -s 'config.editMode=[\"WRITABLE\"]' -s 'config.syncRegistrations=[\"false\"]' -s 'config.vendor=[\"other\"]' -s 'config.usernameLDAPAttribute=[\"uid\"]' -s 'config.rdnLDAPAttribute=[\"uid\"]' -s 'config.uuidLDAPAttribute=[\"entryUUID\"]' -s 'config.userObjectClasses=[\"inetOrgPerson, organizationalPerson\"]' -s 'config.connectionUrl=[\"ldap://localhost:10389\"]'  -s 'config.usersDn=[\"ou=People,dc=keycloak,dc=org\"]' -s 'config.authType=[\"simple\"]' -s 'config.bindDn=[\"uid=admin,ou=system\"]' -s 'config.bindCredential=[\"secret\"]' -s 'config.searchScope=[\"1\"]' -s 'config.useTruststoreSpi=[\"ldapsOnly\"]' -s 'config.connectionPooling=[\"true\"]' -s 'config.pagination=[\"true\"]' -s 'config.allowKerberosAuthentication=[\"true\"]' -s 'config.serverPrincipal=[\"HTTP/localhost@KEYCLOAK.ORG\"]' -s 'config.keyTab=[\"http.keytab\"]' -s 'config.kerberosRealm=[\"KEYCLOAK.ORG\"]' -s 'config.debug=[\"true\"]' -s 'config.useKerberosForPasswordAuthentication=[\"true\"]'\n"
-msgstr ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=google -s providerId=google -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=GOOGLE_CLIENT_ID -s "
+"config.clientSecret=GOOGLE_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1133
+#: source/server_admin/topics/admin-cli.adoc:1126
 #, no-wrap
-msgid "Removing a user storage provider instance"
-msgstr ""
+msgid "Configuring a Twitter identity provider"
+msgstr "Twitterアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1136
+#: source/server_admin/topics/admin-cli.adoc:1130
 msgid ""
-"Use storage provider instance's `id` attribute to compose an endpoint uri - "
-"`components/ID`."
+"Use `twitter` as `providerId`. Provide `config` attributes - `clientId` and "
+"`clientSecret` as obtained from Twitter Application Management application "
+"configuration page for your application."
 msgstr ""
+"`twitter` を `providerId` "
+"として使います。アプリケーションのTwitterアプリケーション管理アプリケーション設定ページから取得した `config` 属性（ "
+"`clientId` と `clientSecret` ）を提供します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1132
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=google -s providerId=google -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=TWITTER_API_KEY -s "
+"config.clientSecret=TWITTER_API_SECRET\n"
+msgstr ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=google -s providerId=google -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=TWITTER_API_KEY -s "
+"config.clientSecret=TWITTER_API_SECRET\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1134
+#, no-wrap
+msgid "Configuring a GitHub identity provider"
+msgstr "GitHubアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1138
-msgid "Perform `delete` operation against this endpoint. For example:"
+msgid ""
+"Use `github` as `providerId`. Provide `config` attributes - `clientId` and "
+"`clientSecret` as obtained from GitHub Developer Application Settings page "
+"for your application."
 msgstr ""
+"`github` を `providerId` として使います。アプリケーションのGitHub開発者アプリケーション設定ページから取得した "
+"`config` 属性（ ` clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1140
 #, no-wrap
-msgid "    $ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r demorealm\n"
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=github -s providerId=github -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=GITHUB_CLIENT_ID -s "
+"config.clientSecret=GITHUB_CLIENT_SECRET\n"
 msgstr ""
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=github "
+"-s providerId=github -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=GITHUB_CLIENT_ID -s "
+"config.clientSecret=GITHUB_CLIENT_SECRET\n"
 
 #. type: Labeled list
 #: source/server_admin/topics/admin-cli.adoc:1142
 #, no-wrap
-msgid "Triggering synchronization of all users for specific user storage provider"
-msgstr ""
+msgid "Configuring a LinkedIn identity provider"
+msgstr "LinkedInアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1146
 msgid ""
-"Use storage provider's `id` attribute to compose an endpoint uri - user-"
-"storage/ID_OF_USER_STORAGE_INSTANCE/sync Add `action=triggerFullSync` query "
-"parameter and use `create`."
+"Use `linkedin` as `providerId`. Provide `config` attributes - `clientId` and"
+" `clientSecret` as obtained from LinkedIn Developer Console application page"
+" for your application."
 msgstr ""
+"`linkedin` を `providerId` "
+"として使用してください。アプリケーションのLinkedIn開発者コンソール・アプリケーション・ページから取得した `config` 属性（ "
+"`clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1150
+#: source/server_admin/topics/admin-cli.adoc:1148
 #, no-wrap
-msgid "    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-947d6a09e1ea/sync?action=triggerFullSync\n"
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=linkedin -s providerId=linkedin -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=LINKEDIN_CLIENT_ID -s "
+"config.clientSecret=LINKEDIN_CLIENT_SECRET\n"
 msgstr ""
+"$ kcadm.sh create identity-provider/instances -r demorealm -s alias=linkedin"
+" -s providerId=linkedin -s enabled=true -s 'config.useJwksUrl=\"true\"' -s "
+"config.clientId=LINKEDIN_CLIENT_ID -s "
+"config.clientSecret=LINKEDIN_CLIENT_SECRET\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1152
+#: source/server_admin/topics/admin-cli.adoc:1150
 #, no-wrap
-msgid "Triggering synchronization of changed users for specific user storage provider"
+msgid "Configuring a Microsoft Live identity provider"
+msgstr "Microsoft Live アイデンティティー・プロバイダーの設定"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1154
+msgid ""
+"Use `microsoft` as `providerId`. Provide `config` attributes - `clientId` "
+"and `clientSecret` as obtained from Microsoft Application Registration "
+"Portal page for your application."
 msgstr ""
+"`microsoft` を `providerId` として使います。アプリケーションのMicrosoftアプリケーション登録ポータルページから取得した"
+" `config` 属性（ `clientId` と `clientSecret` ）を提供します。"
 
 #. type: Plain text
 #: source/server_admin/topics/admin-cli.adoc:1156
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=microsoft -s providerId=microsoft -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=MICROSOFT_APP_ID -s "
+"config.clientSecret=MICROSOFT_PASSWORD\n"
+msgstr ""
+"$ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=microsoft -s providerId=microsoft -s enabled=true -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=MICROSOFT_APP_ID -s "
+"config.clientSecret=MICROSOFT_PASSWORD\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1158
+#, no-wrap
+msgid "Configuring a StackOverflow identity provider"
+msgstr "StackOverflowアイデンティティー・プロバイダーの設定"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1162
+msgid ""
+"Use `stackoverflow` as `providerId`. Provide `config` attributes - "
+"`clientId`, `clientSecret` and `key` as obtained from Stack Apps OAuth page "
+"for your application."
+msgstr ""
+"`stackoverflow` を `providerId` として使用してください。アプリケーションのStack Apps "
+"OAuthページから取得した `config` 属性（ `--clientId` 、 `clientSecret` 、 `key` ）を提供します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1164
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=stackoverflow -s providerId=stackoverflow -s enabled=true  -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=STACKAPPS_CLIENT_ID -s "
+"config.clientSecret=STACKAPPS_CLIENT_SECRET -s config.key=STACKAPPS_KEY\n"
+msgstr ""
+"$ kcadm.sh create identity-provider/instances -r demorealm -s "
+"alias=stackoverflow -s providerId=stackoverflow -s enabled=true -s "
+"'config.useJwksUrl=\"true\"' -s config.clientId=STACKAPPS_CLIENT_ID -s "
+"config.clientSecret=STACKAPPS_CLIENT_SECRET -s config.key=STACKAPPS_KEY\n"
+
+#. type: Title ===
+#: source/server_admin/topics/admin-cli.adoc:1166
+#, no-wrap
+msgid "Storage Providers operations"
+msgstr "ストレージ・プロバイダーの操作"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1168
+#, no-wrap
+msgid "Configuring a Kerberos storage provider"
+msgstr "Kerberosストレージ・プロバイダーの設定"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1171
+msgid ""
+"Use `create` against `user-federation/instances` endpoint. Specify "
+"`kerberos` as a value of `providerName` attribute."
+msgstr ""
+"`user-federation/instances` エンドポイントに対して `create` を使います。 `kerberos` を "
+"`providerName` 属性の値として指定してください。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1175
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create user-federation/instances -r demorealm -s "
+"providerName=kerberos -s priority=0 -s config.debug=false -s "
+"config.allowPasswordAuthentication=true -s 'config.editMode=\"UNSYNCED\"' -s"
+" config.updateProfileFirstLogin=true -s "
+"config.allowKerberosAuthentication=true -s "
+"'config.kerberosRealm=\"KEYCLOAK.ORG\"' -s 'config.keyTab=\"http.keytab\"' "
+"-s 'config.serverPrincipal=\"HTTP/localhost@KEYCLOAK.ORG\"'\n"
+msgstr ""
+"$ kcadm.sh create user-federation/instances -r demorealm -s "
+"providerName=kerberos -s priority=0 -s config.debug=false -s "
+"config.allowPasswordAuthentication=true -s 'config.editMode=\"UNSYNCED\"' -s"
+" config.updateProfileFirstLogin=true -s "
+"config.allowKerberosAuthentication=true -s "
+"'config.kerberosRealm=\"KEYCLOAK.ORG\"' -s 'config.keyTab=\"http.keytab\"' "
+"-s 'config.serverPrincipal=\"HTTP/localhost@KEYCLOAK.ORG\"'\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1177
+#, no-wrap
+msgid "Configuring an LDAP user storage provider"
+msgstr "LDAPユーザー・ストレージ・プロバイダーの設定"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1180
+msgid ""
+"Use `create` against `components` endpoint. Specify `ldap` as a value of "
+"`providerId` attribute, and `org.keycloak.storage.UserStorageProvider` as "
+"value of `providerType` attribute. Provide realm `id` as value of `parentId`"
+" attribute."
+msgstr ""
+"`components` エンドポイントに対して `create` を使います。 `providerId` 属性の値として `ldap` を指定し、 "
+"`providerType` 属性の値として `org.keycloak.storage.UserStorageProvider` を指定します。 "
+"`parentId` 属性の値としてレルム `id` を与えます。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1182
+msgid "For example, to create a Kerberos integrated LDAP provider:"
+msgstr "たとえば、Kerberos統合LDAPプロバイダーを作成するには、次のようにします。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1184
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider"
+" -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider"
+" -s parentId=3d9c572b-8f33-483f-98a6-8bb421667867  -s "
+"'config.priority=[\"1\"]' -s 'config.fullSyncPeriod=[\"-1\"]' -s "
+"'config.changedSyncPeriod=[\"-1\"]' -s 'config.cachePolicy=[\"DEFAULT\"]' -s"
+" config.evictionDay=[] -s config.evictionHour=[] -s config.evictionMinute=[]"
+" -s config.maxLifespan=[] -s 'config.batchSizeForSync=[\"1000\"]' -s "
+"'config.editMode=[\"WRITABLE\"]' -s 'config.syncRegistrations=[\"false\"]' "
+"-s 'config.vendor=[\"other\"]' -s 'config.usernameLDAPAttribute=[\"uid\"]' "
+"-s 'config.rdnLDAPAttribute=[\"uid\"]' -s "
+"'config.uuidLDAPAttribute=[\"entryUUID\"]' -s "
+"'config.userObjectClasses=[\"inetOrgPerson, organizationalPerson\"]' -s "
+"'config.connectionUrl=[\"ldap://localhost:10389\"]'  -s "
+"'config.usersDn=[\"ou=People,dc=keycloak,dc=org\"]' -s "
+"'config.authType=[\"simple\"]' -s 'config.bindDn=[\"uid=admin,ou=system\"]' "
+"-s 'config.bindCredential=[\"secret\"]' -s 'config.searchScope=[\"1\"]' -s "
+"'config.useTruststoreSpi=[\"ldapsOnly\"]' -s "
+"'config.connectionPooling=[\"true\"]' -s 'config.pagination=[\"true\"]' -s "
+"'config.allowKerberosAuthentication=[\"true\"]' -s "
+"'config.serverPrincipal=[\"HTTP/localhost@KEYCLOAK.ORG\"]' -s "
+"'config.keyTab=[\"http.keytab\"]' -s "
+"'config.kerberosRealm=[\"KEYCLOAK.ORG\"]' -s 'config.debug=[\"true\"]' -s "
+"'config.useKerberosForPasswordAuthentication=[\"true\"]'\n"
+msgstr ""
+"$ kcadm.sh create components -r demorealm -s name=kerberos-ldap-provider -s "
+"providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s "
+"parentId=3d9c572b-8f33-483f-98a6-8bb421667867 -s 'config.priority=[\"1\"]' "
+"-s 'config.fullSyncPeriod=[\"-1\"]' -s 'config.changedSyncPeriod=[\"-1\"]' "
+"-s 'config.cachePolicy=[\"DEFAULT\"]' -s config.evictionDay=[] -s "
+"config.evictionHour=[] -s config.evictionMinute=[] -s config.maxLifespan=[] "
+"-s 'config.batchSizeForSync=[\"1000\"]' -s 'config.editMode=[\"WRITABLE\"]' "
+"-s 'config.syncRegistrations=[\"false\"]' -s 'config.vendor=[\"other\"]' -s "
+"'config.usernameLDAPAttribute=[\"uid\"]' -s "
+"'config.rdnLDAPAttribute=[\"uid\"]' -s "
+"'config.uuidLDAPAttribute=[\"entryUUID\"]' -s "
+"'config.userObjectClasses=[\"inetOrgPerson, organizationalPerson\"]' -s "
+"'config.connectionUrl=[\"ldap://localhost:10389\"]' -s "
+"'config.usersDn=[\"ou=People,dc=keycloak,dc=org\"]' -s "
+"'config.authType=[\"simple\"]' -s 'config.bindDn=[\"uid=admin,ou=system\"]' "
+"-s 'config.bindCredential=[\"secret\"]' -s 'config.searchScope=[\"1\"]' -s "
+"'config.useTruststoreSpi=[\"ldapsOnly\"]' -s "
+"'config.connectionPooling=[\"true\"]' -s 'config.pagination=[\"true\"]' -s "
+"'config.allowKerberosAuthentication=[\"true\"]' -s "
+"'config.serverPrincipal=[\"HTTP/localhost@KEYCLOAK.ORG\"]' -s "
+"'config.keyTab=[\"http.keytab\"]' -s "
+"'config.kerberosRealm=[\"KEYCLOAK.ORG\"]' -s 'config.debug=[\"true\"]' -s "
+"'config.useKerberosForPasswordAuthentication=[\"true\"]'\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1186
+#, no-wrap
+msgid "Removing a user storage provider instance"
+msgstr "ユーザー・ストレージ・プロバイダー・インスタンスの削除"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1189
+msgid ""
+"Use storage provider instance's `id` attribute to compose an endpoint uri - "
+"`components/ID`."
+msgstr "ストレージ・プロバイダー・インスタンスの `id` 属性を使用して、エンドポイントuri  `components/ID` を作成します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1191
+msgid "Perform `delete` operation against this endpoint. For example:"
+msgstr "このエンドポイントに対して `delete` 操作を実行します。例えば："
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1193
+#, no-wrap
+msgid ""
+"    $ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r "
+"demorealm\n"
+msgstr ""
+"$ kcadm.sh delete components/3d9c572b-8f33-483f-98a6-8bb421667867 -r "
+"demorealm\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1195
+#, no-wrap
+msgid ""
+"Triggering synchronization of all users for specific user storage provider"
+msgstr "特定のユーザー・ストレージ・プロバイダーに対してすべてのユーザーの同期をトリガーする"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1199
+msgid ""
+"Use storage provider's `id` attribute to compose an endpoint uri - user-"
+"storage/ID_OF_USER_STORAGE_INSTANCE/sync Add `action=triggerFullSync` query "
+"parameter and perform `create` command."
+msgstr ""
+"ストレージ・プロバイダーの `id` 属性を使用してエンドポイントuri `user-"
+"storage/ID_OF_USER_STORAGE_INSTANCE/sync` を作成します。 `action=triggerFullSync` "
+"クエリ・パラメーターを追加し、 `create` コマンドを実行します。"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1203
+#, no-wrap
+msgid ""
+"    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
+"947d6a09e1ea/sync?action=triggerFullSync\n"
+msgstr ""
+"$ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
+"947d6a09e1ea/sync?action=triggerFullSync\n"
+
+#. type: Labeled list
+#: source/server_admin/topics/admin-cli.adoc:1205
+#, no-wrap
+msgid ""
+"Triggering synchronization of changed users for specific user storage "
+"provider"
+msgstr "特定のユーザー・ストレージ・プロバイダーの変更されたユーザーの同期をトリガーする"
+
+#. type: Plain text
+#: source/server_admin/topics/admin-cli.adoc:1209
 msgid ""
 "Use storage provider's `id` attribute to compose an endpoint uri - user-"
 "storage/ID_OF_USER_STORAGE_INSTANCE/sync Add "
 "`action=triggerChangedUsersSync` query parameter and use `create`."
 msgstr ""
+"ストレージ・プロバイダーの `id` 属性を使用してエンドポイントuri `user-"
+"storage/ID_OF_USER_STORAGE_INSTANCE/sync` を作成します。 "
+"`action=triggerChangedUsersSync` クエリー・パラメーターを追加し、 `create` コマンドを実行します。 "
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1160
+#: source/server_admin/topics/admin-cli.adoc:1213
 #, no-wrap
-msgid "    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-947d6a09e1ea/sync?action=triggerChangedUsersSync\n"
+msgid ""
+"    $ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
+"947d6a09e1ea/sync?action=triggerChangedUsersSync\n"
 msgstr ""
+"$ kcadm.sh create user-storage/b7c63d02-b62a-4fc1-977c-"
+"947d6a09e1ea/sync?action=triggerChangedUsersSync\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1162
+#: source/server_admin/topics/admin-cli.adoc:1215
 #, no-wrap
 msgid "Test LDAP user storage connectivity"
-msgstr ""
+msgstr "LDAPユーザー・ストレージの接続をテストする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1165
+#: source/server_admin/topics/admin-cli.adoc:1218
 msgid ""
-"Perform `get` operation against `testLDAPConnection` endpoint. Provide query "
+"Perform `get` operation on `testLDAPConnection` endpoint. Provide query "
 "parameters `bindCredential`, `bindDn`, `connectionUrl`, and "
 "`useTruststoreSpi`, and set `action` query parameter to `testConnection`."
 msgstr ""
+"`testLDAPConnection` エンドポイントで `get` 操作を行います。クエリー・パラメータ ー `bindCredential` 、 "
+"`bindDn` 、 `connectionUrl` 、 `useTruststoreSpi` を指定し、 `action` クエリー・パラメーターを "
+"`testConnection` に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1169
+#: source/server_admin/topics/admin-cli.adoc:1222
 #, no-wrap
-msgid "    $ kcadm.sh get testLDAPConnection -q action=testConnection -q bindCredential=secret -q bindDn=uid=admin,ou=system -q connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
+msgid ""
+"    $ kcadm.sh get testLDAPConnection -q action=testConnection -q "
+"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
+"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 msgstr ""
+"$ kcadm.sh get testLDAPConnection -q action=testConnection -q "
+"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
+"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1171
+#: source/server_admin/topics/admin-cli.adoc:1224
 #, no-wrap
 msgid "Test LDAP user storage authentication"
-msgstr ""
+msgstr "LDAPユーザー・ストレージ認証をテストする"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1174
+#: source/server_admin/topics/admin-cli.adoc:1227
 msgid ""
-"Perform `get` operation against `testLDAPConnection` endpoint. Provide query "
+"Perform `get` operation on `testLDAPConnection` endpoint. Provide query "
 "parameters `bindCredential`, `bindDn`, `connectionUrl`, and "
-"`useTruststoreSpi`, and set `action` query parameter to `testAuthentication`."
+"`useTruststoreSpi`, and set `action` query parameter to "
+"`testAuthentication`."
 msgstr ""
+"`testLDAPConnection` エンドポイントで `get` 操作を行います。クエリー・パラメーター `bindCredential` 、 "
+"`bindDn` 、 `connectionUrl` 、 `useTruststoreSpi` を指定し、 `action` クエリー・パラメーターを "
+"`testAuthentication` に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1178
+#: source/server_admin/topics/admin-cli.adoc:1231
 #, no-wrap
-msgid "    $ kcadm.sh get testLDAPConnection -q action=testAuthentication -q bindCredential=secret -q bindDn=uid=admin,ou=system -q connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
+msgid ""
+"    $ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
+"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
+"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 msgstr ""
+"    $ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
+"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
+"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1181
+#: source/server_admin/topics/admin-cli.adoc:1234
 #, no-wrap
 msgid "Adding mappers"
-msgstr ""
+msgstr "マッパーの追加"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1183
+#: source/server_admin/topics/admin-cli.adoc:1236
 #, no-wrap
 msgid "Adding a hardcoded role LDAP mapper"
-msgstr ""
+msgstr "ハードコードされたロールLDAPマッパー"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1187
+#: source/server_admin/topics/admin-cli.adoc:1240
 msgid ""
-"Use `create` against `components` endpoint. Set `providerType` attribute to "
+"Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
 "attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
 "`hardcoded-ldap-role-mapper`. Make sure to provide a value of `role` config "
 "parameter."
 msgstr ""
+"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
+"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
+"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `hardcoded-ldap-role-"
+"mapper` を設定してください。必ず `role` 設定パラメーターの値を指定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1191
+#: source/server_admin/topics/admin-cli.adoc:1244
 #, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=hardcoded-ldap-role-mapper -s providerId=hardcoded-ldap-role-mapper -s providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.role=[\"realm-management.create-client\"]'\n"
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=hardcoded-ldap-role-"
+"mapper -s providerId=hardcoded-ldap-role-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.role=[\"realm-"
+"management.create-client\"]'\n"
 msgstr ""
+"$ kcadm.sh create components -r demorealm -s name=hardcoded-ldap-role-mapper"
+" -s providerId=hardcoded-ldap-role-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.role=[\"realm-"
+"management.create-client\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1193
+#: source/server_admin/topics/admin-cli.adoc:1246
 #, no-wrap
 msgid "Adding a MS Active Directory mapper"
-msgstr ""
+msgstr "MS Active Directoryマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1197
+#: source/server_admin/topics/admin-cli.adoc:1250
 msgid ""
-"Use `create` against `components` endpoint. Set `providerType` attribute to "
+"Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
 "attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
 "`msad-user-account-control-mapper`."
 msgstr ""
+"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
+"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
+"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `msad-user-account-"
+"control-mapper` を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1201
+#: source/server_admin/topics/admin-cli.adoc:1254
 #, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=msad-user-account-control-mapper -s providerId=msad-user-account-control-mapper -s providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea\n"
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=msad-user-account-"
+"control-mapper -s providerId=msad-user-account-control-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea\n"
 msgstr ""
+"$ kcadm.sh create components -r demorealm -s name=msad-user-account-control-"
+"mapper -s providerId=msad-user-account-control-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1203
+#: source/server_admin/topics/admin-cli.adoc:1256
 #, no-wrap
-msgid "Adding a user attribute LDAP mapper"
-msgstr ""
+msgid "Adding an user attribute LDAP mapper"
+msgstr "ユーザー属性LDAPマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1207
+#: source/server_admin/topics/admin-cli.adoc:1260
 msgid ""
-"Use `create` against `components` endpoint. Set `providerType` attribute to "
+"Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
 "attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
 "`user-attribute-ldap-mapper`."
 msgstr ""
+"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
+"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
+"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `user-attribute-ldap-"
+"mapper` を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1211
+#: source/server_admin/topics/admin-cli.adoc:1264
 #, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-mapper -s providerId=user-attribute-ldap-mapper -s providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"user.model.attribute\"=[\"email\"]' -s 'config.\"ldap.attribute\"=[\"mail\"]' -s 'config.\"read.only\"=[\"false\"]' -s 'config.\"always.read.value.from.ldap\"=[\"false\"]' -s 'config.\"is.mandatory.in.ldap\"=[\"false\"]'\n"
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-"
+"mapper -s providerId=user-attribute-ldap-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
+"'config.\"user.model.attribute\"=[\"email\"]' -s "
+"'config.\"ldap.attribute\"=[\"mail\"]' -s 'config.\"read.only\"=[\"false\"]'"
+" -s 'config.\"always.read.value.from.ldap\"=[\"false\"]' -s "
+"'config.\"is.mandatory.in.ldap\"=[\"false\"]'\n"
 msgstr ""
+"    $ kcadm.sh create components -r demorealm -s name=user-attribute-ldap-"
+"mapper -s providerId=user-attribute-ldap-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
+"'config.\"user.model.attribute\"=[\"email\"]' -s "
+"'config.\"ldap.attribute\"=[\"mail\"]' -s 'config.\"read.only\"=[\"false\"]'"
+" -s 'config.\"always.read.value.from.ldap\"=[\"false\"]' -s "
+"'config.\"is.mandatory.in.ldap\"=[\"false\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1213
+#: source/server_admin/topics/admin-cli.adoc:1266
 #, no-wrap
 msgid "Adding a group LDAP mapper"
-msgstr ""
+msgstr "Adding a group LDAP mapper"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1217
+#: source/server_admin/topics/admin-cli.adoc:1270
 msgid ""
-"Use `create` against `components` endpoint. Set `providerType` attribute to "
+"Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
 "attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
 "`group-ldap-mapper`."
 msgstr ""
+"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
+"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
+"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性を `group-ldap-mapper` "
+"に設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1221
+#: source/server_admin/topics/admin-cli.adoc:1274
 #, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s providerId=group-ldap-mapper -s providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"groups.dn\"=[]' -s 'config.\"group.name.ldap.attribute\"=[\"cn\"]' -s 'config.\"group.object.classes\"=[\"groupOfNames\"]' -s 'config.\"preserve.group.inheritance\"=[\"true\"]' -s 'config.\"membership.ldap.attribute\"=[\"member\"]' -s 'config.\"membership.attribute.type\"=[\"DN\"]' -s 'config.\"groups.ldap.filter\"=[]' -s 'config.mode=[\"LDAP_ONLY\"]' -s 'config.\"user.roles.retrieve.strategy\"=[\"LOAD_GROUPS_BY_MEMBER_ATTRIBUTE\"]' -s 'config.\"mapped.group.attributes\"=[\"admins-group\"]' -s 'config.\"drop.non.existing.groups.during.sync\"=[\"false\"]' -s 'config.roles=[\"admins\"]' -s 'config.groups=[\"admins-group\"]' -s 'config.group=[]' -s 'config.preserve=[\"true\"]' -s 'config.membership=[\"member\"]'\n"
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
+"providerId=group-ldap-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"groups.dn\"=[]' "
+"-s 'config.\"group.name.ldap.attribute\"=[\"cn\"]' -s "
+"'config.\"group.object.classes\"=[\"groupOfNames\"]' -s "
+"'config.\"preserve.group.inheritance\"=[\"true\"]' -s "
+"'config.\"membership.ldap.attribute\"=[\"member\"]' -s "
+"'config.\"membership.attribute.type\"=[\"DN\"]' -s "
+"'config.\"groups.ldap.filter\"=[]' -s 'config.mode=[\"LDAP_ONLY\"]' -s "
+"'config.\"user.roles.retrieve.strategy\"=[\"LOAD_GROUPS_BY_MEMBER_ATTRIBUTE\"]'"
+" -s 'config.\"mapped.group.attributes\"=[\"admins-group\"]' -s "
+"'config.\"drop.non.existing.groups.during.sync\"=[\"false\"]' -s "
+"'config.roles=[\"admins\"]' -s 'config.groups=[\"admins-group\"]' -s "
+"'config.group=[]' -s 'config.preserve=[\"true\"]' -s "
+"'config.membership=[\"member\"]'\n"
 msgstr ""
+"    $ kcadm.sh create components -r demorealm -s name=group-ldap-mapper -s "
+"providerId=group-ldap-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"groups.dn\"=[]' "
+"-s 'config.\"group.name.ldap.attribute\"=[\"cn\"]' -s "
+"'config.\"group.object.classes\"=[\"groupOfNames\"]' -s "
+"'config.\"preserve.group.inheritance\"=[\"true\"]' -s "
+"'config.\"membership.ldap.attribute\"=[\"member\"]' -s "
+"'config.\"membership.attribute.type\"=[\"DN\"]' -s "
+"'config.\"groups.ldap.filter\"=[]' -s 'config.mode=[\"LDAP_ONLY\"]' -s "
+"'config.\"user.roles.retrieve.strategy\"=[\"LOAD_GROUPS_BY_MEMBER_ATTRIBUTE\"]'"
+" -s 'config.\"mapped.group.attributes\"=[\"admins-group\"]' -s "
+"'config.\"drop.non.existing.groups.during.sync\"=[\"false\"]' -s "
+"'config.roles=[\"admins\"]' -s 'config.groups=[\"admins-group\"]' -s "
+"'config.group=[]' -s 'config.preserve=[\"true\"]' -s "
+"'config.membership=[\"member\"]'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1223
+#: source/server_admin/topics/admin-cli.adoc:1276
 #, no-wrap
 msgid "Adding a full name LDAP mapper"
-msgstr ""
+msgstr "フルネームLDAPマッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1227
+#: source/server_admin/topics/admin-cli.adoc:1280
 msgid ""
-"Use `create` against `components` endpoint. Set `providerType` attribute to "
+"Use `create` on `components` endpoint. Set `providerType` attribute to "
 "`org.keycloak.storage.ldap.mappers.LDAPStorageMapper`. Set `parentId` "
 "attribute to `id` of LDAP provider instance.  Set `providerId` attribute to "
 "`full-name-ldap-mapper`."
 msgstr ""
+"`components` エンドポイントで `create` を使います。 `providerType` 属性に "
+"`org.keycloak.storage.ldap.mappers.LDAPStorageMapper` を設定してください。 `parentId` "
+"属性にLDAPプロバイダー・インスタンスの `id` を設定してください。 `providerId` 属性に `full-name-ldap-"
+"mapper` を設定してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1231
+#: source/server_admin/topics/admin-cli.adoc:1284
 #, no-wrap
-msgid "    $ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper -s providerId=full-name-ldap-mapper -s providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s 'config.\"ldap.full.name.attribute\"=[\"cn\"]' -s 'config.\"read.only\"=[\"false\"]' -s 'config.\"write.only\"=[\"true\"]'\n"
+msgid ""
+"    $ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper "
+"-s providerId=full-name-ldap-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
+"'config.\"ldap.full.name.attribute\"=[\"cn\"]' -s "
+"'config.\"read.only\"=[\"false\"]' -s 'config.\"write.only\"=[\"true\"]'\n"
 msgstr ""
+"    $ kcadm.sh create components -r demorealm -s name=full-name-ldap-mapper "
+"-s providerId=full-name-ldap-mapper -s "
+"providerType=org.keycloak.storage.ldap.mappers.LDAPStorageMapper -s "
+"parentId=b7c63d02-b62a-4fc1-977c-947d6a09e1ea -s "
+"'config.\"ldap.full.name.attribute\"=[\"cn\"]' -s "
+"'config.\"read.only\"=[\"false\"]' -s 'config.\"write.only\"=[\"true\"]'\n"
 
 #. type: Title ===
-#: source/server_admin/topics/admin-cli.adoc:1234
+#: source/server_admin/topics/admin-cli.adoc:1287
 #, no-wrap
 msgid "Authentication operations"
-msgstr ""
+msgstr "認証の操作"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1237
+#: source/server_admin/topics/admin-cli.adoc:1290
 #, no-wrap
 msgid "Setting a password policy"
-msgstr ""
+msgstr "パスワード・ポリシーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1240
+#: source/server_admin/topics/admin-cli.adoc:1293
 msgid ""
-"Set realm's `passwordPolicy` attribute to an enumeration expression "
-"including specific policy provider id, and an optional configuration:"
-msgstr ""
+"Set realm's `passwordPolicy` attribute to enumeration expression that "
+"includes the specific policy provider id, and optional configuration."
+msgstr "レルムの `passwordPolicy` 属性を、特定のポリシー・プロバイダー・IDとオプションの設定を含む列挙式に設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1243
+#: source/server_admin/topics/admin-cli.adoc:1296
 msgid ""
-"For example, to set password policy to 20000 hash iterations, requiring at "
-"least one special character, at least one uppercase character, at least one "
-"digit character, not be equal to user's `username`, and be at least 8 "
-"characters long you would use the following:"
+"For example, to set password policy to default values - i.e.: 27500 hashing "
+"iterations, requiring at least one special character, at least one uppercase"
+" character, at least one digit character, not be equal to user's `username`,"
+" and be at least 8 characters long you would use the following:"
 msgstr ""
+"たとえば、パスワード・ポリシーをデフォルト値（27500ハッシュ反復、少なくとも1つの特殊文字、少なくとも1つの大文字、少なくとも1つの数字文字、ユーザーの"
+" `username` と等しくなく、少なくとも8文字の長さ）に設定するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1245
+#: source/server_admin/topics/admin-cli.adoc:1298
 #, no-wrap
-msgid "    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations and specialChars and upperCase and digits and notUsername and length\"'\n"
+msgid ""
+"    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations "
+"and specialChars and upperCase and digits and notUsername and length\"'\n"
 msgstr ""
+"    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations "
+"and specialChars and upperCase and digits and notUsername and length\"'\n"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1247
+#: source/server_admin/topics/admin-cli.adoc:1300
 msgid ""
 "If you want want to use values different from defaults, pass configuration "
 "in brackets."
-msgstr ""
+msgstr "デフォルトと異なる値を使用する場合は、括弧で設定を渡します。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1249
+#: source/server_admin/topics/admin-cli.adoc:1302
 msgid ""
 "For example, to set password policy to 25000 hash iterations, requiring at "
 "least two special characters, at least two uppercase characters, at least "
@@ -2966,51 +3915,59 @@ msgid ""
 "long, not be equal to user's username, and not repeat for at least four "
 "changes back:"
 msgstr ""
+"たとえば、パスワードポリシーを25000ハッシュ反復、少なくとも2つの特殊文字、少なくとも2つ以上の大文字、少なくとも2つ以上の小文字、少なくとも2つ以上の数字、少なくとも9文字の長さ、ユーザー名と等しくなく、過去4回の変更と一致しない、に設定するには、次のようにします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1251
+#: source/server_admin/topics/admin-cli.adoc:1304
 #, no-wrap
-msgid "    $ kcadm.sh update realms/demorealm -s 'passwordPolicy=\"hashIterations(25000) and specialChars(2) and upperCase(2) and lowerCase(2) and digits(2) and length(9) and notUsername and passwordHistory(4)\"'\n"
+msgid ""
+"    $ kcadm.sh update realms/demorealm -s "
+"'passwordPolicy=\"hashIterations(25000) and specialChars(2) and upperCase(2)"
+" and lowerCase(2) and digits(2) and length(9) and notUsername and "
+"passwordHistory(4)\"'\n"
 msgstr ""
+"    $ kcadm.sh update realms/demorealm -s "
+"'passwordPolicy=\"hashIterations(25000) and specialChars(2) and upperCase(2)"
+" and lowerCase(2) and digits(2) and length(9) and notUsername and "
+"passwordHistory(4)\"'\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1253
+#: source/server_admin/topics/admin-cli.adoc:1306
 #, no-wrap
 msgid "Getting the current password policy"
-msgstr ""
+msgstr "現在のパスワード・ポリシーの取得"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1256
+#: source/server_admin/topics/admin-cli.adoc:1309
 msgid ""
 "Get current realm configuration and filter out everything but "
 "`passwordPolicy` attribute."
-msgstr ""
+msgstr "現在のレルムの設定を取得し、 `passwordPolicy` 属性以外のすべてをフィルタリングします。"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1258
+#: source/server_admin/topics/admin-cli.adoc:1311
 msgid "For example, to display `passwordPolicy` for demorealm:"
-msgstr ""
+msgstr "例えば、demorealmの `passwordPolicy` を表示するには："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1260
+#: source/server_admin/topics/admin-cli.adoc:1313
 #, no-wrap
 msgid "    $ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
-msgstr ""
+msgstr "    $ kcadm.sh get realms/demorealm --fields passwordPolicy\n"
 
 #. type: Labeled list
-#: source/server_admin/topics/admin-cli.adoc:1262
+#: source/server_admin/topics/admin-cli.adoc:1315
 #, no-wrap
 msgid "Listing authentication flows"
-msgstr ""
+msgstr "認証フローの一覧表示"
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1265
-msgid ""
-"Use `get` operation against `authentication/flows` endpoint. For example:"
-msgstr ""
+#: source/server_admin/topics/admin-cli.adoc:1318
+msgid "Use `get` operation on `authentication/flows` endpoint. For example:"
+msgstr "`authentication/flows` エンドポイントで `get` 操作を使います。例えば："
 
 #. type: Plain text
-#: source/server_admin/topics/admin-cli.adoc:1267
+#: source/server_admin/topics/admin-cli.adoc:1320
 #, no-wrap
 msgid "    $ kcadm.sh get authentication/flows -r demorealm\n"
-msgstr ""
+msgstr "    $ kcadm.sh get authentication/flows -r demorealm\n"

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -75,7 +75,7 @@ msgid ""
 "use the client from any location on your file system."
 msgstr ""
 "{project_name}サーバー・ディレクトリーを [filename]`PATH` "
-"に追加することで、ファイル・システム上の任意の場所からクライアントを使用することができます。"
+"に追加することで、ファイルシステム上の任意の場所からクライアントを使用することができます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -250,7 +250,7 @@ msgid ""
 "private configuration file. See <<_working_with_alternative_configurations, "
 "next chapter>> for more information on the configuration file."
 msgstr ""
-"このアプローチは、取得したアクセス・トークンと関連するリフレッシュ・トークンを保存することによって、 [command]`kcadm` "
+"このアプローチは、取得したアクセストークンと関連するリフレッシュ・トークンを保存することによって、 [command]`kcadm` "
 "コマンドの呼び出し間で認証されたセッションを維持します。また、プライベート設定ファイルに他のシークレットを保持することもできます。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
 " 次の章>>を参照してください。"
 
@@ -325,7 +325,7 @@ msgid ""
 "are created automatically with proper access limits. If the directory "
 "already exists, its permissions are not updated."
 msgstr ""
-"システム上の他のユーザーが設定ファイルを参照できないようにしてください。プライベートにしておくべきアクセス・トークンとシークレットが含まれています。デフォルトでは、[filename]`~/.keycloak`"
+"システム上の他のユーザーが設定ファイルを参照できないようにしてください。プライベートにしておくべきアクセストークンとシークレットが含まれています。デフォルトでは、[filename]`~/.keycloak`"
 " ディレクトリーとその内容は適切なアクセス制限で自動的に作成されます。ディレクトリーが既に存在する場合、そのパーミッションは更新されません。"
 
 #. type: Plain text
@@ -1167,14 +1167,14 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Listing realm roles"
-msgstr "レルム・ロールの一覧表示"
+msgstr "レルムロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use the [command]`get` command on the [filename]`roles` endpoint to list "
 "existing realm roles."
 msgstr ""
-"[filename]`roles` エンドポイントで [command]`get` コマンドを使用して、既存のレルム・ロール一覧を取得します。"
+"[filename]`roles` エンドポイントで [command]`get` コマンドを使用して、既存のレルムロール一覧を取得します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1193,7 +1193,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm\n"
 #. type: Title ====
 #, no-wrap
 msgid "Listing client roles"
-msgstr "クライアント・ロールの一覧表示"
+msgstr "クライアントロールの一覧表示"
 
 #. type: Plain text
 msgid ""
@@ -1201,7 +1201,7 @@ msgid ""
 "and client roles. It is an extension of the [command]`get` command and "
 "behaves the same with additional semantics for listing roles."
 msgstr ""
-"レルム・ロールとクライアント・ロールを一覧表示するための専用の [command]`get-roles` コマンドがあります。これは[command] "
+"レルムロールとクライアントロールを一覧表示するための専用の [command]`get-roles` コマンドがあります。これは[command] "
 "`get`コマンドの拡張です。"
 
 #. type: Plain text
@@ -1210,8 +1210,8 @@ msgid ""
 "attribute (via the [command]`--cclientid` option) or [command]`id` (via the "
 "[command]`--cid` option) to identify the client to list client roles."
 msgstr ""
-"クライアント・ロールを一覧表示するには、[command]`get-roles` コマンドを使用します。 [command] `clientId` "
-"または [command] `id` 属性を渡すことで（ [command]`--cclientid` または [command]`--cid` "
+"クライアントロールを一覧表示するには、[command]`get-roles` コマンドを使用します。 [command] `clientId` または"
+" [command] `id` 属性を渡すことで（ [command]`--cclientid` または [command]`--cid` "
 "オプションを介して）、クライアントを指定します。"
 
 #. type: delimited block -
@@ -1222,7 +1222,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm --cclientid realm-management\n"
 #. type: Title ====
 #, no-wrap
 msgid "Getting a specific realm role"
-msgstr "特定のレルム・ロールを取得する"
+msgstr "特定のレルムロールを取得する"
 
 #. type: Plain text
 msgid ""
@@ -1230,8 +1230,8 @@ msgid ""
 " endpoint URI for a specific realm role: [filename]`roles/ROLE_NAME`, where "
 "[filename]`user` is the name of the existing role."
 msgstr ""
-"[filename]`roles/ROLE_NAME` のように特定のレルム・ロールのエンドポイントURIを構築するには、 [command]`get`"
-" コマンドとロール [filename]`name` を使用します。ここで、 [filename]`user`は既存のロールです。"
+"[filename]`roles/ROLE_NAME` のように特定のレルムロールのエンドポイントURIを構築するには、 [command]`get` "
+"コマンドとロール [filename]`name` を使用します。ここで、 [filename]`user`は既存のロールです。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1266,7 +1266,7 @@ msgid ""
 "[command]`--roleid`) to identify a specific client role."
 msgstr ""
 "専用の[command]`get-roles` "
-"コマンドを使用します。クライアントを識別するためにclientId属性（[command]`--cclientid`オプションで）またはID（[command]`--cid`オプションで）を渡し、クライアント・ロールを識別するためにロール名（[command]`--rolename`オプションで）またはID（[command]`--roleid`で）を渡します。"
+"コマンドを使用します。クライアントを識別するためにclientId属性（[command]`--cclientid`オプションで）またはID（[command]`--cid`オプションで）を渡し、クライアントロールを識別するためにロール名（[command]`--rolename`オプションで）またはID（[command]`--roleid`で）を渡します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1280,14 +1280,14 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Updating a realm role"
-msgstr "レルム・ロールの更新"
+msgstr "レルムロールの更新"
 
 #. type: Plain text
 msgid ""
 "Use the [command]`update` command with the same endpoint URI that you used "
 "to get a specific realm role."
 msgstr ""
-"特定のレルム・ロールを取得するために使用したものと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
+"特定のレルムロールを取得するために使用したものと同じエンドポイントURIを指定して [command]`update` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1301,7 +1301,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Updating a client role"
-msgstr "クライアント・ロールの更新"
+msgstr "クライアントロールの更新"
 
 #. type: Plain text
 msgid ""
@@ -1321,7 +1321,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Deleting a realm role"
-msgstr "レルム・ロールの削除"
+msgstr "レルムロールの削除"
 
 #. type: Plain text
 msgid ""
@@ -1338,14 +1338,14 @@ msgstr "$ kcadm.sh delete roles/user -r demorealm\n"
 #. type: Title ====
 #, no-wrap
 msgid "Deleting a client role"
-msgstr "クライアント・ロールの削除"
+msgstr "クライアントロールの削除"
 
 #. type: Plain text
 msgid ""
 "Use the [command]`delete` command with the same endpoint URI that you used "
 "to get a specific client role."
 msgstr ""
-"特定のクライアント・ロールを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
+"特定のクライアントロールを取得するために使用したものと同じエンドポイントURIを持つ [command]`delete` コマンドを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1466,7 +1466,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Adding realm roles to a composite role"
-msgstr "レルム・ロールを複合ロールに追加する"
+msgstr "レルムロールを複合ロールに追加する"
 
 #. type: Plain text
 msgid ""
@@ -1488,13 +1488,13 @@ msgstr "$ kcadm.sh add-roles --rname testrole --rolename user -r demorealm\n"
 #. type: Title ====
 #, no-wrap
 msgid "Removing realm roles from a composite role"
-msgstr "複合ロールからレルム・ロールを削除する"
+msgstr "複合ロールからレルムロールを削除する"
 
 #. type: Plain text
 msgid ""
 "There is a dedicated [command]`remove-roles` command that can be used to "
 "remove realm roles and client roles."
-msgstr "レルムロールとクライアント・ロールを削除するための専用の [command]`remove-roles` コマンドがあります。"
+msgstr "レルムロールとクライアントロールを削除するための専用の [command]`remove-roles` コマンドがあります。"
 
 #. type: Plain text
 msgid ""
@@ -1510,13 +1510,13 @@ msgstr "$ kcadm.sh remove-roles --rname testrole --rolename user -r demorealm\n"
 #. type: Title ====
 #, no-wrap
 msgid "Adding client roles to a realm role"
-msgstr "レルム・ロールへのクライアント・ロールの追加"
+msgstr "レルムロールへのクライアントロールの追加"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`add-roles` command that can be used for adding "
 "realm roles and client roles."
-msgstr "レルム・ロールとクライアン・トロールを追加するために使用できる専用の [command]`add-roles` コマンドを使用します。"
+msgstr "レルムロールとクライアントロールを追加するために使用できる専用の [command]`add-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -1539,13 +1539,13 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Adding client roles to a client role"
-msgstr "クライアント・ロールへのクライアント・ロールの追加"
+msgstr "クライアントロールへのクライアントロールの追加"
 
 #. type: Plain text
 msgid ""
 "Determine the ID of the composite client role by using the [command]`get-"
 "roles` command."
-msgstr "[command]`get-roles` コマンドを使用して複合クライアント・ロールのIDを特定します。"
+msgstr "[command]`get-roles` コマンドを使用して複合クライアントロールのIDを特定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1564,7 +1564,7 @@ msgid ""
 "ID of \"fc400897-ef6a-4e8c-872b-1581b7fa8a71\"."
 msgstr ""
 "[filename]`test-client` のclientId属性をもつクライアントと、 [filename]`support` "
-"というクライアント・ロール、および [filename]`operations` という別のクライアント・ロールがあり、IDが\"fc400897"
+"というクライアントロール、および [filename]`operations` という別のクライアントロールがあり、IDが\"fc400897"
 "-ef6a-4e8c-872b-1581b7fa8a71\"という複合ロールになると仮定します。"
 
 #. type: Plain text
@@ -1594,13 +1594,13 @@ msgstr "$ kcadm.sh get-roles --rid fc400897-ef6a-4e8c-872b-1581b7fa8a71 --all\n"
 #. type: Title ====
 #, no-wrap
 msgid "Removing client roles from a composite role"
-msgstr "複合ロールからのクライアント・ロールの削除"
+msgstr "複合ロールからのクライアントロールの削除"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`remove-roles` command to remove client roles from "
 "a composite role."
-msgstr "複合ロールからクライアント・ロールを削除するには、専用の [command]`remove-roles` コマンドを使用します。"
+msgstr "複合ロールからクライアントロールを削除するには、専用の [command]`remove-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -1609,7 +1609,7 @@ msgid ""
 "users` role from the [command]`testrole` composite role."
 msgstr ""
 "次の例を使用して、 [command]`realm management` - `create-client` ロールと [command]`view-"
-"users` ロールで定義された2つのクライアント・ロールを複合ロール [command]`testrole` から削除します。"
+"users` ロールで定義された2つのクライアントロールを複合ロール [command]`testrole` から削除します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2175,12 +2175,12 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Adding client roles to a user"
-msgstr "ユーザーにクライアント・ロールを追加する"
+msgstr "ユーザーにクライアントロールを追加する"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`add-roles` command to add client roles to a user."
-msgstr "クライアント・ロールをユーザーに追加するには、専用の [command]`add-roles` コマンドを使用します。"
+msgstr "クライアントロールをユーザーに追加するには、専用の [command]`add-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -2203,13 +2203,13 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Removing client roles from a user"
-msgstr "ユーザーからのクライアント・ロールの削除"
+msgstr "ユーザーからのクライアントロールの削除"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`remove-roles` command to remove client roles from "
 "a user."
-msgstr "専用の [command]`remove-roles` コマンドを使用して、クライアント・ロールをユーザーから削除します。"
+msgstr "専用の [command]`remove-roles` コマンドを使用して、クライアントロールをユーザーから削除します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -1112,11 +1112,11 @@ msgstr "ロール操作"
 #. type: Title ====
 #, no-wrap
 msgid "Creating a realm role"
-msgstr "レルム・ロールの作成"
+msgstr "レルムロールの作成"
 
 #. type: Plain text
 msgid "Use the [filename]`roles` endpoint to create a realm role."
-msgstr "レルム・ロールを作成するには、 [filename]`roles` エンドポイントを使用します。"
+msgstr "レルムロールを作成するには、 [filename]`roles` エンドポイントを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1130,14 +1130,14 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Creating a client role"
-msgstr "クライアント・ロールの作成"
+msgstr "クライアントロールの作成"
 
 #. type: Plain text
 msgid ""
 "Identify the client first and then use the [command]`get` command to list "
 "available clients when creating a client role."
 msgstr ""
-"クライアント・ロールを作成するときは、最初にクライアントを特定し、 [command]`get` "
+"クライアントロールを作成するときは、最初にクライアントを特定し、 [command]`get` "
 "コマンドを使用して使用可能なクライアントを一覧表示します。"
 
 #. type: delimited block -
@@ -1255,7 +1255,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm --rolename user\n"
 #. type: Title ====
 #, no-wrap
 msgid "Getting a specific client role"
-msgstr "特定のクライアント・ロールを取得する"
+msgstr "特定のクライアントロールを取得する"
 
 #. type: Plain text
 msgid ""
@@ -2521,14 +2521,14 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a group"
-msgstr "グループに割り当てられた、使用可能で、有効なレルム・ロールの一覧表示"
+msgstr "グループに割り当てられた、使用可能で、有効なレルムロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective realm roles for a group."
 msgstr ""
-"グループに割り当てられた、使用可能で、有効なレルム・ロールを一覧表示するには、専用の [command]`get-roles` コマンドを使用します。"
+"グループに割り当てられた、使用可能で、有効なレルムロールを一覧表示するには、専用の [command]`get-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -2538,7 +2538,7 @@ msgid ""
 msgstr ""
 "対象グループを、 [command]`--gname` オプションで名前を指定するか、 [command] `--gpath` "
 "オプションでパスをを指定する、または [command]`--gid` オプションでIDを指定することにとり、そのグループの *割り当てられた* "
-"レルム・ロールを一覧表示します。"
+"レルムロールを一覧表示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2554,7 +2554,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --effective\n"
 msgid ""
 "Use the [command]`--available` option to list realm roles that can still be "
 "added to the group."
-msgstr "グループに追加できるレルム・ロールを表示するには、 [command]`--available` オプションを使用します。"
+msgstr "グループに追加できるレルムロールを表示するには、 [command]`--available` オプションを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2564,14 +2564,14 @@ msgstr "$ kcadm.sh get-roles -r demorealm --gname Group --available\n"
 #. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a group"
-msgstr "グループに割り当てられた、利用可能で、有効なクライアント・ロールの一覧表示"
+msgstr "グループに割り当てられた、利用可能で、有効なクライアントロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective client roles for a group."
 msgstr ""
-"グループに割り当てられた、利用可能で、有効なクライアント・ロールを一覧表示するには、専用の [command]`get-roles` "
+"グループに割り当てられた、利用可能で、有効なクライアントロールを一覧表示するには、専用の [command]`get-roles` "
 "コマンドを使用します。"
 
 #. type: Plain text
@@ -2584,7 +2584,7 @@ msgstr ""
 "[command]`--gname` オプションで名前指定するか、 [command]`--gid` "
 "オプションでIDを指定することでグループを指定します。また、 [command] `--cclientid` "
 "オプションでclientId属性を指定するか、 [command]`--id` オプションでIDを指定することでクライアントを特定し、ユーザーの "
-"*割り当てられた* クライアント・ロールを一覧表示します。"
+"*割り当てられた* クライアントロールを一覧表示します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -1472,7 +1472,7 @@ msgstr "レルムロールを複合ロールに追加する"
 msgid ""
 "There is a dedicated [command]`add-roles` command that can be used for "
 "adding realm roles and client roles."
-msgstr "レルムロールとクライアント・ロールを追加するために使用できる専用の [command]`add-roles` コマンドがあります。"
+msgstr "レルムロールとクライアントロールを追加するために使用できる専用の [command]`add-roles` コマンドがあります。"
 
 #. type: Plain text
 msgid ""
@@ -2038,7 +2038,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective realm roles for a user"
-msgstr "ユーザーに割り当てられた、使用可能な、有効なレルム・ロールの一覧表示"
+msgstr "ユーザーに割り当てられた、使用可能な、有効なレルムロールの一覧表示"
 
 #. type: Plain text
 msgid ""
@@ -2046,13 +2046,13 @@ msgid ""
 "available, and effective realm roles for a user."
 msgstr ""
 "専用の [command]`get-roles` "
-"コマンドを使用して、ユーザーに割り当てられた、利用可能で、有効なレルム・ロールを一覧表示することができます。"
+"コマンドを使用して、ユーザーに割り当てられた、利用可能で、有効なレルムロールを一覧表示することができます。"
 
 #. type: Plain text
 msgid ""
 "Specify the target user by either user name or ID to list *assigned* realm "
 "roles for the user."
-msgstr "ユーザーの *割り当てられた* レルム・ロールを一覧表示するには、ユーザー名またはIDのどちらかを使用して対象ユーザーを指定します。"
+msgstr "ユーザーの *割り当てられた* レルムロールを一覧表示するには、ユーザー名またはIDのどちらかを使用して対象ユーザーを指定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2068,7 +2068,7 @@ msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --effective\n"
 msgid ""
 "Use the [command]`--available` option to list realm roles that can still be "
 "added to the user."
-msgstr "ユーザーに利用可能なレルム・ロールを一覧表示するには、 [command]`--available` オプションを使用します。"
+msgstr "ユーザーに利用可能なレルムロールを一覧表示するには、 [command]`--available` オプションを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2078,14 +2078,14 @@ msgstr "$ kcadm.sh get-roles -r demorealm --uusername testuser --available\n"
 #. type: Title ====
 #, no-wrap
 msgid "Listing assigned, available, and effective client roles for a user"
-msgstr "ユーザーに割り当てられた、利用可能な、有効なクライアント・ロールの一覧表示"
+msgstr "ユーザーに割り当てられた、利用可能な、有効なクライアントロールの一覧表示"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`get-roles` command to list assigned, available, "
 "and effective client roles for a user."
 msgstr ""
-"専用の [command]`get-roles` コマンドを使用して、ユーザーに割り当てられた、利用可能で、有効なクライアント・ロールを一覧表示します。"
+"専用の [command]`get-roles` コマンドを使用して、ユーザーに割り当てられた、利用可能で、有効なクライアントロールを一覧表示します。"
 
 #. type: Plain text
 msgid ""
@@ -2095,10 +2095,9 @@ msgid ""
 "option) or an ID (via the [command]`--cid` option) to list *assigned* client"
 " roles for the user."
 msgstr ""
-"ユーザーに *割り当てられた* クライアント・ロールを一覧表示するには、[command]`--uusername` "
-"オプションでユーザー名を指定するか、 [command]`--uid` オプションでIDを指定して対象ユーザー特定し、 "
-"[command]`--cclientid` オプションでclientId属性を指定するか、 [command]`--cid` "
-"オプションでIDを指定して対象クライアントを特定します。"
+"ユーザーに *割り当てられた* クライアントロールを一覧表示するには、[command]`--uusername` オプションでユーザー名を指定するか、"
+" [command]`--uid` オプションでIDを指定して対象ユーザー特定し、 [command]`--cclientid` "
+"オプションでclientId属性を指定するか、 [command]`--cid` オプションでIDを指定して対象クライアントを特定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -2130,12 +2129,12 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Adding realm roles to a user"
-msgstr "ユーザーにレルム・ロールを追加する"
+msgstr "ユーザーにレルムロールを追加する"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`add-roles` command to add realm roles to a user."
-msgstr "レルム・ロールをユーザーに追加するには、専用の [command]`add-roles` コマンドを使用します。"
+msgstr "レルムロールをユーザーに追加するには、専用の [command]`add-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -2151,13 +2150,13 @@ msgstr "$ kcadm.sh add-roles --username testuser --rolename user -r demorealm\n"
 #. type: Title ====
 #, no-wrap
 msgid "Removing realm roles from a user"
-msgstr "ユーザーからレルム・ロールを削除する"
+msgstr "ユーザーからレルムロールを削除する"
 
 #. type: Plain text
 msgid ""
 "Use a dedicated [command]`remove-roles` command to remove realm roles from a"
 " user."
-msgstr "ユーザーからレルム・ロールを削除するには、専用の [command]`remove-roles` コマンドを使用します。"
+msgstr "ユーザーからレルムロールを削除するには、専用の [command]`remove-roles` コマンドを使用します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__admin-cli/ja_JP/index.html
