### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -41,7 +41,7 @@ msgstr "image:{project_images}/login-events-config.png[]"
 #: source/server_admin/topics/events/login.adoc:24
 #, no-wrap
 msgid "Login Events"
-msgstr "ログイン・イベント"
+msgstr "ログインイベント"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:8
@@ -54,7 +54,7 @@ msgid ""
 "persisting you'll need to enable storage.  Go to the `Events` left menu item"
 " and select the `Config` tab."
 msgstr ""
-"ログイン・イベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、イベントは保存されず、管理コンソールに表示されることもありません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
+"ログインイベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、イベントは保存されず、管理コンソールに表示されることもありません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
 " `Events` メニュー項目に行き、 `Config` タブを選択してください。"
 
 #. type: Plain text
@@ -86,10 +86,10 @@ msgid ""
 "login events and decided on your settings, don't forget to click the `Save` "
 "button on the bottom of this page."
 msgstr ""
-"`Saved Types` フィールドでは、イベント・ストアに保存するイベント・タイプを指定することができます。 `Clear events` "
+"`Saved Types` フィールドでは、イベントストアに保存するイベントタイプを指定することができます。 `Clear events` "
 "ボタンで、データベース内のすべてのイベントを削除できます。 `Expiration` "
-"フィールドでは、イベントを保存する期間を指定することができます。ログイン・イベントの保存を有効にして設定を決定したら、このページの下部にある "
-"`Save` ボタンをクリックすることを忘れないでください。"
+"フィールドでは、イベントを保存する期間を指定することができます。ログインイベントの保存を有効にして設定を決定したら、このページの下部にある `Save`"
+" ボタンをクリックすることを忘れないでください。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:23
@@ -116,7 +116,7 @@ msgstr ""
 #: source/server_admin/topics/events/login.adoc:30
 #, no-wrap
 msgid "Login Event Filter"
-msgstr "ログイン・イベント・フィルター"
+msgstr "ログインイベント・フィルター"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:32
@@ -141,7 +141,7 @@ msgstr "イベントの種類"
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:39
 msgid "Login events:"
-msgstr "ログイン・イベント："
+msgstr "ログインイベント："
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:41
@@ -162,17 +162,17 @@ msgstr "Logout - ユーザーがログアウトしました。"
 #: source/server_admin/topics/events/login.adoc:44
 msgid ""
 "Code to Token - An application/client has exchanged a code for a token."
-msgstr "Code to Token - アプリケーション／クライアントがコードをトークンに交換しました。"
+msgstr "Code to Token - アプリケーション/クライアントがコードをトークンに交換しました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:45
 msgid "Refresh Token - An application/client has refreshed a token."
-msgstr "Refresh Token - アプリケーション／クライアントがトークンをリフレッシュしました。"
+msgstr "Refresh Token - アプリケーション/クライアントがトークンをリフレッシュしました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:47
 msgid "Account events:"
-msgstr "アカウント・イベント："
+msgstr "アカウントイベント："
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:49
@@ -234,7 +234,7 @@ msgstr "すべてのイベントに対応するエラーイベントがありま
 #: source/server_admin/topics/events/login.adoc:61
 #, no-wrap
 msgid "Event Listener"
-msgstr "イベント・リスナー"
+msgstr "イベントリスナー"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:65
@@ -243,8 +243,8 @@ msgid ""
 "  There are two built-in listeners that come with {project_name}: Logging "
 "Event Listener and Email Event Listener."
 msgstr ""
-"イベント・リスナーは、イベントを待ち受け、そのイベントに基づいてアクションを実行します。 "
-"{project_name}にはロギング・イベント・リスナーと電子メール・イベント・リスナーの2つのビルトイン・リスナーがあります。"
+"イベントリスナーは、イベントを待ち受け、そのイベントに基づいてアクションを実行します。 "
+"{project_name}にはロギング・イベントリスナーと電子メール・イベントリスナーの2つのビルトインのリスナーがあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:68
@@ -252,7 +252,7 @@ msgid ""
 "The Logging Event Listener writes to a log file whenever an error event "
 "occurs and is enabled by default.  Here's an example log message:"
 msgstr ""
-"ロギング・イベント・リスナーは、エラーイベントが発生したときにログファイルに書き込みます。デフォルトで有効になっています。次に、ログメッセージの例を示します。"
+"ロギング・イベントリスナーは、エラーイベントが発生したときにログファイルに書き込みます。デフォルトで有効になっています。次に、ログメッセージの例を示します。"
 
 #. type: delimited block -
 #: source/server_admin/topics/events/login.adoc:76
@@ -292,12 +292,12 @@ msgid ""
 "occurs.  The Email Event Listener only supports the following events at the "
 "moment:"
 msgstr ""
-"電子メール・イベント・リスナーは、イベントが発生したときにユーザーのアカウントに電子メールを送信します。電子メール・イベント・リスナーは、現時点で次のイベントのみをサポートしています。"
+"電子メール・イベントリスナーは、イベントが発生したときにユーザーのアカウントに電子メールを送信します。電子メール・イベントリスナーは、現時点で次のイベントのみをサポートしています。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:86
 msgid "Login Error"
-msgstr "ログイン・エラー"
+msgstr "ログインエラー"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:88
@@ -316,7 +316,7 @@ msgid ""
 "Listeners` field.  This will show a drop down list box where you can select "
 "email."
 msgstr ""
-"電子メール・リスナーを有効にするには `Config` タブに行き、 `Event Listeners` "
+"電子メールリスナーを有効にするには `Config` タブに行き、 `Event Listeners` "
 "フィールドをクリックしてください。これにより、電子メールを選択できるドロップダウン・リストボックスが表示されます。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,7 +54,7 @@ msgid ""
 "persisting you'll need to enable storage.  Go to the `Events` left menu item"
 " and select the `Config` tab."
 msgstr ""
-"ログイン・イベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、管理コンソールにイベントは保存されず、表示もされません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
+"ログイン・イベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、イベントは保存されず、管理コンソールに表示されることもありません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
 " `Events` メニュー項目に行き、 `Config` タブを選択してください。"
 
 #. type: Plain text
@@ -63,13 +63,13 @@ msgid ""
 "To start storing events you'll need to turn the `Save Events` switch to on "
 "under the `Login Events Settings`."
 msgstr ""
-"イベントの保存を開始するには、 `Login Events Settings` の `Save Events` スイッチをonにする必要があります。"
+"イベントの保存を開始するには、 `Login Events Settings` の `Save Events` スイッチをオンにする必要があります。"
 
 #. type: Block title
 #: source/server_admin/topics/events/login.adoc:14
 #, no-wrap
 msgid "Save Events"
-msgstr "イベントを保存する"
+msgstr "イベントの保存"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:16
@@ -86,7 +86,7 @@ msgid ""
 "login events and decided on your settings, don't forget to click the `Save` "
 "button on the bottom of this page."
 msgstr ""
-"`Saved Types` フィールドでは、イベント・ストアに保存するイベントタイプを指定することができます。 `Clear events` "
+"`Saved Types` フィールドでは、イベント・ストアに保存するイベント・タイプを指定することができます。 `Clear events` "
 "ボタンで、データベース内のすべてのイベントを削除できます。 `Expiration` "
 "フィールドでは、イベントを保存する期間を指定することができます。ログイン・イベントの保存を有効にして設定を決定したら、このページの下部にある "
 "`Save` ボタンをクリックすることを忘れないでください。"
@@ -94,7 +94,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:23
 msgid "To view events, go to the `Login Events` tab."
-msgstr "イベントを表示するには、 `Login Events` タブに行きます。"
+msgstr "イベントを表示するには、 `Login Events` タブに移動します。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:26
@@ -109,14 +109,14 @@ msgid ""
 "`Filter` button on this page allows you to filter which events you are "
 "actually interested in."
 msgstr ""
-"見てのとおり、多くの情報が保存されています。すべてのイベントを保存している場合は、ログインアクションごとに多数のイベントが保存されています。このページの"
+"見てのとおり、多くの情報が保存されています。すべてのイベントを保存している場合は、ログイン・アクションごとに多数のイベントが保存されています。このページの"
 " `Filter` ボタンを使用すると、実際に関心のあるイベントをフィルタリングすることができます。"
 
 #. type: Block title
 #: source/server_admin/topics/events/login.adoc:30
 #, no-wrap
 msgid "Login Event Filter"
-msgstr "ログイン・イベント・フィルタ"
+msgstr "ログイン・イベント・フィルター"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:32
@@ -129,7 +129,8 @@ msgid ""
 "In this screenshot, we're filtering only `Login` events.  Clicking the "
 "`Update` button runs the filter."
 msgstr ""
-"このスクリーンショットでは、 `Login` イベントのみをフィルタリングしています。 `Update` ボタンをクリックするとフィルタが実行されます。"
+"このスクリーンショットでは、 `Login` イベントのみをフィルタリングしています。 `Update` "
+"ボタンをクリックするとフィルターが実行されます。"
 
 #. type: Title ====
 #: source/server_admin/topics/events/login.adoc:36

--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
@@ -29,32 +28,34 @@ msgstr "パスワードの更新"
 #: source/server_admin/topics/events/login.adoc:9
 #, no-wrap
 msgid "Event Configuration"
-msgstr ""
+msgstr "イベント設定"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:12
 #: source/server_admin/topics/events/login.adoc:11
 msgid "image:{project_images}/login-events-config.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-events-config.png[]"
 
 #. type: Block title
 #: source/server_admin/topics/events/login.adoc:2
 #: source/server_admin/topics/events/login.adoc:24
 #, no-wrap
 msgid "Login Events"
-msgstr ""
+msgstr "ログイン・イベント"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:8
 msgid ""
 "Login events occur for things like when a user logs in successfully, when "
-"somebody enters in a bad password, or when a user account is updated.  Every "
-"single event that happens to a user can be recorded and viewed.  By default, "
-"no events are stored or viewed in the Admin Console.  Only error events are "
-"logged to the console and the server's log file.  To start persisting you'll "
-"need to enable storage.  Go to the `Events` left menu item and select the "
-"`Config` tab."
+"somebody enters in a bad password, or when a user account is updated.  Every"
+" single event that happens to a user can be recorded and viewed.  By "
+"default, no events are stored or viewed in the Admin Console.  Only error "
+"events are logged to the console and the server's log file.  To start "
+"persisting you'll need to enable storage.  Go to the `Events` left menu item"
+" and select the `Config` tab."
 msgstr ""
+"ログイン・イベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、管理コンソールにイベントは保存されず、表示もされません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
+" `Events` メニュー項目に行き、 `Config` タブを選択してください。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:13
@@ -62,38 +63,43 @@ msgid ""
 "To start storing events you'll need to turn the `Save Events` switch to on "
 "under the `Login Events Settings`."
 msgstr ""
+"イベントの保存を開始するには、 `Login Events Settings` の `Save Events` スイッチをonにする必要があります。"
 
 #. type: Block title
 #: source/server_admin/topics/events/login.adoc:14
 #, no-wrap
 msgid "Save Events"
-msgstr ""
+msgstr "イベントを保存する"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:16
 msgid "image:{project_images}/login-events-settings.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-events-settings.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:21
 msgid ""
 "The `Saved Types` field allows you to specify which event types you want to "
 "store in the event store.  The `Clear events` button allows you to delete "
-"all the events in the database. The `Expiration` field allows you to specify "
-"how long you want to keep events stored.  Once you've enabled storage of "
+"all the events in the database. The `Expiration` field allows you to specify"
+" how long you want to keep events stored.  Once you've enabled storage of "
 "login events and decided on your settings, don't forget to click the `Save` "
 "button on the bottom of this page."
 msgstr ""
+"`Saved Types` フィールドでは、イベント・ストアに保存するイベントタイプを指定することができます。 `Clear events` "
+"ボタンで、データベース内のすべてのイベントを削除できます。 `Expiration` "
+"フィールドでは、イベントを保存する期間を指定することができます。ログイン・イベントの保存を有効にして設定を決定したら、このページの下部にある "
+"`Save` ボタンをクリックすることを忘れないでください。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:23
 msgid "To view events, go to the `Login Events` tab."
-msgstr ""
+msgstr "イベントを表示するには、 `Login Events` タブに行きます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:26
 msgid "image:{project_images}/login-events.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-events.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:29
@@ -103,17 +109,19 @@ msgid ""
 "`Filter` button on this page allows you to filter which events you are "
 "actually interested in."
 msgstr ""
+"見てのとおり、多くの情報が保存されています。すべてのイベントを保存している場合は、ログインアクションごとに多数のイベントが保存されています。このページの"
+" `Filter` ボタンを使用すると、実際に関心のあるイベントをフィルタリングすることができます。"
 
 #. type: Block title
 #: source/server_admin/topics/events/login.adoc:30
 #, no-wrap
 msgid "Login Event Filter"
-msgstr ""
+msgstr "ログイン・イベント・フィルタ"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:32
 msgid "image:{project_images}/login-events-filter.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-events-filter.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:34
@@ -121,117 +129,121 @@ msgid ""
 "In this screenshot, we're filtering only `Login` events.  Clicking the "
 "`Update` button runs the filter."
 msgstr ""
+"このスクリーンショットでは、 `Login` イベントのみをフィルタリングしています。 `Update` ボタンをクリックするとフィルタが実行されます。"
 
 #. type: Title ====
 #: source/server_admin/topics/events/login.adoc:36
 #, no-wrap
 msgid "Event Types"
-msgstr ""
+msgstr "イベントの種類"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:39
 msgid "Login events:"
-msgstr ""
+msgstr "ログイン・イベント："
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:41
 msgid "Login - A user has logged in."
-msgstr ""
+msgstr "Login - ユーザーがログインしました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:42
 msgid "Register - A user has registered."
-msgstr ""
+msgstr "Register - ユーザーが登録しました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:43
 msgid "Logout - A user has logged out."
-msgstr ""
+msgstr "Logout - ユーザーがログアウトしました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:44
-msgid "Code to Token - An application/client has exchanged a code for a token."
-msgstr ""
+msgid ""
+"Code to Token - An application/client has exchanged a code for a token."
+msgstr "Code to Token - アプリケーション／クライアントがコードをトークンに交換しました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:45
 msgid "Refresh Token - An application/client has refreshed a token."
-msgstr ""
+msgstr "Refresh Token - アプリケーション／クライアントがトークンをリフレッシュしました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:47
 msgid "Account events:"
-msgstr ""
+msgstr "アカウント・イベント："
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:49
 msgid "Social Link - An account has been linked to a social provider."
-msgstr ""
+msgstr "Social Link - アカウントはソーシャル・プロバイダーにリンクされました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:50
 msgid ""
 "Remove Social Link - A social provider has been removed from an account."
-msgstr ""
+msgstr "Remove Social Link - ソーシャル・プロバイダーがアカウントから削除されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:51
 msgid "Update Email - The email address for an account has changed."
-msgstr ""
+msgstr "Update Email - アカウントのメールアドレスが変更されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:52
 msgid "Update Profile - The profile for an account has changed."
-msgstr ""
+msgstr "Update Profile - アカウントのプロファイルが変更されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:53
 msgid "Send Password Reset - A password reset email has been sent."
-msgstr ""
+msgstr "Send Password Reset - パスワードリセット・メールが送信されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:54
 msgid "Update Password - The password for an account has changed."
-msgstr ""
+msgstr "Update Password - アカウントのパスワードが変更されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:55
 msgid "Update TOTP - The TOTP settings for an account have changed."
-msgstr ""
+msgstr "Update TOTP - アカウントのTOTP設定が変更されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:56
 msgid "Remove TOTP - TOTP has been removed from an account."
-msgstr ""
+msgstr "Remove TOTP - TOTPがアカウントから削除されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:57
 msgid "Send Verify Email - An email verification email has been sent."
-msgstr ""
+msgstr "Send Verify Email - メールアドレス検証のメールが送信されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:58
 msgid "Verify Email - The email address for an account has been verified."
-msgstr ""
+msgstr "Verify Email - アカウントのメールアドレスが検証されました。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:60
 msgid "For all events there is a corresponding error event."
-msgstr ""
+msgstr "すべてのイベントに対応するエラーイベントがあります。"
 
 #. type: Title ====
 #: source/server_admin/topics/events/login.adoc:61
 #, no-wrap
 msgid "Event Listener"
-msgstr ""
+msgstr "イベント・リスナー"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:65
 msgid ""
-"Event listeners listen for events and perform an action based on that "
-"event.  There are two built-in listeners that come with {project_name}: "
-"Logging Event Listener and Email Event Listener."
+"Event listeners listen for events and perform an action based on that event."
+"  There are two built-in listeners that come with {project_name}: Logging "
+"Event Listener and Email Event Listener."
 msgstr ""
+"イベント・リスナーは、イベントを待ち受け、そのイベントに基づいてアクションを実行します。 "
+"{project_name}にはロギング・イベント・リスナーと電子メール・イベント・リスナーの2つのビルトイン・リスナーがあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:68
@@ -239,6 +251,7 @@ msgid ""
 "The Logging Event Listener writes to a log file whenever an error event "
 "occurs and is enabled by default.  Here's an example log message:"
 msgstr ""
+"ロギング・イベント・リスナーは、エラーイベントが発生したときにログファイルに書き込みます。デフォルトで有効になっています。次に、ログメッセージの例を示します。"
 
 #. type: delimited block -
 #: source/server_admin/topics/events/login.adoc:76
@@ -251,16 +264,25 @@ msgid ""
 "                    redirect_uri=http://localhost:8180/myapp,\n"
 "                    code_id=b669da14-cdbb-41d0-b055-0810a0334607, username=admin\n"
 msgstr ""
+"11:36:09,965 WARN [org.keycloak.events] (default task-51) type=LOGIN_ERROR, realmId=master,\n"
+" clientId=myapp,\n"
+" userId=19aeb848-96fc-44f6-b0a3-59a17570d374, ipAddress=127.0.0.1,\n"
+" error=invalid_user_credentials, auth_method=openid-connect, auth_type=code,\n"
+" redirect_uri=http://localhost:8180/myapp,\n"
+" code_id=b669da14-cdbb-41d0-b055-0810a0334607, username=admin\n"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:81
 msgid ""
 "This logging is very useful if you want to use a tool like Fail2Ban to "
 "detect if there is a hacker bot somewhere that is trying to guess user "
-"passwords.  You can parse the log file for `LOGIN_ERROR` and pull out the IP "
-"Address. Then feed this information into Fail2Ban so that it can help "
+"passwords.  You can parse the log file for `LOGIN_ERROR` and pull out the IP"
+" Address. Then feed this information into Fail2Ban so that it can help "
 "prevent attacks."
 msgstr ""
+"このロギングは、Fail2Banのようなツールを使用して、ユーザーのパスワードを推測しようとしているハッカーのボットがあるかどうかを検出する場合に非常に便利です。"
+" `LOGIN_ERROR` "
+"のログファイルを解析してIPアドレスを抜き出すことができます。その後、攻撃を防ぐことができるように、この情報をFail2Banに与えます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:84
@@ -269,21 +291,22 @@ msgid ""
 "occurs.  The Email Event Listener only supports the following events at the "
 "moment:"
 msgstr ""
+"電子メール・イベント・リスナーは、イベントが発生したときにユーザーのアカウントに電子メールを送信します。電子メール・イベント・リスナーは、現時点で次のイベントのみをサポートしています。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:86
 msgid "Login Error"
-msgstr ""
+msgstr "ログイン・エラー"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:88
 msgid "Update TOTP"
-msgstr ""
+msgstr "TOTPの更新"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:89
 msgid "Remove TOTP"
-msgstr ""
+msgstr "TOTPの削除"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:92
@@ -292,6 +315,8 @@ msgid ""
 "Listeners` field.  This will show a drop down list box where you can select "
 "email."
 msgstr ""
+"電子メール・リスナーを有効にするには `Config` タブに行き、 `Event Listeners` "
+"フィールドをクリックしてください。これにより、電子メールを選択できるドロップダウン・リストボックスが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:95
@@ -300,6 +325,8 @@ msgid ""
 "`standalone-ha.xml`, or `domain.xml` that comes with your distribution and "
 "adding for example:"
 msgstr ""
+"1つまたは複数のイベントを除外するには、配布物に付属している`standalone.xml`、` standalone-ha.xml`、 "
+"`domain.xml`を編集して、次のように追加します。"
 
 #. type: delimited block -
 #: source/server_admin/topics/events/login.adoc:105
@@ -313,6 +340,13 @@ msgid ""
 "  </provider>\n"
 "</spi>\n"
 msgstr ""
+"<spi name=\"eventsListener\">\n"
+" <provider name=\"email\" enabled=\"true\">\n"
+" <properties>\n"
+" <property name=\"exclude-events\" value=\"[&quot;UPDATE_TOTP&quot;,&quot;REMOVE_TOTP&quot;]\"/>\n"
+" </properties>\n"
+" </provider>\n"
+"</spi>\n"
 
 #. type: Plain text
 #: source/server_admin/topics/events/login.adoc:108
@@ -320,3 +354,5 @@ msgid ""
 "See the link:{installguide_link}[{installguide_name}] for more details on "
 "where the `standalone.xml`, `standalone-ha.xml`, or `domain.xml` file lives."
 msgstr ""
+"`standalone.xml` 、 `standalone-ha.xml` 、 `domain.xml` ファイルがどこにあるかの詳細は "
+"link:{installguide_link}[{installguide_name}] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__events__login/ja_JP/index.html
