### PR TITLE
Translations for i18n/po/ja_JP/server_development/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/master.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/master.ja_JP.po
@@ -2,21 +2,21 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/server_development/master.adoc:9
 #, no-wrap
 msgid "{developerguide_name}"
-msgstr ""
+msgstr "{developerguide_name}"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__master/ja_JP/index.html
