### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -2,28 +2,40 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
+#: source/server_admin/topics/clients/client-saml.adoc:77
+#: source/server_admin/topics/identity-broker/saml.adoc:43
+#, no-wrap
+msgid "Signature Algorithm"
+msgstr "署名アルゴリズム"
+
+#. type: Plain text
+#: source/server_admin/topics/clients/client-saml.adoc:80
+#: source/server_admin/topics/identity-broker/saml.adoc:46
+#, no-wrap
+msgid "SAML Signature Key Name"
+msgstr "SAML署名鍵名"
+
+#. type: Plain text
 #: source/server_admin/topics/sessions/timeouts.adoc:15
+#: source/server_admin/topics/identity-broker/configuration.adoc:45
 #: source/server_admin/topics/identity-broker/oidc.adoc:19
 #: source/server_admin/topics/identity-broker/saml.adoc:18
-#, fuzzy, no-wrap
-msgid ""
-"|===\n"
-"|Configuration|Description\n"
-msgstr "|=== |名前|説明 |デフォルトで有効"
+msgid "Configuration|Description"
+msgstr "設定|説明"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/configuration.adoc:17
@@ -40,190 +52,264 @@ msgstr "|=== |名前|説明 |デフォルトで有効"
 #: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
-msgstr ""
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/oidc.adoc:30
+#: source/server_admin/topics/identity-broker/saml.adoc:28
+msgid "Backchannel Logout"
+msgstr "バックチャンネルログアウト"
 
 #. type: Title ===
 #: source/server_admin/topics/identity-broker/saml.adoc:2
 #, no-wrap
 msgid "SAML v2.0 Identity Providers"
-msgstr ""
+msgstr "SAML v2.0アイデンティティー・プロバイダー"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:5
-#, no-wrap
-msgid "{project_name} can broker identity providers based on the SAML v2.0 protocol.\n"
-msgstr ""
+msgid ""
+"{project_name} can broker identity providers based on the SAML v2.0 "
+"protocol."
+msgstr "{project_name}は、SAML v2.0プロトコルに基づいて、アイデンティティー・プロバイダーを仲介できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:8
-#, no-wrap
 msgid ""
-"To begin configuring an SAML v2.0 provider, go to the `Identity Providers` left menu item\n"
-"and select `SAML v2.0` from the `Add provider` drop down list.  This will bring you to the `Add identity provider` page.\n"
+"To begin configuring an SAML v2.0 provider, go to the `Identity Providers` "
+"left menu item and select `SAML v2.0` from the `Add provider` drop down "
+"list.  This will bring you to the `Add identity provider` page."
 msgstr ""
+"SAML v2.0プロバイダーの設定を開始するには、左側のメニューの `アイデンティティー・プロバイダー` に行き、 `プロバイダーの追加`  "
+"のドロップダウン・リストから `SAML v2.0` を選択します。これにより、 `アイデンティティー・プロバイダーの追加` ページが表示されます。 "
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:11
-#, fuzzy, no-wrap
-#| msgid "image:{project_images}/add-client.png[]"
-msgid "image:{project_images}/saml-add-identity-provider.png[]\n"
-msgstr "image:{project_images}/add-client.png[]"
+msgid "image:{project_images}/saml-add-identity-provider.png[]"
+msgstr "image:{project_images}/saml-add-identity-provider.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:14
-#, no-wrap
 msgid ""
-"The initial configuration options on this page are described in <<_general-idp-config, General IDP Configuration>>.\n"
-"You must define the SAML configuration options as well.  They basically describe the SAML IDP you are communicating with.\n"
+"The initial configuration options on this page are described in <<_general-"
+"idp-config, General IDP Configuration>>.  You must define the SAML "
+"configuration options as well.  They basically describe the SAML IDP you are"
+" communicating with."
 msgstr ""
+"このページの初期設定オプションについては、<<_general-idp-config, "
+"共通のIDP設定>>で説明しています。SAMLの設定オプションも定義する必要があります。それらは基本的に通信しているSAML IDPを記述します。"
 
 #. type: Block title
 #: source/server_admin/topics/identity-broker/saml.adoc:15
 #, no-wrap
 msgid "SAML Config"
-msgstr ""
+msgstr "SAMLの設定"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:20
+msgid "Single Sign-On Service URL"
+msgstr "シングル・サイン・オン・サービスのURL"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:22
 #, no-wrap
 msgid ""
-"|Single Sign-On Service URL\n"
-"|This is a required field and specifies the SAML endpoint to start the authentication process.  If your SAML IDP publishes an IDP entity descriptor, the value of\n"
+"This is a required field and specifies the SAML endpoint to start the authentication process.  If your SAML IDP publishes an IDP entity descriptor, the value of\n"
 " this field will be specified there.\n"
 msgstr ""
+"これは必須フィールドであり、認証プロセスを開始するSAMLエンドポイントを指定します。SAML "
+"IDPがIDPエンティティ記述子を表記する場合、このフィールドの値がそこに指定されます。\n"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:24
+msgid "Single Logout Service URL"
+msgstr "シングル・ログアウト・サービスのURL"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:26
 #, no-wrap
 msgid ""
-"|Single Logout Service URL\n"
-"|This is an optional field that specifies the SAML logout endpoint. If your SAML IDP publishes an IDP entity descriptor, the value of\n"
+"This is an optional field that specifies the SAML logout endpoint. If your SAML IDP publishes an IDP entity descriptor, the value of\n"
 " this field will be specified there.\n"
 msgstr ""
+"これは、SAMLログアウト・エンドポイントを指定するオプションのフィールドです。SAMLのIDPがIDPエンティティ記述子を表記する場合、このフィールドの値がそこに指定されます。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:29
-#, no-wrap
-msgid ""
-"|Backchannel Logout\n"
-"|Enable if your SAML IDP supports backchannel logout\n"
-msgstr ""
+msgid "Enable if your SAML IDP supports backchannel logout"
+msgstr "SAML IDPがバックチャンネル・ログアウトをサポートしている場合に有効にします。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:31
+msgid "NameID Policy Format"
+msgstr "NameIDのポリシー形式"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:32
-#, no-wrap
 msgid ""
-"|NameID Policy Format\n"
-"|Specifies the URI reference corresponding to a name identifier format. Defaults to urn:oasis:names:tc:SAML:2.0:nameid-format:persistent.\n"
+"Specifies the URI reference corresponding to a name identifier format. "
+"Defaults to urn:oasis:names:tc:SAML:2.0:nameid-format:persistent."
 msgstr ""
+"名前識別子の形式に対応するURI参照を指定します。デフォルトはurn:oasis:names:tc:SAML:2.0:nameid-"
+"format:persistentです。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:34
+msgid "HTTP-POST Binding Response"
+msgstr "HTTP-POSTバインディング・レスポンス"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:35
-#, no-wrap
 msgid ""
-"|HTTP-POST Binding Response\n"
-"|When this realm responds to any SAML requests sent by the external IDP, which SAML binding should be used?  If set to `off`, then the Redirect Binding will be used.\n"
+"When this realm responds to any SAML requests sent by the external IDP, "
+"which SAML binding should be used? If set to `off`, then the Redirect "
+"Binding will be used."
 msgstr ""
+"このレルムが外部IDPから送信されたSAMLリクエストに応答するとき、どのSAMLバインディングを使用する必要があるかを指定します。 `off` "
+"に設定すると、リダイレクト・バインディングが使用されます。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:37
+msgid "HTTP-POST Binding for AuthnRequest"
+msgstr "認証リクエストのHTTP-POSTバインディング"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:38
-#, no-wrap
 msgid ""
-"|HTTP-POST Binding for AuthnRequest\n"
-"|When this realm requests authentication from the external SAML IDP, which SAML binding should be used?  If set to `off`, then the Redirect Binding will be used.\n"
+"When this realm requests authentication from the external SAML IDP, which "
+"SAML binding should be used? If set to `off`, then the Redirect Binding will"
+" be used."
 msgstr ""
+"このレルムが外部SAML IDPからの認証を要求する場合、どのSAMLバインディングを使用する必要がありるかを指定します。 `off` "
+"に設定すると、リダイレクト・バインディングが使用されます。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:40
+msgid "Want AuthnRequests Signed"
+msgstr "認証リクエストへの署名"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:41
-#, no-wrap
 msgid ""
-"|Want AuthnRequests Signed\n"
-"|If true, it will use the realm's keypair to sign requests sent to the external SAML IDP\n"
-msgstr ""
+"If true, it will use the realm's keypair to sign requests sent to the "
+"external SAML IDP"
+msgstr "trueの場合、レルムの鍵ペアを使用して、外部SAML IDPに送信されたリクエストに署名します。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:44
-#, no-wrap
 msgid ""
-"|Signature Algorithm\n"
-"|If `Want AuthnRequests Signed` is on, then you can also pick the signature algorithm to use.\n"
-msgstr ""
+"If `Want AuthnRequests Signed` is on, then you can also pick the signature "
+"algorithm to use."
+msgstr "`認証リクエストへの署名` がオンの場合、使用する署名アルゴリズムを選択することもできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:52
 #, no-wrap
 msgid ""
-"|SAML Signature Key Name\n"
-"|Signed SAML documents sent via POST binding contain identification of signing key in `KeyName`\n"
+"Signed SAML documents sent via POST binding contain identification of signing key in `KeyName`\n"
 " element. This by default contains {project_name} key ID. However various external SAML IDPs might\n"
 " expect a different key name or no key name at all. This switch controls whether `KeyName`\n"
 " contains key ID (option `KEY_ID`), subject from certificate corresponding to the realm key\n"
 " (option `CERT_SUBJECT` - expected for instance by Microsoft Active Directory Federation\n"
 " Services), or that the key name hint is completely omitted from the SAML message (option `NONE`).\n"
 msgstr ""
+"POSTバインディングを介して送信された署名付きSAMLドキュメントは、 `KeyName` "
+"要素内の署名鍵の識別情報を含みます。これは、デフォルトで{project_name}の鍵IDを含みます。しかし、さまざまな外部SAML "
+"IDPでは、異なる鍵名が必要であったり、鍵名がまったくないことが予想されます。このスイッチは `KeyName` が鍵IDを含むか（オプション "
+"`KEY_ID` ）、レルムの鍵に対応する証明書からサブジェクトを含むか（オプション `CERT_SUBJECT` - 例えば、Microsoft "
+"Active Directory Federation "
+"Servicesに対して期待される）、鍵名のヒントがSAMLメッセージから完全に省略されるかを制御します（オプション `NONE` ）。\n"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:54
+msgid "Force Authentication"
+msgstr "強制認証"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:55
-#, no-wrap
 msgid ""
-"|Force Authentication\n"
-"|Indicates that the user will be forced to enter in their credentials at the external IDP even if they are already logged in.\n"
-msgstr ""
+"Indicates that the user will be forced to enter in their credentials at the "
+"external IDP even if they are already logged in."
+msgstr "すでにログインしている場合でも、ユーザーが外部IDPでクレデンシャルを入力するよう強制されることを指定します。"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:57
+msgid "Validate Signature"
+msgstr "署名検証"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:58
-#, no-wrap
 msgid ""
-"|Validate Signature\n"
-"|Whether or not the realm should expect that SAML requests and responses from the external IDP be digitally signed.  It is highly recommended you turn this on!\n"
+"Whether or not the realm should expect that SAML requests and responses from"
+" the external IDP be digitally signed.  It is highly recommended you turn "
+"this on!"
 msgstr ""
+"外部IDPからのSAMLリクエストとレスポンスがデジタル署名されることを、レルムが期待するかどうか。これをオンにすることを強くお勧めします。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:62
-#, no-wrap
+#: source/server_admin/topics/identity-broker/saml.adoc:60
+msgid "Validating X509 Certificate"
+msgstr "X509証明書の検証"
+
+#. type: Plain text
+#: source/server_admin/topics/identity-broker/saml.adoc:61
 msgid ""
-"|Validating X509 Certificate\n"
-"|The public certificate that will be used to validate the signatures of SAML requests and responses from the external IDP.\n"
-"|===\n"
-msgstr ""
+"The public certificate that will be used to validate the signatures of SAML "
+"requests and responses from the external IDP."
+msgstr "外部IDPからのSAMLリクエストとレスポンスの署名を検証するために使用される公開証明書。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:67
-#, no-wrap
 msgid ""
-"You can also import all this configuration data by providing a URL or file that points to the SAML IDP entity descriptor of the external IDP.\n"
-"If you are connecting to a {project_name} external IDP, you can import the IDP setttings from the url `<root>/auth/realms/{realm-name}/protocol/saml/descriptor`.\n"
-"This link is an XML document describing metadata about the IDP.\n"
+"You can also import all this configuration data by providing a URL or file "
+"that points to the SAML IDP entity descriptor of the external IDP.  If you "
+"are connecting to a {project_name} external IDP, you can import the IDP "
+"setttings from the url `<root>/auth/realms/{realm-"
+"name}/protocol/saml/descriptor`.  This link is an XML document describing "
+"metadata about the IDP."
 msgstr ""
+"また、外部IDPのSAML "
+"IDPエンティティ記述子を指すURLまたはファイルを指定することによって、この設定データをすべてインポートすることもできます。{project_name}の外部IDPに接続している場合は、"
+" `<root>/auth/realms/{realm-name}/protocol/saml/descriptor` "
+"からIDP設定をインポートできます。このリンクは、IDPに関するメタデータを記述したXML文書です。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:70
-#, no-wrap
-msgid "You can also import all this configuration data by providing a URL or XML file that points to the entity descriptor of the external SAML IDP you want to connect to.\n"
+msgid ""
+"You can also import all this configuration data by providing a URL or XML "
+"file that points to the entity descriptor of the external SAML IDP you want "
+"to connect to."
 msgstr ""
+"また、接続する外部SAML "
+"IDPのエンティティ記述子を指すURLまたはXMLファイルを提供することによって、この設定データをすべてインポートすることもできます。"
 
 #. type: Title ====
 #: source/server_admin/topics/identity-broker/saml.adoc:72
 #, no-wrap
 msgid "SP Descriptor"
-msgstr ""
+msgstr "SP記述子"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:76
-#, no-wrap
 msgid ""
-"Once you create a SAML provider, there is an `EXPORT` button that appears when viewing that provider.\n"
-"Clicking this button will export a SAML SP entity descriptor which you can use to import into the external SP provider.\n"
+"Once you create a SAML provider, there is an `EXPORT` button that appears "
+"when viewing that provider.  Clicking this button will export a SAML SP "
+"entity descriptor which you can use to import into the external SP provider."
 msgstr ""
+"SAMLプロバイダーを作成すると、そのプロバイダを表示するときに `EXPORT` "
+"ボタンも表示されます。このボタンをクリックすると、外部SPにインポートするために使用できるSAML SPエンティティ記述子がエクスポートされます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/saml.adoc:78
-#, no-wrap
-msgid "This metadata is also available publicly by going to the URL\n"
-msgstr ""
+msgid "This metadata is also available publicly by going to the URL"
+msgstr "このメタデータは、このURLにアクセスすることで一般公開されています"
 
 #. type: delimited block -
 #: source/server_admin/topics/identity-broker/saml.adoc:82
 #, no-wrap
-msgid "http[s]://{host:port}/auth/realms/{realm-name}/broker/{broker-alias}/endpoint/descriptor\n"
+msgid ""
+"http[s]://{host:port}/auth/realms/{realm-name}/broker/{broker-"
+"alias}/endpoint/descriptor\n"
 msgstr ""
+"http[s]://{host:port}/auth/realms/{realm-name}/broker/{broker-"
+"alias}/endpoint/descriptor\n"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -16,80 +16,54 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:77
-#: source/server_admin/topics/identity-broker/saml.adoc:43
 #, no-wrap
 msgid "Signature Algorithm"
-msgstr "署名アルゴリズム"
+msgstr "Signature Algorithm"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:80
-#: source/server_admin/topics/identity-broker/saml.adoc:46
 #, no-wrap
 msgid "SAML Signature Key Name"
-msgstr "SAML署名鍵名"
-
-#. type: Plain text
-#: source/server_admin/topics/sessions/timeouts.adoc:15
-#: source/server_admin/topics/identity-broker/configuration.adoc:45
-#: source/server_admin/topics/identity-broker/oidc.adoc:19
-#: source/server_admin/topics/identity-broker/saml.adoc:18
-msgid "Configuration|Description"
-msgstr "設定|説明"
+msgstr "SAML Signature Key Name"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/oidc.adoc:30
-#: source/server_admin/topics/identity-broker/saml.adoc:28
+msgid "Configuration|Description"
+msgstr "設定|説明"
+
+#. type: Plain text
 msgid "Backchannel Logout"
-msgstr "バックチャンネルログアウト"
+msgstr "Backchannel Logout"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/saml.adoc:2
 #, no-wrap
 msgid "SAML v2.0 Identity Providers"
 msgstr "SAML v2.0アイデンティティー・プロバイダー"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:5
 msgid ""
 "{project_name} can broker identity providers based on the SAML v2.0 "
 "protocol."
 msgstr "{project_name}は、SAML v2.0プロトコルに基づいて、アイデンティティー・プロバイダーを仲介できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:8
 msgid ""
 "To begin configuring an SAML v2.0 provider, go to the `Identity Providers` "
 "left menu item and select `SAML v2.0` from the `Add provider` drop down "
 "list.  This will bring you to the `Add identity provider` page."
 msgstr ""
-"SAML v2.0プロバイダーの設定を開始するには、左側のメニューの `アイデンティティー・プロバイダー` に行き、 `プロバイダーの追加`  "
-"のドロップダウン・リストから `SAML v2.0` を選択します。これにより、 `アイデンティティー・プロバイダーの追加` ページが表示されます。 "
+"SAML v2.0プロバイダーの設定を開始するには、左のメニュー項目の `Identity Providers` に移動し、 `Add "
+"provider` のドロップダウン・リストから `SAML v2.0` を選択します。これにより、 `Add identity provider` "
+"ページが表示されます。 "
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:11
 msgid "image:{project_images}/saml-add-identity-provider.png[]"
 msgstr "image:{project_images}/saml-add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:14
 msgid ""
 "The initial configuration options on this page are described in <<_general-"
 "idp-config, General IDP Configuration>>.  You must define the SAML "
@@ -100,18 +74,15 @@ msgstr ""
 "共通のIDP設定>>で説明しています。SAMLの設定オプションも定義する必要があります。それらは基本的に通信しているSAML IDPを記述します。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/saml.adoc:15
 #, no-wrap
 msgid "SAML Config"
 msgstr "SAMLの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:20
 msgid "Single Sign-On Service URL"
-msgstr "シングル・サイン・オン・サービスのURL"
+msgstr "Single Sign-On Service URL"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:22
 #, no-wrap
 msgid ""
 "This is a required field and specifies the SAML endpoint to start the authentication process.  If your SAML IDP publishes an IDP entity descriptor, the value of\n"
@@ -121,31 +92,27 @@ msgstr ""
 "IDPがIDPエンティティ記述子を表記する場合、このフィールドの値がそこに指定されます。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:24
 msgid "Single Logout Service URL"
-msgstr "シングル・ログアウト・サービスのURL"
+msgstr "Single Logout Service URL"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:26
 #, no-wrap
 msgid ""
 "This is an optional field that specifies the SAML logout endpoint. If your SAML IDP publishes an IDP entity descriptor, the value of\n"
 " this field will be specified there.\n"
 msgstr ""
-"これは、SAMLログアウト・エンドポイントを指定するオプションのフィールドです。SAMLのIDPがIDPエンティティ記述子を表記する場合、このフィールドの値がそこに指定されます。\n"
+"SAMLログアウト・エンドポイントを指定するオプションのフィールドです。SAML "
+"IDPがIDPエンティティ記述子を表記する場合、このフィールドの値がそこに指定されます。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:29
 msgid "Enable if your SAML IDP supports backchannel logout"
 msgstr "SAML IDPがバックチャンネル・ログアウトをサポートしている場合に有効にします。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:31
 msgid "NameID Policy Format"
-msgstr "NameIDのポリシー形式"
+msgstr "NameID Policy Format"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:32
 msgid ""
 "Specifies the URI reference corresponding to a name identifier format. "
 "Defaults to urn:oasis:names:tc:SAML:2.0:nameid-format:persistent."
@@ -154,12 +121,10 @@ msgstr ""
 "format:persistentです。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:34
 msgid "HTTP-POST Binding Response"
-msgstr "HTTP-POSTバインディング・レスポンス"
+msgstr "HTTP-POST Binding Response"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:35
 msgid ""
 "When this realm responds to any SAML requests sent by the external IDP, "
 "which SAML binding should be used? If set to `off`, then the Redirect "
@@ -169,41 +134,35 @@ msgstr ""
 "に設定すると、リダイレクト・バインディングが使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:37
 msgid "HTTP-POST Binding for AuthnRequest"
-msgstr "認証リクエストのHTTP-POSTバインディング"
+msgstr "HTTP-POST Binding for AuthnRequest"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:38
 msgid ""
 "When this realm requests authentication from the external SAML IDP, which "
 "SAML binding should be used? If set to `off`, then the Redirect Binding will"
 " be used."
 msgstr ""
-"このレルムが外部SAML IDPからの認証を要求する場合、どのSAMLバインディングを使用する必要がありるかを指定します。 `off` "
+"このレルムが外部SAML IDPからの認証を要求する場合、どのSAMLバインディングを使用する必要があるかを指定します。 `off` "
 "に設定すると、リダイレクト・バインディングが使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:40
 msgid "Want AuthnRequests Signed"
-msgstr "認証リクエストへの署名"
+msgstr "Want AuthnRequests Signed"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:41
 msgid ""
 "If true, it will use the realm's keypair to sign requests sent to the "
 "external SAML IDP"
 msgstr "trueの場合、レルムの鍵ペアを使用して、外部SAML IDPに送信されたリクエストに署名します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:44
 msgid ""
 "If `Want AuthnRequests Signed` is on, then you can also pick the signature "
 "algorithm to use."
-msgstr "`認証リクエストへの署名` がオンの場合、使用する署名アルゴリズムを選択することもできます。"
+msgstr "`Want AuthnRequests Signed` がonの場合、使用する署名アルゴリズムを選択することもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:52
 #, no-wrap
 msgid ""
 "Signed SAML documents sent via POST binding contain identification of signing key in `KeyName`\n"
@@ -214,52 +173,45 @@ msgid ""
 " Services), or that the key name hint is completely omitted from the SAML message (option `NONE`).\n"
 msgstr ""
 "POSTバインディングを介して送信された署名付きSAMLドキュメントは、 `KeyName` "
-"要素内の署名鍵の識別情報を含みます。これは、デフォルトで{project_name}の鍵IDを含みます。しかし、さまざまな外部SAML "
-"IDPでは、異なる鍵名が必要であったり、鍵名がまったくないことが予想されます。このスイッチは `KeyName` が鍵IDを含むか（オプション "
-"`KEY_ID` ）、レルムの鍵に対応する証明書からサブジェクトを含むか（オプション `CERT_SUBJECT` - 例えば、Microsoft "
-"Active Directory Federation "
+"要素内の署名鍵の識別情報を含みます。これは、デフォルトで{project_name}の鍵IDを含みます。しかし、外部SAML "
+"IDPによっては、異なるKeyNameであったり、KeyName要素のない署名付きSAMLドキュメントとなる場合もあります。このスイッチは "
+"`KeyName` が鍵IDを含むか（オプション `KEY_ID` ）、レルムの鍵に対応する証明書からサブジェクトを含むか（オプション "
+"`CERT_SUBJECT` - 例えば、Microsoft Active Directory Federation "
 "Servicesに対して期待される）、鍵名のヒントがSAMLメッセージから完全に省略されるかを制御します（オプション `NONE` ）。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:54
 msgid "Force Authentication"
-msgstr "強制認証"
+msgstr "Force Authentication"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:55
 msgid ""
 "Indicates that the user will be forced to enter in their credentials at the "
 "external IDP even if they are already logged in."
 msgstr "すでにログインしている場合でも、ユーザーが外部IDPでクレデンシャルを入力するよう強制されることを指定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:57
 msgid "Validate Signature"
-msgstr "署名検証"
+msgstr "Validate Signature"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:58
 msgid ""
 "Whether or not the realm should expect that SAML requests and responses from"
 " the external IDP be digitally signed.  It is highly recommended you turn "
 "this on!"
 msgstr ""
-"外部IDPからのSAMLリクエストとレスポンスがデジタル署名されることを、レルムが期待するかどうか。これをオンにすることを強くお勧めします。"
+"外部IDPからのSAMLリクエストとレスポンスがデジタル署名されることを、レルムが期待するかどうかを指定します。これをonにすることを強くお勧めします。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:60
 msgid "Validating X509 Certificate"
-msgstr "X509証明書の検証"
+msgstr "Validating X509 Certificate"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:61
 msgid ""
 "The public certificate that will be used to validate the signatures of SAML "
 "requests and responses from the external IDP."
 msgstr "外部IDPからのSAMLリクエストとレスポンスの署名を検証するために使用される公開証明書。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:67
 msgid ""
 "You can also import all this configuration data by providing a URL or file "
 "that points to the SAML IDP entity descriptor of the external IDP.  If you "
@@ -268,13 +220,12 @@ msgid ""
 "name}/protocol/saml/descriptor`.  This link is an XML document describing "
 "metadata about the IDP."
 msgstr ""
-"また、外部IDPのSAML "
+"外部IDPのSAML "
 "IDPエンティティ記述子を指すURLまたはファイルを指定することによって、この設定データをすべてインポートすることもできます。{project_name}の外部IDPに接続している場合は、"
 " `<root>/auth/realms/{realm-name}/protocol/saml/descriptor` "
 "からIDP設定をインポートできます。このリンクは、IDPに関するメタデータを記述したXML文書です。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:70
 msgid ""
 "You can also import all this configuration data by providing a URL or XML "
 "file that points to the entity descriptor of the external SAML IDP you want "
@@ -284,28 +235,24 @@ msgstr ""
 "IDPのエンティティ記述子を指すURLまたはXMLファイルを提供することによって、この設定データをすべてインポートすることもできます。"
 
 #. type: Title ====
-#: source/server_admin/topics/identity-broker/saml.adoc:72
 #, no-wrap
 msgid "SP Descriptor"
 msgstr "SP記述子"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:76
 msgid ""
 "Once you create a SAML provider, there is an `EXPORT` button that appears "
 "when viewing that provider.  Clicking this button will export a SAML SP "
 "entity descriptor which you can use to import into the external SP provider."
 msgstr ""
-"SAMLプロバイダーを作成すると、そのプロバイダを表示するときに `EXPORT` "
+"SAMLプロバイダーを作成すると、そのプロバイダーを表示するときに `EXPORT` "
 "ボタンも表示されます。このボタンをクリックすると、外部SPにインポートするために使用できるSAML SPエンティティ記述子がエクスポートされます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/saml.adoc:78
 msgid "This metadata is also available publicly by going to the URL"
-msgstr "このメタデータは、このURLにアクセスすることで一般公開されています"
+msgstr "このメタデータは、このURLにアクセスすることで一般公開されています。"
 
 #. type: delimited block -
-#: source/server_admin/topics/identity-broker/saml.adoc:82
 #, no-wrap
 msgid ""
 "http[s]://{host:port}/auth/realms/{realm-name}/broker/{broker-"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__identity-broker__saml/ja_JP/index.html
