### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -16,23 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:126
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:43
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:35
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:31
 #, no-wrap
 msgid "Required Per WAR Configuration"
 msgstr "WAR設定ごとに必要"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:118
-#: source/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc:18
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:63
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:36
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:24
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:28
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:20
 #, no-wrap
 msgid ""
 "<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
@@ -46,13 +34,6 @@ msgstr ""
 "      version=\"3.0\">\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:186
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:88
-#: source/securing_apps/topics/oidc/java/fuse/classic-war.adoc:50
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:64
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:53
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:60
 #, no-wrap
 msgid ""
 "    <security-role>\n"
@@ -72,39 +53,24 @@ msgstr ""
 "</web-app>\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
-#: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
 #, no-wrap
 msgid "Adapter Installation"
 msgstr "アダプターのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:14
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:14
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:10
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:11
 msgid ""
-"Adapters are no longer included with the appliance or war distribution.Each "
-"adapter is a separate download on the Keycloak download site.  They are also"
-" available as a maven artifact."
+"Adapters are no longer included with the appliance or war distribution. Each"
+" adapter is a separate download on the Keycloak download site.  They are "
+"also available as a maven artifact."
 msgstr ""
-"アダプターは、アプライアンスやwarには含まれないようになりました。各アダプターは、Keycloakダウンロード・サイトで個々にダウンロードできます。 "
-"それらは、Mavenアーティファクトとしても利用可能です。"
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:3
 #, no-wrap
 msgid "Jetty 9.x Adapters"
 msgstr "Jetty 9.xアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:8
 msgid ""
 "Keycloak has a separate adapter for Jetty 9.1.x, Jetty 9.2.x and Jetty 9.3.x"
 " that you will have to install into your Jetty installation.  You then have "
@@ -115,12 +81,11 @@ msgstr ""
 "9.3.x用の個別のアダプターがあります。これらをJettyにインストールする必要があります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:18
 msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's "
 "link:https://www.eclipse.org/jetty/documentation/current/startup-base-and-"
-"home.html[base directory.] Including adapter's jars within your WEB-INF/lib "
-"directory will not work! In the example below, the Jetty base is named "
+"home.html[base directory].  Including adapter's jars within your WEB-INF/lib"
+" directory will not work! In the example below, the Jetty base is named "
 "`your-base`:"
 msgstr ""
 "Jetty 9.x用の配布物をJetty "
@@ -129,7 +94,6 @@ msgstr ""
 "INF/libディレクトリ内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base`です。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:24
 #, no-wrap
 msgid ""
 "$ cd your-base\n"
@@ -139,23 +103,16 @@ msgstr ""
 "$ unzip keycloak-jetty93-adapter-dist-2.5.0.Final.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:27
 msgid ""
 "Next, you will have to enable the `keycloak` module for your Jetty base:"
 msgstr "次に、Jettyベースの `keycloak` モジュールを有効にする必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:32
 #, no-wrap
 msgid "$ java -jar $JETTY_HOME/start.jar --add-to-startd=keycloak\n"
 msgstr "$ java -jar $JETTY_HOME/start.jar --add-to-startd=keycloak\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:38
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:34
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:6
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:5
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:5
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
@@ -163,8 +120,6 @@ msgstr ""
 "このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:41
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:9
 msgid ""
 "The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your"
 " WAR package.  This is a Jetty specific config file and you must define a "
@@ -174,7 +129,6 @@ msgstr ""
 "ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のAuthenticatorを定義する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:56
 #, no-wrap
 msgid ""
 "<?xml version=\"1.0\"?>\n"
@@ -200,23 +154,19 @@ msgstr ""
 "</Configure>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:59
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:48
 msgid ""
 "Next you must create a `keycloak.json` adapter config file within the `WEB-"
 "INF` directory of your WAR."
 msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:61
 #, no-wrap
 msgid ""
-"The format of this config file is describe in the "
+"The format of this config file is described in the "
 "<<_java_adapter_config,Java adapter configuration>>            section.\n"
 msgstr "この設定ファイルの形式は、<<_java_adapter_config,Javaアダプターの設定>>のセクションで説明しています。\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:64
 msgid ""
 "The Jetty 9.1.x adapter will not be able to find the `keycloak.json` file.  "
 "You will have to define all adapter settings within the `jetty-web.xml` file"
@@ -226,7 +176,6 @@ msgstr ""
 "ファイル内にすべてのアダプター設定を定義する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:67
 #, no-wrap
 msgid ""
 "Instead of using keycloak.json, you can define everything within the `jetty-web.xml`.\n"
@@ -236,7 +185,6 @@ msgstr ""
 "json設定が `org.keycloak.representations.adapters.config.AdapterConfig` クラスとどのようにマッチするかを把握する必要があります。\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:99
 #, no-wrap
 msgid ""
 "<?xml version=\"1.0\"?>\n"
@@ -294,7 +242,6 @@ msgstr ""
 "</Configure>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:105
 msgid ""
 "You do not have to crack open your WAR to secure it with keycloak.  Instead "
 "create the jetty-web.xml file in your webapps directory with the name of "
@@ -306,10 +253,6 @@ msgstr ""
 "web.xmlファイルを作成します。Jettyはそれをピックアップします。このモードでは、keycloak.jsonの設定をxmlファイル内で直接宣言する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:108
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:53
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:29
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:21
 msgid ""
 "Finally you must specify both a `login-config` and use standard servlet "
 "security to specify role-base constraints on your URLs.  Here's an example:"
@@ -318,19 +261,11 @@ msgstr ""
 "と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:65
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:38
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:26
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:30
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
 msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:133
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:51
 #, no-wrap
 msgid ""
 "    <security-constraint>\n"
@@ -360,10 +295,6 @@ msgstr ""
 "    </security-constraint>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:138
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:80
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:56
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:45
 #, no-wrap
 msgid ""
 "    <login-config>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jetty9-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__oidc__java__jetty9-adapter/ja_JP/index.html
