### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
@@ -32,22 +32,21 @@ msgid ""
 "Console."
 msgstr ""
 "管理コンソール内で管理者が実行するアクションは、監査目的で記録できます。管理コンソールは、{project_name} "
-"RESTインターフェイスを使用して管理機能を実行します。 "
-"{project_name}は、これらのREST呼び出しを監査します。結果のイベントは、管理コンソールで表示できます。"
+"RESTインターフェイスを使用して管理機能を実行します。{project_name}は、これらのREST呼び出しを監査します。結果のイベントは、管理コンソールで表示できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:9
 msgid ""
 "To enable auditing of Admin actions, go to the `Events` left menu item and "
 "select the `Config` tab."
-msgstr "管理者のアクションの監査を有効にするには、左側の `Events` メニュー項目に行き、 `Config` タブを選択します。"
+msgstr "管理者のアクションの監査を有効にするには、左側の `Events` メニュー項目で、 `Config` タブを選択します。"
 
 #. type: Block title
 #: source/server_admin/topics/events/admin.adoc:10
 #: source/server_admin/topics/events/login.adoc:9
 #, no-wrap
 msgid "Event Configuration"
-msgstr "イベント設定"
+msgstr "イベントの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:12
@@ -88,7 +87,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:22
 msgid "To view the admin events go to the `Admin Events` tab."
-msgstr "管理イベントを表示するには、 `Admin Events` タブに行きます。"
+msgstr "管理イベントを表示するには、 `Admin Events` タブをクリックします。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:25
@@ -108,7 +107,7 @@ msgstr ""
 #: source/server_admin/topics/events/admin.adoc:28
 #, no-wrap
 msgid "Admin Representation"
-msgstr "管理イベントのRepresentation"
+msgstr "管理イベントの表現"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:30

--- a/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -20,7 +20,7 @@ msgstr ""
 #: source/server_admin/topics/events/admin.adoc:23
 #, no-wrap
 msgid "Admin Events"
-msgstr ""
+msgstr "管理イベント"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:7
@@ -31,96 +31,104 @@ msgid ""
 "REST invocations.  The resulting events can then be viewed in the Admin "
 "Console."
 msgstr ""
+"管理コンソール内で管理者が実行するアクションは、監査目的で記録できます。管理コンソールは、{project_name} "
+"RESTインターフェイスを使用して管理機能を実行します。 "
+"{project_name}は、これらのREST呼び出しを監査します。結果のイベントは、管理コンソールで表示できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:9
 msgid ""
 "To enable auditing of Admin actions, go to the `Events` left menu item and "
 "select the `Config` tab."
-msgstr ""
+msgstr "管理者のアクションの監査を有効にするには、左側の `Events` メニュー項目に行き、 `Config` タブを選択します。"
 
 #. type: Block title
 #: source/server_admin/topics/events/admin.adoc:10
 #: source/server_admin/topics/events/login.adoc:9
 #, no-wrap
 msgid "Event Configuration"
-msgstr ""
+msgstr "イベント設定"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:12
 #: source/server_admin/topics/events/login.adoc:11
 msgid "image:{project_images}/login-events-config.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-events-config.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:14
 msgid ""
 "In the `Admin Events Settings` section, turn on the `Save Events` switch."
-msgstr ""
+msgstr "`Admin Events Settings` セクションで `Save Events` スイッチをオンにします。"
 
 #. type: Block title
 #: source/server_admin/topics/events/admin.adoc:15
 #, no-wrap
 msgid "Admin Event Configuration"
-msgstr ""
+msgstr "管理イベントの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:17
 msgid "image:{project_images}/admin-events-settings.png[]"
-msgstr ""
+msgstr "image:{project_images}/admin-events-settings.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:20
 msgid ""
 "The `Include Representation` switch will include any JSON document that is "
 "sent through the admin REST API.  This allows you to view exactly what an "
-"admin has done, but can lead to a lot of information stored in the "
-"database.  The `Clear admin events` button allows you to wipe out the "
-"current information stored."
+"admin has done, but can lead to a lot of information stored in the database."
+"  The `Clear admin events` button allows you to wipe out the current "
+"information stored."
 msgstr ""
+"`Include Representation` スイッチには、管理REST "
+"APIを介して送信される任意のJSONドキュメントが含まれます。これにより、管理者が行ったことを正確に表示できますが、多くの情報がデータベースに保存されることになる可能性があります。"
+" `Clear admin events` ボタンを押すと、保存されている現在の情報を消去することができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:22
 msgid "To view the admin events go to the `Admin Events` tab."
-msgstr ""
+msgstr "管理イベントを表示するには、 `Admin Events` タブに行きます。"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:25
 msgid "image:{project_images}/admin-events.png[]"
-msgstr ""
+msgstr "image:{project_images}/admin-events.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:27
 msgid ""
-"If the `Details` column has a `Representation` box, you can click on that to "
-"view the JSON that was sent with that operation."
+"If the `Details` column has a `Representation` box, you can click on that to"
+" view the JSON that was sent with that operation."
 msgstr ""
+"`Details` カラムに `Representation` "
+"ボックスがある場合、それをクリックして、その操作で送られたJSONを表示することができます。"
 
 #. type: Block title
 #: source/server_admin/topics/events/admin.adoc:28
 #, no-wrap
 msgid "Admin Representation"
-msgstr ""
+msgstr "管理イベントのRepresentation"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:30
 msgid "image:{project_images}/admin-events-representation.png[]"
-msgstr ""
+msgstr "image:{project_images}/admin-events-representation.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:32
 msgid ""
 "You can also filter for the events you are interested in by clicking the "
 "`Filter` button."
-msgstr ""
+msgstr "`Filter` ボタンをクリックすることで、興味のあるイベントをフィルタリングすることもできます。"
 
 #. type: Block title
 #: source/server_admin/topics/events/admin.adoc:33
 #, no-wrap
 msgid "Admin Event Filter"
-msgstr ""
+msgstr "管理イベントのフィルタ"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:35
 msgid "image:{project_images}/admin-events-filter.png[]"
-msgstr ""
+msgstr "image:{project_images}/admin-events-filter.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -125,7 +125,7 @@ msgstr "`Filter` ボタンをクリックすることで、興味のあるイベ
 #: source/server_admin/topics/events/admin.adoc:33
 #, no-wrap
 msgid "Admin Event Filter"
-msgstr "管理イベントのフィルタ"
+msgstr "管理イベントのフィルター"
 
 #. type: Plain text
 #: source/server_admin/topics/events/admin.adoc:35


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__events__admin/ja_JP/index.html
