### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -22,7 +22,7 @@ msgstr ""
 #: source/server_admin/topics/realms/ssl.adoc:14
 #, no-wrap
 msgid "Login Tab"
-msgstr ""
+msgstr "ログイン・タブ"
 
 #. type: Plain text
 #: source/server_admin/topics/login-settings/forgot-password.adoc:9
@@ -30,13 +30,13 @@ msgstr ""
 #: source/server_admin/topics/users/user-registration.adoc:12
 #: source/server_admin/topics/realms/ssl.adoc:16
 msgid "image:{project_images}/login-tab.png[]"
-msgstr ""
+msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Title ===
 #: source/server_admin/topics/users/user-registration.adoc:3
 #, no-wrap
 msgid "User Registration"
-msgstr ""
+msgstr "ユーザー登録"
 
 #. type: Plain text
 #: source/server_admin/topics/users/user-registration.adoc:9
@@ -48,47 +48,51 @@ msgid ""
 "There is a `User Registration` switch on this tab.  Turn it on, then click "
 "the `Save` button."
 msgstr ""
+"{project_name}に対して、ユーザーの自己登録を許可することができます。ユーザーの自己登録を有効にすると、ログインページにはユーザーが新しいアカウントを作成するための登録リンクが表示されます。ユーザーの自己登録を有効にするのは簡単です。左メニューの"
+" `Realm Settings` をクリックし、 `Login` タブに移動します。このタブには `User Registration` "
+"スイッチがありますので、スイッチをオンにしてから、 `Save` ボタンをクリックします。"
 
 #. type: Plain text
 #: source/server_admin/topics/users/user-registration.adoc:14
 msgid ""
-"After you enable this setting, a `Register` link should show up on the login "
-"page."
-msgstr ""
+"After you enable this setting, a `Register` link should show up on the login"
+" page."
+msgstr "この設定を有効にすると、ログインページに `Register` リンクが表示されます。"
 
 #. type: Block title
 #: source/server_admin/topics/users/user-registration.adoc:15
 #, no-wrap
 msgid "Registration Link"
-msgstr ""
+msgstr "登録リンク"
 
 #. type: Plain text
 #: source/server_admin/topics/users/user-registration.adoc:17
 msgid "image:{project_images}/registration-link.png[]"
-msgstr ""
+msgstr "image:{project_images}/registration-link.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/users/user-registration.adoc:20
 msgid ""
 "Clicking on this link will bring the user to the registration page where "
 "they have to enter in some user profile information and a new password."
-msgstr ""
+msgstr "このリンクをクリックすると、登録ページが表示されますので、ユーザープロファイル情報と新しいパスワードを入力します。"
 
 #. type: Block title
 #: source/server_admin/topics/users/user-registration.adoc:21
 #, no-wrap
 msgid "Registration Form"
-msgstr ""
+msgstr "登録フォーム"
 
 #. type: Plain text
 #: source/server_admin/topics/users/user-registration.adoc:23
 msgid "image:{project_images}/registration-form.png[]"
-msgstr ""
+msgstr "image:{project_images}/registration-form.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/users/user-registration.adoc:26
 msgid ""
 "You can change the look and feel of the registration form as well as "
-"removing or adding additional fields that must be entered.  See the link:"
-"{developerguide_link}[{developerguide_name}] for more information."
+"removing or adding additional fields that must be entered.  See the "
+"link:{developerguide_link}[{developerguide_name}] for more information."
 msgstr ""
+"登録フォームのルック・アンド・フィールを変更するだけでなく、項目を追加または削除することができます。詳細については、link:{developerguide_link}[{developerguide_name}]をご参照ください。"

--- a/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroshi Katakura <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: naokiiiii <naoki.dx.xb@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,14 +33,27 @@ msgstr "ユーザー登録"
 msgid ""
 "You can enable {project_name} to allow user self registration.  When "
 "enabled, the login page has a registration link the user can click on to "
-"create their new account.  Enabling registration is pretty simple.  Go to "
-"the `Realm Settings` left menu and click it.  Then go to the `Login` tab.  "
-"There is a `User Registration` switch on this tab.  Turn it on, then click "
-"the `Save` button."
+"create their new account."
 msgstr ""
-"{project_name}に対して、ユーザーの自己登録を許可することができます。ユーザーの自己登録を有効にすると、ログインページにはユーザーが新しいアカウントを作成するための登録リンクが表示されます。ユーザーの自己登録を有効にするのは簡単です。左メニューの"
-" `Realm Settings` をクリックし、 `Login` タブに移動します。このタブには `User Registration` "
-"スイッチがありますので、スイッチをオンにしてから、 `Save` ボタンをクリックします。"
+"{project_name}では、ユーザーの自己登録を許可することができます。有効にすると、ログイン・ページにはユーザーが新しいアカウントを作成するためにクリックできる登録リンクが表示されます。"
+
+#. type: Plain text
+msgid ""
+"When user self registration is enabled it is possible to use the "
+"registration form to detect valid usernames and emails.  To prevent this "
+"enable <<_recaptcha,reCAPTCHA Support>>."
+msgstr ""
+"ユーザーの自己登録が有効になっている場合、登録フォームを使用して有効なユーザー名と電子メールを検出することができます。これを回避するには、<<_recaptcha,reCAPTCHAサポート>>を有効にします。"
+
+#. type: Plain text
+msgid ""
+"Enabling registration is pretty simple.  Go to the `Realm Settings` left "
+"menu and click it.  Then go to the `Login` tab.  There is a `User "
+"Registration` switch on this tab.  Turn it on, then click the `Save` button."
+msgstr ""
+"登録を有効にするのは簡単です。 `Realm Settings` の左メニューに移動し、それをクリックします。次に、 `Login` "
+"タブに移動します。このタブには `User Registration` スイッチがあります。それをオンにしてから、 `Save` "
+"ボタンをクリックします。"
 
 #. type: Plain text
 msgid ""
@@ -61,7 +74,7 @@ msgstr "image:{project_images}/registration-link.png[]"
 msgid ""
 "Clicking on this link will bring the user to the registration page where "
 "they have to enter in some user profile information and a new password."
-msgstr "このリンクをクリックすると、登録ページが表示されますので、ユーザープロファイル情報と新しいパスワードを入力します。"
+msgstr "このリンクをクリックすると、登録ページが表示されますので、ユーザー・プロファイル情報と新しいパスワードを入力します。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: naokiiiii <naoki.dx.xb@gmail.com>, 2017\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,7 +18,7 @@ msgstr ""
 #. type: Block title
 #, no-wrap
 msgid "Login Tab"
-msgstr "ログイン・タブ"
+msgstr "Loginタブ"
 
 #. type: Plain text
 msgid "image:{project_images}/login-tab.png[]"
@@ -35,7 +35,7 @@ msgid ""
 "enabled, the login page has a registration link the user can click on to "
 "create their new account."
 msgstr ""
-"{project_name}では、ユーザーの自己登録を許可することができます。有効にすると、ログイン・ページにはユーザーが新しいアカウントを作成するためにクリックできる登録リンクが表示されます。"
+"{project_name}では、ユーザーの自己登録を許可することができます。有効にすると、ログインページには、ユーザーが新しいアカウントを作成するためにクリックできる登録リンクが表示されます。"
 
 #. type: Plain text
 msgid ""
@@ -43,7 +43,7 @@ msgid ""
 "registration form to detect valid usernames and emails.  To prevent this "
 "enable <<_recaptcha,reCAPTCHA Support>>."
 msgstr ""
-"ユーザーの自己登録が有効になっている場合、登録フォームを使用して有効なユーザー名と電子メールを検出することができます。これを回避するには、<<_recaptcha,reCAPTCHAサポート>>を有効にします。"
+"ユーザーの自己登録が有効になっている場合、登録フォームを使用して有効なユーザー名と電子メールを検出することができます。これを回避するには、<<_recaptcha,reCAPTCHAのサポート>>を有効にします。"
 
 #. type: Plain text
 msgid ""
@@ -51,7 +51,7 @@ msgid ""
 "menu and click it.  Then go to the `Login` tab.  There is a `User "
 "Registration` switch on this tab.  Turn it on, then click the `Save` button."
 msgstr ""
-"登録を有効にするのは簡単です。 `Realm Settings` の左メニューに移動し、それをクリックします。次に、 `Login` "
+"登録を有効にするのは簡単です。 左メニューの `Realm Settings` をクリックし、移動します。次に、 `Login` "
 "タブに移動します。このタブには `User Registration` スイッチがあります。それをオンにしてから、 `Save` "
 "ボタンをクリックします。"
 
@@ -74,7 +74,7 @@ msgstr "image:{project_images}/registration-link.png[]"
 msgid ""
 "Clicking on this link will bring the user to the registration page where "
 "they have to enter in some user profile information and a new password."
-msgstr "このリンクをクリックすると、登録ページが表示されますので、ユーザー・プロファイル情報と新しいパスワードを入力します。"
+msgstr "このリンクをクリックすると、登録ページが表示されるので、ユーザー・プロファイル情報と新しいパスワードを入力します。"
 
 #. type: Block title
 #, no-wrap
@@ -91,4 +91,4 @@ msgid ""
 "removing or adding additional fields that must be entered.  See the "
 "link:{developerguide_link}[{developerguide_name}] for more information."
 msgstr ""
-"登録フォームのルック・アンド・フィールを変更するだけでなく、項目を追加または削除することができます。詳細については、link:{developerguide_link}[{developerguide_name}]をご参照ください。"
+"登録フォームのデザインを変更するだけでなく、入力項目を追加または削除することができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照ください。"

--- a/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroshi Katakura <h.katakura@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,30 +16,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/login-settings/forgot-password.adoc:7
-#: source/server_admin/topics/login-settings/remember-me.adoc:10
-#: source/server_admin/topics/users/user-registration.adoc:10
-#: source/server_admin/topics/realms/ssl.adoc:14
 #, no-wrap
 msgid "Login Tab"
 msgstr "ログイン・タブ"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:9
-#: source/server_admin/topics/login-settings/remember-me.adoc:12
-#: source/server_admin/topics/users/user-registration.adoc:12
-#: source/server_admin/topics/realms/ssl.adoc:16
 msgid "image:{project_images}/login-tab.png[]"
 msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Title ===
-#: source/server_admin/topics/users/user-registration.adoc:3
 #, no-wrap
 msgid "User Registration"
 msgstr "ユーザー登録"
 
 #. type: Plain text
-#: source/server_admin/topics/users/user-registration.adoc:9
 msgid ""
 "You can enable {project_name} to allow user self registration.  When "
 "enabled, the login page has a registration link the user can click on to "
@@ -53,43 +43,36 @@ msgstr ""
 "スイッチがありますので、スイッチをオンにしてから、 `Save` ボタンをクリックします。"
 
 #. type: Plain text
-#: source/server_admin/topics/users/user-registration.adoc:14
 msgid ""
 "After you enable this setting, a `Register` link should show up on the login"
 " page."
 msgstr "この設定を有効にすると、ログインページに `Register` リンクが表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/users/user-registration.adoc:15
 #, no-wrap
 msgid "Registration Link"
 msgstr "登録リンク"
 
 #. type: Plain text
-#: source/server_admin/topics/users/user-registration.adoc:17
 msgid "image:{project_images}/registration-link.png[]"
 msgstr "image:{project_images}/registration-link.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/users/user-registration.adoc:20
 msgid ""
 "Clicking on this link will bring the user to the registration page where "
 "they have to enter in some user profile information and a new password."
 msgstr "このリンクをクリックすると、登録ページが表示されますので、ユーザープロファイル情報と新しいパスワードを入力します。"
 
 #. type: Block title
-#: source/server_admin/topics/users/user-registration.adoc:21
 #, no-wrap
 msgid "Registration Form"
 msgstr "登録フォーム"
 
 #. type: Plain text
-#: source/server_admin/topics/users/user-registration.adoc:23
 msgid "image:{project_images}/registration-form.png[]"
 msgstr "image:{project_images}/registration-form.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/users/user-registration.adoc:26
 msgid ""
 "You can change the look and feel of the registration form as well as "
 "removing or adding additional fields that must be entered.  See the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__user-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__users__user-registration/ja_JP/index.html
