### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
@@ -2,43 +2,43 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/sessions/administering.adoc:2
 #, no-wrap
 msgid "Administering Sessions"
-msgstr ""
+msgstr "セッションの管理"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:5
 msgid ""
 "If you go to the `Sessions` left menu item you can see a top level view of "
 "the number of sessions that are currently active in the realm."
-msgstr ""
+msgstr "左のメニュー項目 `Sessions` に行くと、現在そのレルムでアクティブなセッション数のトップレベルのビューが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/sessions/administering.adoc:6
 #: source/server_admin/topics/account.adoc:34
 #, no-wrap
 msgid "Sessions"
-msgstr ""
+msgstr "セッション"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:8
 msgid "image:{project_images}/sessions.png[]"
-msgstr ""
+msgstr "image:{project_images}/sessions.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:11
@@ -47,22 +47,28 @@ msgid ""
 "for that client. You can also logout all users in the realm by clicking the "
 "`Logout all` button on the right side of this list."
 msgstr ""
+"クライアントと、そのクライアントに現在アクティブなセッションの数が一覧表示されます。また、この一覧表示の右側にある `Logout all` "
+"ボタンをクリックして、レルム内のすべてのユーザーをログアウトすることもできます。"
 
 #. type: Title ====
 #: source/server_admin/topics/sessions/administering.adoc:12
 #, no-wrap
 msgid "Logout All Limitations"
-msgstr ""
+msgstr "Logout all の制限事項"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:17
 msgid ""
 "Any SSO cookies set will now be invalid and clients that request "
 "authentication in active browser sessions will now have to re-login.  Only "
-"certain clients are notified of this logout event, specifically clients that "
-"are using the {project_name} OIDC client adapter. Other client types (i.e. "
+"certain clients are notified of this logout event, specifically clients that"
+" are using the {project_name} OIDC client adapter. Other client types (i.e. "
 "SAML) will not receive a backchannel logout request."
 msgstr ""
+"すべてのSSO "
+"Cookieセットが無効になり、アクティブなブラウザー・セッションで認証を要求するクライアントは再ログインする必要があります。このログアウト・イベントは、特定のクライアント（特に、{project_name}"
+" "
+"OIDCクライアント・アダプターを使用しているクライアント）にのみ通知されます。他のクライアント・タイプ（SAML）はバックチャネル・ログアウト・リクエストを受信しません。"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:21
@@ -72,12 +78,15 @@ msgid ""
 "a <<_revocation-policy, revocation policy>> out to clients, but that also "
 "only works with clients using the {project_name} OIDC client adapter."
 msgstr ""
+"`Logout all` をクリックしても、未処理のアクセス・トークンは取り消されないことに注意することが重要です。それらは自然に失効する必要があります"
+"。<<_revocation-policy, 無効化ポリシー>>をクライアントにプッシュする必要がありますが、これも{project_name} "
+"OIDCクライアント・アダプターを使用するクライアントだけで機能します。"
 
 #. type: Title ====
 #: source/server_admin/topics/sessions/administering.adoc:22
 #, no-wrap
 msgid "Application Drilldown"
-msgstr ""
+msgstr "アプリケーション・ドリルダウン"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:26
@@ -87,38 +96,40 @@ msgid ""
 "Sessions` button there allows you to see which users are logged into that "
 "application."
 msgstr ""
+"`Sessions` ページでは、各クライアントにドリルダウンすることもできます。これにより、そのクライアントの `Sessions` "
+"タブが表示されます。 `Show Sessions` ボタンをクリックすると、そのアプリケーションにログインしているユーザーを見ることができます。"
 
 #. type: Block title
 #: source/server_admin/topics/sessions/administering.adoc:27
 #, no-wrap
 msgid "Application Sessions"
-msgstr ""
+msgstr "アプリケーション・セッション"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:29
 msgid "image:{project_images}/application-sessions.png[]"
-msgstr ""
+msgstr "image:{project_images}/application-sessions.png[]"
 
 #. type: Title ====
 #: source/server_admin/topics/sessions/administering.adoc:30
 #, no-wrap
 msgid "User Drilldown"
-msgstr ""
+msgstr "ユーザー・ドリルダウン"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:33
 msgid ""
-"If you go to the `Sessions` tab of an individual user, you can also view the "
-"session information."
-msgstr ""
+"If you go to the `Sessions` tab of an individual user, you can also view the"
+" session information."
+msgstr "個々のユーザの `Sessions` タブに移動すると、セッション情報を表示することもできます。"
 
 #. type: Block title
 #: source/server_admin/topics/sessions/administering.adoc:34
 #, no-wrap
 msgid "User Sessions"
-msgstr ""
+msgstr "ユーザー・セッション"
 
 #. type: Plain text
 #: source/server_admin/topics/sessions/administering.adoc:36
 msgid "image:{project_images}/user-sessions.png[]"
-msgstr ""
+msgstr "image:{project_images}/user-sessions.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,33 +15,27 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Sessions"
+msgstr "セッション"
+
 #. type: Title ===
-#: source/server_admin/topics/sessions/administering.adoc:2
 #, no-wrap
 msgid "Administering Sessions"
 msgstr "セッションの管理"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:5
 msgid ""
 "If you go to the `Sessions` left menu item you can see a top level view of "
 "the number of sessions that are currently active in the realm."
-msgstr "左のメニュー項目 `Sessions` に行くと、現在そのレルムでアクティブなセッション数のトップレベルのビューが表示されます。"
-
-#. type: Block title
-#: source/server_admin/topics/sessions/administering.adoc:6
-#: source/server_admin/topics/account.adoc:34
-#, no-wrap
-msgid "Sessions"
-msgstr "セッション"
+msgstr "左のメニュー項目 `Sessions` をクリックすると、現在そのレルムでアクティブなセッション数のトップレベルのビューが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:8
 msgid "image:{project_images}/sessions.png[]"
 msgstr "image:{project_images}/sessions.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:11
 msgid ""
 "A list of clients is given and how many active sessions there currently are "
 "for that client. You can also logout all users in the realm by clicking the "
@@ -51,13 +45,11 @@ msgstr ""
 "ボタンをクリックして、レルム内のすべてのユーザーをログアウトすることもできます。"
 
 #. type: Title ====
-#: source/server_admin/topics/sessions/administering.adoc:12
 #, no-wrap
 msgid "Logout All Limitations"
-msgstr "Logout all の制限事項"
+msgstr "Logout allの制限事項"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:17
 msgid ""
 "Any SSO cookies set will now be invalid and clients that request "
 "authentication in active browser sessions will now have to re-login.  Only "
@@ -71,25 +63,22 @@ msgstr ""
 "OIDCクライアント・アダプターを使用しているクライアント）にのみ通知されます。他のクライアント・タイプ（SAML）はバックチャネル・ログアウト・リクエストを受信しません。"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:21
 msgid ""
 "It is important to note that any outstanding access tokens are not revoked "
 "by clicking `Logout all`.  They have to expire naturally.  You have to push "
 "a <<_revocation-policy, revocation policy>> out to clients, but that also "
 "only works with clients using the {project_name} OIDC client adapter."
 msgstr ""
-"`Logout all` をクリックしても、未処理のアクセス・トークンは取り消されないことに注意することが重要です。それらは自然に失効する必要があります"
-"。<<_revocation-policy, 無効化ポリシー>>をクライアントにプッシュする必要がありますが、これも{project_name} "
+"`Logout all` をクリックしても、未処理のアクセス・トークンは取り消されないことに注意することが重要です。それらは失効する必要があります"
+"。<<_revocation-policy, 失効ポリシー>>をクライアントにプッシュする必要がありますが、これも{project_name} "
 "OIDCクライアント・アダプターを使用するクライアントだけで機能します。"
 
 #. type: Title ====
-#: source/server_admin/topics/sessions/administering.adoc:22
 #, no-wrap
 msgid "Application Drilldown"
 msgstr "アプリケーション・ドリルダウン"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:26
 msgid ""
 "On the `Sessions` page, you can also drill down to each client. This will "
 "bring you to the `Sessions` tab of that client.  Clicking on the `Show "
@@ -97,39 +86,33 @@ msgid ""
 "application."
 msgstr ""
 "`Sessions` ページでは、各クライアントにドリルダウンすることもできます。これにより、そのクライアントの `Sessions` "
-"タブが表示されます。 `Show Sessions` ボタンをクリックすると、そのアプリケーションにログインしているユーザーを見ることができます。"
+"タブが表示されます。 `Show Sessions` ボタンをクリックすると、そのアプリケーションにログインしているユーザーを参照できます。"
 
 #. type: Block title
-#: source/server_admin/topics/sessions/administering.adoc:27
 #, no-wrap
 msgid "Application Sessions"
 msgstr "アプリケーション・セッション"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:29
 msgid "image:{project_images}/application-sessions.png[]"
 msgstr "image:{project_images}/application-sessions.png[]"
 
 #. type: Title ====
-#: source/server_admin/topics/sessions/administering.adoc:30
 #, no-wrap
 msgid "User Drilldown"
 msgstr "ユーザー・ドリルダウン"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:33
 msgid ""
 "If you go to the `Sessions` tab of an individual user, you can also view the"
 " session information."
-msgstr "個々のユーザの `Sessions` タブに移動すると、セッション情報を表示することもできます。"
+msgstr "個々のユーザーの `Sessions` タブに移動すると、セッション情報を表示することもできます。"
 
 #. type: Block title
-#: source/server_admin/topics/sessions/administering.adoc:34
 #, no-wrap
 msgid "User Sessions"
 msgstr "ユーザー・セッション"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions/administering.adoc:36
 msgid "image:{project_images}/user-sessions.png[]"
 msgstr "image:{project_images}/user-sessions.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
@@ -69,7 +69,7 @@ msgid ""
 "a <<_revocation-policy, revocation policy>> out to clients, but that also "
 "only works with clients using the {project_name} OIDC client adapter."
 msgstr ""
-"`Logout all` をクリックしても、未処理のアクセス・トークンは取り消されないことに注意することが重要です。それらは失効する必要があります"
+"`Logout all` をクリックしても、未処理のアクセストークンは取り消されないことに注意することが重要です。それらは失効する必要があります"
 "。<<_revocation-policy, 失効ポリシー>>をクライアントにプッシュする必要がありますが、これも{project_name} "
 "OIDCクライアント・アダプターを使用するクライアントだけで機能します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__administering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sessions__administering/ja_JP/index.html
