### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -16,14 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/securing_apps/topics/docker/docker-overview.adoc:2
 #, no-wrap
 msgid "Docker Registry Configuration"
 msgstr "Dockerレジストリーの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:5
-#: source/server_admin/topics/sso-protocols/docker.adoc:6
 msgid ""
 "Docker authentication is disabled by default. To enable see "
 "link:{installguide_profile_link}[{installguide_profile_name}]."
@@ -31,7 +28,6 @@ msgstr ""
 "Docker認証はデフォルトで無効です。有効にするには、link:{installguide_profile_link}[{installguide_profile_name}]を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:7
 msgid ""
 "This section describes how you can configure a Docker registry to use "
 "{project_name} as its authentication server."
@@ -39,9 +35,8 @@ msgstr ""
 "このセクションでは、{project_name}を認証サーバーとして使用するようにDockerレジストリーを設定する方法について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:9
 msgid ""
-"Fore more information on how to set up and configure a Docker registry, see "
+"For more information on how to set up and configure a Docker registry, see "
 "the link:https://docs.docker.com/registry/configuration/[Docker Registry "
 "Configuration Guide]."
 msgstr ""
@@ -49,13 +44,11 @@ msgstr ""
 " Registry Configuration Guide]を参照してください。"
 
 #. type: Title ===
-#: source/securing_apps/topics/docker/docker-overview.adoc:12
 #, no-wrap
 msgid "Docker Registry Configuration File Installation"
 msgstr "Dockerレジストリーの設定ファイルのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:15
 msgid ""
 "For users with more advanced docker registry configurations, it is generally"
 " recommended to provide your own registry configuration file.  The "
@@ -68,7 +61,6 @@ msgstr ""
 "Optionを使用してこのメカニズムをサポートしています。このオプションを選択すると、次のような出力が生成されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:21
 #, no-wrap
 msgid ""
 "\tauth:\n"
@@ -84,7 +76,6 @@ msgstr ""
 "\t    issuer: http://localhost:8080/auth/auth/realms/master\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:23
 msgid ""
 "This output can then be copied into any existing registry config file.  See "
 "the link:https://docs.docker.com/registry/configuration/[registry config "
@@ -97,7 +88,6 @@ msgstr ""
 "/config-example.yml[基本的な例]から始めてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:25
 msgid ""
 "Don't forget to configure the `rootcertbundle` field with the location of "
 "the {project_name} realm's pulic certificate.  The auth configuration will "
@@ -107,16 +97,14 @@ msgstr ""
 "フィールドに{project_name}のレルムの公開証明書の場所を設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"
 
 #. type: Title ===
-#: source/securing_apps/topics/docker/docker-overview.adoc:27
 #, no-wrap
 msgid "Docker Registry Environment Variable Override Installation"
 msgstr "Dockerレジストリー環境変数のオーバーライド・インストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:30
 msgid ""
 "Often times it is appropriate to use a simple environment variable override "
-"for develop or POC Docker registries.  While this apporach is usually not "
+"for develop or POC Docker registries.  While this approach is usually not "
 "recommended for production use, it can be helpful when one requires quick-"
 "and-dirty way to stand up a registry.  Simply use the _Variable Override_ "
 "Format Option from the client installation tab, and an output should appear "
@@ -126,7 +114,6 @@ msgstr ""
 " _Variable Override_ Format Optionを使用するだけで、出力は次のようになります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:34
 #, no-wrap
 msgid ""
 "    REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080/auth/auth/realms/master/protocol/docker-v2/auth\n"
@@ -138,7 +125,6 @@ msgstr ""
 "    REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080/auth/auth/realms/master\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:36
 msgid ""
 "Don't forget to configure the `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` override "
 "with the location of the {project_name} realm's pulic certificate.  The auth"
@@ -148,13 +134,11 @@ msgstr ""
 "オーバーライドを{project_name}レルムの公開証明書の場所で設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"
 
 #. type: Title ===
-#: source/securing_apps/topics/docker/docker-overview.adoc:38
 #, no-wrap
 msgid "Docker Compose YAML File"
 msgstr "Docker Compose YAMLファイル"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:41
 msgid ""
 "This installation method is meant to be an easy way to get a docker registry"
 " authenticating against a keycloak server.  It is intended for development "
@@ -164,7 +148,6 @@ msgstr ""
 "このインストール方法は、Keycloakサーバーで認証するDockerレジストリーを構築する簡易的な方法です。これは開発目的のみを対象としており、本番環境やそれと同等の環境には使用しないでください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:43
 msgid ""
 "The zip file installation mechanism provides a quickstart for developers who"
 " want to understand how the keycloak server can interact with the docker "
@@ -174,7 +157,6 @@ msgstr ""
 " 下記のとおりに設定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:45
 msgid ""
 "From the desired realm, create a client configuration.  At this point you "
 "won't have a docker registry - the quickstart will take care of that part."
@@ -182,24 +164,20 @@ msgstr ""
 "目的のレルムから、クライアント設定を作成します。この時点で、Dockerレジストリーはありません。クイック・スタートがその部分を担当します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:46
 msgid ""
 "Choose the \"Docker Compose YAML\" option from the installation tab and "
 "download the .zip file"
 msgstr "インストール・タブから\"Docker Compose YAML\"オプションを選択し、.zipファイルをダウンロードします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:47
 msgid "Unzip the archive to the desired location, and open the directory."
 msgstr "アーカイブを目的の場所に解凍し、ディレクトリーを開きます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:48
 msgid "Start the docker registry with `docker-compose up`"
 msgstr "Dockerレジストリーを `docker-compose up` で起動します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:50
 msgid ""
 "INFO: it is recommended that you configure the docker registry client in a "
 "realm other than 'master', since the HTTP Basic auth flow will not present "
@@ -209,14 +187,12 @@ msgstr ""
 "BASIC認証のフローはフォームを提示しないので、Dockerレジストリー・クライアントを'master'以外のレルムに設定することをお勧めします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:52
 msgid ""
 "Once the above configuration has taken place, and the keycloak server and "
 "docker registry are running, docker authentication should be successful:"
 msgstr "上記の設定が完了し、KeycloakサーバーとDockerレジストリーが実行されたら、Docker認証が成功するはずです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/docker/docker-overview.adoc:55
 #, no-wrap
 msgid ""
 "\t[user ~]# docker login localhost:5000 -u $username\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__docker__docker-overview/ja_JP/index.html
