### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -38,9 +38,7 @@ msgid ""
 "You can rename roles.  Basically you have a lot of control of what exactly "
 "goes back to the client."
 msgstr ""
-"IDトークン、アクセス・トークン、またはSAMLアサーションを受け取るアプリケーションでは、異なるユーザーのメタデータとロールが必要または欲しい場合があります。"
-" "
-"{project_name}では、正確に何が転送されるかを定義することができます。ロール、クレーム、カスタム属性をハードコードすることができます。ユーザー・メタデータをトークンまたはアサーションに取り込むことができます。ロールの名前を変更できます。基本的に、正確に何がクライアントに戻るのかをコントロールできます。"
+"IDトークン、アクセストークン、またはSAMLアサーションを受け取るアプリケーションでは、異なるユーザーのメタデータとロールが必要または求める場合があります。{project_name}では、正確に何が転送されるかを定義することができます。ロール、クレーム、カスタム属性をハードコードすることができます。ユーザー・メタデータをトークンまたはアサーションに取り込むことができます。ロールの名前を変更できます。基本的に、正確に何がクライアントに戻るのかをコントロールできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:14
@@ -48,7 +46,8 @@ msgid ""
 "Within the Admin Console, if you go to an application you've registered, "
 "you'll see a `Mappers` tab.  Here's one for an OIDC based client."
 msgstr ""
-"管理コンソール内で、登録したアプリケーションに移動すると `Mappers` タブが表示されます。ここにOIDCベースのクライアントの一例を示します。"
+"管理コンソール内で、登録したアプリケーションに移動すると `Mappers` "
+"タブが表示されます。ここには、OIDCベースのクライアントの一例があります。"
 
 #. type: Block title
 #: source/server_admin/topics/clients/protocol-mappers.adoc:15
@@ -71,8 +70,8 @@ msgid ""
 "that are not attached to the client that you can add by clicking the `Add "
 "Builtin` button."
 msgstr ""
-"各クライアントには、そのためにデフォルトで作成されたいくつかのビルトイン・マッパーがあります。それらのマッパーは、たとえば、電子メール・アドレスをアイデンティティー・トークンとアクセス・トークンの特定のクレームにマッピングします。それらの機能はそれぞれの名前から自明でなければなりません。"
-" `Add Builtin` ボタンをクリックすることで追加できるクライアントに、付属されていない追加の事前設定されたマッパーがあります。"
+"各クライアントには、そのためにデフォルトで作成されたいくつかのビルトイン・マッパーがあります。それらのマッパーは、たとえば、メールアドレスをアイデンティティー・トークンとアクセストークンの特定のクレームにマッピングします。それらの機能はそれぞれの名前から自明でなければなりません。クライアントにアタッチされていない追加の事前設定されたマッパーがあり、"
+" `Add Builtin` ボタンをクリックすることで追加できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:25
@@ -81,7 +80,7 @@ msgid ""
 "which type of mapper you are adding.  Click the `Edit` button next to one of"
 " the mappers in the list to get to the config screen."
 msgstr ""
-"各マッパーには、追加するマッパーのタイプに応じて、共通の設定と追加の設定があります。リスト内のマッパーの1つ選択し、横にある `Edit` "
+"各マッパーには、追加するマッパーのタイプに応じて、共通の設定と追加の設定があります。リスト内のマッパーの1つを選択し、横にある `Edit` "
 "ボタンをクリックして、設定画面を表示します。"
 
 #. type: Block title
@@ -101,7 +100,7 @@ msgid ""
 "The best way to learn about a config option is to hover over its tooltip.  "
 "There are a few config options that are common to all mappers:"
 msgstr ""
-"設定オプションについて学ぶ最も良い方法は、ツールチップにカーソルを合わせることです。すべてのマッパーに共通の設定オプションがいくつかあります："
+"設定オプションについて学ぶ最も良い方法は、ツールチップにカーソルを合わせることです。すべてのマッパーに共通の設定オプションがいくつかあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:34
@@ -126,8 +125,8 @@ msgid ""
 "your theme.  See the link:{developerguide_link}[{developerguide_name}] for "
 "more information on localization."
 msgstr ""
-"クライアントが同意を必要とし、 `Consent` スイッチがオンの場合、このテキストがユーザーに表示されます。このテキストの値は、 `$\\{var-"
-"name}` "
+"クライアントが同意を必要とし、 `Consent Required` スイッチがオンの場合、このテキストがユーザーに表示されます。このテキストの値は、 "
+"`$\\{var-name}` "
 "文字列で置換変数を指定することによってローカライズ可能です。ローカライズされた値は、テーマのプロパティー・ファイル内で設定されます。ローカリゼーションの詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Plain text
@@ -139,7 +138,7 @@ msgid ""
 "switches."
 msgstr ""
 "ほとんどのOIDCマッパーでは、クレームがどこに置かれるかを制御することもできます。 `Add to ID token` と `Add to "
-"access token` のスイッチを押すことで、 _id_ トークンと _access_ "
+"access token` のスイッチを切り替えることで、 _id_ トークンと _access_ "
 "トークンの両方にクレームを含めるかどうかを制御することができます。"
 
 #. type: Plain text
@@ -147,8 +146,7 @@ msgstr ""
 msgid ""
 "Finally, you can also add other mapper types.  If you go back to the "
 "`Mappers` tab, click the `Create` button."
-msgstr ""
-"最後に、他のマッパータイプを追加することもできます。 `Mappers` タブに戻ったら、 `Create` ボタンをクリックしてください。"
+msgstr "最後に、他のマッパータイプを追加することもできます。 `Mappers` タブに戻ったら、 `Create` ボタンをクリックします。"
 
 #. type: Block title
 #: source/server_admin/topics/clients/protocol-mappers.adoc:45
@@ -169,4 +167,4 @@ msgid ""
 "parameters will appear for different mapper types."
 msgstr ""
 "リストボックスから `Mapper Type` "
-"を選びます。ツールチップにカーソルを合わせると、そのマッパー・タイプが何をするのかの説明が表示されます。さまざまなマッパー・タイプに対して異なる設定パラメーターが表示されます。"
+"を選びます。ツールチップにカーソルを合わせると、そのマッパータイプが何をするのかの説明が表示されます。さまざまなマッパータイプに対して異なる設定パラメーターが表示されます。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
@@ -20,13 +20,13 @@ msgstr ""
 #: source/server_admin/topics/clients/protocol-mappers.adoc:32
 #, no-wrap
 msgid "Consent Required"
-msgstr ""
+msgstr "Consent Required"
 
 #. type: Title ===
 #: source/server_admin/topics/clients/protocol-mappers.adoc:3
 #, no-wrap
 msgid "OIDC Token and SAML Assertion Mappings"
-msgstr ""
+msgstr "OIDCトークンとSAMLアサーションのマッピング"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:11
@@ -38,6 +38,9 @@ msgid ""
 "You can rename roles.  Basically you have a lot of control of what exactly "
 "goes back to the client."
 msgstr ""
+"IDトークン、アクセス・トークン、またはSAMLアサーションを受け取るアプリケーションでは、異なるユーザーのメタデータとロールが必要または欲しい場合があります。"
+" "
+"{project_name}では、正確に何が転送されるかを定義することができます。ロール、クレーム、カスタム属性をハードコードすることができます。ユーザー・メタデータをトークンまたはアサーションに取り込むことができます。ロールの名前を変更できます。基本的に、正確に何がクライアントに戻るのかをコントロールできます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:14
@@ -45,47 +48,52 @@ msgid ""
 "Within the Admin Console, if you go to an application you've registered, "
 "you'll see a `Mappers` tab.  Here's one for an OIDC based client."
 msgstr ""
+"管理コンソール内で、登録したアプリケーションに移動すると `Mappers` タブが表示されます。ここにOIDCベースのクライアントの一例を示します。"
 
 #. type: Block title
 #: source/server_admin/topics/clients/protocol-mappers.adoc:15
 #, no-wrap
 msgid "Mappers Tab"
-msgstr ""
+msgstr "Mappersタブ"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:17
 msgid "image:{project_images}/mappers-oidc.png[]"
-msgstr ""
+msgstr "image:{project_images}/mappers-oidc.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:22
 msgid ""
-"Each client has several built-in mappers that are created for it by "
-"default.  They map things like, for example, email address to a specific "
-"claim in the identity and access token.  Their function should each be self "
+"Each client has several built-in mappers that are created for it by default."
+"  They map things like, for example, email address to a specific claim in "
+"the identity and access token.  Their function should each be self "
 "explanatory from their name.  There are additional pre-configured mappers "
 "that are not attached to the client that you can add by clicking the `Add "
 "Builtin` button."
 msgstr ""
+"各クライアントには、そのためにデフォルトで作成されたいくつかのビルトイン・マッパーがあります。それらのマッパーは、たとえば、電子メール・アドレスをアイデンティティー・トークンとアクセス・トークンの特定のクレームにマッピングします。それらの機能はそれぞれの名前から自明でなければなりません。"
+" `Add Builtin` ボタンをクリックすることで追加できるクライアントに、付属されていない追加の事前設定されたマッパーがあります。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:25
 msgid ""
 "Each mapper has common settings as well as additional ones depending on "
-"which type of mapper you are adding.  Click the `Edit` button next to one of "
-"the mappers in the list to get to the config screen."
+"which type of mapper you are adding.  Click the `Edit` button next to one of"
+" the mappers in the list to get to the config screen."
 msgstr ""
+"各マッパーには、追加するマッパーのタイプに応じて、共通の設定と追加の設定があります。リスト内のマッパーの1つ選択し、横にある `Edit` "
+"ボタンをクリックして、設定画面を表示します。"
 
 #. type: Block title
 #: source/server_admin/topics/clients/protocol-mappers.adoc:26
 #, no-wrap
 msgid "Mapper Config"
-msgstr ""
+msgstr "マッパーの設定"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:28
 msgid "image:{project_images}/mapper-config.png[]"
-msgstr ""
+msgstr "image:{project_images}/mapper-config.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:31
@@ -93,19 +101,20 @@ msgid ""
 "The best way to learn about a config option is to hover over its tooltip.  "
 "There are a few config options that are common to all mappers:"
 msgstr ""
+"設定オプションについて学ぶ最も良い方法は、ツールチップにカーソルを合わせることです。すべてのマッパーに共通の設定オプションがいくつかあります："
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:34
 msgid ""
 "If your client requires consent, this mapper will be displayed on the "
 "consent screen shown to the user."
-msgstr ""
+msgstr "クライアントが同意する必要がある場合、このマッパーがユーザーに表示される同意画面に表示されます。"
 
 #. type: Labeled list
 #: source/server_admin/topics/clients/protocol-mappers.adoc:34
 #, no-wrap
 msgid "Consent Text"
-msgstr ""
+msgstr "Consent Text"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:39
@@ -117,6 +126,9 @@ msgid ""
 "your theme.  See the link:{developerguide_link}[{developerguide_name}] for "
 "more information on localization."
 msgstr ""
+"クライアントが同意を必要とし、 `Consent` スイッチがオンの場合、このテキストがユーザーに表示されます。このテキストの値は、 `$\\{var-"
+"name}` "
+"文字列で置換変数を指定することによってローカライズ可能です。ローカライズされた値は、テーマのプロパティー・ファイル内で設定されます。ローカリゼーションの詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:42
@@ -126,6 +138,9 @@ msgid ""
 "tokens by fiddling with the `Add to ID token` and `Add to access token` "
 "switches."
 msgstr ""
+"ほとんどのOIDCマッパーでは、クレームがどこに置かれるかを制御することもできます。 `Add to ID token` と `Add to "
+"access token` のスイッチを押すことで、 _id_ トークンと _access_ "
+"トークンの両方にクレームを含めるかどうかを制御することができます。"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:44
@@ -133,17 +148,18 @@ msgid ""
 "Finally, you can also add other mapper types.  If you go back to the "
 "`Mappers` tab, click the `Create` button."
 msgstr ""
+"最後に、他のマッパータイプを追加することもできます。 `Mappers` タブに戻ったら、 `Create` ボタンをクリックしてください。"
 
 #. type: Block title
 #: source/server_admin/topics/clients/protocol-mappers.adoc:45
 #, no-wrap
 msgid "Add Mapper"
-msgstr ""
+msgstr "マッパーの追加"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:47
 msgid "image:{project_images}/add-mapper.png[]"
-msgstr ""
+msgstr "image:{project_images}/add-mapper.png[]"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/protocol-mappers.adoc:49
@@ -152,3 +168,5 @@ msgid ""
 "you'll see a description of what that mapper type does.  Different config "
 "parameters will appear for different mapper types."
 msgstr ""
+"リストボックスから `Mapper Type` "
+"を選びます。ツールチップにカーソルを合わせると、そのマッパー・タイプが何をするのかの説明が表示されます。さまざまなマッパー・タイプに対して異なる設定パラメーターが表示されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__clients__protocol-mappers/ja_JP/index.html
