### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users.ja_JP.po
@@ -2,26 +2,27 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_admin/topics/users.adoc:2
 #, no-wrap
 msgid "User Management"
-msgstr ""
+msgstr "ユーザーの管理"
 
 #. type: Plain text
 #: source/server_admin/topics/users.adoc:4
-msgid "This section describes the administration functions for managing users."
-msgstr ""
+msgid ""
+"This section describes the administration functions for managing users."
+msgstr "このセクションでは、ユーザーを管理するための管理機能について説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__users/ja_JP/index.html
