### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -57,7 +57,7 @@ msgid ""
 "`Google` from the `Add provider` drop down list.  This will bring you to the"
 " `Add identity provider` page."
 msgstr ""
-"Googleにログインするには、いくつかのステップを完了しなければなりません。まず、左のメニュー項目の `Identity Providers` "
+"Googleにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
 "に移動し、 `Add provider` のドロップダウン・リストから `Google` を選択します。これにより、 `Add identity "
 "provider` ページが表示されます。"
 

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,8 +40,8 @@ msgid ""
 "enter them into the {project_name} `Add identity provider` page.  Go back to"
 " {project_name} and specify those items."
 msgstr ""
-"{project_name}の `アイデンティティー・プロバイダーの追加` "
-"ページに戻って入力するために、このページからクライアントIDとシークレットを取得します。{project_name}に戻り、それらの項目を入力します。"
+"このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
+"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
 
 #. type: Title ====
 #: source/server_admin/topics/identity-broker/social/google.adoc:1
@@ -57,9 +57,9 @@ msgid ""
 "`Google` from the `Add provider` drop down list.  This will bring you to the"
 " `Add identity provider` page."
 msgstr ""
-"Googleにログインするには、いくつかのステップを完了しなければなりません。まず、 `アイデンティティー・プロバイダー` の左メニュー項目に移動し、 "
-"`プロバイダーの追加` ドロップ・ダウン・リストから `Google` を選択します。これにより、 `アイデンティティー・プロバイダーの追加` "
-"ページが表示されます。"
+"Googleにログインするには、いくつかのステップを完了しなければなりません。まず、左のメニュー項目の `Identity Providers` "
+"に移動し、 `Add provider` のドロップダウン・リストから `Google` を選択します。これにより、 `Add identity "
+"provider` ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:8
@@ -86,9 +86,9 @@ msgid ""
 "Then you need to copy the client id and secret into the {project_name} Admin"
 " Console."
 msgstr ""
-"Googleでのログインを可能にするには、まずhttps://console.cloud.google.com/project[Google "
-"Developer "
-"Console]でプロジェクトとクライアントを作成する必要があります。次に、クライアントIDとシークレットを{project_name}の管理コンソールにコピーする必要があります。"
+"Googleでのログインを可能にするには、まず https://console.cloud.google.com/project[Google "
+"Developer Console] "
+"でプロジェクトとクライアントを作成する必要があります。次に、クライアントIDとシークレットを{project_name}の管理コンソールにコピーする必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:18
@@ -133,7 +133,7 @@ msgid ""
 " to be created (this may take a while).  Once created you will be brought to"
 " the project's dashboard."
 msgstr ""
-"`Create Project` ボタンをクリックしてください。 `Project name` と `Project ID` に任意の値を使い、 "
+"`Create Project` ボタンをクリックします。 `Project name` と `Project ID` に任意の値を使用し、 "
 "`Create` "
 "ボタンをクリックします。プロジェクトが作成されるのを待ちます（これには時間がかかることがあります）。作成されると、プロジェクトのダッシュボードに遷移します。"
 
@@ -176,8 +176,8 @@ msgid ""
 "must create the credentials of your project.  So click the `Go to "
 "Credentials` button."
 msgstr ""
-"このページの `Enable` ボタンをクリックしてください。プロジェクトのクレデンシャルを作成する必要があるというメッセージが表示されます。そこで、 "
-"`Go to Credentials` ボタンをクリックしてください。"
+"このページの `Enable` ボタンをクリックします。プロジェクトのクレデンシャルを作成する必要があるというメッセージが表示されます。そこで、 `Go"
+" to Credentials` ボタンをクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:43
@@ -249,8 +249,8 @@ msgid ""
 "redirect URIs` field.  After you do this, click the `Create client ID` "
 "button."
 msgstr ""
-"次に、OAuth 2.0クライアントIDを作成する必要があります。クライアントに必要な名前を指定します。また、{project_name}の "
-"`アイデンティティー・プロバイダーの追加` ページから `リダイレクトURI` をコピーし、 `Authorized redirect URIs` "
+"次に、OAuth 2.0クライアントIDを作成する必要があります。クライアントに必要な名前を指定します。また、{project_name}の `Add "
+"Identity Provider` ページから `Redirect URI` をコピーし、 `Authorized redirect URIs` "
 "フィールドに貼り付ける必要があります。これを済ませたら、 `Create client ID` ボタンをクリックします。"
 
 #. type: Plain text
@@ -261,7 +261,7 @@ msgid ""
 "view information about their user profile.  The next Google config screen "
 "asks you for information about this screen."
 msgstr ""
-"ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。次のGoogleの設定画面にこの画面に関する情報が表示されます。"
+"ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。次のGoogleの設定画面に、この画面に関する情報が表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:71
@@ -270,7 +270,7 @@ msgid ""
 "on your new OAuth 2.0 Client ID to view the settings of your new Google "
 "Client."
 msgstr ""
-"`Done` をクリックすると `Credentials` ページが表示されます。 新しいOAuth "
+"`Done` をクリックすると、 `Credentials` ページが表示されます。 新しいOAuth "
 "2.0クライアントのIDをクリックすると、新しいGoogleクライアントの設定が表示されます。"
 
 #. type: Block title
@@ -294,6 +294,7 @@ msgid ""
 "https://developers.google.com/oauthplayground/ . By default, {project_name} "
 "uses the following scopes: `openid` `profile` `email`."
 msgstr ""
-"Googleの `アイデンティティー・プロバイダーの追加` ページの注目すべき1つの設定オプションは、 `Default Scopes` "
-"フィールドです。このフィールドでは、このプロバイダで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、https://developers.google.com/oauthplayground/をご覧ください。"
-" デフォルトでは、{project_name}は次のスコープを使用します： `openid` `profile` `email`。"
+"Google用の `Add identity provider` ページで注意が必要な1つの設定オプションは、 `Default Scopes` "
+"フィールドです。 このフィールドでは、プロバイダで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、 "
+"https://developers.google.com/oauthplayground/ をご覧ください。 "
+"デフォルトでは、{project_name}は `openid` `profile` `email` のスコープを使用します。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -30,54 +30,65 @@ msgstr ""
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr ""
+msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/github.adoc:37
 #: source/server_admin/topics/identity-broker/social/google.adoc:78
 msgid ""
 "You will need to obtain the client ID and secret from this page so you can "
-"enter them into the {project_name} `Add identity provider` page.  Go back to "
-"{project_name} and specify those items."
+"enter them into the {project_name} `Add identity provider` page.  Go back to"
+" {project_name} and specify those items."
 msgstr ""
+"{project_name}の `アイデンティティー・プロバイダーの追加` "
+"ページに戻って入力するために、このページからクライアントIDとシークレットを取得します。{project_name}に戻り、それらの項目を入力します。"
 
 #. type: Title ====
 #: source/server_admin/topics/identity-broker/social/google.adoc:1
 #, no-wrap
 msgid "Google"
-msgstr ""
+msgstr "Google"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:5
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "Google.  First, go to the `Identity Providers` left menu item and select "
-"`Google` from the `Add provider` drop down list.  This will bring you to the "
-"`Add identity provider` page."
+"`Google` from the `Add provider` drop down list.  This will bring you to the"
+" `Add identity provider` page."
 msgstr ""
+"Googleにログインするには、いくつかのステップを完了しなければなりません。まず、 `アイデンティティー・プロバイダー` の左メニュー項目に移動し、 "
+"`プロバイダーの追加` ドロップ・ダウン・リストから `Google` を選択します。これにより、 `アイデンティティー・プロバイダーの追加` "
+"ページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:8
 msgid "image:{project_images}/google-add-identity-provider.png[]"
-msgstr ""
+msgstr "image:{project_images}/google-add-identity-provider.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:12
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client "
-"Secret` from Google.  One piece of data you'll need from this page is the "
+"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
+" Secret` from Google.  One piece of data you'll need from this page is the "
 "`Redirect URI`.  You'll have to provide that to Google when you register "
 "{project_name} as a client there, so copy this URI to your clipboard."
 msgstr ""
+"Googleから `Client ID` と `Client Secret` "
+"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
+"です。Googleに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:15
 msgid ""
 "To enable login with Google you first have to create a project and a client "
 "in the https://console.cloud.google.com/project[Google Developer Console].  "
-"Then you need to copy the client id and secret into the {project_name} Admin "
-"Console."
+"Then you need to copy the client id and secret into the {project_name} Admin"
+" Console."
 msgstr ""
+"Googleでのログインを可能にするには、まずhttps://console.cloud.google.com/project[Google "
+"Developer "
+"Console]でプロジェクトとクライアントを作成する必要があります。次に、クライアントIDとシークレットを{project_name}の管理コンソールにコピーする必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:18
@@ -86,68 +97,77 @@ msgid ""
 "Google often changes the look and feel of the Google Developer Console, so these directions might not always be up to date and the\n"
 "      configuration steps might be slightly different.\n"
 msgstr ""
+"GoogleはGoogle Developer "
+"Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:20
 msgid "Let's see first how to create a project with Google."
-msgstr ""
+msgstr "最初にGoogleでプロジェクトを作成する方法を説明します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:22
 msgid ""
-"Log in to the link:https://console.cloud.google.com/project[Google Developer "
-"Console]."
+"Log in to the link:https://console.cloud.google.com/project[Google Developer"
+" Console]."
 msgstr ""
+"link:https://console.cloud.google.com/project[Google Developer "
+"Console]にログインします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:23
 #, no-wrap
 msgid "Google Developer Console"
-msgstr ""
+msgstr "Google Developer Console"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:25
 msgid "image:images/google-developer-console.png[]"
-msgstr ""
+msgstr "image:images/google-developer-console.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:30
 msgid ""
 "Click the `Create Project` button.  Use any value for `Project name` and "
-"`Project ID` you want, then click the `Create` button.  Wait for the project "
-"to be created (this may take a while).  Once created you will be brought to "
-"the project's dashboard."
+"`Project ID` you want, then click the `Create` button.  Wait for the project"
+" to be created (this may take a while).  Once created you will be brought to"
+" the project's dashboard."
 msgstr ""
+"`Create Project` ボタンをクリックしてください。 `Project name` と `Project ID` に任意の値を使い、 "
+"`Create` "
+"ボタンをクリックします。プロジェクトが作成されるのを待ちます（これには時間がかかることがあります）。作成されると、プロジェクトのダッシュボードに遷移します。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:31
 #, no-wrap
 msgid "Dashboard"
-msgstr ""
+msgstr "ダッシュボード"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:33
 msgid "image:images/google-dashboard.png[]"
-msgstr ""
+msgstr "image:images/google-dashboard.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:36
 msgid ""
-"To be able to retrieve the profiles of Google users, you need to turn on the "
-"Google+ APIs.  Select the `Enable and manage APIs` and click the `Google+ "
+"To be able to retrieve the profiles of Google users, you need to turn on the"
+" Google+ APIs.  Select the `Enable and manage APIs` and click the `Google+ "
 "API` link."
 msgstr ""
+"Googleユーザーのプロファイルを取得するには、Google+ APIsを有効にする必要があります。 `Enable and manage APIs`"
+" を選択し、 `Google+ API` リンクをクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:37
 #, no-wrap
 msgid "APIs"
-msgstr ""
+msgstr "API"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:39
 msgid "image:images/google-api-list.png[]"
-msgstr ""
+msgstr "image:images/google-api-list.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:42
@@ -156,22 +176,24 @@ msgid ""
 "must create the credentials of your project.  So click the `Go to "
 "Credentials` button."
 msgstr ""
+"このページの `Enable` ボタンをクリックしてください。プロジェクトのクレデンシャルを作成する必要があるというメッセージが表示されます。そこで、 "
+"`Go to Credentials` ボタンをクリックしてください。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:43
 #, no-wrap
 msgid "Go To Credentials"
-msgstr ""
+msgstr "クレデンシャルへ移動"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:45
 msgid "image:images/google-go-to-credentials.png[]"
-msgstr ""
+msgstr "image:images/google-go-to-credentials.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:47
 msgid "You will then be brought to the credentials page."
-msgstr ""
+msgstr "これで、クレデンシャルのページが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:50
@@ -179,25 +201,25 @@ msgstr ""
 msgid ""
 "If you logout in the middle of this, there is a menu in the top left hand corner.  Select `API Manager` and it\n"
 "       will bring you to your desired screen.\n"
-msgstr ""
+msgstr "この間にログアウトすると、左上隅にメニューが表示されます。 `API Manager` を選択すると、目的の画面が表示されます。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:52
 msgid ""
-"You will then be asked to specify what credentials you need and what type of "
-"data you will be accessing."
-msgstr ""
+"You will then be asked to specify what credentials you need and what type of"
+" data you will be accessing."
+msgstr "次に、必要なクレデンシャルとアクセスするデータの種類を指定するよう求められます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:53
 #, no-wrap
 msgid "Add Credentials"
-msgstr ""
+msgstr "クレデンシャルの追加"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:55
 msgid "image:images/google-add-credentials.png[]"
-msgstr ""
+msgstr "image:images/google-add-credentials.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:57
@@ -205,27 +227,31 @@ msgid ""
 "Select `Web server` and `User data` and click the `What credentials do I "
 "need?` button."
 msgstr ""
+"`Web server` と `User data` を選択し、 `What credentials do I need?` ボタンをクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:58
 #, no-wrap
 msgid "Create OAuth ID"
-msgstr ""
+msgstr "OAuth IDの作成"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:60
 msgid "image:images/google-create-oauth-id.png[]"
-msgstr ""
+msgstr "image:images/google-create-oauth-id.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:64
 msgid ""
 "Next you'll need to create an OAuth 2.0 client ID.  Specify the name you "
-"want for your client.  You'll also need to copy and paste the `Redirect URI` "
-"from the {project_name} `Add Identity Provider` page into the `Authorized "
+"want for your client.  You'll also need to copy and paste the `Redirect URI`"
+" from the {project_name} `Add Identity Provider` page into the `Authorized "
 "redirect URIs` field.  After you do this, click the `Create client ID` "
 "button."
 msgstr ""
+"次に、OAuth 2.0クライアントIDを作成する必要があります。クライアントに必要な名前を指定します。また、{project_name}の "
+"`アイデンティティー・プロバイダーの追加` ページから `リダイレクトURI` をコピーし、 `Authorized redirect URIs` "
+"フィールドに貼り付ける必要があります。これを済ませたら、 `Create client ID` ボタンをクリックします。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:68
@@ -235,6 +261,7 @@ msgid ""
 "view information about their user profile.  The next Google config screen "
 "asks you for information about this screen."
 msgstr ""
+"ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。次のGoogleの設定画面にこの画面に関する情報が表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:71
@@ -243,17 +270,19 @@ msgid ""
 "on your new OAuth 2.0 Client ID to view the settings of your new Google "
 "Client."
 msgstr ""
+"`Done` をクリックすると `Credentials` ページが表示されます。 新しいOAuth "
+"2.0クライアントのIDをクリックすると、新しいGoogleクライアントの設定が表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/social/google.adoc:72
 #, no-wrap
 msgid "Google Client Credentials"
-msgstr ""
+msgstr "Googleクライアント・クレデンシャル"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:74
 msgid "image:images/google-client-credentials.png[]"
-msgstr ""
+msgstr "image:images/google-client-credentials.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/social/google.adoc:82
@@ -261,7 +290,10 @@ msgid ""
 "One config option to note on the `Add identity provider` page for Google is "
 "the `Default Scopes` field.  This field allows you to manually specify the "
 "scopes that users must authorize when authenticating with this provider.  "
-"For a complete list of scopes, please take a look at https://developers."
-"google.com/oauthplayground/ . By default, {project_name} uses the following "
-"scopes: `openid` `profile` `email`."
+"For a complete list of scopes, please take a look at "
+"https://developers.google.com/oauthplayground/ . By default, {project_name} "
+"uses the following scopes: `openid` `profile` `email`."
 msgstr ""
+"Googleの `アイデンティティー・プロバイダーの追加` ページの注目すべき1つの設定オプションは、 `Default Scopes` "
+"フィールドです。このフィールドでは、このプロバイダで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、https://developers.google.com/oauthplayground/をご覧ください。"
+" デフォルトでは、{project_name}は次のスコープを使用します： `openid` `profile` `email`。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__social__google/ja_JP/index.html
