### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,8 +39,9 @@ msgid ""
 "form of an `HTTP 307` (Temporary Redirect) via the response's `Location` "
 "header."
 msgstr ""
-"クライアントが `HTTP GET` 要求を介してこのエンドポイントにアクセスすると、{project_name}は応答の `Location` "
-"ヘッダを介して `HTTP 307` （Temporary Redirect）形式で、指定されたクライアントとレルムの設定済みのベースURLを返します。"
+"クライアントが `HTTP GET` リクエストを介してこのエンドポイントにアクセスすると、{project_name}はレスポンスの "
+"`Location` ヘッダを介して `HTTP 307` "
+"（テンポラリー・リダイレクト）形式で、指定されたクライアントとレルムの設定済みのベースURLを返します。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-link.adoc:10
@@ -53,7 +54,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_admin/topics/clients/client-link.adoc:12
 msgid "As an example, given the realm `master` and the client-id `account`:"
-msgstr "一例として、レルムの `master` とクライアントIDの ` account` が指定されているとします。"
+msgstr "一例として、レルムの `master` とクライアントIDの `account` が指定されているとします。"
 
 #. type: delimited block -
 #: source/server_admin/topics/clients/client-link.adoc:16
@@ -65,4 +66,4 @@ msgstr "http://host:port/auth/realms/master/clients/account/redirect\n"
 #: source/server_admin/topics/clients/client-link.adoc:18
 msgid ""
 "Would temporarily redirect to: http://host:port/auth/realms/master/account"
-msgstr "一時的に http://host:port/auth/realms/master/account にリダイレクトされます。"
+msgstr "一時的に http://host:port/auth/realms/master/account にリダイレクトします。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
@@ -2,41 +2,45 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Shinsuke UEDA <ueda.shinsuke.f2@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/clients/client-link.adoc:2
 #, no-wrap
 msgid "Client Links"
-msgstr ""
+msgstr "クライアントのリンク"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-link.adoc:5
 msgid ""
 "For scenarios where one wants to link from one client to another, "
-"{project_name} provides a special redirect endpoint: `/realms/realm_name/"
-"clients/\\{client-id}/redirect`."
+"{project_name} provides a special redirect endpoint: "
+"`/realms/realm_name/clients/\\{client-id}/redirect`."
 msgstr ""
+"あるクライアントから別のクライアントにリンクしたい場合のために、{project_name}は特別なリダイレクト・エンドポイント "
+"`/realms/realm_name/clients/\\{client-id}/redirect` を提供します。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-link.adoc:7
 msgid ""
-"If a client accesses this endpoint via an `HTTP GET` request, {project_name} "
-"returns the configured base URL for the provided Client and Realm in the "
+"If a client accesses this endpoint via an `HTTP GET` request, {project_name}"
+" returns the configured base URL for the provided Client and Realm in the "
 "form of an `HTTP 307` (Temporary Redirect) via the response's `Location` "
 "header."
 msgstr ""
+"クライアントが `HTTP GET` 要求を介してこのエンドポイントにアクセスすると、{project_name}は応答の `Location` "
+"ヘッダを介して `HTTP 307` （Temporary Redirect）形式で、指定されたクライアントとレルムの設定済みのベースURLを返します。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-link.adoc:10
@@ -44,17 +48,21 @@ msgid ""
 "Thus, a client only needs to know the Realm name and the Client ID in order "
 "to link to them.  This indirection helps avoid hard-coding client base URLs."
 msgstr ""
+"したがって、クライアントは、それらにリンクするために、レルム名とクライアントIDだけを知る必要があります。この間接参照は、クライアントのベースURLのハード・コーディングを避けるのに役立ちます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-link.adoc:12
 msgid "As an example, given the realm `master` and the client-id `account`:"
-msgstr ""
+msgstr "一例として、レルムの `master` とクライアントIDの ` account` が指定されているとします。"
 
 #. type: delimited block -
-#: source/server_admin/topics/clients/client-link.adoc:18
+#: source/server_admin/topics/clients/client-link.adoc:16
 #, no-wrap
+msgid "http://host:port/auth/realms/master/clients/account/redirect\n"
+msgstr "http://host:port/auth/realms/master/clients/account/redirect\n"
+
+#. type: Plain text
+#: source/server_admin/topics/clients/client-link.adoc:18
 msgid ""
-"http://host:port/auth/realms/master/clients/account/redirect\n"
-"----               \n"
-"Would temporarily redirect to: http://host:port/auth/realms/master/account\n"
-msgstr ""
+"Would temporarily redirect to: http://host:port/auth/realms/master/account"
+msgstr "一時的に http://host:port/auth/realms/master/account にリダイレクトされます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-link
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__clients__client-link/ja_JP/index.html
