### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
@@ -35,7 +35,7 @@ msgstr ""
 "_認証フロー_ "
 "は、ログイン、登録、その他の{project_name}ワークフロー利用時に発生するすべての認証、画面、およびアクションのためのコンテナーです。管理コンソールの左メニュー項目"
 " `Authentication` から、 `Flows` "
-"タブを表示することで、システム内の定義されたすべてのフローと、各フローが必要とするアクションとチェックを見ることができます。このセクションでは、ブラウザのログイン・フローについて説明します。左側のドロップダウン・リストで"
+"タブを表示することで、システム内の定義されたすべてのフローと、各フローが必要とするアクションとチェックを見ることができます。このセクションでは、ブラウザーのログインフローについて説明します。左側のドロップダウン・リストで"
 " `browser` を選択すると、以下の画面が表示されます。"
 
 #. type: Block title
@@ -43,7 +43,7 @@ msgstr ""
 #: source/server_admin/topics/authentication/kerberos.adoc:88
 #, no-wrap
 msgid "Browser Flow"
-msgstr "ブラウザー・フロー"
+msgstr "ブラウザーフロー"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:13
@@ -68,7 +68,7 @@ msgid ""
 "the action will execute.  Let's describe what each radio button means:"
 msgstr ""
 "`Auth Type` "
-"列は、実行される認証またはアクションの名前です。認証がインデントされている場合、これはサブ・フローにあり、親の動作に応じて実行される場合と実行されない場合があります。"
+"列は、実行される認証またはアクションの名前です。認証がインデントされている場合、これはサブフローにあり、親の動作に応じて実行される場合と実行されない場合があります。"
 " `Requirement` 列は、アクションが実行されるかどうかを定義するラジオボタンのセットです。各ラジオボタンの意味を説明します。"
 
 #. type: Labeled list
@@ -87,7 +87,7 @@ msgid ""
 "Form` to `Required`, users that don't have an OTP generator configured will "
 "be asked to do so."
 msgstr ""
-"この認証の実行は必ず成功しなければなりません。ユーザーにあるタイプの認証メカニズムが設定されておらず、その認証タイプに関連する必須アクションがある場合、必須アクションがそのアカウントにアタッチされます。例えば、"
+"この認証のエグゼキューションは正常に実行されなければなりません。ユーザーにそのタイプの認証メカニズムが設定されておらず、その認証タイプに関連する必須アクションがある場合、必須アクションがそのアカウントにアタッチされます。例えば、"
 " `OTP Form` を `Required` "
 "に切り替えると、OTPジェネレーターが設定されていないユーザーには、OTPジェネレーターの設定が要求されます。"
 
@@ -102,7 +102,7 @@ msgstr "Optional"
 msgid ""
 "If the user has the authentication type configured, it will be executed.  "
 "Otherwise, it will be ignored."
-msgstr "ユーザーに認証タイプが設定されている場合は、その認証タイプが実行されます。 それ以外の場合は無視されます。"
+msgstr "ユーザーに認証タイプが設定されている場合は、その認証タイプが実行されます。それ以外の場合は無視されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:29
@@ -126,7 +126,7 @@ msgstr "Alternative"
 msgid ""
 "This means that at least one alternative authentication type must execute "
 "successfully at that level of the flow."
-msgstr "少なくとも1つの `alternative` 認証タイプが、そのフローのレベルで正常に実行されなければならないことを意味します。"
+msgstr "少なくとも1つの代替の認証タイプが、そのフローのレベルで正常に実行されなければならないことを意味します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:35
@@ -146,15 +146,16 @@ msgid ""
 "successful login."
 msgstr ""
 "最初の認証タイプは `Cookie` "
-"です。ユーザーが最初に正常にログインすると、セッションCookieが設定されます。このCookieがすでに設定されている場合、この認証タイプは正常です。Cookieプロバイダーは成功を返し、このフローのレベルでの各実行は"
-" _alternative_ であるため、他の実行は実行されず、ログインに成功します。"
+"です。ユーザーが最初に正常にログインすると、セッションCookieが設定されます。このCookieがすでに設定されている場合、この認証タイプは正常です。Cookieプロバイダーは成功を返し、このフローのレベルでの各エグゼキューションは"
+" _alternative_ であるため、他のエグゼキューションは実行されず、ログインに成功します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:40
 msgid ""
 "Next the flow looks at the Kerberos execution.  This authenticator is "
 "disabled by default and will be skipped."
-msgstr "フローの次の認証タイプは、Kerberos実行です。このオーセンティケーターはデフォルトで無効になっており、スキップされます。"
+msgstr ""
+"フローの次の認証タイプは、Kerberosエグゼキューションです。このオーセンティケーターはデフォルトで無効になっており、スキップされます。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:43
@@ -165,8 +166,8 @@ msgid ""
 " be executed.  The executions for this subflow are loaded and the same "
 "processing logic occurs"
 msgstr ""
-"次の実行はFormsと呼ばれるサブ・フローです。このサブ・フローは _alternative_ とマークされているので、 `Cookie` "
-"認証タイプが成功すると実行されません。このサブ・フローには、実行する必要のある追加の認証タイプが含まれています。サブ・フローの実行はロードされ、同じ処理ロジックが発生します。"
+"次のエグゼキューションはFormsと呼ばれるサブフローです。このサブフローは _alternative_ とマークされているので、 `Cookie` "
+"認証タイプが成功すると実行されません。このサブフローには、実行する必要のある追加の認証タイプが含まれています。サブフローのエグゼキューションはロードされ、同じ処理ロジックが発生します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:45
@@ -176,8 +177,9 @@ msgid ""
 "marked as _required_ so the user must enter in a valid username and "
 "password."
 msgstr ""
-"Formsサブフローでの最初の実行は、Username Password Formです。この認証タイプは、ユーザー名とパスワードのページを表示します。 "
-"_required_ とされているため、ユーザーは有効なユーザー名とパスワードを入力する必要があります。"
+"Formsサブフローでの最初のエグゼキューションは、Username Password "
+"Formです。この認証タイプは、ユーザー名とパスワードのページを表示します。 _required_ "
+"とされているため、ユーザーは有効なユーザー名とパスワードを入力する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:48
@@ -187,19 +189,19 @@ msgid ""
 "successful.  If the user doesn't have OTP set up, this authentication type "
 "is ignored."
 msgstr ""
-"次の実行はOTPフォームです。 これは _optional_ "
+"次のエグゼキューションはOTPフォームです。 これは _optional_ "
 "としてマークされています。ユーザーがOTPを設定している場合は、この認証タイプを実行して成功させる必要があります。ユーザーにOTPが設定されていない場合、この認証タイプは無視されます。"
 
 #. type: Title ===
 #: source/server_admin/topics/authentication/flows.adoc:50
 #, no-wrap
 msgid "Executions"
-msgstr "実行"
+msgstr "エグゼキューション"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:53
 msgid "Executions can be used"
-msgstr "実行は利用可能です。"
+msgstr "以下のエグゼキューションが利用可能です。"
 
 #. type: Block title
 #: source/server_admin/topics/authentication/flows.adoc:54

--- a/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/authentication/flows.adoc:3
 #, no-wrap
 msgid "Authentication Flows"
-msgstr ""
+msgstr "認証フロー"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:10
@@ -27,138 +27,159 @@ msgid ""
 "An _authentication flow_ is a container for all authentications, screens, "
 "and actions that must happen during login, registration, and other "
 "{project_name} workflows.  If you go to the admin console `Authentication` "
-"left menu item and go to the `Flows` tab, you can view all the defined flows "
-"in the system and what actions and checks each flow requires.  This section "
-"does a walk through of the browser login flow.  In the left drop down list "
+"left menu item and go to the `Flows` tab, you can view all the defined flows"
+" in the system and what actions and checks each flow requires.  This section"
+" does a walk through of the browser login flow.  In the left drop down list "
 "select `browser` to come to the screen shown below:"
 msgstr ""
+"_authenticationフロー_は、ログイン、登録、その他の{project_name}ワークフロー利用時に発生するすべての認証、画面、およびアクションのためのコンテナです。"
+" 管理コンソールの左メニュー項目 `Authentication` から、 `Flows` "
+"タブを表示することで、システム内の定義されたすべてのフローと、各フローが必要とするアクションとチェックを見ることができます。 "
+"このセクションでは、ブラウザのログインフローについて説明します。 左側のドロップダウンリストで `browser` "
+"を選択すると、以下の画面が表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/authentication/flows.adoc:11
 #: source/server_admin/topics/authentication/kerberos.adoc:88
 #, no-wrap
 msgid "Browser Flow"
-msgstr ""
+msgstr "ブラウザー・フロー"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:13
 #: source/server_admin/topics/authentication/kerberos.adoc:90
 msgid "image:{project_images}/browser-flow.png[]"
-msgstr ""
+msgstr "image:{project_images}/browser-flow.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:16
 msgid ""
 "If you hover over the tooltip (the tiny question mark) to the right of the "
 "flow selection list, this will describe what the flow is and does."
-msgstr ""
+msgstr "フロー選択リストの右側にあるツールチップ（小さな疑問符）の上にカーソルを合わせると、フローの内容とその説明が表示されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:21
 msgid ""
 "The `Auth Type` column is the name of authentication or action that will be "
 "executed.  If an authentication is indented this means it is in a sub-flow "
-"and may or may not be executed depending on the behavior of its parent.  The "
-"`Requirement` column is a set of radio buttons which define whether or not "
+"and may or may not be executed depending on the behavior of its parent.  The"
+" `Requirement` column is a set of radio buttons which define whether or not "
 "the action will execute.  Let's describe what each radio button means:"
 msgstr ""
+"`Auth Type` カラムは、実行される認証またはアクションの名前です。 "
+"認証がインデントされている場合、これはサブ・フローにあり、親の動作に応じて実行される場合と実行されない場合があります。 `Requirement` "
+"列は、アクションが実行されるかどうかを定義するラジオボタンのセットです。 各ラジオボタンの意味を説明します。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:22
 #, no-wrap
 msgid "Required"
-msgstr ""
+msgstr "Required"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:27
 msgid ""
 "This authentication execution must execute successfully.  If the user "
-"doesn't have that type of authentication mechanism configured and there is a "
-"required action associated with that authentication type, then a required "
+"doesn't have that type of authentication mechanism configured and there is a"
+" required action associated with that authentication type, then a required "
 "action will be attached to that account.  For example, if you switch `OTP "
 "Form` to `Required`, users that don't have an OTP generator configured will "
 "be asked to do so."
 msgstr ""
+"この認証の実行は必ず成功しなければなりません。 "
+"ユーザーにあるタイプの認証メカニズムが設定されておらず、その認証タイプに関連する必須アクションがある場合、必須アクションがそのアカウントにアタッチされます。"
+" 例えば、 `OTP Form` を `Required` "
+"に切り替えると、OTPジェネレーターが設定されていないユーザーには、OTPジェネレーターの設定が要求されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:27
 #, no-wrap
 msgid "Optional"
-msgstr ""
+msgstr "Optional"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:29
 msgid ""
 "If the user has the authentication type configured, it will be executed.  "
 "Otherwise, it will be ignored."
-msgstr ""
+msgstr "ユーザーに認証タイプが設定されている場合は、その認証タイプが実行されます。 それ以外の場合は無視されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:29
 #, no-wrap
 msgid "Disabled"
-msgstr ""
+msgstr "Disabled"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:31
 msgid "If disabled, the authentication type is not executed."
-msgstr ""
+msgstr "無効にします。認証タイプは実行されません。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:31
 #, no-wrap
 msgid "Alternative"
-msgstr ""
+msgstr "Alternative"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:33
 msgid ""
 "This means that at least one alternative authentication type must execute "
 "successfully at that level of the flow."
-msgstr ""
+msgstr "フロー中の同じレベルにおいて、少なくとも1つの `alternative` 認証タイプが、成功しなければなりません。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:35
 msgid ""
 "This is better described in an example.  Let's walk through the `browser` "
 "authentication flow."
-msgstr ""
+msgstr "以下の `ブラウザー` 認証フローの例を見てみましょう。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:39
 msgid ""
-"The first authentication type is `Cookie`.  When a user successfully logs in "
-"for the first time, a session cookie is set.  If this cookie has already "
+"The first authentication type is `Cookie`.  When a user successfully logs in"
+" for the first time, a session cookie is set.  If this cookie has already "
 "been set, then this authentication type is successful.  Since the cookie "
 "provider returned success and each execution at this level of the flow is "
 "_alternative_, no other execution is executed and this results in a "
 "successful login."
 msgstr ""
+"最初の認証タイプは `Cookie` です。 ユーザーが最初に正常にログインすると、セッションCookieが設定されます。 "
+"このCookieがすでに設定されている場合、この認証タイプは正常です。 Cookieプロバイダーは成功を返し、このフローのレベルでの各実行は "
+"_alternative_ であるため、他の実行は実行されず、ログインに成功します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:40
 msgid ""
 "Next the flow looks at the Kerberos execution.  This authenticator is "
 "disabled by default and will be skipped."
-msgstr ""
+msgstr "フローの次の認証タイプは、Kerberosです。 この認証はデフォルトで無効になっており、スキップされます。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:43
 msgid ""
 "The next execution is a subflow called Forms.  Since this subflow is marked "
-"as _alternative_ it will not be executed if the `Cookie` authentication type "
-"passed.  This subflow contains additional authentication type that needs to "
-"be executed.  The executions for this subflow are loaded and the same "
+"as _alternative_ it will not be executed if the `Cookie` authentication type"
+" passed.  This subflow contains additional authentication type that needs to"
+" be executed.  The executions for this subflow are loaded and the same "
 "processing logic occurs"
 msgstr ""
+"次の実行はFormsと呼ばれるサブ・フローです。 このサブ・フローは _alternative_ とマークされているので、 `Cookie` "
+"認証タイプが成功すると実行されません。 このサブ・フローには、実行する必要のある追加の認証タイプが含まれています。 "
+"サブ・フローの実行はロードされ、同じ処理ロジックが発生します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:45
 msgid ""
 "The first execution in the Forms subflow is the Username Password Form.  "
 "This authentication type renders the username and password page.  It is "
-"marked as _required_ so the user must enter in a valid username and password."
+"marked as _required_ so the user must enter in a valid username and "
+"password."
 msgstr ""
+"Formsサブフローでの最初の実行は、Username Password Formです。 この認証タイプは、ユーザー名とパスワードのページを表示します。"
+" _required_ とされているため、ユーザーは有効なユーザー名とパスワードを入力する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:48
@@ -168,23 +189,26 @@ msgid ""
 "successful.  If the user doesn't have OTP set up, this authentication type "
 "is ignored."
 msgstr ""
+"次の実行はOTPフォームです。 これは _optional_ としてマークされています。 "
+"ユーザーがOTPを設定している場合は、この認証タイプを実行して成功させる必要があります。 "
+"ユーザーにOTPが設定されていない場合、この認証タイプは無視されます。"
 
 #. type: Title ===
 #: source/server_admin/topics/authentication/flows.adoc:50
 #, no-wrap
 msgid "Executions"
-msgstr ""
+msgstr "実行"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:53
 msgid "Executions can be used"
-msgstr ""
+msgstr "実行は利用可能です。"
 
 #. type: Block title
 #: source/server_admin/topics/authentication/flows.adoc:54
 #, no-wrap
 msgid "Script Authenticator"
-msgstr ""
+msgstr "スクリプト・オーセンティケーター"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:59
@@ -195,6 +219,11 @@ msgid ""
 "from `Authenticator#authenticate(AuthenticationFlowContext)` `action(..)` "
 "which is called from `Authenticator#action(AuthenticationFlowContext)`"
 msgstr ""
+"_スクリプト_ オーセンティケーターを使用すると、JavaScript経由でカスタム認証ロジックを定義できます。 カスタム・オーセンティケーター。 "
+"認証スクリプトは、少なくとも次の機能のうちの1つを提供する必要があります。 "
+"`Authenticator#authenticate(AuthenticationFlowContext)` から呼び出される "
+"`authenticate(..)`。 `Authenticator#action(AuthenticationFlowContext)` "
+"から呼び出される `action(..)`。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:62
@@ -203,108 +232,116 @@ msgid ""
 "function.  The following script `javax.script.Bindings` are available for "
 "convenient use within script code."
 msgstr ""
+"カスタム `オーセンティケーター` は、 `authenticate（..）` 関数を提供するべきです。 次のスクリプト "
+"`javax.script.Bindings` は、スクリプトコード内で便利に利用できます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:63
 #, no-wrap
 msgid "`script`"
-msgstr ""
+msgstr "`script`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:65
 msgid "the `ScriptModel` to access script metadata"
-msgstr ""
+msgstr "スクリプトのメタデータにアクセスするための `スクリプト・モデル` "
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:65
 #, no-wrap
 msgid "`realm`"
-msgstr ""
+msgstr "`realm`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:67
 msgid "the `RealmModel`"
-msgstr ""
+msgstr "`レルム・モデル`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:67
 #, no-wrap
 msgid "`user`"
-msgstr ""
+msgstr "`user`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:69
 msgid "the current `UserModel`"
-msgstr ""
+msgstr "現在の `ユーザー・モデル`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:69
 #, no-wrap
 msgid "`session`"
-msgstr ""
+msgstr "`session`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:71
 msgid "the active `KeycloakSession`"
-msgstr ""
+msgstr "アクティブな `Keycloakセッション`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:71
 #, no-wrap
 msgid "`authenticationSession`"
-msgstr ""
+msgstr "`authenticationSession`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:73
 msgid "the current `AuthenticationSessionModel`"
-msgstr ""
+msgstr "現在の `認証セッション・モデル`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:73
 #, no-wrap
 msgid "`httpRequest`"
-msgstr ""
+msgstr "`httpRequest`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:75
 msgid "the current `org.jboss.resteasy.spi.HttpRequest`"
-msgstr ""
+msgstr "現在の `org.jboss.resteasy.spi.HttpRequest`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:75
 #, no-wrap
 msgid "`LOG`"
-msgstr ""
+msgstr "`LOG`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:77
 msgid "a `org.jboss.logging.Logger` scoped to `ScriptBasedAuthenticator`"
-msgstr ""
+msgstr "`ScriptBasedAuthenticator` にスコープされた `org.jboss.logging.Logger`"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:80
 msgid ""
-"Note that additional context information can be extracted from the `context` "
-"argument passed to the `authenticate(context)` `action(context)` function."
+"Note that additional context information can be extracted from the `context`"
+" argument passed to the `authenticate(context)` `action(context)` function."
 msgstr ""
+"追加のコンテキスト情報は、 `authenticate（context）` や、 `action(context)` 関数に渡される `context`"
+" 引数から抽出できます。"
 
 #. type: delimited block -
 #: source/server_admin/topics/authentication/flows.adoc:84
 #, no-wrap
-msgid "AuthenticationFlowError = Java.type(\"org.keycloak.authentication.AuthenticationFlowError\");\n"
+msgid ""
+"AuthenticationFlowError = "
+"Java.type(\"org.keycloak.authentication.AuthenticationFlowError\");\n"
 msgstr ""
+"AuthenticationFlowError = "
+"Java.type(\"org.keycloak.authentication.AuthenticationFlowError\");\n"
 
 #. type: delimited block -
 #: source/server_admin/topics/authentication/flows.adoc:86
 #, no-wrap
 msgid "function authenticate(context) {\n"
-msgstr ""
+msgstr "function authenticate(context) {\n"
 
 #. type: delimited block -
 #: source/server_admin/topics/authentication/flows.adoc:88
 #, no-wrap
 msgid "  LOG.info(script.name + \" --> trace auth for: \" + user.username);\n"
-msgstr ""
+msgstr "  LOG.info(script.name + \" --> trace auth for: \" + user.username);\n"
 
 #. type: delimited block -
 #: source/server_admin/topics/authentication/flows.adoc:92
@@ -314,6 +351,9 @@ msgid ""
 "      && user.getAttribute(\"someAttribute\")\n"
 "      && user.getAttribute(\"someAttribute\").contains(\"someValue\")) {\n"
 msgstr ""
+"  if (   user.username === \"tester\"\n"
+"      && user.getAttribute(\"someAttribute\")\n"
+"      && user.getAttribute(\"someAttribute\").contains(\"someValue\")) {\n"
 
 #. type: delimited block -
 #: source/server_admin/topics/authentication/flows.adoc:96
@@ -323,13 +363,16 @@ msgid ""
 "      return;\n"
 "  }\n"
 msgstr ""
+"      context.failure(AuthenticationFlowError.INVALID_USER);\n"
+"      return;\n"
+"  }\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:100
+#: source/server_admin/topics/authentication/flows.adoc:99
 #, no-wrap
 msgid ""
 "  context.success();\n"
 "}\n"
-"----                        \n"
-"endif::[]\n"
 msgstr ""
+"  context.success();\n"
+"}\n"

--- a/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,11 +32,11 @@ msgid ""
 " does a walk through of the browser login flow.  In the left drop down list "
 "select `browser` to come to the screen shown below:"
 msgstr ""
-"_authenticationフロー_は、ログイン、登録、その他の{project_name}ワークフロー利用時に発生するすべての認証、画面、およびアクションのためのコンテナです。"
-" 管理コンソールの左メニュー項目 `Authentication` から、 `Flows` "
-"タブを表示することで、システム内の定義されたすべてのフローと、各フローが必要とするアクションとチェックを見ることができます。 "
-"このセクションでは、ブラウザのログインフローについて説明します。 左側のドロップダウンリストで `browser` "
-"を選択すると、以下の画面が表示されます。"
+"_認証フロー_ "
+"は、ログイン、登録、その他の{project_name}ワークフロー利用時に発生するすべての認証、画面、およびアクションのためのコンテナーです。管理コンソールの左メニュー項目"
+" `Authentication` から、 `Flows` "
+"タブを表示することで、システム内の定義されたすべてのフローと、各フローが必要とするアクションとチェックを見ることができます。このセクションでは、ブラウザのログイン・フローについて説明します。左側のドロップダウン・リストで"
+" `browser` を選択すると、以下の画面が表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/authentication/flows.adoc:11
@@ -67,9 +67,9 @@ msgid ""
 " `Requirement` column is a set of radio buttons which define whether or not "
 "the action will execute.  Let's describe what each radio button means:"
 msgstr ""
-"`Auth Type` カラムは、実行される認証またはアクションの名前です。 "
-"認証がインデントされている場合、これはサブ・フローにあり、親の動作に応じて実行される場合と実行されない場合があります。 `Requirement` "
-"列は、アクションが実行されるかどうかを定義するラジオボタンのセットです。 各ラジオボタンの意味を説明します。"
+"`Auth Type` "
+"列は、実行される認証またはアクションの名前です。認証がインデントされている場合、これはサブ・フローにあり、親の動作に応じて実行される場合と実行されない場合があります。"
+" `Requirement` 列は、アクションが実行されるかどうかを定義するラジオボタンのセットです。各ラジオボタンの意味を説明します。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:22
@@ -87,9 +87,8 @@ msgid ""
 "Form` to `Required`, users that don't have an OTP generator configured will "
 "be asked to do so."
 msgstr ""
-"この認証の実行は必ず成功しなければなりません。 "
-"ユーザーにあるタイプの認証メカニズムが設定されておらず、その認証タイプに関連する必須アクションがある場合、必須アクションがそのアカウントにアタッチされます。"
-" 例えば、 `OTP Form` を `Required` "
+"この認証の実行は必ず成功しなければなりません。ユーザーにあるタイプの認証メカニズムが設定されておらず、その認証タイプに関連する必須アクションがある場合、必須アクションがそのアカウントにアタッチされます。例えば、"
+" `OTP Form` を `Required` "
 "に切り替えると、OTPジェネレーターが設定されていないユーザーには、OTPジェネレーターの設定が要求されます。"
 
 #. type: Labeled list
@@ -114,7 +113,7 @@ msgstr "Disabled"
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:31
 msgid "If disabled, the authentication type is not executed."
-msgstr "無効にします。認証タイプは実行されません。"
+msgstr "無効にすると、認証タイプは実行されません。"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:31
@@ -127,14 +126,14 @@ msgstr "Alternative"
 msgid ""
 "This means that at least one alternative authentication type must execute "
 "successfully at that level of the flow."
-msgstr "フロー中の同じレベルにおいて、少なくとも1つの `alternative` 認証タイプが、成功しなければなりません。"
+msgstr "少なくとも1つの `alternative` 認証タイプが、そのフローのレベルで正常に実行されなければならないことを意味します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:35
 msgid ""
 "This is better described in an example.  Let's walk through the `browser` "
 "authentication flow."
-msgstr "以下の `ブラウザー` 認証フローの例を見てみましょう。"
+msgstr "以下の `browser` 認証フローの例を見てみましょう。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:39
@@ -146,16 +145,16 @@ msgid ""
 "_alternative_, no other execution is executed and this results in a "
 "successful login."
 msgstr ""
-"最初の認証タイプは `Cookie` です。 ユーザーが最初に正常にログインすると、セッションCookieが設定されます。 "
-"このCookieがすでに設定されている場合、この認証タイプは正常です。 Cookieプロバイダーは成功を返し、このフローのレベルでの各実行は "
-"_alternative_ であるため、他の実行は実行されず、ログインに成功します。"
+"最初の認証タイプは `Cookie` "
+"です。ユーザーが最初に正常にログインすると、セッションCookieが設定されます。このCookieがすでに設定されている場合、この認証タイプは正常です。Cookieプロバイダーは成功を返し、このフローのレベルでの各実行は"
+" _alternative_ であるため、他の実行は実行されず、ログインに成功します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:40
 msgid ""
 "Next the flow looks at the Kerberos execution.  This authenticator is "
 "disabled by default and will be skipped."
-msgstr "フローの次の認証タイプは、Kerberosです。 この認証はデフォルトで無効になっており、スキップされます。"
+msgstr "フローの次の認証タイプは、Kerberos実行です。このオーセンティケーターはデフォルトで無効になっており、スキップされます。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:43
@@ -166,9 +165,8 @@ msgid ""
 " be executed.  The executions for this subflow are loaded and the same "
 "processing logic occurs"
 msgstr ""
-"次の実行はFormsと呼ばれるサブ・フローです。 このサブ・フローは _alternative_ とマークされているので、 `Cookie` "
-"認証タイプが成功すると実行されません。 このサブ・フローには、実行する必要のある追加の認証タイプが含まれています。 "
-"サブ・フローの実行はロードされ、同じ処理ロジックが発生します。"
+"次の実行はFormsと呼ばれるサブ・フローです。このサブ・フローは _alternative_ とマークされているので、 `Cookie` "
+"認証タイプが成功すると実行されません。このサブ・フローには、実行する必要のある追加の認証タイプが含まれています。サブ・フローの実行はロードされ、同じ処理ロジックが発生します。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:45
@@ -178,8 +176,8 @@ msgid ""
 "marked as _required_ so the user must enter in a valid username and "
 "password."
 msgstr ""
-"Formsサブフローでの最初の実行は、Username Password Formです。 この認証タイプは、ユーザー名とパスワードのページを表示します。"
-" _required_ とされているため、ユーザーは有効なユーザー名とパスワードを入力する必要があります。"
+"Formsサブフローでの最初の実行は、Username Password Formです。この認証タイプは、ユーザー名とパスワードのページを表示します。 "
+"_required_ とされているため、ユーザーは有効なユーザー名とパスワードを入力する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:48
@@ -189,9 +187,8 @@ msgid ""
 "successful.  If the user doesn't have OTP set up, this authentication type "
 "is ignored."
 msgstr ""
-"次の実行はOTPフォームです。 これは _optional_ としてマークされています。 "
-"ユーザーがOTPを設定している場合は、この認証タイプを実行して成功させる必要があります。 "
-"ユーザーにOTPが設定されていない場合、この認証タイプは無視されます。"
+"次の実行はOTPフォームです。 これは _optional_ "
+"としてマークされています。ユーザーがOTPを設定している場合は、この認証タイプを実行して成功させる必要があります。ユーザーにOTPが設定されていない場合、この認証タイプは無視されます。"
 
 #. type: Title ===
 #: source/server_admin/topics/authentication/flows.adoc:50
@@ -219,9 +216,9 @@ msgid ""
 "from `Authenticator#authenticate(AuthenticationFlowContext)` `action(..)` "
 "which is called from `Authenticator#action(AuthenticationFlowContext)`"
 msgstr ""
-"_スクリプト_ オーセンティケーターを使用すると、JavaScript経由でカスタム認証ロジックを定義できます。 カスタム・オーセンティケーター。 "
-"認証スクリプトは、少なくとも次の機能のうちの1つを提供する必要があります。 "
-"`Authenticator#authenticate(AuthenticationFlowContext)` から呼び出される "
+"_スクリプト_ "
+"オーセンティケーターを使用すると、JavaScript経由でカスタム認証ロジックを定義できます。カスタム・オーセンティケーター。認証スクリプトは、少なくとも次の機能のうちの1つを提供する必要があります。"
+" `Authenticator#authenticate(AuthenticationFlowContext)` から呼び出される "
 "`authenticate(..)`。 `Authenticator#action(AuthenticationFlowContext)` "
 "から呼び出される `action(..)`。"
 
@@ -232,7 +229,7 @@ msgid ""
 "function.  The following script `javax.script.Bindings` are available for "
 "convenient use within script code."
 msgstr ""
-"カスタム `オーセンティケーター` は、 `authenticate（..）` 関数を提供するべきです。 次のスクリプト "
+"カスタム `オーセンティケーター` は、 `authenticate(..)` 関数を提供するべきです。次のスクリプト "
 "`javax.script.Bindings` は、スクリプトコード内で便利に利用できます。"
 
 #. type: Labeled list
@@ -244,7 +241,7 @@ msgstr "`script`"
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:65
 msgid "the `ScriptModel` to access script metadata"
-msgstr "スクリプトのメタデータにアクセスするための `スクリプト・モデル` "
+msgstr "スクリプトのメタデータにアクセスするための `ScriptModel` "
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:65
@@ -255,7 +252,7 @@ msgstr "`realm`"
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:67
 msgid "the `RealmModel`"
-msgstr "`レルム・モデル`"
+msgstr "`RealmModel`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:67
@@ -266,7 +263,7 @@ msgstr "`user`"
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:69
 msgid "the current `UserModel`"
-msgstr "現在の `ユーザー・モデル`"
+msgstr "現在の `UserModel`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:69
@@ -277,7 +274,7 @@ msgstr "`session`"
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:71
 msgid "the active `KeycloakSession`"
-msgstr "アクティブな `Keycloakセッション`"
+msgstr "アクティブな `KeycloakSession`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:71
@@ -288,7 +285,7 @@ msgstr "`authenticationSession`"
 #. type: Plain text
 #: source/server_admin/topics/authentication/flows.adoc:73
 msgid "the current `AuthenticationSessionModel`"
-msgstr "現在の `認証セッション・モデル`"
+msgstr "現在の `AuthenticationSessionModel`"
 
 #. type: Labeled list
 #: source/server_admin/topics/authentication/flows.adoc:73
@@ -318,7 +315,7 @@ msgid ""
 "Note that additional context information can be extracted from the `context`"
 " argument passed to the `authenticate(context)` `action(context)` function."
 msgstr ""
-"追加のコンテキスト情報は、 `authenticate（context）` や、 `action(context)` 関数に渡される `context`"
+"追加のコンテキスト情報は、 `authenticate(context)` や、 `action(context)` 関数に渡される `context`"
 " 引数から抽出できます。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__flows
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__authentication__flows/ja_JP/index.html
