### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/client-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/client-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/client-roles.ja_JP.po
@@ -2,33 +2,35 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/roles/client-roles.adoc:1
 #, no-wrap
 msgid "Client Roles"
-msgstr ""
+msgstr "クライアント・ロール"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/client-roles.adoc:4
 msgid ""
 "Client roles are basically a namespace dedicated to a client. Each client "
-"gets its own namespace. Client roles are managed under the `Roles` tab under "
-"each individual client. You interact with this UI the same way you do for "
+"gets its own namespace. Client roles are managed under the `Roles` tab under"
+" each individual client. You interact with this UI the same way you do for "
 "realm-level roles."
 msgstr ""
+"クライアント・ロールは、基本的にクライアント専用の名前空間です。各クライアントは独自の名前空間を取得します。クライアント・ロールは、個々のクライアントの"
+" `Roles` タブで管理されます。レルム・レベルのロールと同じ方法で、このUIとやりとりします。"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/client-roles.adoc:6
@@ -38,15 +40,17 @@ msgid ""
 "parameter. For example, if the client ID is `account` and the role is "
 "`admin`, the scope parameter is:"
 msgstr ""
+"クライアントが別のクライアントのロールを明示的に要求しなければならない場合は、scopeパラメーターを使用して要求を実行するときに、ロールにクライアントIDの接頭辞を付ける必要があります。たとえば、クライアントIDが"
+" `account` でロールが `admin` の場合、scopeパラメーターは次のようになります。"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/client-roles.adoc:8
 #, no-wrap
 msgid " `scope=account/admin`\n"
-msgstr ""
+msgstr "`scope=account/admin`\n"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/client-roles.adoc:10
 msgid ""
 "As noted in the realm roles section, multiple roles are separated by spaces."
-msgstr ""
+msgstr "レルム・ロールの節で説明したように、複数のロールはスペースで区切られます。"

--- a/i18n/po/ja_JP/server_admin/topics/roles/client-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/client-roles.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Shinsuke UEDA, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_admin/topics/roles/client-roles.adoc:1
 #, no-wrap
 msgid "Client Roles"
-msgstr "クライアント・ロール"
+msgstr "クライアントロール"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/client-roles.adoc:4
@@ -29,8 +29,8 @@ msgid ""
 " each individual client. You interact with this UI the same way you do for "
 "realm-level roles."
 msgstr ""
-"クライアント・ロールは、基本的にクライアント専用の名前空間です。各クライアントは独自の名前空間を取得します。クライアント・ロールは、個々のクライアントの"
-" `Roles` タブで管理されます。レルム・レベルのロールと同じ方法で、このUIとやりとりします。"
+"クライアントロールは、基本的にクライアント専用の名前空間です。各クライアントは独自の名前空間を取得します。クライアントロールは、個々のクライアントの "
+"`Roles` タブで管理されます。レルムレベルのロールと同じ方法で、このUIとやりとりします。"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/client-roles.adoc:6
@@ -53,4 +53,4 @@ msgstr "`scope=account/admin`\n"
 #: source/server_admin/topics/roles/client-roles.adoc:10
 msgid ""
 "As noted in the realm roles section, multiple roles are separated by spaces."
-msgstr "レルム・ロールの節で説明したように、複数のロールはスペースで区切られます。"
+msgstr "レルムロールの節で説明したように、複数のロールはスペースで区切られます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/client-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__client-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__roles__client-roles/ja_JP/index.html
