### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,7 +30,7 @@ msgid ""
 "switch."
 msgstr ""
 "これを有効にすると、ユーザーはパスワードを忘れたり、OTPジェネレーターを無くした場合でも、クレデンシャルをリセットできます。左のメニュー項目の "
-"`Realm Settings` に行き、 ` Login` タブをクリックしてください。 `Forgot Password` スイッチをオンにします。"
+"`Realm Settings` に移動し、 ` Login` タブをクリックします。 `Forgot Password` スイッチをオンにします。"
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:7
@@ -39,7 +39,7 @@ msgstr ""
 #: source/server_admin/topics/realms/ssl.adoc:14
 #, no-wrap
 msgid "Login Tab"
-msgstr "ログイン・タブ"
+msgstr "Loginタブ"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:9
@@ -105,14 +105,14 @@ msgid ""
 "`Authentication` left menu item, clicking on the `Flows` tab, and selecting "
 "the `Reset Credentials` flow:"
 msgstr ""
-"ユーザーがメール・リンクをクリックすると、パスワードの更新が求められ、OTPジェネレーターが設定されている場合は、パスワードの再設定も求められます。組織のセキュリティ要件によっては、ユーザーが電子メールでOTPジェネレーターをリセットできないようにすることができます。この動作を変更するには、左メニュー項目の"
-" `Authentication` で `Flows` タブをクリックし、 `Reset Credentials` フローを選択します："
+"ユーザーが電子メールのリンクをクリックすると、パスワードの更新が求められ、OTPジェネレーターが設定されている場合は、パスワードの再設定も求められます。組織のセキュリティ要件によっては、電子メールを使ってユーザーがOTPジェネレーターをリセットできないようにすることができます。この動作を変更するには、左メニュー項目の"
+" `Authentication` で `Flows` タブをクリックし、 `Reset Credentials` フローを選択します。"
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:29
 #, no-wrap
 msgid "Reset Credentials Flow"
-msgstr "リセット・クレデンシャル・フロー"
+msgstr "Reset Credentialsフロー"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:31

--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -2,33 +2,35 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_admin/topics/login-settings/forgot-password.adoc:2
 #, no-wrap
 msgid "Forgot Password"
-msgstr ""
+msgstr "パスワード忘れ"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:6
 msgid ""
 "If you enable it, users are able to reset their credentials if they forget "
-"their password or lose their OTP generator.  Go to the `Realm Settings` left "
-"menu item, and click on the `Login` tab.  Switch on the `Forgot Password` "
+"their password or lose their OTP generator.  Go to the `Realm Settings` left"
+" menu item, and click on the `Login` tab.  Switch on the `Forgot Password` "
 "switch."
 msgstr ""
+"これを有効にすると、ユーザーはパスワードを忘れたり、OTPジェネレーターを無くした場合でも、クレデンシャルをリセットできます。左のメニュー項目の "
+"`Realm Settings` に行き、 ` Login` タブをクリックしてください。 `Forgot Password` スイッチをオンにします。"
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:7
@@ -37,7 +39,7 @@ msgstr ""
 #: source/server_admin/topics/realms/ssl.adoc:14
 #, no-wrap
 msgid "Login Tab"
-msgstr ""
+msgstr "ログイン・タブ"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:9
@@ -45,23 +47,23 @@ msgstr ""
 #: source/server_admin/topics/users/user-registration.adoc:12
 #: source/server_admin/topics/realms/ssl.adoc:16
 msgid "image:{project_images}/login-tab.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:11
 msgid "A `forgot password` link will now show up on your login pages."
-msgstr ""
+msgstr "ログインページに `forgot password` リンクが表示されるようになります。"
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:12
 #, no-wrap
 msgid "Forgot Password Link"
-msgstr ""
+msgstr "パスワード忘れリンク"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:14
 msgid "image:{project_images}/forgot-password-link.png[]"
-msgstr ""
+msgstr "image:{project_images}/forgot-password-link.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:17
@@ -70,52 +72,56 @@ msgid ""
 "their username or email and receive an email with a link to reset their "
 "credentials."
 msgstr ""
+"このリンクをクリックすると、ユーザー名またはメールアドレスを入力できるページに移動し、クレデンシャルをリセットするためのリンクが記載されたメールが送信されます。"
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:18
 #, no-wrap
 msgid "Forgot Password Page"
-msgstr ""
+msgstr "パスワード忘れページ"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:20
 msgid "image:{project_images}/forgot-password-page.png[]"
-msgstr ""
+msgstr "image:{project_images}/forgot-password-page.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:23
 msgid ""
 "The text sent in the email is completely configurable. You just need to "
-"extend or edit the theme associated with it.  See the link:"
-"{developerguide_link}[{developerguide_name}] for more information."
+"extend or edit the theme associated with it.  See the "
+"link:{developerguide_link}[{developerguide_name}] for more information."
 msgstr ""
+"電子メールで送信されるテキストは完全に設定可能です。それに関連するテーマを拡張または編集するだけです。詳細については、link:{developerguide_link}[{developerguide_name}]のリンクをご覧ください。"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:28
 msgid ""
 "When the user clicks on the email link, they will be asked to update their "
-"password, and, if they have an OTP generator set up, they will also be asked "
-"to reconfigure this as well.  Depending on the security requirements of your "
-"organization you may not want users to be able to reset their OTP generator "
-"through email.  You can change this behavior by going to the "
+"password, and, if they have an OTP generator set up, they will also be asked"
+" to reconfigure this as well.  Depending on the security requirements of "
+"your organization you may not want users to be able to reset their OTP "
+"generator through email.  You can change this behavior by going to the "
 "`Authentication` left menu item, clicking on the `Flows` tab, and selecting "
 "the `Reset Credentials` flow:"
 msgstr ""
+"ユーザーがメール・リンクをクリックすると、パスワードの更新が求められ、OTPジェネレーターが設定されている場合は、パスワードの再設定も求められます。組織のセキュリティ要件によっては、ユーザーが電子メールでOTPジェネレーターをリセットできないようにすることができます。この動作を変更するには、左メニュー項目の"
+" `Authentication` で `Flows` タブをクリックし、 `Reset Credentials` フローを選択します："
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:29
 #, no-wrap
 msgid "Reset Credentials Flow"
-msgstr ""
+msgstr "リセット・クレデンシャル・フロー"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:31
 msgid "image:{project_images}/reset-credentials-flow.png[]"
-msgstr ""
+msgstr "image:{project_images}/reset-credentials-flow.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:32
 msgid ""
-"If you do not want OTP reset, then just chose the `disabled` radio button to "
-"the right of `Reset OTP`."
-msgstr ""
+"If you do not want OTP reset, then just chose the `disabled` radio button to"
+" the right of `Reset OTP`."
+msgstr "OTPをリセットしたくない場合は、 `Reset OTP` の右にある `disabled` ラジオボタンを選択してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__login-settings__forgot-password
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__login-settings__forgot-password/ja_JP/index.html
