### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
@@ -16,14 +16,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:118
-#: source/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc:18
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:63
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:36
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:24
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:28
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:20
 #, no-wrap
 msgid ""
 "<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
@@ -37,13 +29,6 @@ msgstr ""
 "      version=\"3.0\">\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:186
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:50
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:60
 #, no-wrap
 msgid ""
 "    <security-role>\n"
@@ -63,11 +48,6 @@ msgstr ""
 "</web-app>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:38
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:34
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:6
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:5
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:5
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
@@ -75,8 +55,6 @@ msgstr ""
 "このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:41
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:9
 msgid ""
 "The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your"
 " WAR package.  This is a Jetty specific config file and you must define a "
@@ -86,10 +64,6 @@ msgstr ""
 "ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のAuthenticatorを定義する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:29
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:21
 msgid ""
 "Finally you must specify both a `login-config` and use standard servlet "
 "security to specify role-base constraints on your URLs.  Here's an example:"
@@ -98,19 +72,11 @@ msgstr ""
 "と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:65
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:38
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:26
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:30
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
 msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:133
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:51
 #, no-wrap
 msgid ""
 "    <security-constraint>\n"
@@ -140,10 +106,6 @@ msgstr ""
 "    </security-constraint>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:138
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:80
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:56
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:45
 #, no-wrap
 msgid ""
 "    <login-config>\n"
@@ -157,13 +119,11 @@ msgstr ""
 "    </login-config>\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:3
 #, no-wrap
 msgid "Jetty 9 Per WAR Configuration"
 msgstr "WARごとのJetty 9の設定"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:22
 #, no-wrap
 msgid ""
 "<?xml version=\"1.0\"?>\n"
@@ -189,12 +149,10 @@ msgstr ""
 "</Configure>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:26
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:18
 msgid ""
 "Next you must create a `keycloak-saml.xml` adapter config file within the "
-"`WEB-INF` directory of your WAR.  The format of this config file is describe"
-" in the <<_saml-general-config,General Adapter Config>> section."
+"`WEB-INF` directory of your WAR.  The format of this config file is "
+"described in the <<_saml-general-config,General Adapter Config>> section."
 msgstr ""
 "次に、WARの `WEB-INF` ディレクトリに `keycloak-saml.xml` "
 "アダプター設定ファイルを作成する必要があります。この設定ファイルの形式は、<<_saml-general-"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty9_per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty9_per_war_config/ja_JP/index.html
