### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/events.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/events.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/events.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_development/topics/events.adoc:2
 #, no-wrap
 msgid "Event Listener SPI"
-msgstr ""
+msgstr "イベント・リスナーSPI"
 
 #. type: Plain text
 #: source/server_development/topics/events.adoc:6
@@ -28,6 +28,9 @@ msgid ""
 "`EventListenerProvider` and `EventListenerProviderFactory` interfaces. "
 "Please see the Javadoc and examples for complete details on how to do this."
 msgstr ""
+"イベント・リスナー・プロバイダーの作成は、 `EventListenerProvider` インタフェースと "
+"`EventListenerProviderFactory` "
+"インタフェースを実装することから始まります。これを行う方法の詳細については、Javadocとサンプルを参照してください。"
 
 #. type: Plain text
 #: source/server_development/topics/events.adoc:8
@@ -37,3 +40,4 @@ msgid ""
 "For details on how to package and deploy a custom provider refer to the "
 "<<providers.adoc#providers,Service Provider Interfaces>> chapter."
 msgstr ""
+"カスタム・プロバイダーをパッケージ化してデプロイする方法の詳細については、<<providers.adoc#providers,サービス・プロバイダー・インタフェース>>の章を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/events.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__events
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__events/ja_JP/index.html
