### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,21 +16,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:14
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:10
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
-"Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also"
-" available as a maven artifact."
+"Adapters are no longer included with the appliance or war distribution. Each"
+" adapter is a separate download on the Keycloak download site.  They are "
+"also available as a maven artifact."
 msgstr ""
-"アダプターは、アプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。 "
-"それらは、Mavenアーティファクトとしても利用可能です。"
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:17
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:13
 msgid ""
 "You must unzip the Jetty 8.1.x distro into Jetty 8.1.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
@@ -39,16 +32,12 @@ msgstr ""
 "ディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:28
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:21
 msgid ""
 "Next, you will have to enable the keycloak option.  Edit start.ini and add "
 "keycloak to the options"
 msgstr "次に、keycloakオプションを有効にする必要があります。start.iniを編集し、オプションにkeycloakを追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:41
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:31
 #, no-wrap
 msgid ""
 "#===========================================================\n"
@@ -68,13 +57,11 @@ msgstr ""
 "OPTIONS=Server,jsp,jmx,resources,websocket,ext,plus,annotations,keycloak\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:2
 #, no-wrap
 msgid "Jetty 8 Adapter Installation"
 msgstr "Jetty 8 アダプターのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:7
 msgid ""
 "Keycloak has a separate SAML adapter for Jetty 8.1.x that you will have to "
 "install into your Jetty installation.  You then have to provide some extra "
@@ -84,7 +71,6 @@ msgstr ""
 "8.1.x用のSAMLアダプターがあります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:18
 #, no-wrap
 msgid ""
 "$ cd $JETTY_HOME\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty8-installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jetty-adapter__jetty8-installation/ja_JP/index.html
