### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Shinsuke UEDA, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +19,20 @@ msgstr ""
 #: source/server_admin/topics/roles/user-role-mappings.adoc:2
 #, no-wrap
 msgid "User Role Mappings"
-msgstr "ユーザー・ロール・マッピング"
+msgstr "ユーザー・ロールマッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:5
 msgid ""
 "User role mappings can be assigned individually to each user through the "
 "`Role Mappings` tab for that single user."
-msgstr "ユーザ・ロール・マッピングは、各ユーザーの `Role Mappings`  タブを介して個別に割り当てることができます。"
+msgstr "ユーザ・ロールマッピングは、各ユーザーの `Role Mappings`  タブを介して個別に割り当てることができます。"
 
 #. type: Block title
 #: source/server_admin/topics/roles/user-role-mappings.adoc:6
 #, no-wrap
 msgid "Role Mappings"
-msgstr "ロール・マッピング"
+msgstr "ロールマッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:8
@@ -45,13 +45,13 @@ msgid ""
 "In the above example, we are about to assign the composite role `developer` "
 "that was created in the <<_composite-roles, Composite Roles>> chapter."
 msgstr ""
-"上の例では、<<_composite-roles, ロールの合成>>章で作成した複合ロール `developer` を割り当てようとしています。"
+"上の例では、<<_composite-roles, 複合ロール>>の章で作成した複合ロール `developer` を割り当てようとしています。"
 
 #. type: Block title
 #: source/server_admin/topics/roles/user-role-mappings.adoc:12
 #, no-wrap
 msgid "Effective Role Mappings"
-msgstr "有効なロール・マッピング"
+msgstr "有効なロールマッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:14
@@ -66,6 +66,6 @@ msgid ""
 "Roles`.  `Effective Roles` are all roles that are explicitly assigned to the"
 " user as well as any roles that are inherited from composites."
 msgstr ""
-"`developer` ロールが割り当てられると、` developer` のコンポジットに関連付けられた `employee` ロールが "
+"`developer` ロールが割り当てられると、 `developer` のコンポジットに関連付けられた `employee` ロールが "
 "`Effective Roles` に現れます。 `Effective Roles` "
 "は、ユーザーに明示的に割り当てられたすべてのロールと、コンポジットから継承されたロールです。"

--- a/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
@@ -19,14 +19,14 @@ msgstr ""
 #: source/server_admin/topics/roles/user-role-mappings.adoc:2
 #, no-wrap
 msgid "User Role Mappings"
-msgstr "ユーザー・ロールマッピング"
+msgstr "ユーザー・ロール・マッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:5
 msgid ""
 "User role mappings can be assigned individually to each user through the "
 "`Role Mappings` tab for that single user."
-msgstr "ユーザ・ロールマッピングは、各ユーザーの `Role Mappings`  タブを介して個別に割り当てることができます。"
+msgstr "ユーザ・ロール・マッピングは、各ユーザーの `Role Mappings`  タブを介して個別に割り当てることができます。"
 
 #. type: Block title
 #: source/server_admin/topics/roles/user-role-mappings.adoc:6

--- a/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
@@ -2,42 +2,42 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/roles/user-role-mappings.adoc:2
 #, no-wrap
 msgid "User Role Mappings"
-msgstr ""
+msgstr "ユーザー・ロール・マッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:5
 msgid ""
 "User role mappings can be assigned individually to each user through the "
 "`Role Mappings` tab for that single user."
-msgstr ""
+msgstr "ユーザ・ロール・マッピングは、各ユーザーの `Role Mappings`  タブを介して個別に割り当てることができます。"
 
 #. type: Block title
 #: source/server_admin/topics/roles/user-role-mappings.adoc:6
 #, no-wrap
 msgid "Role Mappings"
-msgstr ""
+msgstr "ロール・マッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:8
 msgid "image:{project_images}/user-role-mappings.png[]"
-msgstr ""
+msgstr "image:{project_images}/user-role-mappings.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:11
@@ -45,23 +45,27 @@ msgid ""
 "In the above example, we are about to assign the composite role `developer` "
 "that was created in the <<_composite-roles, Composite Roles>> chapter."
 msgstr ""
+"上の例では、<<_composite-roles, ロールの合成>>章で作成した複合ロール `developer` を割り当てようとしています。"
 
 #. type: Block title
 #: source/server_admin/topics/roles/user-role-mappings.adoc:12
 #, no-wrap
 msgid "Effective Role Mappings"
-msgstr ""
+msgstr "有効なロール・マッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:14
 msgid "image:{project_images}/effective-role-mappings.png[]"
-msgstr ""
+msgstr "image:{project_images}/effective-role-mappings.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/roles/user-role-mappings.adoc:17
 msgid ""
-"Once the `developer` role is assigned, you see that the `employee` role that "
-"is associated with the `developer` composite shows up in the `Effective "
-"Roles`.  `Effective Roles` are all roles that are explicitly assigned to the "
-"user as well as any roles that are inherited from composites."
+"Once the `developer` role is assigned, you see that the `employee` role that"
+" is associated with the `developer` composite shows up in the `Effective "
+"Roles`.  `Effective Roles` are all roles that are explicitly assigned to the"
+" user as well as any roles that are inherited from composites."
 msgstr ""
+"`developer` ロールが割り当てられると、` developer` のコンポジットに関連付けられた `employee` ロールが "
+"`Effective Roles` に現れます。 `Effective Roles` "
+"は、ユーザーに明示的に割り当てられたすべてのロールと、コンポジットから継承されたロールです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__user-role-mappings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__roles__user-role-mappings/ja_JP/index.html
