### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -30,10 +30,10 @@ msgid ""
 "based on the OAuth2 access token previously issued by {project_name} to a "
 "specific client acting on behalf of an user or on its own behalf."
 msgstr ""
-"Requesting party token (RPT) は https://www.rfc-"
-"editor.org/rfc/rfc7515.txt[JSON web signature (JWS)] でデジタル署名された "
-"https://tools.ietf.org/html/rfc7519[JSON web token (JWT)] "
-"です。RPTは、{project_name}によって発行されたOAuth2アクセス・トークンをベースとして、ユーザーの代わりに動作する特定のクライアントに組み込まれます。"
+"Requesting party token（RPT）は https://www.rfc-editor.org/rfc/rfc7515.txt[JSON"
+" web signature（JWS）] でデジタル署名された https://tools.ietf.org/html/rfc7519[JSON web"
+" token（JWT）] "
+"です。RPTは、{project_name}によって発行されたOAuth2アクセストークンをベースとして、ユーザーの代わりに動作する特定のクライアントに組み込まれます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:8

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -1,39 +1,45 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/service-rpt-overview.adoc:2
 #, no-wrap
 msgid "Requesting Party Token"
-msgstr ""
+msgstr "Requesting Party Token"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:6
 msgid ""
-"A requesting party token (RPT) is a https://tools.ietf.org/html/rfc7519[JSON "
-"web token (JWT)] digitally signed using https://www.rfc-editor.org/rfc/"
-"rfc7515.txt[JSON web signature (JWS)]. The token is built based on the "
-"OAuth2 access token previously issued by {project_name} to a specific client "
-"acting on behalf of an user or on its own behalf."
+"A requesting party token (RPT) is a https://tools.ietf.org/html/rfc7519[JSON"
+" web token (JWT)] digitally signed using https://www.rfc-"
+"editor.org/rfc/rfc7515.txt[JSON web signature (JWS)]. The token is built "
+"based on the OAuth2 access token previously issued by {project_name} to a "
+"specific client acting on behalf of an user or on its own behalf."
 msgstr ""
+"Requesting party token (RPT) は https://www.rfc-"
+"editor.org/rfc/rfc7515.txt[JSON web signature (JWS)] でデジタル署名された "
+"https://tools.ietf.org/html/rfc7519[JSON web token (JWT)] です。 RPT "
+"は、{project_name} によって発行された OAuth2 "
+"アクセストークンをベースとして、ユーザーの代わりに動作する特定のクライアントに組み込まれます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:8
 msgid "When you decode an RPT, you see a payload similar to the following:"
-msgstr ""
+msgstr "RPT をデコードすると、次のようなペイロードが得られます："
 
 #. type: Code block
 #: source/authorization_services/topics/service-rpt-overview.adoc:27
@@ -57,13 +63,30 @@ msgid ""
 "  \"azp\": \"hello-world-authz-service\"\n"
 "}\n"
 msgstr ""
+"{\n"
+"  \"authorization\": {\n"
+"      \"permissions\": [\n"
+"        {\n"
+"          \"resource_set_id\": \"d2fe9843-6462-4bfc-baba-b5787bb6e0e7\",\n"
+"          \"resource_set_name\": \"Hello World Resource\"\n"
+"        }\n"
+"      ]\n"
+"  },\n"
+"  \"jti\": \"d6109a09-78fd-4998-bf89-95730dfd0892-1464906679405\",\n"
+"  \"exp\": 1464906971,\n"
+"  \"nbf\": 0,\n"
+"  \"iat\": 1464906671,\n"
+"  \"sub\": \"f1888f4d-5172-4359-be0c-af338505d86c\",\n"
+"  \"typ\": \"kc_ett\",\n"
+"  \"azp\": \"hello-world-authz-service\"\n"
+"}\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:30
 msgid ""
 "From this token you can obtain all permissions granted by the server from "
 "the *permissions* claim."
-msgstr ""
+msgstr "このトークンの *permissions* クレームから、サーバーによって与えられる全ての権限を取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:32
@@ -71,4 +94,4 @@ msgid ""
 "Also note that permissions are directly related with the resources/scopes "
 "you are protecting and complete decoupled from the access control methods "
 "that were used to actually grant and issue these same permissions."
-msgstr ""
+msgstr "権限は保護されたリソース/スコープに直接関連していますが、アクセスコントロールメソッドからは完全に独立していることに注意して下さい。"

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/authorization_services/topics/service-rpt-overview.adoc:2
 #, no-wrap
 msgid "Requesting Party Token"
-msgstr "Requesting Party Token"
+msgstr "リクエスティング・パーティ・トークン"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:6

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,9 +32,8 @@ msgid ""
 msgstr ""
 "Requesting party token (RPT) は https://www.rfc-"
 "editor.org/rfc/rfc7515.txt[JSON web signature (JWS)] でデジタル署名された "
-"https://tools.ietf.org/html/rfc7519[JSON web token (JWT)] です。 RPT "
-"は、{project_name} によって発行された OAuth2 "
-"アクセストークンをベースとして、ユーザーの代わりに動作する特定のクライアントに組み込まれます。"
+"https://tools.ietf.org/html/rfc7519[JSON web token (JWT)] "
+"です。RPTは、{project_name}によって発行されたOAuth2アクセス・トークンをベースとして、ユーザーの代わりに動作する特定のクライアントに組み込まれます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:8
@@ -86,7 +85,7 @@ msgstr ""
 msgid ""
 "From this token you can obtain all permissions granted by the server from "
 "the *permissions* claim."
-msgstr "このトークンの *permissions* クレームから、サーバーによって与えられる全ての権限を取得できます。"
+msgstr "このトークンの *permissions* クレームから、サーバーによって与えられる全てのパーミッションを取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-rpt-overview.adoc:32
@@ -94,4 +93,5 @@ msgid ""
 "Also note that permissions are directly related with the resources/scopes "
 "you are protecting and complete decoupled from the access control methods "
 "that were used to actually grant and issue these same permissions."
-msgstr "権限は保護されたリソース/スコープに直接関連していますが、アクセスコントロールメソッドからは完全に独立していることに注意して下さい。"
+msgstr ""
+"パーミッションは保護されたリソース/スコープに直接関連していますが、アクセス・コントロール・メソッドからは完全に独立していることに注意して下さい。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-rpt-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-rpt-overview/ja_JP/index.html
