### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/realms/email.adoc:3
 #, no-wrap
 msgid "Email Settings"
 msgstr "電子メールの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:10
 msgid ""
 "{project_name} sends emails to users to verify their email address, when "
 "they forget their passwords, or when an admin needs to receive notifications"
@@ -31,113 +29,96 @@ msgid ""
 "per realm.  Go to the `Realm Settings` left menu item and click the `Email` "
 "tab."
 msgstr ""
-"{project_name}は、メールアドレスの確認、パスワードを忘れたとき、または管理者がサーバー・イベントに関する通知を受け取るときに、ユーザーに電子メールを送信します。"
-" {project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を行う必要があります。 "
-"SMTPサーバーの設定は、レルムごとに設定することができます。 `Realm Settings` 左のメニュー項目に移動し、 `Email` "
-"タブをクリックしてください。"
+"{project_name}は、パスワードを忘れたとき、または管理者がサーバー・イベントに関する通知を受け取るときに、メールアドレスの確認するためユーザーに電子メールを送信します。{project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を行う必要があります。SMTPサーバーの設定は、レルムごとに設定することができます。"
+" `Realm Settings` 左のメニュー項目に移動し、 `Email` タブをクリックしてください。"
 
 #. type: Block title
-#: source/server_admin/topics/realms/email.adoc:11
 #, no-wrap
 msgid "Email Tab"
-msgstr "Email Tab"
+msgstr "Emailタブ"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:13
 msgid "image:{project_images}/email-tab.png[]"
 msgstr "image:{project_images}/email-tab.png[]"
 
-#. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:14
+#. type: Title ===
 #, no-wrap
 msgid "Host"
 msgstr "Host"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:16
 msgid "`Host` denotes the SMTP server hostname used for sending emails."
-msgstr "`Host` は、電子メールの送信に使用されるSMTPサーバのホスト名です。"
+msgstr "`Host` は、電子メールの送信に使用されるSMTPサーバーのホスト名です。"
 
 #. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:17
 #, no-wrap
 msgid "Port"
 msgstr "Port"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:19
 msgid "`Port` denotes the SMTP server port."
-msgstr "`Port` は、SMTPサーバのポート番号です。"
+msgstr "`Port` は、SMTPサーバーのポート番号です。"
 
 #. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:20
 #, no-wrap
 msgid "From"
 msgstr "From"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:22
 msgid ""
 "`From` denotes the address used for the `From` SMTP-Header for the emails "
 "sent."
 msgstr "`From` は、送信された電子メールの `From` SMTPヘッダーに使用されるアドレスです。"
 
 #. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:23
 #, no-wrap
 msgid "From Display Name"
 msgstr "From Display Name"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:25
 msgid ""
 "`From Display Name` allows to configure an user friendly email address "
 "aliases (optional). If not set the plain `From` email address will be "
 "displayed in email clients."
 msgstr ""
-"`From Display Name` は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。 "
-"設定されていない場合は、電子メール・クライアントに `From` メールアドレスが表示されます。"
+"`From Display Name` "
+"は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。設定されていない場合は、電子メール・クライアントに `From` "
+"メールアドレスが表示されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:26
 #, no-wrap
 msgid "Reply To"
 msgstr "Reply To"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:28
 msgid ""
 "`Reply To` denotes the address used for the `Reply-To` SMTP-Header for the "
 "mails sent (optional). If not set the plain `From` email address will be "
 "used."
 msgstr ""
-"`Reply To` は、送信された電子メールのための `Reply-To` SMTPヘッダーに使用されるアドレスです（オプション）。 "
-"設定されていない場合は、通常の `From` メールアドレスが使用されます。"
+"`Reply To` は、送信された電子メールの `Reply-To` SMTPヘッダーに使用されるアドレスです（オプション）。 "
+"設定されていない場合は、通常の `From` メール・アドレスが使用されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:29
 #, no-wrap
 msgid "Reply To Display Name"
 msgstr "Reply To Display Name"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:31
 msgid ""
 "`Reply To Display Name` allows to configure an user friendly email address "
 "aliases (optional). If not set the plain `Reply To` email address will be "
 "displayed."
 msgstr ""
-"`Reply To Display Name` は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。 "
-"設定されていない場合は、 `Reply To` メールアドレスが表示されます。"
+"`Reply To Display Name` は、ユーザー・フレンドリーなメール・アドレスのエイリアスを設定します（オプション）。 "
+"設定されていない場合は、 `Reply To` 電子メール・アドレスが表示されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/realms/email.adoc:32
 #, no-wrap
 msgid "Envelope From"
 msgstr "Envelope From"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:34
 msgid ""
 "`Envelope From` denotes the "
 "https://en.wikipedia.org/wiki/Bounce_address[Bounce Address] used for the "
@@ -147,7 +128,6 @@ msgstr ""
 "SMTPヘッダーに使用されるlink:https://en.wikipedia.org/wiki/Bounce_address[バウンス・アドレス]です（オプション）。"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:38
 msgid ""
 "As emails are used for recovering usernames and passwords it's recommended "
 "to use SSL or TLS, especially if the SMTP server is on an external network."
@@ -155,15 +135,14 @@ msgid ""
 "TLS`.  You will most likely also need to change the `Port` (the default port"
 " for SSL/TLS is 465)."
 msgstr ""
-"電子メールは、ユーザー名とパスワードの回復に使用されるため、特にSMTPサーバーが外部ネットワーク上にある場合は、SSLまたはTLSを使用することを推奨します。"
-" SSLを有効にするには、 `Enable SSL` をクリックするか、TLSを有効にするには `Enable TLS` をクリックします。 "
-"`Port` も変更する必要があります（SSL/TLSのデフォルトポートは465）。"
+"電子メールは、ユーザー名とパスワードの回復に使用されるため、特にSMTPサーバーが外部ネットワーク上にある場合は、SSLまたはTLSを使用することを推奨します。SSLを有効にするため"
+" `Enable SSL` をクリックするか、TLSを有効にするため `Enable TLS` をクリックします。 `Port` "
+"も変更する必要があります（SSL/TLSのデフォルト・ポートは465）。"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/email.adoc:40
 msgid ""
 "If your SMTP server requires authentication click on `Enable Authentication`"
 " and insert the `Username` and `Password`."
 msgstr ""
-"SMTPサーバが認証を必要とする場合は、 `Enable Authentication` をクリックし、 `Username` と `Password`"
-" を入力します。"
+"SMTPサーバーが認証を必要とする場合は、 `Enable Authentication` をクリックし、 `Username` と "
+"`Password` を入力します。"

--- a/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgid ""
 "per realm.  Go to the `Realm Settings` left menu item and click the `Email` "
 "tab."
 msgstr ""
-"{project_name}は、パスワードを忘れたとき、または管理者がサーバー・イベントに関する通知を受け取るときに、メールアドレスの確認するためユーザーに電子メールを送信します。{project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を行う必要があります。SMTPサーバーの設定は、レルムごとに設定することができます。"
+"{project_name}は、パスワードを忘れたとき、または管理者がサーバーイベントに関する通知を受け取るときに、メールアドレスの確認するためユーザーに電子メールを送信します。{project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を行う必要があります。SMTPサーバーの設定は、レルムごとに設定することができます。"
 " `Realm Settings` 左のメニュー項目に移動し、 `Email` タブをクリックしてください。"
 
 #. type: Block title
@@ -82,7 +82,7 @@ msgid ""
 "displayed in email clients."
 msgstr ""
 "`From Display Name` "
-"は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。設定されていない場合は、電子メール・クライアントに `From` "
+"は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。設定されていない場合は、電子メールクライアントに `From` "
 "メールアドレスが表示されます。"
 
 #. type: Labeled list
@@ -97,7 +97,7 @@ msgid ""
 "used."
 msgstr ""
 "`Reply To` は、送信された電子メールの `Reply-To` SMTPヘッダーに使用されるアドレスです（オプション）。 "
-"設定されていない場合は、通常の `From` メール・アドレスが使用されます。"
+"設定されていない場合は、通常の `From` メールアドレスが使用されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -110,8 +110,8 @@ msgid ""
 "aliases (optional). If not set the plain `Reply To` email address will be "
 "displayed."
 msgstr ""
-"`Reply To Display Name` は、ユーザー・フレンドリーなメール・アドレスのエイリアスを設定します（オプション）。 "
-"設定されていない場合は、 `Reply To` 電子メール・アドレスが表示されます。"
+"`Reply To Display Name` は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。 "
+"設定されていない場合は、 `Reply To` 電子メールアドレスが表示されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -125,7 +125,7 @@ msgid ""
 "`Return-Path` SMTP-Header for the mails sent (optional)."
 msgstr ""
 "`Envelope From` は、送信された電子メールの `Return-Path` "
-"SMTPヘッダーに使用されるlink:https://en.wikipedia.org/wiki/Bounce_address[バウンス・アドレス]です（オプション）。"
+"SMTPヘッダーに使用されるlink:https://en.wikipedia.org/wiki/Bounce_address[バウンスアドレス]です（オプション）。"
 
 #. type: Plain text
 msgid ""
@@ -137,7 +137,7 @@ msgid ""
 msgstr ""
 "電子メールは、ユーザー名とパスワードの回復に使用されるため、特にSMTPサーバーが外部ネットワーク上にある場合は、SSLまたはTLSを使用することを推奨します。SSLを有効にするため"
 " `Enable SSL` をクリックするか、TLSを有効にするため `Enable TLS` をクリックします。 `Port` "
-"も変更する必要があります（SSL/TLSのデフォルト・ポートは465）。"
+"も変更する必要があります（SSL/TLSのデフォルトポートは465）。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
@@ -2,87 +2,91 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/realms/email.adoc:3
 #, no-wrap
 msgid "Email Settings"
-msgstr ""
+msgstr "電子メールの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:10
 msgid ""
 "{project_name} sends emails to users to verify their email address, when "
-"they forget their passwords, or when an admin needs to receive notifications "
-"about a server event.  To enable {project_name} to send emails you need to "
+"they forget their passwords, or when an admin needs to receive notifications"
+" about a server event.  To enable {project_name} to send emails you need to "
 "provide {project_name} with your SMTP server settings.  This is configured "
 "per realm.  Go to the `Realm Settings` left menu item and click the `Email` "
 "tab."
 msgstr ""
+"{project_name}は、メールアドレスの確認、パスワードを忘れたとき、または管理者がサーバー・イベントに関する通知を受け取るときに、ユーザーに電子メールを送信します。"
+" {project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を行う必要があります。 "
+"SMTPサーバーの設定は、レルムごとに設定することができます。 `Realm Settings` 左のメニュー項目に移動し、 `Email` "
+"タブをクリックしてください。"
 
 #. type: Block title
 #: source/server_admin/topics/realms/email.adoc:11
 #, no-wrap
 msgid "Email Tab"
-msgstr ""
+msgstr "Email Tab"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:13
 msgid "image:{project_images}/email-tab.png[]"
-msgstr ""
+msgstr "image:{project_images}/email-tab.png[]"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:14
 #, no-wrap
 msgid "Host"
-msgstr ""
+msgstr "Host"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:16
 msgid "`Host` denotes the SMTP server hostname used for sending emails."
-msgstr ""
+msgstr "`Host` は、電子メールの送信に使用されるSMTPサーバのホスト名です。"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:17
 #, no-wrap
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:19
 msgid "`Port` denotes the SMTP server port."
-msgstr ""
+msgstr "`Port` は、SMTPサーバのポート番号です。"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:20
 #, no-wrap
 msgid "From"
-msgstr ""
+msgstr "From"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:22
 msgid ""
 "`From` denotes the address used for the `From` SMTP-Header for the emails "
 "sent."
-msgstr ""
+msgstr "`From` は、送信された電子メールの `From` SMTPヘッダーに使用されるアドレスです。"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:23
 #, no-wrap
 msgid "From Display Name"
-msgstr ""
+msgstr "From Display Name"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:25
@@ -91,12 +95,14 @@ msgid ""
 "aliases (optional). If not set the plain `From` email address will be "
 "displayed in email clients."
 msgstr ""
+"`From Display Name` は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。 "
+"設定されていない場合は、電子メール・クライアントに `From` メールアドレスが表示されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:26
 #, no-wrap
 msgid "Reply To"
-msgstr ""
+msgstr "Reply To"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:28
@@ -105,12 +111,14 @@ msgid ""
 "mails sent (optional). If not set the plain `From` email address will be "
 "used."
 msgstr ""
+"`Reply To` は、送信された電子メールのための `Reply-To` SMTPヘッダーに使用されるアドレスです（オプション）。 "
+"設定されていない場合は、通常の `From` メールアドレスが使用されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:29
 #, no-wrap
 msgid "Reply To Display Name"
-msgstr ""
+msgstr "Reply To Display Name"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:31
@@ -119,34 +127,43 @@ msgid ""
 "aliases (optional). If not set the plain `Reply To` email address will be "
 "displayed."
 msgstr ""
+"`Reply To Display Name` は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。 "
+"設定されていない場合は、 `Reply To` メールアドレスが表示されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/realms/email.adoc:32
 #, no-wrap
 msgid "Envelope From"
-msgstr ""
+msgstr "Envelope From"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:34
 msgid ""
-"`Envelope From` denotes the https://en.wikipedia.org/wiki/"
-"Bounce_address[Bounce Address] used for the `Return-Path` SMTP-Header for "
-"the mails sent (optional)."
+"`Envelope From` denotes the "
+"https://en.wikipedia.org/wiki/Bounce_address[Bounce Address] used for the "
+"`Return-Path` SMTP-Header for the mails sent (optional)."
 msgstr ""
+"`Envelope From` は、送信された電子メールの `Return-Path` "
+"SMTPヘッダーに使用されるlink:https://en.wikipedia.org/wiki/Bounce_address[バウンス・アドレス]です（オプション）。"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:38
 msgid ""
 "As emails are used for recovering usernames and passwords it's recommended "
-"to use SSL or TLS, especially if the SMTP server is on an external network.  "
-"To enable SSL click on `Enable SSL` or to enable TLS click on `Enable TLS`.  "
-"You will most likely also need to change the `Port` (the default port for "
-"SSL/TLS is 465)."
+"to use SSL or TLS, especially if the SMTP server is on an external network."
+"  To enable SSL click on `Enable SSL` or to enable TLS click on `Enable "
+"TLS`.  You will most likely also need to change the `Port` (the default port"
+" for SSL/TLS is 465)."
 msgstr ""
+"電子メールは、ユーザー名とパスワードの回復に使用されるため、特にSMTPサーバーが外部ネットワーク上にある場合は、SSLまたはTLSを使用することを推奨します。"
+" SSLを有効にするには、 `Enable SSL` をクリックするか、TLSを有効にするには `Enable TLS` をクリックします。 "
+"`Port` も変更する必要があります（SSL/TLSのデフォルトポートは465）。"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/email.adoc:40
 msgid ""
-"If your SMTP server requires authentication click on `Enable Authentication` "
-"and insert the `Username` and `Password`."
+"If your SMTP server requires authentication click on `Enable Authentication`"
+" and insert the `Username` and `Password`."
 msgstr ""
+"SMTPサーバが認証を必要とする場合は、 `Enable Authentication` をクリックし、 `Username` と `Password`"
+" を入力します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__email
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__realms__email/ja_JP/index.html
