### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
@@ -53,7 +53,7 @@ msgid ""
 msgstr ""
 "SAMLを使用するユースケースは、実際には2つの種類があります。1つ目は、{project_name}サーバーにユーザーの認証を要求するアプリケーションのユースケースです。ログインが成功すると、アプリケーションは"
 " "
-"ユーザーに関する様々な属性を指定するSAMLアサーションと呼ばれるものが含まれるXMLドキュメントを受け取ります。このXMLドキュメントはレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報(ユーザー・ロール・マッピングのような)が含まれています。"
+"ユーザーに関する様々な属性を指定するSAMLアサーションと呼ばれるものが含まれるXMLドキュメントを受け取ります。このXMLドキュメントはレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報（ユーザー・ロール・マッピングのような）が含まれています。"
 " "
 
 #. type: Plain text
@@ -80,22 +80,22 @@ msgid ""
 "browser based applications.  The _ECP_ binding covers REST invocations.  "
 "There are other binding types but {project_name} only supports those three."
 msgstr ""
-"SAMLは、認証プロトコルを実行する際にXMLドキュメントを交換するためのいくつかの異なる方法を定義しています。 _リダイレクト_ バインディングと "
-"_POST_ バインディングは、ブラウザー・ベースのアプリケーションをカバーします。 _ECP_ "
+"SAMLは、認証プロトコルを実行する際にXMLドキュメントを交換するためのいくつかの異なる方法を定義しています。 _REDIRECT_ バインディングと"
+" _POST_ バインディングは、ブラウザーベースのアプリケーションをカバーします。 _ECP_ "
 "バインディングは、REST呼び出しを扱います。他のバインディング種別もありますが、{project_name}はこれらの3つしかサポートしていません。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:25
 #, no-wrap
 msgid "Redirect Binding"
-msgstr "リダイレクト・バインディング"
+msgstr "REDIRECTバインディング"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:29
 msgid ""
 "The _Redirect_ Binding uses a series of browser redirect URIs to exchange "
 "information.  This is a rough overview of how it works."
-msgstr "_リダイレクト_ バインディングは、一連のブラウザー・リダイレクトURIを使用して情報を交換します。その動作の概要を示します。"
+msgstr "_REDIRECT_ バインディングは、一連のブラウザー・リダイレクトURIを使用して情報を交換します。その動作の概要を示します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:35
@@ -167,7 +167,7 @@ msgid ""
 "loaded, the JavaScript automatically invokes the form.  You really don't "
 "need to know about this stuff, but it is a pretty clever trick."
 msgstr ""
-"SAML _POST_ バインディングは、_リダイレクト_ "
+"SAML _POST_ バインディングは、_REDIRECT_ "
 "バインディングとほぼ同じ方法で動作しますが、GETリクエストではなく、POSTリクエストによってXMLドキュメントが交換されます。 _POST_ "
 "バインディングは、JavaScriptを使用して、ドキュメントを交換するときに{project_name}サーバーまたはアプリケーションに対してPOSTリクエストを行うようにブラウザを操作します。基本的にHTTPレスポンスには、JavaScriptが埋め込まれたフォームを含むHTMLが含まれています。ページが読み込まれると、JavaScriptはフォームを自動的に呼び出します。このことについて実際に知る必要はありませんが、これはかなり巧妙なトリックです。"
 

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
@@ -35,9 +35,9 @@ msgid ""
 "responses."
 msgstr ""
 "link:http://saml.xml.org/saml-specifications[SAML "
-"2.0]はOIDCと同質的な仕様ですが、より古くて成熟しています。SOAPをルーツとしていて、WS- "
+"2.0]はOIDCと似た仕様ですが、より古くて成熟しています。SOAPをルーツとしていて、WS- "
 "*の仕様も多すぎるため、OIDCよりも冗長な傾向があります。SAML "
-"2.0は主に、認証サーバーとアプリケーションの間でXMLドキュメントを交換することによって機能する認証プロトコルです。XML署名と暗号化は、要求と応答を検証するために使用されます。"
+"2.0は主に、認証サーバーとアプリケーションの間でXMLドキュメントを交換することによって機能する認証プロトコルです。XML署名と暗号化は、リクエストとレスポンスを検証するために使用されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:15
@@ -51,7 +51,10 @@ msgid ""
 "the application can use to determine what resources the user is allowed to "
 "access on the application."
 msgstr ""
-"SAMLを使用する場合、2つのタイプのユースケースがあります。最初のものは{project_name}サーバーにユーザーの認証を求めるアプリケーションです。ログインに成功すると、アプリケーションは、ユーザーに関するさまざまな属性を指定するSAMLアサーションと呼ばれるものを含むXMLドキュメントを受け取ります。このXMLドキュメントは、レルムによってデジタル署名され、ユーザーがアプリケーションでアクセスできるリソースを決定するためにアプリケーションが使用できるアクセス情報（ユーザー・ロール・マッピングなど）を含んでいます。"
+"SAMLを使用するユースケースは、実際には2つの種類があります。1つ目は、{project_name}サーバーにユーザーの認証を要求するアプリケーションのユースケースです。ログインが成功すると、アプリケーションは"
+" "
+"ユーザーに関する様々な属性を指定するSAMLアサーションと呼ばれるものが含まれるXMLドキュメントを受け取ります。このXMLドキュメントはレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報(ユーザー・ロール・マッピングのような)が含まれています。"
+" "
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:18
@@ -77,22 +80,22 @@ msgid ""
 "browser based applications.  The _ECP_ binding covers REST invocations.  "
 "There are other binding types but {project_name} only supports those three."
 msgstr ""
-"SAMLは、認証プロトコルを実行する際にXMLドキュメントを交換するためのいくつかの異なる方法を定義しています。 _Redirect_ と _Post_"
-" バインディングは、ブラウザー・ベースのアプリケーションをカバーします。 _ECP_ "
+"SAMLは、認証プロトコルを実行する際にXMLドキュメントを交換するためのいくつかの異なる方法を定義しています。 _リダイレクト_ バインディングと "
+"_POST_ バインディングは、ブラウザー・ベースのアプリケーションをカバーします。 _ECP_ "
 "バインディングは、REST呼び出しを扱います。他のバインディング種別もありますが、{project_name}はこれらの3つしかサポートしていません。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:25
 #, no-wrap
 msgid "Redirect Binding"
-msgstr "Redirectバインディング"
+msgstr "リダイレクト・バインディング"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:29
 msgid ""
 "The _Redirect_ Binding uses a series of browser redirect URIs to exchange "
 "information.  This is a rough overview of how it works."
-msgstr "_Redirect_ Bindingは、一連のブラウザー・リダイレクトURIを使用して情報を交換します。その動作の概要を示します。"
+msgstr "_リダイレクト_ バインディングは、一連のブラウザー・リダイレクトURIを使用して情報を交換します。その動作の概要を示します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:35
@@ -105,7 +108,7 @@ msgid ""
 "param in the redirect URI to {project_name}.  This signature is used to "
 "validate the client that sent this request."
 msgstr ""
-"ユーザーがアプリケーションへアクセスすると、認証されていないことがアプリケーションによって検出されます。XML認証要求ドキュメントを生成し、それを{project_name}サーバーにリダイレクトするために使用されるURIのクエリ・パラメーターとしてエンコードします。設定に応じて、アプリケーションはこのXMLドキュメントにデジタル署名し、この署名を{project_name}へのリダイレクトURIのクエリ・パラメーターとして埋め込むこともできます。この署名は、この要求を送信したクライアントを検証するために使用されます。"
+"ユーザーがアプリケーションへアクセスすると、認証されていないことがアプリケーションによって検出されます。XML認証リクエスト・ドキュメントを生成し、それを{project_name}サーバーにリダイレクトするために使用されるURIのクエリー・パラメーターとしてエンコードします。設定に応じて、アプリケーションはこのXMLドキュメントにデジタル署名し、この署名を{project_name}へのリダイレクトURIのクエリー・パラメーターとして埋め込むこともできます。この署名は、このリクエストを送信したクライアントを検証するために使用されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:37
@@ -114,7 +117,7 @@ msgid ""
 "auth request document and verifies the digital signature if required.  The "
 "user then has to enter in their credentials to be authenticated."
 msgstr ""
-"ブラウザーは{project_name}にリダイレクトされます。サーバーは、XML認証要求ドキュメントを抽出し、必要に応じてデジタル署名を検証します。ユーザーは認証されるためにクレデンシャルを入力する必要があります。"
+"ブラウザーは{project_name}にリダイレクトされます。サーバーは、XML認証リクエスト・ドキュメントを抽出し、必要に応じてデジタル署名を検証します。ユーザーは認証されるためにクレデンシャルを入力する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:40
@@ -125,7 +128,7 @@ msgid ""
 "have.  This document is almost always digitally signed using XML signatures,"
 " and may also be encrypted."
 msgstr ""
-"認証後、サーバーはXML認証応答ドキュメントを生成します。このドキュメントには、ユーザーの名前、住所、電子メール、およびユーザーが持つロール・マッピングなどのユーザーに関するメタデータを保持するSAMLアサーションが含まれています。このドキュメントは、ほとんどの場合、XML署名を使用してデジタル署名されており、暗号化されている場合もあります。"
+"認証後、サーバーはXML認証レスポンス・ドキュメントを生成します。このドキュメントには、ユーザーの名前、住所、電子メール、およびユーザーが持つロール・マッピングなどのユーザーに関するメタデータを保持するSAMLアサーションが含まれています。このドキュメントは、ほとんどの場合、XML署名を使用してデジタル署名されており、暗号化されている場合もあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:42
@@ -134,7 +137,7 @@ msgid ""
 "redirect URI that brings the browser back to the application.  The digital "
 "signature is also included as a query param."
 msgstr ""
-"次に、XML認証応答ドキュメントは、ブラウザーをアプリケーションへ戻すためのリダイレクトURIのクエリ・パラメーターとしてエンコードされます。デジタル署名はクエリ・パラメーターとしても含まれています。"
+"次に、XML認証レスポンス・ドキュメントは、ブラウザーをアプリケーションへ戻すためのリダイレクトURIのクエリー・パラメーターとしてエンコードされます。デジタル署名はクエリー・パラメーターとしても含まれています。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:45
@@ -144,7 +147,7 @@ msgid ""
 "response.  The information inside the SAML assertion is then used to make "
 "access decisions or display user data."
 msgstr ""
-"アプリケーションは、リダイレクトURIを受け取った後、XMLドキュメントを抽出し、レルムの署名を検証して正しい認証応答かどうかを検証します。SAMLアサーション内の情報は、アクセスの決定やユーザー・データの表示に使用されます。"
+"アプリケーションは、リダイレクトURIを受け取った後、XMLドキュメントを抽出し、レルムの署名を検証して正しい認証レスポンスかどうかを検証します。SAMLアサーション内の情報は、アクセスの決定やユーザー・データの表示に使用されます。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:46
@@ -164,9 +167,9 @@ msgid ""
 "loaded, the JavaScript automatically invokes the form.  You really don't "
 "need to know about this stuff, but it is a pretty clever trick."
 msgstr ""
-"SAML _POST_ バインディングは、_Redirect_ "
+"SAML _POST_ バインディングは、_リダイレクト_ "
 "バインディングとほぼ同じ方法で動作しますが、GETリクエストではなく、POSTリクエストによってXMLドキュメントが交換されます。 _POST_ "
-"バインディングは、JavaScriptを使用して、ドキュメントを交換するときに{project_name}サーバーまたはアプリケーションに対してPOSTリクエストを行うようにブラウザを操作します。基本的にHTTPレスポンスには、JavaScriptが埋め込まれたフォームを含むHTMLが含まれています。ページが読み込まれると、JavaScriptはフォームを自動的に呼び出します。"
+"バインディングは、JavaScriptを使用して、ドキュメントを交換するときに{project_name}サーバーまたはアプリケーションに対してPOSTリクエストを行うようにブラウザを操作します。基本的にHTTPレスポンスには、JavaScriptが埋め込まれたフォームを含むHTMLが含まれています。ページが読み込まれると、JavaScriptはフォームを自動的に呼び出します。このことについて実際に知る必要はありませんが、これはかなり巧妙なトリックです。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:54
@@ -181,8 +184,8 @@ msgid ""
 "allows for the exchange of SAML attributes outside the context of a web "
 "browser.  This is used most often for REST or SOAP-based clients."
 msgstr ""
-"ECPは、Webブラウザーのコンテキスト外でSAML属性を交換できるようにするSAML "
-"v.2.0プロファイルの\"拡張クライアントまたはプロキシ\"の略です。これは、RESTまたはSOAPベースのクライアントで最も頻繁に使用されます。"
+"ECPは、Webブラウザーのコンテキスト外でSAML属性を交換できるようにするSAML v.2.0プロファイルの\"Enhanced Client or"
+" Proxy\"の略です。これは、RESTまたはSOAPベースのクライアントで最も頻繁に使用されます。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/saml.adoc:59
@@ -193,7 +196,7 @@ msgstr "{project_name}サーバーSAML URIエンドポイント"
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:62
 msgid "{project_name} really only has one endpoint for all SAML requests."
-msgstr "{project_name}ではすべてのSAML要求に対して1つのエンドポイントしかありません。"
+msgstr "{project_name}ではすべてのSAMLリクエストに対して1つのエンドポイントしかありません。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:64

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
@@ -26,15 +25,6 @@ msgstr "SAML"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:9
-#, fuzzy
-#| msgid ""
-#| "link:http://saml.xml.org/saml-specifications[SAML 2.0] is a similar "
-#| "specification to OIDC but a lot older and more mature.  It has its roots "
-#| "in SOAP and the plethora of WS-* specifications so it tends to be a bit "
-#| "more verbose than OIDC.  SAML 2.0 is primarily an authentication protocol "
-#| "that works by exchanging XML documents between the authentication server "
-#| "and the application.  XML signatures and encryption are used to verify "
-#| "requests and responses."
 msgid ""
 "link:http://saml.xml.org/saml-specifications[SAML 2.0] is a similar "
 "specification to OIDC but a lot older and more mature.  It has its roots in "
@@ -44,66 +34,40 @@ msgid ""
 "application.  XML signatures and encryption is used to verify requests and "
 "responses."
 msgstr ""
-"link:http://saml.xml.org/saml-specifications[SAML 2.0] は、OIDCに似ています"
-"が、それよりも古く成熟した仕様です。SOAPと過度なWS-*の仕様をそのルーツを持っ"
-"ているため、OIDCよりも少し冗長になる傾向があります。SAML 2.0は、主に認証サー"
-"バーとアプリケーション間のXMLドキュメントの交換によって動作する認証プロトコル"
-"です。XML署名と暗号化を使用して、要求と応答を検証します。"
+"link:http://saml.xml.org/saml-specifications[SAML "
+"2.0]はOIDCと同質的な仕様ですが、より古くて成熟しています。SOAPをルーツとしていて、WS- "
+"*の仕様も多すぎるため、OIDCよりも冗長な傾向があります。SAML "
+"2.0は主に、認証サーバーとアプリケーションの間でXMLドキュメントを交換することによって機能する認証プロトコルです。XML署名と暗号化は、要求と応答を検証するために使用されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:15
-#, fuzzy
-#| msgid ""
-#| "There is really two types of use cases when using SAML.  The first is an "
-#| "application that asks the {project_name} server to authenticate a user "
-#| "for them.  After a successful login, the application will receive an XML "
-#| "document that contains something called a SAML assertion that specifies "
-#| "various attributes about the user.  This XML document is digitally signed "
-#| "by the realm and contains access information (like user role mappings) "
-#| "that the application can use to determine what resources the user is "
-#| "allowed to access on the application."
 msgid ""
 "There is really two types of use cases when using SAML.  The first is an "
 "application that asks the {project_name} server to authenticate a user for "
 "them.  After a successful login, the application will receive an XML "
 "document that contains something called a SAML assertion that specify "
-"various attributes about the user.  This XML document is digitally signed by "
-"the realm and contains access information (like user role mappings) that the "
-"application can use to determine what resources the user is allowed to "
+"various attributes about the user.  This XML document is digitally signed by"
+" the realm and contains access information (like user role mappings) that "
+"the application can use to determine what resources the user is allowed to "
 "access on the application."
 msgstr ""
-"OIDCを使用するユース・ケースは、実際には2つの種類があります。1つ目は、"
-"{project_name}サーバーにユーザーの認証を要求するアプリケーションのユース・"
-"ケースです。ログインが成功すると、アプリケーションは ユーザーに関する様々な属"
-"性を指定するSAMLアサーションと呼ばれるものが含まれるXMLドキュメントを受け取り"
-"ます。このXMLドキュメントはレルムによってデジタル署名されており、アプリケー"
-"ションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情"
-"報(ユーザー・ロール・マッピングのような)が含まれています。"
+"SAMLを使用する場合、2つのタイプのユースケースがあります。最初のものは{project_name}サーバーにユーザーの認証を求めるアプリケーションです。ログインに成功すると、アプリケーションは、ユーザーに関するさまざまな属性を指定するSAMLアサーションと呼ばれるものを含むXMLドキュメントを受け取ります。このXMLドキュメントは、レルムによってデジタル署名され、ユーザーがアプリケーションでアクセスできるリソースを決定するためにアプリケーションが使用できるアクセス情報（ユーザー・ロール・マッピングなど）を含んでいます。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:18
-#, fuzzy
-#| msgid ""
-#| "The second type of use cases is that of a client that wants to gain "
-#| "access to remote services.  In this case, the client asks {project_name} "
-#| "to obtain a SAML assertion it can use to invoke on other remote services "
-#| "on behalf of the user."
 msgid ""
 "The second type of use cases is that of a client that wants to gain access "
 "to remote services.  In this case, the client asks {project_name} to obtain "
-"an SAML assertion it can use to invoke on other remote services on behalf of "
-"the user."
+"an SAML assertion it can use to invoke on other remote services on behalf of"
+" the user."
 msgstr ""
-"2つ目のタイプは、リモート・サービスへのアクセス権を取得したいクライアントの"
-"ユース・ケースです。この場合、クライアントは、ユーザーの代理として他のリモー"
-"ト・サービスの呼び出しに使用できるSAMLアサーションの取得を{project_name}に要"
-"求します。"
+"2番目のユースケースは、リモートサービスにアクセスしたいクライアントです。この場合、クライアントはユーザーの代わりに他のリモートサービスで呼び出すために使用できるSAMLアサーションを取得するよう{project_name}に求めます。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/saml.adoc:19
 #, no-wrap
 msgid "SAML Bindings"
-msgstr ""
+msgstr "SAMLバインディング"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:24
@@ -113,19 +77,22 @@ msgid ""
 "browser based applications.  The _ECP_ binding covers REST invocations.  "
 "There are other binding types but {project_name} only supports those three."
 msgstr ""
+"SAMLは、認証プロトコルを実行する際にXMLドキュメントを交換するためのいくつかの異なる方法を定義しています。 _Redirect_ と _Post_"
+" バインディングは、ブラウザー・ベースのアプリケーションをカバーします。 _ECP_ "
+"バインディングは、REST呼び出しを扱います。他のバインディング種別もありますが、{project_name}はこれらの3つしかサポートしていません。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:25
 #, no-wrap
 msgid "Redirect Binding"
-msgstr ""
+msgstr "Redirectバインディング"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:29
 msgid ""
 "The _Redirect_ Binding uses a series of browser redirect URIs to exchange "
 "information.  This is a rough overview of how it works."
-msgstr ""
+msgstr "_Redirect_ Bindingは、一連のブラウザー・リダイレクトURIを使用して情報を交換します。その動作の概要を示します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:35
@@ -133,11 +100,12 @@ msgid ""
 "The user visits the application and the application finds the user is not "
 "authenticated.  It generates an XML authentication request document and "
 "encodes it as a query param in a URI that is used to redirect to the "
-"{project_name} server.  Depending on your settings, the application may also "
-"digitally sign this XML document and also stuff this signature as a query "
+"{project_name} server.  Depending on your settings, the application may also"
+" digitally sign this XML document and also stuff this signature as a query "
 "param in the redirect URI to {project_name}.  This signature is used to "
 "validate the client that sent this request."
 msgstr ""
+"ユーザーがアプリケーションへアクセスすると、認証されていないことがアプリケーションによって検出されます。XML認証要求ドキュメントを生成し、それを{project_name}サーバーにリダイレクトするために使用されるURIのクエリ・パラメーターとしてエンコードします。設定に応じて、アプリケーションはこのXMLドキュメントにデジタル署名し、この署名を{project_name}へのリダイレクトURIのクエリ・パラメーターとして埋め込むこともできます。この署名は、この要求を送信したクライアントを検証するために使用されます。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:37
@@ -146,16 +114,18 @@ msgid ""
 "auth request document and verifies the digital signature if required.  The "
 "user then has to enter in their credentials to be authenticated."
 msgstr ""
+"ブラウザーは{project_name}にリダイレクトされます。サーバーは、XML認証要求ドキュメントを抽出し、必要に応じてデジタル署名を検証します。ユーザーは認証されるためにクレデンシャルを入力する必要があります。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:40
 msgid ""
 "After authentication, the server generates an XML authentication response "
-"document.  This document contains a SAML assertion that holds metadata about "
-"the user like name, address, email, and any role mappings the user might "
-"have.  This document is almost always digitally signed using XML signatures, "
-"and may also be encrypted."
+"document.  This document contains a SAML assertion that holds metadata about"
+" the user like name, address, email, and any role mappings the user might "
+"have.  This document is almost always digitally signed using XML signatures,"
+" and may also be encrypted."
 msgstr ""
+"認証後、サーバーはXML認証応答ドキュメントを生成します。このドキュメントには、ユーザーの名前、住所、電子メール、およびユーザーが持つロール・マッピングなどのユーザーに関するメタデータを保持するSAMLアサーションが含まれています。このドキュメントは、ほとんどの場合、XML署名を使用してデジタル署名されており、暗号化されている場合もあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:42
@@ -164,6 +134,7 @@ msgid ""
 "redirect URI that brings the browser back to the application.  The digital "
 "signature is also included as a query param."
 msgstr ""
+"次に、XML認証応答ドキュメントは、ブラウザーをアプリケーションへ戻すためのリダイレクトURIのクエリ・パラメーターとしてエンコードされます。デジタル署名はクエリ・パラメーターとしても含まれています。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:45
@@ -173,12 +144,13 @@ msgid ""
 "response.  The information inside the SAML assertion is then used to make "
 "access decisions or display user data."
 msgstr ""
+"アプリケーションは、リダイレクトURIを受け取った後、XMLドキュメントを抽出し、レルムの署名を検証して正しい認証応答かどうかを検証します。SAMLアサーション内の情報は、アクセスの決定やユーザー・データの表示に使用されます。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:46
 #, no-wrap
 msgid "POST Binding"
-msgstr ""
+msgstr "POSTバインディング"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:53
@@ -192,12 +164,15 @@ msgid ""
 "loaded, the JavaScript automatically invokes the form.  You really don't "
 "need to know about this stuff, but it is a pretty clever trick."
 msgstr ""
+"SAML _POST_ バインディングは、_Redirect_ "
+"バインディングとほぼ同じ方法で動作しますが、GETリクエストではなく、POSTリクエストによってXMLドキュメントが交換されます。 _POST_ "
+"バインディングは、JavaScriptを使用して、ドキュメントを交換するときに{project_name}サーバーまたはアプリケーションに対してPOSTリクエストを行うようにブラウザを操作します。基本的にHTTPレスポンスには、JavaScriptが埋め込まれたフォームを含むHTMLが含まれています。ページが読み込まれると、JavaScriptはフォームを自動的に呼び出します。"
 
 #. type: Title =====
 #: source/server_admin/topics/sso-protocols/saml.adoc:54
 #, no-wrap
 msgid "ECP"
-msgstr ""
+msgstr "ECP"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:58
@@ -206,24 +181,26 @@ msgid ""
 "allows for the exchange of SAML attributes outside the context of a web "
 "browser.  This is used most often for REST or SOAP-based clients."
 msgstr ""
+"ECPは、Webブラウザーのコンテキスト外でSAML属性を交換できるようにするSAML "
+"v.2.0プロファイルの\"拡張クライアントまたはプロキシ\"の略です。これは、RESTまたはSOAPベースのクライアントで最も頻繁に使用されます。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/saml.adoc:59
 #, no-wrap
 msgid "{project_name} Server SAML URI Endpoints"
-msgstr ""
+msgstr "{project_name}サーバーSAML URIエンドポイント"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:62
 msgid "{project_name} really only has one endpoint for all SAML requests."
-msgstr ""
+msgstr "{project_name}ではすべてのSAML要求に対して1つのエンドポイントしかありません。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:64
 msgid "`http(s)://authserver.host/auth/realms/{realm-name}/protocol/saml`"
-msgstr ""
+msgstr "`http(s)://authserver.host/auth/realms/{realm-name}/protocol/saml`"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/saml.adoc:66
 msgid "All bindings use this endpoint."
-msgstr ""
+msgstr "すべてのバインディングはこのエンドポイントを使用します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sso-protocols__saml/ja_JP/index.html
