### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -55,7 +55,7 @@ msgid ""
 "`Twitter` from the `Add provider` drop down list.  This will bring you to "
 "the `Add identity provider` page."
 msgstr ""
-"Twitterにログインするには、いくつかのステップを完了しなければなりません。まず、左のメニュー項目の `Identity Providers` "
+"Twitterにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
 "に移動し、 `Add identity provider` のドロップダウン・リストから `Twitter` を選択します。 これにより、 `Add "
 "identity provider` ページが表示されます。"
 

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -30,7 +30,7 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr ""
+msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/microsoft.adoc:20
@@ -39,13 +39,13 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:22
 #, no-wrap
 msgid "Register Application"
-msgstr ""
+msgstr "アプリケーションの登録"
 
 #. type: Title ====
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:2
 #, no-wrap
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:6
@@ -55,20 +55,26 @@ msgid ""
 "`Twitter` from the `Add provider` drop down list.  This will bring you to "
 "the `Add identity provider` page."
 msgstr ""
+"Twitterにログインするには、いくつかの手順を完了する必要があります。まず、左メニュー項目の `アイデンティティー・プロバイダー` に移動し、 "
+"`プロバイダーの追加` のドロップダウン・リストから `Twitter` を選択します。 これにより、 `アイデンティティー・プロバイダーの追加` "
+"ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:9
 msgid "image:{project_images}/twitter-add-identity-provider.png[]"
-msgstr ""
+msgstr "image:{project_images}/twitter-add-identity-provider.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:13
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client "
-"Secret` from Twitter.  One piece of data you'll need from this page is the "
+"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
+" Secret` from Twitter.  One piece of data you'll need from this page is the "
 "`Redirect URI`.  You'll have to provide that to Twitter when you register "
 "{project_name} as a client there, so copy this URI to your clipboard."
 msgstr ""
+"Twitterから `Client ID` と `Client Secret` "
+"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `リダイレクトURI` "
+"です。クライアントとして{project_name}を登録するときに、Twitterにそれを提供する必要がありますので、このURIをクリップボードにコピーしておいてください。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:15
@@ -76,23 +82,25 @@ msgid ""
 "To enable login with Twtter you first have to create an application in the "
 "https://apps.twitter.com[Twitter Application Management]."
 msgstr ""
+"Twtterでログインを有効にするには、まずhttps://apps.twitter.com[Twitterアプリケーションの管理]でアプリケーションを作成する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:18
 msgid "image:images/twitter-app-register.png[]"
-msgstr ""
+msgstr "image:images/twitter-app-register.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:21
 msgid ""
-"Click on the `Create New App` button.  This will bring you to the `Create an "
-"Application` page."
+"Click on the `Create New App` button.  This will bring you to the `Create an"
+" Application` page."
 msgstr ""
+"`Create New App` ボタンをクリックします。これにより、  `Create an Application` ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:24
 msgid "image:images/twitter-app-create.png[]"
-msgstr ""
+msgstr "image:images/twitter-app-create.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:28
@@ -101,6 +109,8 @@ msgid ""
 "have a `localhost` address.  For the `Callback URL` you must copy the "
 "`Redirect URI` from the {project_name} `Add Identity Provider` page."
 msgstr ""
+"名前と説明を入力します。ウェブサイトは何でも構いませんが、 `localhost` アドレスを持つことはできません。 `Callback URL` "
+"には、{project_name} の `アイデンティティー・プロバイダーの追加` ページから `リダイレクトURI` をコピーしなければなりません。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:31
@@ -109,38 +119,40 @@ msgid ""
 "You cannot use `localhost` in the `Callback URL`.  Instead replace it with `127.0.0.1` if you are trying to\n"
 "         testdrive Twitter login on your laptop.\n"
 msgstr ""
+"`Callback URL` に `localhost` "
+"を使うことはできません。ラップトップでTwitterのログインを試してみる場合は、代わりにそれを `127.0.0.1` に置き換えてください。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:33
 msgid "After clicking save you will be brought to the `Details` page."
-msgstr ""
+msgstr "保存をクリックすると、 `詳細` ページに移動します。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:34
 #, no-wrap
 msgid "App Details"
-msgstr ""
+msgstr "App Details"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:36
 msgid "image:images/twitter-details.png[]"
-msgstr ""
+msgstr "image:images/twitter-details.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:39
 msgid "Next go to the `Keys and Access Tokens` tab."
-msgstr ""
+msgstr "次は `Keys and Access Tokens` タブをクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:40
 #, no-wrap
 msgid "Keys and Access Tokens"
-msgstr ""
+msgstr "Keys and Access Tokens"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:42
 msgid "image:images/twitter-keys.png[]"
-msgstr ""
+msgstr "image:images/twitter-keys.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:44
@@ -149,3 +161,5 @@ msgid ""
 "copy them back into the `Client ID` and `Client Secret` fields on the "
 "{project_name} `Add identity provider` page."
 msgstr ""
+"最後に、このページからAPIキーとシークレットを取得し、{project_name}の `アイデンティティー・プロバイダの追加` ページの "
+"`クライアントID` フィールドと `クライアント・シークレット` フィールドにコピーする必要があります。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,9 +55,9 @@ msgid ""
 "`Twitter` from the `Add provider` drop down list.  This will bring you to "
 "the `Add identity provider` page."
 msgstr ""
-"Twitterにログインするには、いくつかの手順を完了する必要があります。まず、左メニュー項目の `アイデンティティー・プロバイダー` に移動し、 "
-"`プロバイダーの追加` のドロップダウン・リストから `Twitter` を選択します。 これにより、 `アイデンティティー・プロバイダーの追加` "
-"ページが表示されます。"
+"Twitterにログインするには、いくつかのステップを完了しなければなりません。まず、左のメニュー項目の `Identity Providers` "
+"に移動し、 `Add identity provider` のドロップダウン・リストから `Twitter` を選択します。 これにより、 `Add "
+"identity provider` ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:9
@@ -73,8 +73,8 @@ msgid ""
 "{project_name} as a client there, so copy this URI to your clipboard."
 msgstr ""
 "Twitterから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `リダイレクトURI` "
-"です。クライアントとして{project_name}を登録するときに、Twitterにそれを提供する必要がありますので、このURIをクリップボードにコピーしておいてください。"
+"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
+"です。Twitterに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:15
@@ -82,7 +82,8 @@ msgid ""
 "To enable login with Twtter you first have to create an application in the "
 "https://apps.twitter.com[Twitter Application Management]."
 msgstr ""
-"Twtterでログインを有効にするには、まずhttps://apps.twitter.com[Twitterアプリケーションの管理]でアプリケーションを作成する必要があります。"
+"Twtterでログインを可能にするには、まず https://apps.twitter.com[Twitter Application "
+"Management] でアプリケーションを作成する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:18
@@ -95,7 +96,7 @@ msgid ""
 "Click on the `Create New App` button.  This will bring you to the `Create an"
 " Application` page."
 msgstr ""
-"`Create New App` ボタンをクリックします。これにより、  `Create an Application` ページが表示されます。"
+"`Create New App` ボタンをクリックします。これにより、 `Create an Application` ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:24
@@ -109,8 +110,9 @@ msgid ""
 "have a `localhost` address.  For the `Callback URL` you must copy the "
 "`Redirect URI` from the {project_name} `Add Identity Provider` page."
 msgstr ""
-"名前と説明を入力します。ウェブサイトは何でも構いませんが、 `localhost` アドレスを持つことはできません。 `Callback URL` "
-"には、{project_name} の `アイデンティティー・プロバイダーの追加` ページから `リダイレクトURI` をコピーしなければなりません。"
+"NameとDescriptionを入力します。Websiteは何でも構いませんが、 `localhost` アドレスを持つことはできません。 "
+"`Callback URL` には、{project_name} の `Add Identity Provider` ページから `Redirect "
+"URI` をコピーする必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:31
@@ -119,13 +121,13 @@ msgid ""
 "You cannot use `localhost` in the `Callback URL`.  Instead replace it with `127.0.0.1` if you are trying to\n"
 "         testdrive Twitter login on your laptop.\n"
 msgstr ""
-"`Callback URL` に `localhost` "
-"を使うことはできません。ラップトップでTwitterのログインを試してみる場合は、代わりにそれを `127.0.0.1` に置き換えてください。\n"
+"`Callback URL` に `localhost` を使うことはできません。ラップトップでTwitterのログインを試してみる場合は、 "
+"`127.0.0.1` に置き換えてください。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:33
 msgid "After clicking save you will be brought to the `Details` page."
-msgstr "保存をクリックすると、 `詳細` ページに移動します。"
+msgstr "保存をクリックすると、 `Details` ページに移動します。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:34
@@ -141,7 +143,7 @@ msgstr "image:images/twitter-details.png[]"
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:39
 msgid "Next go to the `Keys and Access Tokens` tab."
-msgstr "次は `Keys and Access Tokens` タブをクリックします。"
+msgstr "次に、 `Keys and Access Tokens` タブをクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:40
@@ -161,5 +163,5 @@ msgid ""
 "copy them back into the `Client ID` and `Client Secret` fields on the "
 "{project_name} `Add identity provider` page."
 msgstr ""
-"最後に、このページからAPIキーとシークレットを取得し、{project_name}の `アイデンティティー・プロバイダの追加` ページの "
-"`クライアントID` フィールドと `クライアント・シークレット` フィールドにコピーする必要があります。"
+"最後に、このページからAPIキーとシークレットを取得し、{project_name}の `Add identity provider` ページの "
+"`Client ID` フィールドと `Client Secret` フィールドにコピーする必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__twitter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__social__twitter/ja_JP/index.html
