### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/realms/cache.adoc:2
 #, no-wrap
 msgid "Clearing Server Caches"
-msgstr ""
+msgstr "サーバー・キャッシュのクリア"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/cache.adoc:9
@@ -31,19 +31,22 @@ msgid ""
 " external clients or Identity providers, which {project_name} usually uses for verify signatures of particular external entity) from the Admin Console by going\n"
 "to the `Realm Settings` left menu item and the `Cache` tab.\n"
 msgstr ""
+"{project_name}は、JVMとあなたが設定した制限の範囲内で、できる限りすべてをキャッシュします。\n"
+"サーバーのREST APIまたは管理コンソールの範囲外のDBAのような第三者によって{project_name}データベースが変更された場合、インメモリ・キャッシュの一部が失効する可能性があります。\n"
+"左側メニュー項目 `Realm Settings` の `Cache` タブから、レルム・キャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントの公開鍵または{project_name}が特定の外部エンティティの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
 
 #. type: Block title
 #: source/server_admin/topics/realms/cache.adoc:10
 #, no-wrap
 msgid "Cache tab"
-msgstr ""
+msgstr "Cache タブ"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/cache.adoc:12
 msgid "image:{project_images}/cache-tab.png[]"
-msgstr ""
+msgstr "image:{project_images}/cache-tab.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/realms/cache.adoc:13
 msgid "Just click the `clear` button on the cache you want to evict."
-msgstr ""
+msgstr "クリアしたいキャッシュの `clear` ボタンをクリックします。"

--- a/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,14 +15,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
-#: source/server_admin/topics/realms/cache.adoc:2
+#. type: Attribute :adminguide_clearcache_name:
 #, no-wrap
 msgid "Clearing Server Caches"
 msgstr "サーバー・キャッシュのクリア"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/cache.adoc:9
 #, no-wrap
 msgid ""
 "{project_name} will cache everything it can in memory within the limits of your JVM and/or the limits you've configured\n"
@@ -31,22 +29,20 @@ msgid ""
 " external clients or Identity providers, which {project_name} usually uses for verify signatures of particular external entity) from the Admin Console by going\n"
 "to the `Realm Settings` left menu item and the `Cache` tab.\n"
 msgstr ""
-"{project_name}は、JVMとあなたが設定した制限の範囲内で、できる限りすべてをキャッシュします。\n"
-"サーバーのREST APIまたは管理コンソールの範囲外のDBAのような第三者によって{project_name}データベースが変更された場合、インメモリ・キャッシュの一部が失効する可能性があります。\n"
-"左側メニュー項目 `Realm Settings` の `Cache` タブから、レルム・キャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントの公開鍵または{project_name}が特定の外部エンティティの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
+"{project_name}は、JVMおよび/または設定した制限の範囲内で、できる限りすべてをキャッシュします。サーバーのREST "
+"APIまたは管理コンソールの範囲外のDBAのような第三者によって{project_name}データベースが変更された場合、インメモリ・キャッシュの一部が失効する可能性があります。管理コンソール左側メニュー項目"
+" `Realm Settings` の `Cache` "
+"タブから、レルム・キャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントやアイデンティティー・プロバイダーの公開鍵など、{project_name}が外部エンティティーの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
 
 #. type: Block title
-#: source/server_admin/topics/realms/cache.adoc:10
 #, no-wrap
 msgid "Cache tab"
 msgstr "Cache タブ"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/cache.adoc:12
 msgid "image:{project_images}/cache-tab.png[]"
 msgstr "image:{project_images}/cache-tab.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/cache.adoc:13
 msgid "Just click the `clear` button on the cache you want to evict."
 msgstr "クリアしたいキャッシュの `clear` ボタンをクリックします。"

--- a/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,12 +32,12 @@ msgstr ""
 "{project_name}は、JVMおよび/または設定した制限の範囲内で、できる限りすべてをキャッシュします。サーバーのREST "
 "APIまたは管理コンソールの範囲外のDBAのような第三者によって{project_name}データベースが変更された場合、インメモリ・キャッシュの一部が失効する可能性があります。管理コンソール左側メニュー項目"
 " `Realm Settings` の `Cache` "
-"タブから、レルム・キャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントやアイデンティティー・プロバイダーの公開鍵など、{project_name}が外部エンティティーの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
+"タブから、レルムキャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントやアイデンティティー・プロバイダーの公開鍵など、{project_name}が外部エンティティーの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
 
 #. type: Block title
 #, no-wrap
 msgid "Cache tab"
-msgstr "Cache タブ"
+msgstr "Cacheタブ"
 
 #. type: Plain text
 msgid "image:{project_images}/cache-tab.png[]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__realms__cache/ja_JP/index.html
