### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
@@ -2,81 +2,75 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:125
-#: source/server_development/topics/admin-rest-api.adoc:13
 #, no-wrap
 msgid "Example using CURL"
 msgstr "CURLを使用した例"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/rest.adoc:66
-#: source/server_development/topics/admin-rest-api.adoc:53
 #, no-wrap
 msgid ""
 "import org.keycloak.admin.client.Keycloak;\n"
 "import org.keycloak.representations.idm.RealmRepresentation;\n"
 "...\n"
 msgstr ""
+"import org.keycloak.admin.client.Keycloak;\n"
+"import org.keycloak.representations.idm.RealmRepresentation;\n"
+"...\n"
 
-#. type: Title ===
-#: source/server_development/topics/admin-rest-api.adoc:1
-#: source/upgrading/topics/rhsso/changes.adoc:16
+#. type: Title ==
 #, no-wrap
 msgid "Admin REST API"
-msgstr ""
+msgstr "管理REST API"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:4
 msgid ""
 "{project_name} comes with a fully functional Admin REST API with all "
 "features provided by the Admin Console."
-msgstr ""
+msgstr "{project_name}には、完全に機能する管理REST APIを含め、管理コンソールにより提供されるすべての機能が備わっています。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:7
 msgid ""
 "To invoke the API you need to obtain an access token with the appropriate "
-"permissions. The required permissions are described in {adminguide_link}"
-"[{adminguide_name}]."
+"permissions. The required permissions are described in "
+"{adminguide_link}[{adminguide_name}]."
 msgstr ""
+"APIを呼び出すには、適切な権限を持つアクセス・トークンを取得する必要があります。必要な権限については{adminguide_link}[{adminguide_name}]を参照ください。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:10
 msgid ""
 "A token can be obtained by enabling authenticating to your application with "
 "{project_name}; see the {adapterguide_link}[{adapterguide_name}]. You can "
 "also use direct access grant to obtain an access token."
 msgstr ""
+"トークンは、{project_name}を使用してアプリケーションの認証を有効にすることで取得することができます。{adapterguide_link}[{adapterguide_name}]を参照ください。また、ダイレクト・アクセス許可を使用してもアクセス・トークンを取得することができます。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:12
 msgid "For complete documentation see {apidocs_link}[{apidocs_name}]."
-msgstr ""
+msgstr "完全なドキュメントについては、{apidocs_link}[{apidocs_name}]を参照ください。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:16
 msgid ""
-"Obtain access token for user in the realm `master` with username `admin` and "
-"password `password`:"
+"Obtain access token for user in the realm `master` with username `admin` and"
+" password `password`:"
 msgstr ""
+"ユーザー名 `admin` とパスワード `password` を使用して、以下の通り、レルム `master` "
+"内のユーザー用にアクセス・トークンを取得します。"
 
 #. type: delimited block -
-#: source/server_development/topics/admin-rest-api.adoc:24
 #, no-wrap
 msgid ""
 "curl \\\n"
@@ -86,57 +80,64 @@ msgid ""
 "  -d \"grant_type=password\" \\\n"
 "  \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 msgstr ""
+"curl \\\n"
+" -d \"client_id=admin-cli\" \\\n"
+" -d \"username=admin\" \\\n"
+" -d \"password=password\" \\\n"
+" -d \"grant_type=password\" \\\n"
+" \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:27
 msgid "By default this token expires in 1 minute"
-msgstr ""
+msgstr "デフォルトではこのトークンは1分で使用期限切れとなります。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:30
 msgid ""
 "The result will be a JSON document. To invoke the API you need to extract "
 "the value of the `access_token` property. You can then invoke the API by "
 "including the value in the `Authorization` header of requests to the API."
 msgstr ""
+"この結果から、JSONのドキュメントを確認することになります。APIを呼び起こすには `access_token` "
+"プロパティの値を抽出する必要があります。その後、APIへのリクエストの `Authorization` "
+"ヘッダー内での値を含むことによって、APIを呼び起こすことができます。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:32
-msgid "The following example shows how to get the details of the master realm:"
-msgstr ""
+msgid ""
+"The following example shows how to get the details of the master realm:"
+msgstr "マスターレルムの詳細を確認する方法については、以下のサンプルの通りです。"
 
 #. type: delimited block -
-#: source/server_development/topics/admin-rest-api.adoc:38
 #, no-wrap
 msgid ""
 "curl \\\n"
 "  -H \"Authorization: bearer eyJhbGciOiJSUz...\" \\\n"
 "  \"http://localhost:8080/auth/admin/realms/master\"\n"
 msgstr ""
+"curl \\\n"
+" -H \"Authorization: bearer eyJhbGciOiJSUz...\" \\\n"
+" \"http://localhost:8080/auth/admin/realms/master\"\n"
 
 #. type: Title ===
-#: source/server_development/topics/admin-rest-api.adoc:41
 #, no-wrap
 msgid "Example using Java"
-msgstr ""
+msgstr "Javaを使用したサンプル"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:45
 msgid ""
 "There's a Java client library for the Admin REST API that makes it easy to "
 "use from Java. To use it from your application add a dependency on the "
 "`keycloak-admin-client` library."
 msgstr ""
+"Javaの使用を簡単にする管理REST API用のJavaクライアント・ライブラリというものがあります。アプリケーションでこれを使用するには、 "
+"`keycloak-admin-client` ライブラリ上で依存関係を追加します。"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:47
 msgid ""
 "The following example shows how to use the Java client library to get the "
 "details of the master realm:"
-msgstr ""
+msgstr "マスター・レルムの詳細を確認するためにJavaクライアント・ライブラリを使用する方法については、以下のサンプルの通りです。"
 
 #. type: delimited block -
-#: source/server_development/topics/admin-rest-api.adoc:61
 #, no-wrap
 msgid ""
 "Keycloak keycloak = Keycloak.getInstance(\n"
@@ -147,10 +148,16 @@ msgid ""
 "    \"admin-cli\");\n"
 "RealmRepresentation realm = keycloak.realm(\"master\").toRepresentation();\n"
 msgstr ""
+"Keycloak keycloak = Keycloak.getInstance(\n"
+" \"http://localhost:8080/auth\",\n"
+" \"master\",\n"
+" \"admin\",\n"
+" \"password\",\n"
+" \"admin-cli\");\n"
+"RealmRepresentation realm = keycloak.realm(\"master\").toRepresentation();\n"
 
 #. type: Plain text
-#: source/server_development/topics/admin-rest-api.adoc:64
 msgid ""
-"Complete Javadoc for the admin client is available at {apidocs_link}"
-"[{apidocs_name}]."
-msgstr ""
+"Complete Javadoc for the admin client is available at "
+"{apidocs_link}[{apidocs_name}]."
+msgstr "管理クライアント用の完全なJavaのドキュメントについては、{apidocs_link}[{apidocs_name}]を参照ください。"

--- a/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,7 +40,7 @@ msgstr "管理REST API"
 msgid ""
 "{project_name} comes with a fully functional Admin REST API with all "
 "features provided by the Admin Console."
-msgstr "{project_name}には、完全に機能する管理REST APIを含め、管理コンソールにより提供されるすべての機能が備わっています。"
+msgstr "{project_name}には、管理コンソールが提供するすべての機能を完全に備えた管理REST APIが付属しています。"
 
 #. type: Plain text
 msgid ""
@@ -56,7 +56,7 @@ msgid ""
 "{project_name}; see the {adapterguide_link}[{adapterguide_name}]. You can "
 "also use direct access grant to obtain an access token."
 msgstr ""
-"トークンは、{project_name}を使用してアプリケーションの認証を有効にすることで取得することができます。{adapterguide_link}[{adapterguide_name}]を参照ください。また、ダイレクト・アクセス許可を使用してもアクセス・トークンを取得することができます。"
+"トークンは、{project_name}を使用したアプリケーションへの認証を有効にすることで取得できます。{adapterguide_link}[{adapterguide_name}]を参照ください。また、ダイレクト・アクセス・グラントを使用しても、アクセス・トークンを取得できます。"
 
 #. type: Plain text
 msgid "For complete documentation see {apidocs_link}[{apidocs_name}]."
@@ -67,8 +67,8 @@ msgid ""
 "Obtain access token for user in the realm `master` with username `admin` and"
 " password `password`:"
 msgstr ""
-"ユーザー名 `admin` とパスワード `password` を使用して、以下の通り、レルム `master` "
-"内のユーザー用にアクセス・トークンを取得します。"
+"ユーザー名 `admin` とパスワード `password` を使用して、以下の通り、 `master` "
+"レルム内のユーザー用にアクセス・トークンを取得します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -97,14 +97,14 @@ msgid ""
 "the value of the `access_token` property. You can then invoke the API by "
 "including the value in the `Authorization` header of requests to the API."
 msgstr ""
-"この結果から、JSONのドキュメントを確認することになります。APIを呼び起こすには `access_token` "
+"結果はJSONドキュメントになります。APIを呼び出すには、 `access_token` "
 "プロパティの値を抽出する必要があります。その後、APIへのリクエストの `Authorization` "
-"ヘッダー内での値を含むことによって、APIを呼び起こすことができます。"
+"ヘッダーに値を含めることで、APIを呼び出すことができます。"
 
 #. type: Plain text
 msgid ""
 "The following example shows how to get the details of the master realm:"
-msgstr "マスターレルムの詳細を確認する方法については、以下のサンプルの通りです。"
+msgstr "次の例は、マスターレルムの詳細を取得する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -128,14 +128,14 @@ msgid ""
 "use from Java. To use it from your application add a dependency on the "
 "`keycloak-admin-client` library."
 msgstr ""
-"Javaの使用を簡単にする管理REST API用のJavaクライアント・ライブラリというものがあります。アプリケーションでこれを使用するには、 "
-"`keycloak-admin-client` ライブラリ上で依存関係を追加します。"
+"Javaから簡単に使用できるようにする管理REST API用のJavaクライアント・ライブラリーがあります。アプリケーションからそれを使用するには、 "
+"`keycloak-admin-client` ライブラリーに依存関係を追加します。"
 
 #. type: Plain text
 msgid ""
 "The following example shows how to use the Java client library to get the "
 "details of the master realm:"
-msgstr "マスター・レルムの詳細を確認するためにJavaクライアント・ライブラリを使用する方法については、以下のサンプルの通りです。"
+msgstr "次の例は、Javaクライアント・ライブラリーを使用して、マスター・レルムの詳細を取得する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -160,4 +160,4 @@ msgstr ""
 msgid ""
 "Complete Javadoc for the admin client is available at "
 "{apidocs_link}[{apidocs_name}]."
-msgstr "管理クライアント用の完全なJavaのドキュメントについては、{apidocs_link}[{apidocs_name}]を参照ください。"
+msgstr "管理クライアントの完全なJavaのドキュメントは、{apidocs_link}[{apidocs_name}]を参照ください。"

--- a/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
@@ -81,11 +81,11 @@ msgid ""
 "  \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 msgstr ""
 "curl \\\n"
-" -d \"client_id=admin-cli\" \\\n"
-" -d \"username=admin\" \\\n"
-" -d \"password=password\" \\\n"
-" -d \"grant_type=password\" \\\n"
-" \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
+"  -d \"client_id=admin-cli\" \\\n"
+"  -d \"username=admin\" \\\n"
+"  -d \"password=password\" \\\n"
+"  -d \"grant_type=password\" \\\n"
+"  \"http://localhost:8080/auth/realms/master/protocol/openid-connect/token\"\n"
 
 #. type: Plain text
 msgid "By default this token expires in 1 minute"
@@ -104,7 +104,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The following example shows how to get the details of the master realm:"
-msgstr "次の例は、マスターレルムの詳細を取得する方法を示しています。"
+msgstr "次の例は、masterレルムの詳細を取得する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -114,8 +114,8 @@ msgid ""
 "  \"http://localhost:8080/auth/admin/realms/master\"\n"
 msgstr ""
 "curl \\\n"
-" -H \"Authorization: bearer eyJhbGciOiJSUz...\" \\\n"
-" \"http://localhost:8080/auth/admin/realms/master\"\n"
+"  -H \"Authorization: bearer eyJhbGciOiJSUz...\" \\\n"
+"  \"http://localhost:8080/auth/admin/realms/master\"\n"
 
 #. type: Title ===
 #, no-wrap
@@ -135,7 +135,7 @@ msgstr ""
 msgid ""
 "The following example shows how to use the Java client library to get the "
 "details of the master realm:"
-msgstr "次の例は、Javaクライアント・ライブラリーを使用して、マスター・レルムの詳細を取得する方法を示しています。"
+msgstr "次の例は、Javaクライアント・ライブラリーを使用して、masterレルムの詳細を取得する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -149,11 +149,11 @@ msgid ""
 "RealmRepresentation realm = keycloak.realm(\"master\").toRepresentation();\n"
 msgstr ""
 "Keycloak keycloak = Keycloak.getInstance(\n"
-" \"http://localhost:8080/auth\",\n"
-" \"master\",\n"
-" \"admin\",\n"
-" \"password\",\n"
-" \"admin-cli\");\n"
+"    \"http://localhost:8080/auth\",\n"
+"    \"master\",\n"
+"    \"admin\",\n"
+"    \"password\",\n"
+"    \"admin-cli\");\n"
 "RealmRepresentation realm = keycloak.realm(\"master\").toRepresentation();\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__admin-rest-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__admin-rest-api/ja_JP/index.html
