### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty8-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty8-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty8-adapter.ja_JP.po
@@ -16,22 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:126
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:43
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:35
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:31
 #, no-wrap
 msgid "Required Per WAR Configuration"
 msgstr "WAR設定ごとに必要"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:3
 #, no-wrap
 msgid "Jetty 8.1.x Adapter"
 msgstr "Jetty 8.1.xアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:8
 msgid ""
 "Keycloak has a separate adapter for Jetty 8.1.x that you will have to "
 "install into your Jetty installation.  You then have to provide some extra "
@@ -41,33 +35,19 @@ msgstr ""
 "8.1.x用の別のアダプターがあります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
-#: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
 msgstr "アダプターのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:14
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:10
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
-"Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also"
-" available as a maven artifact."
+"Adapters are no longer included with the appliance or war distribution. Each"
+" adapter is a separate download on the Keycloak download site.  They are "
+"also available as a maven artifact."
 msgstr ""
-"アダプターはアプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。これらは、Mavenアーティファクトとしても利用可能です。"
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:17
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:13
 msgid ""
 "You must unzip the Jetty 8.1.x distro into Jetty 8.1.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
@@ -76,7 +56,6 @@ msgstr ""
 "ディレクトリ内にアダプターのjarを含めても動作しません！"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:24
 #, no-wrap
 msgid ""
 "$ cd $JETTY_HOME\n"
@@ -86,16 +65,12 @@ msgstr ""
 "$ unzip keycloak-jetty81-adapter-dist.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:28
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:21
 msgid ""
 "Next, you will have to enable the keycloak option.  Edit start.ini and add "
 "keycloak to the options"
 msgstr "次に、keycloakオプションを有効にする必要があります。start.iniを編集し、オプションにkeycloakを追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:41
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:31
 #, no-wrap
 msgid ""
 "#===========================================================\n"
@@ -115,7 +90,6 @@ msgstr ""
 "OPTIONS=Server,jsp,jmx,resources,websocket,ext,plus,annotations,keycloak\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:47
 msgid ""
 "Enabling Keycloak for your WARs is the same as the Jetty 9.x adapter.  Our "
 "8.1.x adapter supports both keycloak.json and the jboss-web.xml advanced "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty8-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jetty8-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__jetty8-adapter/ja_JP/index.html
