### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/preface.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/preface.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/preface.ja_JP.po
@@ -2,37 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/application-clustering.adoc:89
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:31
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:56
-#: source/securing_apps/topics/oidc/javascript-adapter.adoc:66
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.adoc:23
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.adoc:23
-#: source/server_development/topics/auth-spi.adoc:148
-#: source/server_development/topics/preface.adoc:16
-#, no-wrap
-msgid "[source]\n"
-msgstr ""
 
 #. type: Title ==
 #: source/server_development/topics/preface.adoc:1
 #, no-wrap
 msgid "Preface"
-msgstr ""
+msgstr "はじめに"
 
 #. type: Plain text
 #: source/server_development/topics/preface.adoc:5
@@ -42,24 +29,34 @@ msgid ""
 "up. A '\\' at the end of a line means that a break has been introduced to "
 "fit in the page, with the following lines indented.  So:"
 msgstr ""
+"サンプルの行には、1行で表示されることを意図した行がページ幅に収まらないことがあります。これらの行は壊れています。行の最後尾の '\\' "
+"は、ページ内に収まるよう壊されたことを意味します。例えば、以下のような行を意図したものになります。"
 
 #. type: delimited block -
-#: source/server_development/topics/preface.adoc:14
+#: source/server_development/topics/preface.adoc:12
 #, no-wrap
 msgid ""
 "Let's pretend to have an extremely \\\n"
 "long line that \\\n"
 "does not fit\n"
 "This one is short\n"
-"----         \n"
-"Is really: \n"
 msgstr ""
+"Let's pretend to have an extremely \\\n"
+"long line that \\\n"
+"does not fit\n"
+"This one is short\n"
 
 #. type: Plain text
-#: source/server_development/topics/preface.adoc:20
+#: source/server_development/topics/preface.adoc:14
+msgid "Is really:"
+msgstr "上記は、本当は下記の通りになります。"
+
+#. type: delimited block -
+#: source/server_development/topics/preface.adoc:19
 #, no-wrap
 msgid ""
 "Let's pretend to have an extremely long line that does not fit\n"
 "This one is short\n"
-"----      \n"
 msgstr ""
+"Let's pretend to have an extremely long line that does not fit\n"
+"This one is short\n"

--- a/i18n/po/ja_JP/server_development/topics/preface.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/preface.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,8 +29,8 @@ msgid ""
 "up. A '\\' at the end of a line means that a break has been introduced to "
 "fit in the page, with the following lines indented.  So:"
 msgstr ""
-"サンプルの行には、1行で表示されることを意図した行がページ幅に収まらないことがあります。これらの行は壊れています。行の最後尾の '\\' "
-"は、ページ内に収まるよう壊されたことを意味します。例えば、以下のような行を意図したものになります。"
+"いくつかの例にあるように、1行で表示されることを意図した行がページ幅に収まらないことがあります。これらの行は改行されています。行末の '\\' "
+"は、次の行がインデントされたページに収まるように改行が導入されたことを意味します。したがって、"
 
 #. type: delimited block -
 #: source/server_development/topics/preface.adoc:12
@@ -49,7 +49,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_development/topics/preface.adoc:14
 msgid "Is really:"
-msgstr "上記は、本当は下記の通りになります。"
+msgstr "上記は、実際には下記の通りになります。"
 
 #. type: delimited block -
 #: source/server_development/topics/preface.adoc:19


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/preface.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__preface
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__preface/ja_JP/index.html
