### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/login-settings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/login-settings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,11 +19,11 @@ msgstr ""
 #: source/server_admin/topics/login-settings.adoc:2
 #, no-wrap
 msgid "Login Page Settings"
-msgstr "ログイン・ページの設定"
+msgstr "ログインページの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings.adoc:4
 msgid ""
 "There are several nice built-in login page features you can enable if you "
 "need the functionality."
-msgstr "必要な場合に有効にできる便利な組み込みのログイン・ページ機能がいくつかあります。"
+msgstr "必要な場合に有効にできる便利な組み込みのログインページ機能がいくつかあります。"

--- a/i18n/po/ja_JP/server_admin/topics/login-settings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings.ja_JP.po
@@ -2,28 +2,28 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_admin/topics/login-settings.adoc:2
 #, no-wrap
 msgid "Login Page Settings"
-msgstr ""
+msgstr "ログイン・ページの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings.adoc:4
 msgid ""
 "There are several nice built-in login page features you can enable if you "
 "need the functionality."
-msgstr ""
+msgstr "必要な場合に有効にできる便利な組み込みのログイン・ページ機能がいくつかあります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/login-settings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__login-settings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__login-settings/ja_JP/index.html
