### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
@@ -1,77 +1,75 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: masahiro suzuki <suzmasah@fsi.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/resource-view.adoc:2
 #, no-wrap
 msgid "Viewing Resources"
-msgstr ""
+msgstr "リソースの表示"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:5
 msgid ""
 "On the *Resource* page, you see a list of the resources associated with a "
 "resource server."
-msgstr ""
+msgstr "*Resource*ページには、リソースサーバーに関連付けられているリソースの一覧が表示されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-view.adoc:6
-#, fuzzy, no-wrap
-#| msgid "resource"
+#, no-wrap
 msgid "Resources"
-msgstr "resource"
+msgstr "リソース"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:8
-#, fuzzy
-#| msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgid "image:{project_images}/resource/view.png[alt=\"Resources\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
+msgstr "image:{project_images}/resource/view.png[alt=\"Resources\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:10
 msgid ""
 "The resource list provides information about the protected resources, such "
 "as:"
-msgstr ""
+msgstr "リソースリストには、次のような保護されたリソースに関する情報が表示されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:12
 msgid "Type"
-msgstr ""
+msgstr "タイプ"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:13
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:14
 msgid "Owner"
-msgstr ""
+msgstr "オーナー"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:15
 msgid "Associated scopes, if any"
-msgstr ""
+msgstr "関連スコープ（存在する場合）"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:16
 msgid "Associated permissions"
-msgstr ""
+msgstr "関連する権限"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:18
@@ -79,11 +77,11 @@ msgid ""
 "From this list, you can also directly create a permission by clicking "
 "*Create Permission* for the resource for which you want to create the "
 "permission."
-msgstr ""
+msgstr "このリストから、権限を作成するリソースの*アクセス権を作成*をクリックして、権限を直接作成することもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:20
 msgid ""
 "Before creating permissions for your resources, be sure you have already "
 "defined the policies that you want to associate with the permission."
-msgstr ""
+msgstr "リソースのアクセス許可を作成する前に、そのアクセス許可に関連付けるポリシーを定義済みであることを確認してください。"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
@@ -26,7 +26,7 @@ msgstr "リソースの表示"
 msgid ""
 "On the *Resource* page, you see a list of the resources associated with a "
 "resource server."
-msgstr "*Resource* ページには、リソース・サーバーに関連付けられているリソースの一覧が表示されます。"
+msgstr "*Resource* ページには、リソースサーバーに関連付けられているリソースの一覧が表示されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-view.adoc:6
@@ -44,7 +44,7 @@ msgstr "image:{project_images}/resource/view.png[alt=\"Resources\"]"
 msgid ""
 "The resource list provides information about the protected resources, such "
 "as:"
-msgstr "リソース・リストには、次のような保護されたリソースに関する情報が表示されます。"
+msgstr "リソースリストには、次のような保護されたリソースに関する情報が表示されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:12
@@ -78,7 +78,8 @@ msgid ""
 "*Create Permission* for the resource for which you want to create the "
 "permission."
 msgstr ""
-"このリストから、パーミッションを作成したいリソースに対して *パーミッションの作成* をクリックして、パーミッションを直接作成することもできます。"
+"このリストから、パーミッションを作成したいリソースに対して *Create Permission* "
+"をクリックして、パーミッションを直接作成することもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:20

--- a/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: masahiro suzuki <suzmasah@fsi.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +26,7 @@ msgstr "リソースの表示"
 msgid ""
 "On the *Resource* page, you see a list of the resources associated with a "
 "resource server."
-msgstr "*Resource*ページには、リソースサーバーに関連付けられているリソースの一覧が表示されます。"
+msgstr "*Resource* ページには、リソース・サーバーに関連付けられているリソースの一覧が表示されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-view.adoc:6
@@ -44,7 +44,7 @@ msgstr "image:{project_images}/resource/view.png[alt=\"Resources\"]"
 msgid ""
 "The resource list provides information about the protected resources, such "
 "as:"
-msgstr "リソースリストには、次のような保護されたリソースに関する情報が表示されます。"
+msgstr "リソース・リストには、次のような保護されたリソースに関する情報が表示されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:12
@@ -69,7 +69,7 @@ msgstr "関連スコープ（存在する場合）"
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:16
 msgid "Associated permissions"
-msgstr "関連する権限"
+msgstr "関連するパーミッション"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:18
@@ -77,11 +77,12 @@ msgid ""
 "From this list, you can also directly create a permission by clicking "
 "*Create Permission* for the resource for which you want to create the "
 "permission."
-msgstr "このリストから、権限を作成するリソースの*アクセス権を作成*をクリックして、権限を直接作成することもできます。"
+msgstr ""
+"このリストから、パーミッションを作成したいリソースに対して *パーミッションの作成* をクリックして、パーミッションを直接作成することもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-view.adoc:20
 msgid ""
 "Before creating permissions for your resources, be sure you have already "
 "defined the policies that you want to associate with the permission."
-msgstr "リソースのアクセス許可を作成する前に、そのアクセス許可に関連付けるポリシーを定義済みであることを確認してください。"
+msgstr "リソースに対するパーミッションを作成する前に、そのパーミッションに関連付けたいポリシーを定義済みであることを確認してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-view
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__resource-view/ja_JP/index.html
