### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
@@ -65,14 +65,14 @@ msgid ""
 "Testing the upgrade in a non-production environment first, to prevent any "
 "installation issues from being exposed in production, is a best practice."
 msgstr ""
-"まずは非プロダクション環境でアップグレードのテストをして、プロダクション環境ではインストールの問題に直面しないようにすることがベストプラクティスです。"
+"プロダクション環境でインストールの問題に直面しないように、まずは非プロダクション環境でアップグレードのテストをすることがベストプラクティスです。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:17
 msgid ""
 "Be aware that after the upgrade the database will no longer be compatible "
 "with the old server"
-msgstr "アップグレード後、データベースは古いサーバーとの互換性がなくなります。"
+msgstr "アップグレード後、データベースは古いサーバーとの互換性がなくなることに注意してください。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:18
@@ -91,4 +91,4 @@ msgstr "アップグレードを元に戻す必要がある場合は、まず古
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:20
 msgid "Upgrade the adapters."
-msgstr "アダプターのアップグレード"
+msgstr "アダプターをアップグレードします。"

--- a/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -22,12 +22,13 @@ msgid ""
 "Prior to applying the upgrade, handle any open transactions and delete the "
 "data/tx-object-store/ transaction directory."
 msgstr ""
+"アップグレードする前に、オープンしているトランザクションを処理し、data/tx-object-store/トランザクション・ディレクトリを削除します。"
 
 #. type: Title ==
 #: source/upgrading/topics/prep_migration.adoc:3
 #, no-wrap
 msgid "Preparing for Upgrading"
-msgstr ""
+msgstr "アップグレードする準備"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:8
@@ -37,11 +38,13 @@ msgid ""
 "process. In general, you must upgrade {project_name} server first, and then "
 "upgrade the adapters."
 msgstr ""
+"アップグレードする前に、踏まなければならない手順がありますので、その順序に気をつけてください。また、アップグレードする過程で起こり得る問題についても注意してください。通常は、まず{project_name}サーバーをアップグレーしてから、アダプターをアップグレードする必要があります。"
+" "
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:11
 msgid "Back up the old installation (configuration, themes, and so on)."
-msgstr ""
+msgstr "古いインストール（設定、テーマなど）をバックアップします。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:13
@@ -49,11 +52,12 @@ msgid ""
 "Back up the database. For detailed information on how to back up the "
 "database, see the documentation for the relational database you’re using."
 msgstr ""
+"データベースをバックアップします。データベースのバックアップの仕方について、詳しくは、使用しているデータベースの関連ドキュメントを参照ください。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:14
 msgid "Upgrade {project_name} server."
-msgstr ""
+msgstr "{project_name}サーバーのアップグレード"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:16
@@ -61,29 +65,30 @@ msgid ""
 "Testing the upgrade in a non-production environment first, to prevent any "
 "installation issues from being exposed in production, is a best practice."
 msgstr ""
+"まずは非プロダクション環境でアップグレードのテストをして、プロダクション環境ではインストールの問題に直面しないようにすることがベストプラクティスです。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:17
 msgid ""
 "Be aware that after the upgrade the database will no longer be compatible "
 "with the old server"
-msgstr ""
+msgstr "アップグレード後、データベースは古いサーバーとの互換性がなくなります。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:18
 msgid ""
 "Ensure the upgraded server is functional before upgrading adapters in "
 "production."
-msgstr ""
+msgstr "プロダクション環境でアダプターをアップグレードする前に、アップグレードしたサーバーが機能していることを確認してください。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:19
 msgid ""
 "If you need to revert the upgrade, first restore the old installation, and "
 "then restore the database from the backup copy."
-msgstr ""
+msgstr "アップグレードを元に戻す必要がある場合は、まず古いインストールを復元してから、バックアップのコピーからデータベースを復元します。"
 
 #. type: Plain text
 #: source/upgrading/topics/prep_migration.adoc:20
 msgid "Upgrade the adapters."
-msgstr ""
+msgstr "アダプターのアップグレード"

--- a/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -38,7 +38,7 @@ msgid ""
 "process. In general, you must upgrade {project_name} server first, and then "
 "upgrade the adapters."
 msgstr ""
-"アップグレードする前に、踏まなければならない手順がありますので、その順序に気をつけてください。また、アップグレードする過程で起こり得る問題についても注意してください。通常は、まず{project_name}サーバーをアップグレーしてから、アダプターをアップグレードする必要があります。"
+"アップグレードする前に、踏まなければならない手順がありますので、その順序に気をつけてください。また、アップグレードする過程で起こり得る問題についても注意してください。通常は、まず{project_name}サーバーをアップグレードしてから、アダプターをアップグレードする必要があります。"
 " "
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__prep_migration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-upgrading__topics__prep_migration/ja_JP/index.html
