### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,213 +16,161 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/overview/supported-platforms.adoc:1
 #, no-wrap
 msgid "Supported Platforms"
 msgstr "サポートされているプラットフォーム"
 
 #. type: Title ==
-#: source/securing_apps/topics/overview/supported-platforms.adoc:3
-#: source/securing_apps/topics/overview/supported-protocols.adoc:5
-#: source/securing_apps/topics/oidc/oidc-overview.adoc:1
 #, no-wrap
 msgid "OpenID Connect"
 msgstr "OpenID Connect"
 
 #. type: Title =====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:5
-#: source/securing_apps/topics/overview/supported-platforms.adoc:68
 #, no-wrap
 msgid "Java"
 msgstr "Java"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:7
 msgid "<<_jboss_adapter,JBoss EAP>>"
 msgstr "<<_jboss_adapter,JBoss EAP>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:9
 msgid "<<_jboss_adapter,WildFly>>"
 msgstr "<<_jboss_adapter,WildFly>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:11
 msgid "<<_fuse_adapter,Fuse>>"
 msgstr "<<_fuse_adapter,Fuse>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:13
-#: source/securing_apps/topics/overview/supported-platforms.adoc:74
 msgid "<<_tomcat_adapter,Tomcat>>"
 msgstr "<<_tomcat_adapter,Tomcat>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:14
 msgid "<<_jetty8_adapter,Jetty 8>>"
 msgstr "<<_jetty8_adapter,Jetty 8>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:18
 msgid "<<_servlet_filter_adapter,Servlet Filter>>"
 msgstr "<<_servlet_filter_adapter,Servlet Filter>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:19
 msgid "<<_spring_security_adapter,Spring Security>> (community)"
 msgstr "<<_spring_security_adapter,Spring Security>> (community)"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:20
 msgid "<<_spring_boot_adapter,Spring Boot>> (community)"
 msgstr "<<_spring_boot_adapter,Spring Boot>> (community)"
 
 #. type: Title =====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:23
 #, no-wrap
 msgid "JavaScript (client-side)"
 msgstr "JavaScript（クライアントサイド）"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:25
-#: source/securing_apps/topics/overview/supported-platforms.adoc:32
 msgid "<<_javascript_adapter,JavaScript>>"
 msgstr "<<_javascript_adapter,JavaScript>>"
 
 #. type: Title =====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:27
 #, no-wrap
 msgid "Node.js (server-side)"
 msgstr "Node.js（サーバーサイド）"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:29
 msgid "<<_nodejs_adapter,Node.js>>"
 msgstr "<<_nodejs_adapter,Node.js>>"
 
 #. type: Title =====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:30
 #, no-wrap
 msgid "JavaScript"
 msgstr "JavaScript"
 
 #. type: Title =====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:34
 #, no-wrap
 msgid "Node.js"
 msgstr "Node.js"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:36
 msgid ""
 "https://github.com/keycloak/keycloak-nodejs-connect[{project_name} Connect] "
 "(community)"
 msgstr ""
 "https://github.com/keycloak/keycloak-nodejs-connect[{project_name} Connect] "
 "(community)"
-
-#. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:37
-msgid ""
-"https://github.com/keycloak/keycloak-nodejs-auth-utils[{project_name} Auth "
-"Utils] (community)"
-msgstr ""
-"https://github.com/keycloak/keycloak-nodejs-auth-utils[{project_name} Auth "
-"Utils] (community)"
 
 #. type: Title ====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:40
 #, no-wrap
 msgid "C#"
 msgstr "C#"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:42
 msgid ""
 "https://github.com/dylanplecki/KeycloakOwinAuthentication[OWIN] (community)"
 msgstr ""
 "https://github.com/dylanplecki/KeycloakOwinAuthentication[OWIN] (community)"
 
 #. type: Title ====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:45
 #, no-wrap
 msgid "Python"
 msgstr "Python"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:47
 msgid "https://pypi.python.org/pypi/oic/[oidc] (generic)"
 msgstr "https://pypi.python.org/pypi/oic/[oidc] (generic)"
 
 #. type: Title ====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:50
 #, no-wrap
 msgid "Android"
 msgstr "Android"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:52
 msgid "https://github.com/openid/AppAuth-Android[AppAuth] (generic)"
 msgstr "https://github.com/openid/AppAuth-Android[AppAuth] (generic)"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:53
 msgid "https://github.com/aerogear/aerogear-android-authz[AeroGear] (generic)"
 msgstr ""
 "https://github.com/aerogear/aerogear-android-authz[AeroGear] (generic)"
 
 #. type: Title ====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:56
 #, no-wrap
 msgid "iOS"
 msgstr "iOS"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:58
 msgid "https://github.com/openid/AppAuth-iOS[AppAuth] (generic)"
 msgstr "https://github.com/openid/AppAuth-iOS[AppAuth] (generic)"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:59
 msgid "https://github.com/aerogear/aerogear-ios-oauth2[AeroGear] (generic)"
 msgstr "https://github.com/aerogear/aerogear-ios-oauth2[AeroGear] (generic)"
 
 #. type: Title =====
-#: source/securing_apps/topics/overview/supported-platforms.adoc:62
-#: source/securing_apps/topics/overview/supported-platforms.adoc:77
 #, no-wrap
 msgid "Apache HTTP Server"
 msgstr "Apache HTTP Server"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:64
-msgid "https://github.com/pingidentity/mod_auth_openidc[mod_auth_openidc]"
-msgstr "https://github.com/pingidentity/mod_auth_openidc[mod_auth_openidc]"
+msgid "https://github.com/zmartzone/mod_auth_openidc[mod_auth_openidc]"
+msgstr "https://github.com/zmartzone/mod_auth_openidc[mod_auth_openidc]"
 
 #. type: Title ===
-#: source/securing_apps/topics/overview/supported-platforms.adoc:66
-#: source/securing_apps/topics/saml/saml-overview.adoc:1
-#: source/server_admin/topics/sso-protocols/saml.adoc:3
 #, no-wrap
 msgid "SAML"
 msgstr "SAML"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:71
 msgid "<<_saml_jboss_adapter,JBoss EAP>>"
 msgstr "<<_saml_jboss_adapter,JBoss EAP>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:73
 msgid "<<_saml_jboss_adapter,WildFly>>"
 msgstr "<<_saml_jboss_adapter,WildFly>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:75
 msgid "<<_jetty_saml_adapter,Jetty>>"
 msgstr "<<_jetty_saml_adapter,Jetty>>"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-platforms.adoc:79
 msgid "<<_mod_auth_mellon,mod_auth_mellon>>"
 msgstr "<<_mod_auth_mellon,mod_auth_mellon>>"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__supported-platforms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__overview__supported-platforms/ja_JP/index.html
