### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/groups/groups-vs-roles.adoc:3
 #, no-wrap
 msgid "Groups vs. Roles"
-msgstr ""
+msgstr "グループ VS ロール"
 
 #. type: Plain text
 #: source/server_admin/topics/groups/groups-vs-roles.adoc:8
@@ -29,14 +29,19 @@ msgid ""
 "that you can apply roles and attributes to in one place.  Roles define a "
 "type of user and applications assign permission and access control to roles"
 msgstr ""
+"ITの世界では、グループとロールの概念はしばしば曖昧になり、互換性があります。 "
+"{project_name}では、グループはロールと属性を1か所に適用できるユーザーのコレクションです。 "
+"ロールはユーザーのタイプを定義し、アプリケーションはロールにパーミッションとアクセス制御を割り当てます。"
 
 #. type: Plain text
 #: source/server_admin/topics/groups/groups-vs-roles.adoc:13
 msgid ""
 "Aren't <<_composite-roles,Composite Roles>> also similar to Groups? "
 "Logically they provide the same exact functionality, but the difference is "
-"conceptual.  Composite roles should be used to apply the permission model to "
-"your set of services and applications.  Groups should focus on collections "
-"of users and their roles in your organization.  Use groups to manage users.  "
-"Use composite roles to manage applications and services."
+"conceptual.  Composite roles should be used to apply the permission model to"
+" your set of services and applications.  Groups should focus on collections "
+"of users and their roles in your organization.  Use groups to manage users."
+"  Use composite roles to manage applications and services."
 msgstr ""
+"<<_composite-"
+"roles,複合ロール>>もグループに似ているでしょうか？論理的には同等の機能を提供しますが、概念的である点が異なります。複合ロールは、サービスとアプリケーションのセットにパーミッション・モデルを適用するために使用されるべきです。グループは、組織内のユーザーとロールのコレクションに焦点を当てるべきです。グループは、ユーザーを管理するために使用します。複合ロールは、アプリケーションとサービスを管理するために使用します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__groups__groups-vs-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__groups__groups-vs-roles/ja_JP/index.html
