### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-overview.ja_JP.po
@@ -1,64 +1,65 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/policy-overview.adoc:2
 #, no-wrap
 msgid "Managing Policies"
-msgstr ""
+msgstr "ポリシーの管理"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:5
 msgid ""
 "As mentioned previously, policies define the conditions that must be "
 "satisfied before granting access to an object."
-msgstr ""
+msgstr "前の章で述べたように、ポリシーはオブジェクトへのアクセスを与えられる前に満たすべきコンディションを定義します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:7
 msgid ""
 "You can view all policies associated with a resource server by clicking the "
 "*Policy* tab when editing a resource server."
-msgstr ""
+msgstr "リソースサーバーに関連付けられたポリシーを閲覧するには、リソースサーバーの設定画面上の *Policy* タブをクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:8
 #: source/authorization_services/topics/resource-server-import-config.adoc:8
 #, no-wrap
 msgid "Policies"
-msgstr ""
+msgstr "ポリシー"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:10
-#, fuzzy
-#| msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgid "image:{project_images}/policy/view.png[alt=\"Policies\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
+msgstr "image:{project_images}/policy/view.png[alt=\"Policies\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:12
 msgid ""
-"On this tab, you can view the list of previously created policies as well as "
-"create and edit a policy."
-msgstr ""
+"On this tab, you can view the list of previously created policies as well as"
+" create and edit a policy."
+msgstr "このタブ上で、ポリシーの閲覧、作成、変更を行うことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:13
 msgid ""
-"To create a new policy, in the upper right corner of the policy list, select "
-"a policy type from the `Create policy` dropdown list. Details about each "
+"To create a new policy, in the upper right corner of the policy list, select"
+" a policy type from the `Create policy` dropdown list. Details about each "
 "policy type are described in this section."
 msgstr ""
+"新規ポリシーを作成するには、ポリシーのリストの右上の `Create policy` "
+"ドロップダウンリストからポリシータイプを選択します。それぞれのポリシータイプの詳細については本章で説明します。"

--- a/i18n/po/ja_JP/authorization_services/topics/policy-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,14 +26,14 @@ msgstr "ポリシーの管理"
 msgid ""
 "As mentioned previously, policies define the conditions that must be "
 "satisfied before granting access to an object."
-msgstr "前の章で述べたように、ポリシーはオブジェクトへのアクセスを与えられる前に満たすべきコンディションを定義します。"
+msgstr "前の章で述べたように、ポリシーはオブジェクトへのアクセスを与えられる前に満たすべき条件を定義します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:7
 msgid ""
 "You can view all policies associated with a resource server by clicking the "
 "*Policy* tab when editing a resource server."
-msgstr "リソースサーバーに関連付けられたポリシーを閲覧するには、リソースサーバーの設定画面上の *Policy* タブをクリックします。"
+msgstr "リソース・サーバーに関連付けられたポリシーを閲覧するには、リソース・サーバーの設定画面上の *Policy* タブをクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:8
@@ -52,7 +52,7 @@ msgstr "image:{project_images}/policy/view.png[alt=\"Policies\"]"
 msgid ""
 "On this tab, you can view the list of previously created policies as well as"
 " create and edit a policy."
-msgstr "このタブ上で、ポリシーの閲覧、作成、変更を行うことができます。"
+msgstr "このタブでは、ポリシーの閲覧、作成、変更を行うことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:13
@@ -62,4 +62,4 @@ msgid ""
 "policy type are described in this section."
 msgstr ""
 "新規ポリシーを作成するには、ポリシーのリストの右上の `Create policy` "
-"ドロップダウンリストからポリシータイプを選択します。それぞれのポリシータイプの詳細については本章で説明します。"
+"ドロップダウン・リストからポリシー・タイプを選択します。それぞれのポリシー・タイプの詳細については本章で説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__policy-overview/ja_JP/index.html
