### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/identity-brokering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/identity-brokering.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/identity-brokering.ja_JP.po
@@ -2,32 +2,33 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_development/topics/identity-brokering.adoc:2
 #, no-wrap
 msgid "Identity Brokering APIs"
-msgstr ""
+msgstr "アイデンティティー・ブローキングAPI"
 
 #. type: Plain text
 #: source/server_development/topics/identity-brokering.adoc:8
 msgid ""
 "{project_name} can delegate authentication to a parent IDP for login.  A "
-"typical example of this is the case where you want users to be able to login "
-"through a social provider like Facebook or Google.  {project_name} also "
+"typical example of this is the case where you want users to be able to login"
+" through a social provider like Facebook or Google.  {project_name} also "
 "allows you to link existing accounts to a brokered IDP.  This section talks "
 "about some APIs that your applications can use as it pertains to identity "
 "brokering."
 msgstr ""
+"{project_name}はログイン用の親IDPに認証を委譲できます。これの典型的な例は、ユーザーがFacebookやGoogleなどのソーシャル・プロバイダーを介してログインできるようにする場合です。{project_name}では、既存のアカウントを仲介されたIDPにリンクすることもできます。このセクションでは、アプリケーションがアイデンティティー・ブローキングに関連して使用できるいくつかのAPIについて説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/identity-brokering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__identity-brokering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__identity-brokering/ja_JP/index.html
