### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -30,13 +30,13 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr ""
+msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ====
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:2
 #, no-wrap
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:6
@@ -46,20 +46,26 @@ msgid ""
 "`LinkedIn` from the `Add provider` drop down list.  This will bring you to "
 "the `Add identity provider` page."
 msgstr ""
+"LinkedInにログインするには、いくつかの手順を完了する必要があります。まず、左メニュー項目の `アイデンティティー・プロバイダー` に移動し、 "
+"`プロバイダーの追加` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 `アイデンティティー・プロバイダーの追加` "
+"ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:9
 msgid "image:{project_images}/linked-in-add-identity-provider.png[]"
-msgstr ""
+msgstr "image:{project_images}/linked-in-add-identity-provider.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:13
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client "
-"Secret` from LinkedIn.  One piece of data you'll need from this page is the "
-"`Redirect URI`.  You'll have to provide that to LinkedIn when you register "
+"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
+" Secret` from LinkedIn.  One piece of data you'll need from this page is the"
+" `Redirect URI`.  You'll have to provide that to LinkedIn when you register "
 "{project_name} as a client there, so copy this URI to your clipboard."
 msgstr ""
+"LinkedInから `Client ID` と `Client Secret` "
+"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `リダイレクトURI` "
+"です。クライアントとして{project_name}を登録するときに、LinkedInにそれを提供する必要がありますので、このURIをクリップボードにコピーしておいてください。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:15
@@ -67,24 +73,26 @@ msgid ""
 "To enable login with LinkedIn you first have to create an application in "
 "https://www.linkedin.com/developer/apps[LinkedIn Developer Network]."
 msgstr ""
+"LinkedInでログインを有効にするには、まずhttps://www.linkedin.com/developer/apps[LinkedIn "
+"Developer Network]でアプリケーションを作成する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:17
 msgid ""
 "LinkedIn may change the look and feel of application registration, so these "
 "directions may not always be up to date."
-msgstr ""
+msgstr "Githubはアプリケーション登録のデザインを変更する可能性があるため、これらの指示は常に最新のものではない場合があります。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:18
 #, no-wrap
 msgid "Developer Network"
-msgstr ""
+msgstr "Developer Network"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:20
 msgid "image:images/linked-in-developer-network.png[]"
-msgstr ""
+msgstr "image:images/linked-in-developer-network.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:22
@@ -92,35 +100,37 @@ msgid ""
 "Click on the `Create Application` button.  This will bring you to the "
 "`Create a New Application` Page."
 msgstr ""
+"`Create Application` ボタンをクリックします。これにより、 `Create a New Application` "
+"ページが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:23
 #, no-wrap
 msgid "Create App"
-msgstr ""
+msgstr "アプリケーションの作成"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:25
 msgid "image:images/linked-in-create-app.png[]"
-msgstr ""
+msgstr "image:images/linked-in-create-app.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:27
 msgid ""
-"Fill in the form with the approriate values, then click the `Submit` "
-"button.  This will bring you to the new application's settings page."
-msgstr ""
+"Fill in the form with the approriate values, then click the `Submit` button."
+"  This will bring you to the new application's settings page."
+msgstr "フォームに適切な値を入力し、 `Submit` ボタンをクリックします。 これにより、新しいアプリケーションの設定ページが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:28
 #, no-wrap
 msgid "App Settings"
-msgstr ""
+msgstr "アプリケーションの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:30
 msgid "image:images/linked-in-app-settings.png[]"
-msgstr ""
+msgstr "image:images/linked-in-app-settings.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:35
@@ -131,6 +141,10 @@ msgid ""
 "2.0` `Authorized Redirect URLs` field on the LinkedIn app settings page.  "
 "Don't forget to click the `Update` button after you do this!"
 msgstr ""
+"`Default Application Permissions` セクションで `r_basicprofile` と `r_emailaddress`"
+" を選択してください。{project_name}の `アイデンティティー・プロバイダーの追加` ページから `リダイレクトURI` "
+"をコピーし、それをLinkedInアプリ設定ページの `OAuth 2.0` の `Authorized Redirect "
+"URLs`フィールドに入力する必要があります。入力後、 `Update` ボタンをクリックすることを忘れないでください！"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:37
@@ -139,3 +153,5 @@ msgid ""
 "can enter them into the {project_name} `Add identity provider` page.  Go "
 "back to {project_name} and specify those items."
 msgstr ""
+"{project_name}の `アイデンティティー・プロバイダーの追加` "
+"ページに戻って入力するために、このページからクライアントIDとシークレットを取得します。{project_name}に戻り、それらの項目を入力します。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -46,9 +46,9 @@ msgid ""
 "`LinkedIn` from the `Add provider` drop down list.  This will bring you to "
 "the `Add identity provider` page."
 msgstr ""
-"LinkedInにログインするには、いくつかの手順を完了する必要があります。まず、左メニュー項目の `アイデンティティー・プロバイダー` に移動し、 "
-"`プロバイダーの追加` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 `アイデンティティー・プロバイダーの追加` "
-"ページが表示されます。"
+"LinkedInにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
+"に移動し、 `Add provider` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 `Add identity "
+"provider` ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:9
@@ -64,7 +64,7 @@ msgid ""
 "{project_name} as a client there, so copy this URI to your clipboard."
 msgstr ""
 "LinkedInから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `リダイレクトURI` "
+"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `Redirect URI` "
 "です。クライアントとして{project_name}を登録するときに、LinkedInにそれを提供する必要がありますので、このURIをクリップボードにコピーしておいてください。"
 
 #. type: Plain text
@@ -73,15 +73,15 @@ msgid ""
 "To enable login with LinkedIn you first have to create an application in "
 "https://www.linkedin.com/developer/apps[LinkedIn Developer Network]."
 msgstr ""
-"LinkedInでログインを有効にするには、まずhttps://www.linkedin.com/developer/apps[LinkedIn "
-"Developer Network]でアプリケーションを作成する必要があります。"
+"LinkedInでログインを可能にするには、まず https://www.linkedin.com/developer/apps[LinkedIn "
+"Developer Network] でアプリケーションを作成する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:17
 msgid ""
 "LinkedIn may change the look and feel of application registration, so these "
 "directions may not always be up to date."
-msgstr "Githubはアプリケーション登録のデザインを変更する可能性があるため、これらの指示は常に最新のものではない場合があります。"
+msgstr "LinkedInはアプリケーション登録のデザインを変更する可能性があるため、これらの指示は常に最新のものではない場合があります。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:18
@@ -142,9 +142,9 @@ msgid ""
 "Don't forget to click the `Update` button after you do this!"
 msgstr ""
 "`Default Application Permissions` セクションで `r_basicprofile` と `r_emailaddress`"
-" を選択してください。{project_name}の `アイデンティティー・プロバイダーの追加` ページから `リダイレクトURI` "
-"をコピーし、それをLinkedInアプリ設定ページの `OAuth 2.0` の `Authorized Redirect "
-"URLs`フィールドに入力する必要があります。入力後、 `Update` ボタンをクリックすることを忘れないでください！"
+" を選択してください。{project_name}の `Add Identity Provider` ページから `Redirect URI` "
+"をコピーし、それをLinkedInアプリ設定ページの `OAuth 2.0` の `Authorized Redirect URLs` "
+"フィールドに入力する必要があります。入力後、 `Update` ボタンをクリックすることを忘れないでください！"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/linked-in.adoc:37
@@ -153,5 +153,5 @@ msgid ""
 "can enter them into the {project_name} `Add identity provider` page.  Go "
 "back to {project_name} and specify those items."
 msgstr ""
-"{project_name}の `アイデンティティー・プロバイダーの追加` "
-"ページに戻って入力するために、このページからクライアントIDとシークレットを取得します。{project_name}に戻り、それらの項目を入力します。"
+"このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
+"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__linked-in
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__social__linked-in/ja_JP/index.html
