### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -35,7 +35,7 @@ msgid ""
 "user store and the internal user object model that {project_name} uses to "
 "log in users and manage them."
 msgstr ""
-"ユーザー・ストレージSPIを使用して、外部ユーザー・データベースとクレデンシャル・ストアに接続するように、{project_name}の拡張機能を実装できます。組み込みのLDAPとActiveDirectoryのサポートは、このSPIを実際に実装したものです。設定などをせずすぐに、{project_name}はローカル・データベースを使用して、ユーザーの作成、更新、検索とクレデンシャルの検証をします。しかし、多くの場合、組織は{project_name}のデータモデルに移行できない既存の外部独自のユーザー・データベースを持っています。このような状況では、アプリケーション開発者は、ユーザー・ストレージSPIの実装を記述して、外部ユーザー・ストアと、{project_name}がユーザーのログインおよび管理に使用する内部ユーザー・オブジェクト・モデルをブリッジすることができます。"
+"ユーザー・ストレージSPIを使用して、外部ユーザー・データベースとクレデンシャル・ストアに接続するように、{project_name}の拡張機能を実装できます。組み込みのLDAPとActiveDirectoryのサポートは、このSPIを実際に実装したものです。設定などの作業をせず、すぐに{project_name}はローカル・データベースを使用して、ユーザーの作成、更新、検索とクレデンシャルの検証をします。しかし、多くの場合、組織は{project_name}のデータモデルに移行できない既存の外部独自のユーザー・データベースを持っています。このような状況では、アプリケーション開発者は、ユーザー・ストレージSPIの実装を記述して、外部ユーザー・ストアと、{project_name}がユーザーのログインおよび管理に使用する内部ユーザー・オブジェクト・モデルをブリッジすることができます。"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage.adoc:7
@@ -50,7 +50,7 @@ msgid ""
 "queries the external user store for the user and maps the external data "
 "representation of the user to {project_name}'s user metamodel."
 msgstr ""
-"{project_name}ランタイムは、ユーザーがログインしているときなど、ユーザーを検索する必要があるときに、ユーザーを特定するためにいくつかの手順を実行します。まず、ユーザーがユーザー・キャッシュに入っているかどうかを調べます。ユーザーが見つかった場合は、そのメモリー内表現を使用します。次に、{project_name}ローカル・データベース内のユーザーを探します。ユーザーが見つからない場合は、ユーザー・ストレージSPIプロバイダの実装をループして、そのうちの1つがランタイムが探しているユーザーを返すまでユーザー・クエリーを実行します。プロバイダーは外部ユーザー・ストアにユーザーを照会し、ユーザーの外部データ表現を{project_name}のユーザー・メタモデルにマップします。"
+"{project_name}ランタイムは、ユーザーがログインしているときなど、ユーザーを検索する必要があるときに、ユーザーを特定するためにいくつかの手順を実行します。まず、ユーザーがユーザー・キャッシュに入っているかどうかを調べます。ユーザーが見つかった場合は、そのメモリー内表現を使用します。次に、{project_name}ローカル・データベース内のユーザーを探します。ユーザーが見つからない場合は、ユーザー・ストレージSPIプロバイダの実装をループして、そのうちの1つがランタイムが探しているユーザーを返すまでユーザークエリーを実行します。プロバイダーは外部ユーザーストアにユーザーを照会し、ユーザーの外部データ表現を{project_name}のユーザー・メタモデルにマップします。"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage.adoc:9
@@ -72,4 +72,4 @@ msgid ""
 msgstr ""
 "ユーザー・ストレージSPIプロバイダーの実装は、Java EEコンポーネントと同様にパッケージ化され、デプロイされます（しばしばJava "
 "EEコンポーネントです）。デフォルトでは有効になっていませんが、管理コンソールの `User Federation` "
-"tタブでレルムごとに有効にして設定する必要があります。"
+"タブでレルムごとに有効にして設定する必要があります。"

--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -2,24 +2,24 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/server_development/topics/user-storage.adoc:2
 #, no-wrap
 msgid "User Storage SPI"
-msgstr ""
+msgstr "ユーザー・ストレージSPI"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage.adoc:5
@@ -35,12 +35,13 @@ msgid ""
 "user store and the internal user object model that {project_name} uses to "
 "log in users and manage them."
 msgstr ""
+"ユーザー・ストレージSPIを使用して、外部ユーザー・データベースとクレデンシャル・ストアに接続するように、{project_name}の拡張機能を実装できます。組み込みのLDAPとActiveDirectoryのサポートは、このSPIを実際に実装したものです。設定などをせずすぐに、{project_name}はローカル・データベースを使用して、ユーザーの作成、更新、検索とクレデンシャルの検証をします。しかし、多くの場合、組織は{project_name}のデータモデルに移行できない既存の外部独自のユーザー・データベースを持っています。このような状況では、アプリケーション開発者は、ユーザー・ストレージSPIの実装を記述して、外部ユーザー・ストアと、{project_name}がユーザーのログインおよび管理に使用する内部ユーザー・オブジェクト・モデルをブリッジすることができます。"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage.adoc:7
 msgid ""
-"When the {project_name} runtime needs to look up a user, such as when a user "
-"is logging in, it performs a number of steps to locate the user. It first "
+"When the {project_name} runtime needs to look up a user, such as when a user"
+" is logging in, it performs a number of steps to locate the user. It first "
 "looks to see if the user is in the user cache; if the user is found it uses "
 "that in-memory representation. Then it looks for the user within the "
 "{project_name} local database. If the user is not found, it then loops "
@@ -49,6 +50,7 @@ msgid ""
 "queries the external user store for the user and maps the external data "
 "representation of the user to {project_name}'s user metamodel."
 msgstr ""
+"{project_name}ランタイムは、ユーザーがログインしているときなど、ユーザーを検索する必要があるときに、ユーザーを特定するためにいくつかの手順を実行します。まず、ユーザーがユーザー・キャッシュに入っているかどうかを調べます。ユーザーが見つかった場合は、そのメモリー内表現を使用します。次に、{project_name}ローカル・データベース内のユーザーを探します。ユーザーが見つからない場合は、ユーザー・ストレージSPIプロバイダの実装をループして、そのうちの1つがランタイムが探しているユーザーを返すまでユーザー・クエリーを実行します。プロバイダーは外部ユーザー・ストアにユーザーを照会し、ユーザーの外部データ表現を{project_name}のユーザー・メタモデルにマップします。"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage.adoc:9
@@ -58,6 +60,7 @@ msgid ""
 "or perform bulk updates of many users at once. It depends on the "
 "capabilities of the external store."
 msgstr ""
+"ユーザー・ストレージSPIプロバイダーの実装では、複雑な条件のクエリーを実行したり、ユーザーに対してCRUD操作を実行したり、クレデンシャルを検証および管理したり、一度に多くのユーザーの一括更新を実行することもできます。これは外部ストアーの機能に依存します。"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage.adoc:11
@@ -67,3 +70,6 @@ msgid ""
 "default, but instead must be enabled and configured per realm under the "
 "`User Federation` tab in the administration console."
 msgstr ""
+"ユーザー・ストレージSPIプロバイダーの実装は、Java EEコンポーネントと同様にパッケージ化され、デプロイされます（しばしばJava "
+"EEコンポーネントです）。デフォルトでは有効になっていませんが、管理コンソールの `User Federation` "
+"tタブでレルムごとに有効にして設定する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__user-storage/ja_JP/index.html
