### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_admin/topics/sessions.adoc:2
 #, no-wrap
 msgid "User Session Management"
-msgstr ""
+msgstr "ユーザー・セッションの管理"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions.adoc:9
@@ -32,3 +32,4 @@ msgid ""
 "Admins can logout a user or set of users from the Admin Console. They can "
 "revoke tokens and set up all the token and session timeouts there too."
 msgstr ""
+"ユーザーがレルムにログインすると、{project_name}はユーザー・セッションを維持し、セッション内で訪問したすべてのクライアントを記憶します。これらのユーザー・セッションに対してレルム管理者が実行できる多くの管理機能があります。レルム全体のログイン統計を表示し、各クライアントに誰がどこからログインしているのかを確認できます。管理者は、管理コンソールからユーザーまたはユーザーのセットをログアウトできます。トークンを取り消したり、すべてのトークンとセッションのタイムアウトを設定することも可能です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sessions/ja_JP/index.html
