### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -16,25 +16,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:14
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:10
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
-"Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also"
-" available as a maven artifact."
+"Adapters are no longer included with the appliance or war distribution. Each"
+" adapter is a separate download on the Keycloak download site.  They are "
+"also available as a maven artifact."
 msgstr ""
-"アダプターはアプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。これらは、Mavenアーティファクトとしても利用可能です。"
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:3
 #, no-wrap
 msgid "Jetty 9 Adapter Installation"
 msgstr "Jetty 9アダプターのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:8
 msgid ""
 "Keycloak has a separate SAML adapter for Jetty 9.x.  You then have to "
 "provide some extra configuration in each WAR you deploy to Jetty.  Let's go "
@@ -44,7 +38,6 @@ msgstr ""
 "9.x用のSAMLアダプターがあります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:14
 msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
@@ -53,7 +46,6 @@ msgstr ""
 "INF/libディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:19
 #, no-wrap
 msgid ""
 "$ cd $JETTY_HOME\n"
@@ -63,12 +55,10 @@ msgstr ""
 "$ unzip keycloak-saml-jetty92-adapter-dist.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:21
 msgid "Next, you will have to enable the keycloak module for your jetty.base."
 msgstr "次に、jetty.base用のkeycloakモジュールを有効にする必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:26
 #, no-wrap
 msgid ""
 "$ cd your-base\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty9_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty9_installation/ja_JP/index.html
