### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po
@@ -87,8 +87,8 @@ msgid ""
 "If your server is accessible from `localhost`, you can boot it up and create"
 " this admin user by going to the http://localhost:8080/auth URL."
 msgstr ""
-"サーバーが `localhost` からアクセス可能な場合は、 http://localhost:8080/auth "
-"のURLにアクセスすることで、起動とこの管理者ユーザーの作成ができます。"
+"サーバーが `localhost` からアクセス可能な場合は、 サーバーを起動して http://localhost:8080/auth "
+"のURLにアクセスすることで、この管理者ユーザーの作成ができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:17
@@ -124,8 +124,7 @@ msgid ""
 "standalone operation mode or domain operation mode.  For standalone mode, "
 "here is how you use the script."
 msgstr ""
-"スタンドアローン動作モードまたはドメイン動作モードを使用している場合、パラメーターは少し異なります。 "
-"スタンドアローン・モードの場合の、スクリプトの使用方法を次に示します。"
+"スタンドアローン動作モードまたはドメイン動作モードを使用している場合、パラメーターは少し異なります。スタンドアローン・モードの場合のスクリプトの使用方法を次に示します。"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:31

--- a/i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -77,7 +77,7 @@ msgid ""
 "start creating realms, users and registering applications to be secured by "
 "{project_name}."
 msgstr ""
-"link:{installguide_link}[{installguide_name}]に定義されているすべてのインストールおよび設定タスクを実行したら、初期管理者アカウントを作成する必要があります。{project_name}には設定済みの管理者アカウントはありません。このアカウントを使用すると、"
+"link:{installguide_link}[{installguide_name}]に定義されているすべてのインストールおよび設定タスクを実行したら、初期管理者アカウントを作成する必要があります。{project_name}には、設定済みの管理者アカウントはありません。このアカウントを使用すると、"
 " _master_ "
 "レルムの管理コンソールにログインできる管理者を作成できるため、レルム、ユーザー、および{project_name}によって保護されるアプリケーションの登録を開始できます。"
 
@@ -87,14 +87,14 @@ msgid ""
 "If your server is accessible from `localhost`, you can boot it up and create"
 " this admin user by going to the http://localhost:8080/auth URL."
 msgstr ""
-"サーバーが `localhost` "
-"からアクセス可能な場合は、http://localhost:8080/authのURLにアクセスすることで、起動とこの管理者ユーザーの作成ができます。"
+"サーバーが `localhost` からアクセス可能な場合は、 http://localhost:8080/auth "
+"のURLにアクセスすることで、起動とこの管理者ユーザーの作成ができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:17
 msgid ""
 "Simply specify the username and password you want for this initial admin."
-msgstr "この初期管理者に対するユーザー名とパスワードを指定するだけです。"
+msgstr "初期管理者に対するユーザー名とパスワードを指定するだけです。"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:20
@@ -104,7 +104,7 @@ msgid ""
 "`.../bin/add-user-keycloak` script."
 msgstr ""
 "`localhost` アドレスでサーバーにアクセスできない場合や、コマンドラインから{project_name}をプロビジョニングしたい場合は、 "
-"`.../bin/add-user-keycloak` スクリプトを使ってそれを実行できます。"
+"`.../bin/add-user-keycloak` スクリプトを使ってそれらを実行できます。"
 
 #. type: Block title
 #: source/server_admin/topics/initialization.adoc:21
@@ -124,8 +124,8 @@ msgid ""
 "standalone operation mode or domain operation mode.  For standalone mode, "
 "here is how you use the script."
 msgstr ""
-"スタンドアロン動作モードまたはドメイン動作モードを使用している場合、パラメーターは少し異なります。 "
-"スタンドアロンモードの場合の、スクリプトの使用方法を次に示します。"
+"スタンドアローン動作モードまたはドメイン動作モードを使用している場合、パラメーターは少し異なります。 "
+"スタンドアローン・モードの場合の、スクリプトの使用方法を次に示します。"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:31
@@ -144,7 +144,7 @@ msgstr "> ...\\bin\\add-user-keycloak.bat -r master -u <username> -p <password>\
 msgid ""
 "For domain mode, you have to point the script to one of your server hosts "
 "using the `-sc` switch."
-msgstr "ドメインモードでは、 `-sc` スイッチを使ってスクリプトをサーバー・ホストの1つに向ける必要があります。"
+msgstr "ドメインモードでは、 `-sc` スイッチを使ってスクリプトをサーバーホストの1つに向ける必要があります。"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:45

--- a/i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po
@@ -2,18 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -27,7 +26,7 @@ msgstr ""
 #: source/server_installation/topics/manage.adoc:15
 #: source/server_admin/topics/initialization.adoc:27
 #: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started/overview.adoc:9
+#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
@@ -43,7 +42,7 @@ msgstr "Linux/Unix"
 #: source/server_installation/topics/manage.adoc:21
 #: source/server_admin/topics/initialization.adoc:33
 #: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started/overview.adoc:15
+#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
@@ -65,51 +64,58 @@ msgstr "image:{project_images}/initial-welcome-page.png[]"
 #: source/server_admin/topics/initialization.adoc:2
 #, no-wrap
 msgid "Server Initialization"
-msgstr ""
+msgstr "サーバーの初期化"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:9
 msgid ""
-"After performing all the installation and configuration tasks defined in the "
-"link:{installguide_link}[{installguide_name}], you will need to create an "
+"After performing all the installation and configuration tasks defined in the"
+" link:{installguide_link}[{installguide_name}], you will need to create an "
 "initial admin account.  {project_name} does not have any configured admin "
-"account out of the box.  This account will allow you to create an admin that "
-"can log into the _master_ realm's administration console so that you can "
+"account out of the box.  This account will allow you to create an admin that"
+" can log into the _master_ realm's administration console so that you can "
 "start creating realms, users and registering applications to be secured by "
 "{project_name}."
 msgstr ""
+"link:{installguide_link}[{installguide_name}]に定義されているすべてのインストールおよび設定タスクを実行したら、初期管理者アカウントを作成する必要があります。{project_name}には設定済みの管理者アカウントはありません。このアカウントを使用すると、"
+" _master_ "
+"レルムの管理コンソールにログインできる管理者を作成できるため、レルム、ユーザー、および{project_name}によって保護されるアプリケーションの登録を開始できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:12
 msgid ""
-"If your server is accessible from `localhost`, you can boot it up and create "
-"this admin user by going to the http://localhost:8080/auth URL."
+"If your server is accessible from `localhost`, you can boot it up and create"
+" this admin user by going to the http://localhost:8080/auth URL."
 msgstr ""
+"サーバーが `localhost` "
+"からアクセス可能な場合は、http://localhost:8080/authのURLにアクセスすることで、起動とこの管理者ユーザーの作成ができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:17
 msgid ""
 "Simply specify the username and password you want for this initial admin."
-msgstr ""
+msgstr "この初期管理者に対するユーザー名とパスワードを指定するだけです。"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:20
 msgid ""
 "If you cannot access the server via a `localhost` address, or just want to "
-"provision {project_name} from the command line you can do this with the `.../"
-"bin/add-user-keycloak` script."
+"provision {project_name} from the command line you can do this with the "
+"`.../bin/add-user-keycloak` script."
 msgstr ""
+"`localhost` アドレスでサーバーにアクセスできない場合や、コマンドラインから{project_name}をプロビジョニングしたい場合は、 "
+"`.../bin/add-user-keycloak` スクリプトを使ってそれを実行できます。"
 
 #. type: Block title
 #: source/server_admin/topics/initialization.adoc:21
 #, no-wrap
 msgid "add-user-keycloak script"
-msgstr ""
+msgstr "add-user-keycloakスクリプト"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:23
 msgid "image:{project_images}/add-user-script.png[]"
-msgstr ""
+msgstr "image:{project_images}/add-user-script.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:26
@@ -118,34 +124,44 @@ msgid ""
 "standalone operation mode or domain operation mode.  For standalone mode, "
 "here is how you use the script."
 msgstr ""
+"スタンドアロン動作モードまたはドメイン動作モードを使用している場合、パラメーターは少し異なります。 "
+"スタンドアロンモードの場合の、スクリプトの使用方法を次に示します。"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:31
 #, no-wrap
 msgid "$ .../bin/add-user-keycloak.sh -r master -u <username> -p <password>\n"
-msgstr ""
+msgstr "$ .../bin/add-user-keycloak.sh -r master -u <username> -p <password>\n"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:37
 #, no-wrap
 msgid "> ...\\bin\\add-user-keycloak.bat -r master -u <username> -p <password>\n"
-msgstr ""
+msgstr "> ...\\bin\\add-user-keycloak.bat -r master -u <username> -p <password>\n"
 
 #. type: Plain text
 #: source/server_admin/topics/initialization.adoc:40
 msgid ""
 "For domain mode, you have to point the script to one of your server hosts "
 "using the `-sc` switch."
-msgstr ""
+msgstr "ドメインモードでは、 `-sc` スイッチを使ってスクリプトをサーバー・ホストの1つに向ける必要があります。"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:45
 #, no-wrap
-msgid "$ .../bin/add-user-keycloak.sh --sc domain/servers/server-one/configuration -r master -u <username> -p <password>\n"
+msgid ""
+"$ .../bin/add-user-keycloak.sh --sc domain/servers/server-one/configuration "
+"-r master -u <username> -p <password>\n"
 msgstr ""
+"$ .../bin/add-user-keycloak.sh --sc domain/servers/server-one/configuration "
+"-r master -u <username> -p <password>\n"
 
 #. type: delimited block -
 #: source/server_admin/topics/initialization.adoc:51
 #, no-wrap
-msgid "> ...\\bin\\add-user-keycloak.bat --sc domain/servers/server-one/configuration -r master -u <username> -p <password>\n"
+msgid ""
+"> ...\\bin\\add-user-keycloak.bat --sc domain/servers/server-"
+"one/configuration -r master -u <username> -p <password>\n"
 msgstr ""
+"> ...\\bin\\add-user-keycloak.bat --sc domain/servers/server-"
+"one/configuration -r master -u <username> -p <password>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/initialization.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__initialization
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__initialization/ja_JP/index.html
