### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/roles/realm-roles.adoc:2
 #, no-wrap
 msgid "Realm Roles"
-msgstr ""
+msgstr "レルム・ロール"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:5
@@ -28,40 +28,46 @@ msgid ""
 "the list of built-in and created roles by clicking the `Roles` left menu "
 "item."
 msgstr ""
+"レルム・レベルのロールは、ロールを定義するグローバルな名前空間です。左のメニュー項目の `Roles` "
+"をクリックすると、組み込みのロールと作成されたロールのリストが表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:7
 msgid "image:{project_images}/roles.png[]"
-msgstr ""
+msgstr "image:{project_images}/roles.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:9
 msgid ""
 "To create a role, click *Add Role* on this page, enter in the name and "
 "description of the role, and click *Save*."
-msgstr ""
+msgstr "ロールを作成するには、このページの *Add Role* をクリックし、ロールの名前と説明を入力して、 *Save* をクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/roles/realm-roles.adoc:10
 #, no-wrap
 msgid "Add Role"
-msgstr ""
+msgstr "ロールの追加"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:12
 msgid "image:{project_images}/role.png[]"
-msgstr ""
+msgstr "image:{project_images}/role.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:14
 msgid ""
 "The value for the `description` field is localizable by specifying a "
 "substitution variable with `$\\{var-name}` strings. The localized value is "
-"then configured within property files in your theme. See the link:"
-"{developerguide_link}[{developerguide_name}] for more information on "
+"then configured within property files in your theme. See the "
+"link:{developerguide_link}[{developerguide_name}] for more information on "
 "localization. If a client requires user _consent_, this description string "
 "is displayed on the consent page for the user."
 msgstr ""
+"`description` フィールドの値は、置換変数を `$\\{var-name}` "
+"文字列で指定することによってローカライズ可能です。ローカライズされた値は、テーマのプロパティファイル内で設定します。ローカリゼーションの詳細については、{developerguide_link}"
+" [{developerguide_name}]のリンクを参照してください。クライアントがユーザー _同意_ "
+"を必要とする場合、このdescription文字列はユーザ​​ーの同意ページに表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:16
@@ -71,8 +77,11 @@ msgid ""
 "parameter when requesting a token. Multiple realm roles are separated by "
 "space:"
 msgstr ""
+"クライアントがレルム・ロールを明示的に要求しなければならない場合は、  `Scope Param Required` "
+"をtrueに設定してください。その場合、トークンを要求するときに `scope` "
+"パラメーターを使用してロールを指定する必要があります。複数のレルム・ロールは、スペースで区切られます。"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/realm-roles.adoc:18
 msgid "`scope=admin user`"
-msgstr ""
+msgstr "`scope=admin user`"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__realm-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__roles__realm-roles/ja_JP/index.html
