### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po
@@ -1,24 +1,25 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: masahiro suzuki <suzmasah@fsi.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/permission-decision-strategy.adoc:2
 #, no-wrap
 msgid "Policy Decision Strategies"
-msgstr ""
+msgstr "ポリシー決定戦略"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:5
@@ -27,13 +28,14 @@ msgid ""
 "strategy to specify how to evaluate the outcome of the associated policies "
 "to determine access."
 msgstr ""
+"ポリシーにアクセス許可を関連付けるときに、決定戦略を定義して、関連付けされたポリシーの結果を評価して最終的なアクセスを判断する方法を指定できます"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:7
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:47
 #, no-wrap
 msgid "*Unanimous*\n"
-msgstr ""
+msgstr "*Unanimous*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:9
@@ -41,28 +43,28 @@ msgstr ""
 msgid ""
 "The default strategy if none is provided. In this case, _all_ policies must "
 "evaluate to a positive decision for the final decision to be also positive."
-msgstr ""
+msgstr "デフォルトの戦略。この場合、最終的に全てのポリシー判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:11
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:51
 #, no-wrap
 msgid "*Affirmative*\n"
-msgstr ""
+msgstr "*Affirmative*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:13
 msgid ""
-"In this case, _at least one_ policy must evaluate to a positive decision for "
-"the final decision to be also positive."
-msgstr ""
+"In this case, _at least one_ policy must evaluate to a positive decision for"
+" the final decision to be also positive."
+msgstr "この場合、最終的に少なくとも1つのポリシーの判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:15
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:55
 #, no-wrap
 msgid "*Consensus*\n"
-msgstr ""
+msgstr "*Consensus*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:16
@@ -70,4 +72,4 @@ msgid ""
 "In this case, the number of positive decisions must be greater than the "
 "number of negative decisions. If the number of positive and negative "
 "decisions is equal, the final decision will be negative."
-msgstr ""
+msgstr "この場合、肯定判定数は否定判定数よりも多くなければならない。肯定と否定の判定数が等しい場合、最終的に否定と判定されます。"

--- a/i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: masahiro suzuki <suzmasah@fsi.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgid ""
 "strategy to specify how to evaluate the outcome of the associated policies "
 "to determine access."
 msgstr ""
-"ポリシーにアクセス許可を関連付けるときに、決定戦略を定義して、関連付けされたポリシーの結果を評価して最終的なアクセスを判断する方法を指定できます"
+"ポリシーにパーミッションを関連付けるときに、決定戦略を定義して、関連付けされたポリシーの結果を評価して最終的なアクセスを判断する方法を指定できます"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:7
@@ -43,7 +43,7 @@ msgstr "*Unanimous*\n"
 msgid ""
 "The default strategy if none is provided. In this case, _all_ policies must "
 "evaluate to a positive decision for the final decision to be also positive."
-msgstr "デフォルトの戦略。この場合、最終的に全てのポリシー判定結果が肯定と判定される必要があります。"
+msgstr "デフォルトの戦略。この場合、最終的に _全て_ のポリシー判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:11
@@ -57,7 +57,7 @@ msgstr "*Affirmative*\n"
 msgid ""
 "In this case, _at least one_ policy must evaluate to a positive decision for"
 " the final decision to be also positive."
-msgstr "この場合、最終的に少なくとも1つのポリシーの判定結果が肯定と判定される必要があります。"
+msgstr "この場合、最終的に _少なくとも1つの_ ポリシーの判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-decision-strategy.adoc:15


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__permission-decision-strategy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__permission-decision-strategy/ja_JP/index.html
