### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,8 +34,9 @@ msgstr ""
 "IDP Initiated "
 "ログインは、特定のアプリケーション／クライアントにログインするエンドポイントを{project_name}サーバーに設定できるようにする機能です。クライアントの"
 " `Settings` タブで、 `IDP Initiated SSO URL Name` "
-"を指定する必要があります。これは空白を含まない単純な文字列です。その後、次のURLでクライアントを参照することができます "
-"`root/auth/realms/{realm}/protocol/saml/clients/{url-name}` 。"
+"を指定する必要があります。これは空白を含まない単純な文字列です。その後、 "
+"`root/auth/realms/{realm}/protocol/saml/clients/{url-name}` "
+"のURLでクライアントを参照することができます  。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:12
@@ -46,10 +47,10 @@ msgid ""
 "parameter, i.e.  `root/auth/realms/{realm}/protocol/saml/clients/{url-"
 "name}?RelayState=thestate`."
 msgstr ""
-"クライアントが特別なリレー状態を必要とする場合は、 `IDP Initiated SSO Relay State` フィールドの `Settings` "
-"タブでこれを設定することもできます。あるいはブラウザーは `RelayState` クエリパラメータ "
+"クライアントが特別なリレーステートを必要とする場合は、 `IDP Initiated SSO Relay State` フィールドの "
+"`Settings` タブでこれを設定することもできます。あるいはブラウザーは `RelayState` クエリー・パラメーター "
 "`root/auth/realms/{realm}/protocol/saml/clients/{url-"
-"name}?RelayState=thestate` でリレー状態を指定することができます。"
+"name}?RelayState=thestate` でリレーステートを指定することができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:18
@@ -62,9 +63,9 @@ msgid ""
 " Initiated Login endpoint for a selected client at the brokering IDP. This "
 "means that in client settings at the external IDP:"
 msgstr ""
-"<<_identity_broker,アイデンティティー・ブローカリング>>を使用する場合、外部IDPからクライアントのIDP Initiated "
-"ログインを設定することができます。実際のクライアントは、上記のようにブローカーIDPでIDP Initiated "
-"ログイン用に設定されます。外部IDPはクライアントを、特別なURLを指し示す、アプリケーションIDP Initiated "
+"<<_identity_broker,アイデンティティー・ブローカリング>>を使用する場合、クライアントに対して外部IDPからのIDP "
+"Initiated ログインを設定することができます。実際のクライアントは、上記のようにブローカーIDPでIDP Initiated "
+"ログインするように設定されます。外部IDPはクライアントを、特別なURLを指し示す、アプリケーションIDP Initiated "
 "ログインのためにセットアップする必要があります。URLはブローカーを指し、ブローカリングIDPで選択されたクライアントのために、IDP "
 "Initiated ログイン・エンドポイントを代理します。つまり、外部IDPのクライアント設定では次のようになります。"
 
@@ -74,7 +75,8 @@ msgid ""
 "`IDP Initiated SSO URL Name` is set to a name that will be published as IDP "
 "Initiated Login initial point,"
 msgstr ""
-"`IDP Initiated SSO URL Name` は、IDP Initiated ログインのイニシャル・ポイントとして公開される名前に設定され、"
+"`IDP Initiated SSO URL Name` は、IDP Initiated "
+"ログインのイニシャル・ポイントとして公開される名前に設定されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:23
@@ -85,8 +87,8 @@ msgid ""
 "id}`, where:"
 msgstr ""
 "`Fine Grain SAML Endpoint Configuration` 欄の `Assertion Consumer Service POST"
-" Binding URL`  は次のURL `broker-root/auth/realms/{broker-realm}/broker/{idp-"
-"name}/endpoint/clients/{client-id}` に設定する必要があり、"
+" Binding URL` は `broker-root/auth/realms/{broker-realm}/broker/{idp-"
+"name}/endpoint/clients/{client-id}` のURLで設定する必要があります。URLの詳細は次のとおりです。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:28
@@ -97,10 +99,10 @@ msgid ""
 "** _idp-name_ is name of the external IDP at broker\n"
 "** _client-id_ is the value of `IDP Initiated SSO URL Name` attribute of the SAML client defined at broker. It is\n"
 msgstr ""
-"** _broker-root_ はベース・ブローカーURLです。\n"
+"** _broker-root_ はベースブローカーURLです。\n"
 "** _broker-realm_ は外部IDPが宣言されているブローカーのレルムの名前です。\n"
 "** _idp-name_ はブローカーでの外部IDPの名前です。\n"
-"** _client-id_ は、ブローカーで定義されたSAMLクライアントのIDP Initiated SSO URL Name属性の値です。\n"
+"** _client-id_ は、ブローカーで定義されたSAMLクライアントの `IDP Initiated SSO URL Name` 属性の値です。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:29
@@ -108,7 +110,7 @@ msgstr ""
 msgid ""
 "this client, which will be made available for IDP Initiated Login from the "
 "external IDP.\n"
-msgstr "このクライアントは、外部IDPからIDP Initiated ログイン用に利用可能になります。\n"
+msgstr "このクライアントは、外部IDPからのIDP Initiated ログインに対して利用可能になります。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:32

--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
@@ -2,35 +2,40 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:2
 #, no-wrap
 msgid "IDP Initiated Login"
-msgstr ""
+msgstr "IDP Initiated ログイン"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:8
 msgid ""
 "IDP Initiated Login is a feature that allows you to set up an endpoint on "
-"the {project_name} server that will log you into a specific application/"
-"client.  In the `Settings` tab for your client, you need to specify the `IDP "
-"Initiated SSO URL Name`.  This is a simple string with no whitespace in it.  "
-"After this you can reference your client at the following URL: `root/auth/"
-"realms/{realm}/protocol/saml/clients/{url-name}`"
+"the {project_name} server that will log you into a specific "
+"application/client.  In the `Settings` tab for your client, you need to "
+"specify the `IDP Initiated SSO URL Name`.  This is a simple string with no "
+"whitespace in it.  After this you can reference your client at the following"
+" URL: `root/auth/realms/{realm}/protocol/saml/clients/{url-name}`"
 msgstr ""
+"IDP Initiated "
+"ログインは、特定のアプリケーション／クライアントにログインするエンドポイントを{project_name}サーバーに設定できるようにする機能です。クライアントの"
+" `Settings` タブで、 `IDP Initiated SSO URL Name` "
+"を指定する必要があります。これは空白を含まない単純な文字列です。その後、次のURLでクライアントを参照することができます "
+"`root/auth/realms/{realm}/protocol/saml/clients/{url-name}` 。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:12
@@ -38,21 +43,30 @@ msgid ""
 "If your client requires a special relay state, you can also configure this "
 "on the `Settings` tab in the `IDP Initiated SSO Relay State` field.  "
 "Alternatively, browsers can specify the relay state in a `RelayState` query "
-"parameter, i.e.  `root/auth/realms/{realm}/protocol/saml/clients/{url-name}?"
-"RelayState=thestate`."
+"parameter, i.e.  `root/auth/realms/{realm}/protocol/saml/clients/{url-"
+"name}?RelayState=thestate`."
 msgstr ""
+"クライアントが特別なリレー状態を必要とする場合は、 `IDP Initiated SSO Relay State` フィールドの `Settings` "
+"タブでこれを設定することもできます。あるいはブラウザーは `RelayState` クエリパラメータ "
+"`root/auth/realms/{realm}/protocol/saml/clients/{url-"
+"name}?RelayState=thestate` でリレー状態を指定することができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:18
 msgid ""
-"When using <<_identity_broker,identity brokering>>, it is possible to set up "
-"an IDP Initiated Login for a client from an external IDP. The actual client "
-"is set up for IDP Initiated Login at broker IDP as described above. The "
+"When using <<_identity_broker,identity brokering>>, it is possible to set up"
+" an IDP Initiated Login for a client from an external IDP. The actual client"
+" is set up for IDP Initiated Login at broker IDP as described above. The "
 "external IDP has to set up the client for application IDP Initiated Login "
-"that will point to a special URL pointing to the broker and representing IDP "
-"Initiated Login endpoint for a selected client at the brokering IDP. This "
+"that will point to a special URL pointing to the broker and representing IDP"
+" Initiated Login endpoint for a selected client at the brokering IDP. This "
 "means that in client settings at the external IDP:"
 msgstr ""
+"<<_identity_broker,アイデンティティー・ブローカリング>>を使用する場合、外部IDPからクライアントのIDP Initiated "
+"ログインを設定することができます。実際のクライアントは、上記のようにブローカーIDPでIDP Initiated "
+"ログイン用に設定されます。外部IDPはクライアントを、特別なURLを指し示す、アプリケーションIDP Initiated "
+"ログインのためにセットアップする必要があります。URLはブローカーを指し、ブローカリングIDPで選択されたクライアントのために、IDP "
+"Initiated ログイン・エンドポイントを代理します。つまり、外部IDPのクライアント設定では次のようになります。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:20
@@ -60,6 +74,7 @@ msgid ""
 "`IDP Initiated SSO URL Name` is set to a name that will be published as IDP "
 "Initiated Login initial point,"
 msgstr ""
+"`IDP Initiated SSO URL Name` は、IDP Initiated ログインのイニシャル・ポイントとして公開される名前に設定され、"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:23
@@ -69,6 +84,9 @@ msgid ""
 "root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-"
 "id}`, where:"
 msgstr ""
+"`Fine Grain SAML Endpoint Configuration` 欄の `Assertion Consumer Service POST"
+" Binding URL`  は次のURL `broker-root/auth/realms/{broker-realm}/broker/{idp-"
+"name}/endpoint/clients/{client-id}` に設定する必要があり、"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:28
@@ -79,19 +97,27 @@ msgid ""
 "** _idp-name_ is name of the external IDP at broker\n"
 "** _client-id_ is the value of `IDP Initiated SSO URL Name` attribute of the SAML client defined at broker. It is\n"
 msgstr ""
+"** _broker-root_ はベース・ブローカーURLです。\n"
+"** _broker-realm_ は外部IDPが宣言されているブローカーのレルムの名前です。\n"
+"** _idp-name_ はブローカーでの外部IDPの名前です。\n"
+"** _client-id_ は、ブローカーで定義されたSAMLクライアントのIDP Initiated SSO URL Name属性の値です。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:29
 #, no-wrap
-msgid "this client, which will be made available for IDP Initiated Login from the external IDP.\n"
-msgstr ""
+msgid ""
+"this client, which will be made available for IDP Initiated Login from the "
+"external IDP.\n"
+msgstr "このクライアントは、外部IDPからIDP Initiated ログイン用に利用可能になります。\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/saml/idp-initiated-login.adoc:32
 msgid ""
-"Please note that you can import basic client settings from the brokering IDP "
-"into client settings of the external IDP - just use "
+"Please note that you can import basic client settings from the brokering IDP"
+" into client settings of the external IDP - just use "
 "<<_identity_broker_saml_sp_descriptor,SP Descriptor>> available from the "
-"settings of the identity provider in the brokering IDP, and add `clients/"
-"_client-id_` to the endpoint URL."
+"settings of the identity provider in the brokering IDP, and add `clients"
+"/_client-id_` to the endpoint URL."
 msgstr ""
+"基本的なクライアント設定をブローカリングIDPから外部IDPのクライアント設定にインポートすることができます。ブローカリングIDPのアイデンティティー・プロバイダーの設定から利用可能な<<_identity_broker_saml_sp_descriptor,SP"
+" 記述子>>を使用し、 `clients/_client-id_` をエンドポイントURLに追加します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__saml__idp-initiated-login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__clients__saml__idp-initiated-login/ja_JP/index.html
