### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
@@ -22,7 +22,7 @@ msgstr ""
 #: source/server_development/topics/providers.adoc:143
 #, no-wrap
 msgid "}\n"
-msgstr ""
+msgstr "}\n"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:196
@@ -34,46 +34,49 @@ msgid ""
 "    ...\n"
 "}\n"
 msgstr ""
+"    ...\n"
+"}\n"
 
 #. type: Title ==
 #: source/server_development/topics/extensions.adoc:3
 #, no-wrap
 msgid "Extending the Server"
-msgstr ""
+msgstr "サーバー拡張"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:7
 msgid ""
 "The {project_name} SPI framework offers the possibility to implement or "
-"override particular built-in providers. However {project_name} also provides "
-"capabilities to extend it's core functionalities and domain. This includes "
+"override particular built-in providers. However {project_name} also provides"
+" capabilities to extend it's core functionalities and domain. This includes "
 "possibilities to:"
 msgstr ""
+"{project_name}SPIフレームワークによって、特定のビルトイン・プロバイダーを実行、または上書きすることが可能になります。ただし、{project_name}でも、その主機能とドメインを拡張することはできます。このことによって、以下の項目も可能になります。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:9
 msgid "Add custom REST endpoints to the {project_name} server"
-msgstr ""
+msgstr "カスタムRESTエンドポイントを{project_name}サーバーに追加"
 
 #. type: Title ===
 #: source/server_development/topics/extensions.adoc:10
 #: source/server_development/topics/extensions.adoc:35
 #, no-wrap
 msgid "Add your own custom SPI"
-msgstr ""
+msgstr "独自のカスタムSPIを追加"
 
 #. type: Title ===
 #: source/server_development/topics/extensions.adoc:11
 #: source/server_development/topics/extensions.adoc:89
 #, no-wrap
 msgid "Add custom JPA entities to the {project_name} data model"
-msgstr ""
+msgstr "カスタムJPAエンティティを{project_name}データモデルへ追加"
 
 #. type: Title ===
 #: source/server_development/topics/extensions.adoc:13
 #, no-wrap
 msgid "Add custom REST endpoints"
-msgstr ""
+msgstr "カスタムRESTエンドポイントを追加"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:17
@@ -84,6 +87,7 @@ msgid ""
 "server, which is not available through the default set of built-in "
 "{project_name} REST endpoints."
 msgstr ""
+"これは大変強力な拡張機能で、独自のRESTエンドポイントを{project_name}サーバーにデプロイすることができます。これによって、あらゆる種類の拡張が可能になります。例えば、たとえば、{project_name}サーバー上で機能のトリガーとなる可能性があるものがあります。これについては、ビルトインの{project_name}RESTエンドポイントのデフォルトセットでは使用できません。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:19
@@ -92,25 +96,34 @@ msgid ""
 "`RealmResourceProviderFactory` and `RealmResourceProvider` interfaces. "
 "`RealmResourceProvider` has one important method:"
 msgstr ""
+"カスタムRESTエンドポイントを追加するには、 `RealmResourceProviderFactory` と "
+"`RealmResourceProvider` のインターフェイスを実行する必要があります。 `RealmResourceProvider` "
+"には、以下の通り、重要なメソッドが1つあります。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:24
 #, no-wrap
 msgid "Object getResource();\n"
-msgstr ""
+msgstr "Object getResource();\n"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:31
 msgid ""
-"which allows you to return an object, which acts as a https://github.com/jax-"
-"rs[JAX-RS Resource]. For more details, see the Javadoc and our examples.  "
-"There is a very simple example in the example distribution in `providers/"
-"rest` and there is a more advanced example in `providers/domain-extension`, "
-"which shows how to add an authenticated REST endpoint and other "
-"functionalities like <<extensions.adoc#_extensions_spi,Adding your own SPI>> "
-"or <<extensions.adoc#_extensions_jpa,Extending datamodel with your own JPA "
+"which allows you to return an object, which acts as a https://github.com"
+"/jax-rs[JAX-RS Resource]. For more details, see the Javadoc and our "
+"examples.  There is a very simple example in the example distribution in "
+"`providers/rest` and there is a more advanced example in `providers/domain-"
+"extension`, which shows how to add an authenticated REST endpoint and other "
+"functionalities like <<extensions.adoc#_extensions_spi,Adding your own SPI>>"
+" or <<extensions.adoc#_extensions_jpa,Extending datamodel with your own JPA "
 "entities>>."
 msgstr ""
+"配布物これによって、オブジェクトを返却し、https://github.com/jax-rs[JAX-RS "
+"Resource]として機能することができます。詳しくは、Javaのドキュメントとサンプルを参照ください。 `providers/rest` "
+"のサンプル配布物には非常に簡単なサンプルがあり、 `providers/domain-extension` "
+"にはさらに高度なサンプルがあります。この高度なサンプルによって、認証済みのRESTエンドポイントと、<<extensions.adoc#_extensions_spi,Adding"
+" your own SPI>>や<<extensions.adoc#_extensions_jpa,Extending datamodel with "
+"your own JPA entities>>のような、その他の機能が示されます。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:33
@@ -118,21 +131,27 @@ msgid ""
 "For details on how to package and deploy a custom provider, refer to the "
 "<<providers.adoc#_providers,Service Provider Interfaces>> chapter."
 msgstr ""
+"カスタム・プロバイダーをパッケージしてデプロイする方法について、詳しくは、<<providers.adoc#_providers,Service "
+"Provider Interfaces>>の章を参照ください。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:39
 msgid ""
-"This is useful especially with the <<extensions.adoc#_extensions_rest,Custom "
-"REST endpoints>>. To add your own kind of SPI, you need to implement the "
+"This is useful especially with the <<extensions.adoc#_extensions_rest,Custom"
+" REST endpoints>>. To add your own kind of SPI, you need to implement the "
 "interface `org.keycloak.provider.Spi` and define the ID of your SPI and the "
 "`ProviderFactory` and `Provider` classes. That looks like this:"
 msgstr ""
+"これは特に<<extensions.adoc#_extensions_rest,Custom REST "
+"endpoints>>を使用する際に便利です。独自のSPIを追加するには、you need to  "
+"`org.keycloak.provider.Spi` インターフェイスを実行してSPIのIDと `ProviderFactory` および "
+"`Provider` のクラスを定義する必要があります。そうすると、以下のように表示されます。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:43
 #, no-wrap
 msgid "package org.keycloak.examples.domainextension.spi;\n"
-msgstr ""
+msgstr "package org.keycloak.examples.domainextension.spi;\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:45
@@ -141,13 +160,13 @@ msgstr ""
 #: source/server_development/topics/providers.adoc:161
 #, no-wrap
 msgid "import ...\n"
-msgstr ""
+msgstr "import ...\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:47
 #, no-wrap
 msgid "public class ExampleSpi implements Spi {\n"
-msgstr ""
+msgstr "public class ExampleSpi implements Spi {\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:52
@@ -158,6 +177,10 @@ msgid ""
 "        return false;\n"
 "    }\n"
 msgstr ""
+"@Override\n"
+" public boolean isInternal() {\n"
+" return false;\n"
+" }\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:57
@@ -168,6 +191,10 @@ msgid ""
 "        return \"example\";\n"
 "    }\n"
 msgstr ""
+"@Override\n"
+" public String getName() {\n"
+" return \"example\";\n"
+" }\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:62
@@ -178,6 +205,10 @@ msgid ""
 "        return ExampleService.class;\n"
 "    }\n"
 msgstr ""
+"@Override\n"
+" public Class<? extends Provider> getProviderClass() {\n"
+" return ExampleService.class;\n"
+" }\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:68
@@ -189,19 +220,27 @@ msgid ""
 "        return ExampleServiceProviderFactory.class;\n"
 "    }\n"
 msgstr ""
+"@Override\n"
+" @SuppressWarnings(\"rawtypes\")\n"
+" public Class<? extends ProviderFactory> getProviderFactoryClass() {\n"
+" return ExampleServiceProviderFactory.class;\n"
+" }\n"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:74
 msgid ""
-"Then you need to create the file `META-INF/services/org.keycloak.provider."
-"Spi` and add the class of your SPI to it. For example:"
+"Then you need to create the file `META-"
+"INF/services/org.keycloak.provider.Spi` and add the class of your SPI to it."
+" For example:"
 msgstr ""
+"次に、 `META-INF/services/org.keycloak.provider.Spi` "
+"ファイルを作成し、そのファイルにSPIのクラスを追加する必要があります。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:78
 #, no-wrap
 msgid "org.keycloak.examples.domainextension.spi.ExampleSpi\n"
-msgstr ""
+msgstr "org.keycloak.examples.domainextension.spi.ExampleSpi\n"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:83
@@ -214,20 +253,29 @@ msgid ""
 "however `ExampleService` is scoped per-request (or more accurately per "
 "`KeycloakSession` lifecycle)."
 msgstr ""
+"次の手順では、`ExampleServiceProviderFactory` インターフィスを作成します。このインターフィスは、 `Provider` "
+"から拡張する `ProviderFactory` と `ExampleService` から拡張します。 `ExampleService` "
+"には通常、ユースケースのために必要なビジネスメソッドが含まれます。 `ExampleServiceProviderFactory` "
+"インスタンスは常にアプリケーション毎にスコープされます。ただし、 `ExampleService` "
+"はリクエスト毎にスコープされます（または、より厳密に言うと `KeycloakSession` ライフサイクル毎になります）。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:85
 msgid ""
-"Finally you need to implement your providers in the same manner as described "
-"in the <<providers.adoc#_providers,Service Provider Interfaces>> chapter."
+"Finally you need to implement your providers in the same manner as described"
+" in the <<providers.adoc#_providers,Service Provider Interfaces>> chapter."
 msgstr ""
+"最後に、<<providers.adoc#_providers,Service Provider "
+"Interfaces>>の章で説明したのと同じ方法で、プロバイダーを実装する必要があります。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:87
 msgid ""
-"For more details, take a look at the example distribution at `providers/"
-"domain-extension`, which shows an Example SPI similar to the one above."
+"For more details, take a look at the example distribution at `providers"
+"/domain-extension`, which shows an Example SPI similar to the one above."
 msgstr ""
+"詳しくは、 `providers/domain-extension` "
+"配布物のサンプルを参照ください。そこには、上記と同じようなSPIのサンプルが示されています。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:94
@@ -235,9 +283,11 @@ msgid ""
 "If the {project_name} data model does not exactly match your desired "
 "solution, or if you want to add some core functionality to {project_name}, "
 "or when you have your own REST endpoint, you might want to extend the "
-"{project_name} data model. We enable you to add your own JPA entities to the "
-"{project_name} JPA `EntityManager` ."
+"{project_name} data model. We enable you to add your own JPA entities to the"
+" {project_name} JPA `EntityManager` ."
 msgstr ""
+"{project_name}データモデルが思い描いていたソリューションとは厳密には違っていた場合、または主機能を{project_name}に追加する場合、もしくは独自のRESTエンドポイントがある場合、{project_name}データモデルの拡張が検討されるかもしれません。独自のJPAエンティティを{project_name}JPA"
+" `EntityManager` へ追加することが可能になりました。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:97
@@ -248,12 +298,16 @@ msgid ""
 "location and id of the liquibase changelog. An example implementation can "
 "look like this:"
 msgstr ""
+"独自のJPAエンティティを追加するには、 `JpaEntityProviderFactory` と `JpaEntityProvider` "
+"を実装する必要があります。 `JpaEntityProvider` "
+"によって、カスタムJPAエンティティのリストを返し、liquibase変更履歴の場所とidを指定することができます。 "
+"実装サンプルは、以下の通りになります。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:101
 #, no-wrap
 msgid "public class ExampleJpaEntityProvider implements JpaEntityProvider {\n"
-msgstr ""
+msgstr "public class ExampleJpaEntityProvider implements JpaEntityProvider {\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:107
@@ -265,6 +319,11 @@ msgid ""
 "        return Collections.<Class<?>>singletonList(Company.class);\n"
 "    }\n"
 msgstr ""
+"// List of your JPA entities.\n"
+" @Override\n"
+" public List<Class<?>> getEntities() {\n"
+" return Collections.<Class<?>>singletonList(Company.class);\n"
+" }\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:114
@@ -277,6 +336,12 @@ msgid ""
 "    \treturn \"META-INF/example-changelog.xml\";\n"
 "    }\n"
 msgstr ""
+"// This is used to return the location of the Liquibase changelog file.\n"
+" // You can return null if you don't want Liquibase to create and update the DB schema.\n"
+" @Override\n"
+" public String getChangelogLocation() {\n"
+" \treturn \"META-INF/example-changelog.xml\";\n"
+" }\n"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:120
@@ -288,6 +353,11 @@ msgid ""
 "        return \"sample\";\n"
 "    }\n"
 msgstr ""
+"// Helper method, which will be used internally by Liquibase.\n"
+" @Override\n"
+" public String getFactoryId() {\n"
+" return \"sample\";\n"
+" }\n"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:127
@@ -296,6 +366,9 @@ msgid ""
 "`Company`. In the code of your REST endpoint, you can then use something "
 "like this to retrieve `EntityManager` and call DB operations on it."
 msgstr ""
+"上記のサンプルに、 `Company` "
+"クラスによって表現された単一のJPAエンティティを追加しました。次に、RESTエンドポイントのコード内で、これと同じようなものを使用して "
+"`EntityManager` を取得し、その上でDBオペレーションを呼び出すことができます。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:133
@@ -304,35 +377,44 @@ msgid ""
 "EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();\n"
 "Company myCompany = em.find(Company.class, \"123\");\n"
 msgstr ""
+"EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();\n"
+"Company myCompany = em.find(Company.class, \"123\");\n"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:143
 msgid ""
 "The methods `getChangelogLocation` and `getFactoryId` are important to "
-"support automatic updating of your entities by Liquibase. http://www."
-"liquibase.org/[Liquibase] is a framework for updating the database schema, "
-"which {project_name} internally uses to create the DB schema and update the "
-"DB schema among versions. You may need to use it as well and create a "
-"changelog for your entities. Note that versioning of your own liquibase "
-"changelog is independent of {project_name} versions. In other words, when "
-"you update to a new {project_name} version, you are not forced to update "
-"your schema at the same time. And vice versa, you can update your schema "
-"even without updating the {project_name} version. The Liquibase update is "
-"always done at the server startup, so to trigger a DB update of your schema, "
-"you just need to add the new changeset to your liquibase changelog file (in "
-"the example above it's the file `META-INF/example-changelog.xml` (which must "
-"be packed in same JAR as the JPA entities and `ExampleJpaEntityProvider`) "
-"and then restart server.  The DB schema will be automatically updated at "
-"startup."
+"support automatic updating of your entities by Liquibase. "
+"http://www.liquibase.org/[Liquibase] is a framework for updating the "
+"database schema, which {project_name} internally uses to create the DB "
+"schema and update the DB schema among versions. You may need to use it as "
+"well and create a changelog for your entities. Note that versioning of your "
+"own liquibase changelog is independent of {project_name} versions. In other "
+"words, when you update to a new {project_name} version, you are not forced "
+"to update your schema at the same time. And vice versa, you can update your "
+"schema even without updating the {project_name} version. The Liquibase "
+"update is always done at the server startup, so to trigger a DB update of "
+"your schema, you just need to add the new changeset to your liquibase "
+"changelog file (in the example above it's the file `META-INF/example-"
+"changelog.xml` (which must be packed in same JAR as the JPA entities and "
+"`ExampleJpaEntityProvider`) and then restart server.  The DB schema will be "
+"automatically updated at startup."
 msgstr ""
+"`getChangelogLocation` と `getFactoryId` "
+"のメソッドは、Liquibaseでエンティティを自動的に更新するのをサポートするために重要です。http://www.liquibase.org/[Liquibase]はデータベース・スキーマを更新するためのフレームワークです。これは{project_name}で内部的に使用され、DBスキーマを作成してバージョン間でDBスキーマを更新します。これを同じように使用して、エンティティの変更履歴を作成する必要があるかもしれません。独自のliquibaseの変更履歴のバージョニングは{project_name}のバージョンとは異なる独立したものであることに注意してください。つまり、新しい{project_name}バージョンへ更新した際、同時にスキーマを更新する必要はありません。また、その逆の場合でも、{project_name}バージョンを更新しなくてもスキーマを更新することができます。Liquibaseの更新は常にサーバー起動時に実行されるので、スキーマのDB更新のトリガーとなるには、新しい変更セットをliquibaseの変更履歴ファイルへ追加するだけです（上記のサンプルでは、これは"
+" `META-INF/example-changelog.xml` ファイルになります。これは同じJAR内でJPAエンティティと "
+"`ExampleJpaEntityProvider` "
+"として含まれているはずです）。これで次に、再起動します。起動時に、DBスキーマが自動的に更新されます。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:145
 msgid ""
 "For more details, take a look at the example distribution at example "
-"`providers/domain-extension`, which shows the `ExampleJpaEntityProvider` and "
-"`example-changelog.xml` described above."
+"`providers/domain-extension`, which shows the `ExampleJpaEntityProvider` and"
+" `example-changelog.xml` described above."
 msgstr ""
+"詳しくは、 `providers/domain-extension` サンプル内のサンプル配布物を参照ください。そこでは、上記で説明された "
+"`ExampleJpaEntityProvider` と `example-changelog.xml` のサンプルが示されています。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:147
@@ -340,3 +422,4 @@ msgid ""
 "Don't forget to always backup your database before doing any changes in the "
 "Liquibase changelog and triggering a DB update."
 msgstr ""
+"Liquibase変更履歴に変更を加えたりDBの更新をトリガーにする前に、必ずデータベースをバックアップすることを忘れないようにしてください。"

--- a/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
@@ -41,7 +41,7 @@ msgstr ""
 #: source/server_development/topics/extensions.adoc:3
 #, no-wrap
 msgid "Extending the Server"
-msgstr "サーバー拡張"
+msgstr "サーバーの拡張"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:7
@@ -51,7 +51,7 @@ msgid ""
 " capabilities to extend it's core functionalities and domain. This includes "
 "possibilities to:"
 msgstr ""
-"{project_name}SPIフレームワークによって、特定のビルトイン・プロバイダーを実行、または上書きすることが可能になります。ただし、{project_name}でも、その主機能とドメインを拡張することはできます。このことによって、以下の項目も可能になります。"
+"{project_name}SPIフレームワークによって、特定のビルトイン・プロバイダーを実装、またはオーバーライドすることが可能になります。ただし、{project_name}でも、その主機能とドメインを拡張することはできます。これにより、以下も可能になります。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:9
@@ -70,7 +70,7 @@ msgstr "独自のカスタムSPIを追加"
 #: source/server_development/topics/extensions.adoc:89
 #, no-wrap
 msgid "Add custom JPA entities to the {project_name} data model"
-msgstr "カスタムJPAエンティティを{project_name}データモデルへ追加"
+msgstr "カスタムJPAエンティティーを{project_name}データモデルへ追加"
 
 #. type: Title ===
 #: source/server_development/topics/extensions.adoc:13
@@ -87,7 +87,7 @@ msgid ""
 "server, which is not available through the default set of built-in "
 "{project_name} REST endpoints."
 msgstr ""
-"これは大変強力な拡張機能で、独自のRESTエンドポイントを{project_name}サーバーにデプロイすることができます。これによって、あらゆる種類の拡張が可能になります。例えば、たとえば、{project_name}サーバー上で機能のトリガーとなる可能性があるものがあります。これについては、ビルトインの{project_name}RESTエンドポイントのデフォルトセットでは使用できません。"
+"これは大変強力な拡張機能で、独自のRESTエンドポイントを{project_name}サーバーにデプロイすることができます。これによって、あらゆる種類の拡張が可能になります。例えば、{project_name}サーバー上の機能を起動すことができます。これについては、ビルトインの{project_name}RESTエンドポイントのデフォルトセットでは利用できません。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:19
@@ -97,7 +97,7 @@ msgid ""
 "`RealmResourceProvider` has one important method:"
 msgstr ""
 "カスタムRESTエンドポイントを追加するには、 `RealmResourceProviderFactory` と "
-"`RealmResourceProvider` のインターフェイスを実行する必要があります。 `RealmResourceProvider` "
+"`RealmResourceProvider` のインターフェイスを実装する必要があります。 `RealmResourceProvider` "
 "には、以下の通り、重要なメソッドが1つあります。"
 
 #. type: delimited block -
@@ -118,12 +118,10 @@ msgid ""
 " or <<extensions.adoc#_extensions_jpa,Extending datamodel with your own JPA "
 "entities>>."
 msgstr ""
-"配布物これによって、オブジェクトを返却し、https://github.com/jax-rs[JAX-RS "
-"Resource]として機能することができます。詳しくは、Javaのドキュメントとサンプルを参照ください。 `providers/rest` "
+"これによって、オブジェクトを返却し、https://github.com/jax-rs[JAX-RS "
+"Resource]として機能することができます。詳しくは、Javadocとサンプルを参照ください。 `providers/rest` "
 "のサンプル配布物には非常に簡単なサンプルがあり、 `providers/domain-extension` "
-"にはさらに高度なサンプルがあります。この高度なサンプルによって、認証済みのRESTエンドポイントと、<<extensions.adoc#_extensions_spi,Adding"
-" your own SPI>>や<<extensions.adoc#_extensions_jpa,Extending datamodel with "
-"your own JPA entities>>のような、その他の機能が示されます。"
+"にはさらに高度なサンプルがあります。この高度なサンプルによって、認証済みのRESTエンドポイントと、<<extensions.adoc#_extensions_spi,独自のSPIを追加する>>や<<extensions.adoc#_extensions_jpa,独自のJPAエンティティーでデータモデルを拡張する>>のような、その他の機能を追加する方法が示されます。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:33
@@ -131,8 +129,7 @@ msgid ""
 "For details on how to package and deploy a custom provider, refer to the "
 "<<providers.adoc#_providers,Service Provider Interfaces>> chapter."
 msgstr ""
-"カスタム・プロバイダーをパッケージしてデプロイする方法について、詳しくは、<<providers.adoc#_providers,Service "
-"Provider Interfaces>>の章を参照ください。"
+"カスタム・プロバイダーをパッケージングしてデプロイする方法についての詳細は、<<providers.adoc#_providers,サービス・プロバイダー・インタフェース>>の章を参照ください。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:39
@@ -143,9 +140,9 @@ msgid ""
 "`ProviderFactory` and `Provider` classes. That looks like this:"
 msgstr ""
 "これは特に<<extensions.adoc#_extensions_rest,Custom REST "
-"endpoints>>を使用する際に便利です。独自のSPIを追加するには、you need to  "
-"`org.keycloak.provider.Spi` インターフェイスを実行してSPIのIDと `ProviderFactory` および "
-"`Provider` のクラスを定義する必要があります。そうすると、以下のように表示されます。"
+"endpoints>>を使用する際に便利です。独自のSPIを追加するには、 `org.keycloak.provider.Spi` "
+"インターフェイスを実装して、SPIのIDと `ProviderFactory` および `Provider` "
+"のクラスを定義する必要があります。以下のようになります。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:43
@@ -234,7 +231,7 @@ msgid ""
 " For example:"
 msgstr ""
 "次に、 `META-INF/services/org.keycloak.provider.Spi` "
-"ファイルを作成し、そのファイルにSPIのクラスを追加する必要があります。"
+"ファイルを作成し、そのファイルにSPIのクラスを追加する必要があります。例えば、"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:78
@@ -254,8 +251,8 @@ msgid ""
 "`KeycloakSession` lifecycle)."
 msgstr ""
 "次の手順では、`ExampleServiceProviderFactory` インターフィスを作成します。このインターフィスは、 `Provider` "
-"から拡張する `ProviderFactory` と `ExampleService` から拡張します。 `ExampleService` "
-"には通常、ユースケースのために必要なビジネスメソッドが含まれます。 `ExampleServiceProviderFactory` "
+"を継承する `ProviderFactory` と `ExampleService` を継承します。 `ExampleService` "
+"には通常、ユースケースで必要なビジネスメソッドが含まれます。 `ExampleServiceProviderFactory` "
 "インスタンスは常にアプリケーション毎にスコープされます。ただし、 `ExampleService` "
 "はリクエスト毎にスコープされます（または、より厳密に言うと `KeycloakSession` ライフサイクル毎になります）。"
 
@@ -265,8 +262,7 @@ msgid ""
 "Finally you need to implement your providers in the same manner as described"
 " in the <<providers.adoc#_providers,Service Provider Interfaces>> chapter."
 msgstr ""
-"最後に、<<providers.adoc#_providers,Service Provider "
-"Interfaces>>の章で説明したのと同じ方法で、プロバイダーを実装する必要があります。"
+"最後に、<<providers.adoc#_providers,サービス・プロバイダー・インタフェース>>の章で説明したのと同じ方法で、プロバイダーを実装する必要があります。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:87
@@ -286,7 +282,7 @@ msgid ""
 "{project_name} data model. We enable you to add your own JPA entities to the"
 " {project_name} JPA `EntityManager` ."
 msgstr ""
-"{project_name}データモデルが思い描いていたソリューションとは厳密には違っていた場合、または主機能を{project_name}に追加する場合、もしくは独自のRESTエンドポイントがある場合、{project_name}データモデルの拡張が検討されるかもしれません。独自のJPAエンティティを{project_name}JPA"
+"{project_name}データモデルが要求するソリューションとは厳密には違っていた場合、またはコアの機能を{project_name}に追加する場合、もしくは独自のRESTエンドポイントがある場合、{project_name}データモデルの拡張が検討されるかもしれません。独自のJPAエンティティーを{project_name}JPA"
 " `EntityManager` へ追加することが可能になりました。"
 
 #. type: Plain text
@@ -299,9 +295,8 @@ msgid ""
 "look like this:"
 msgstr ""
 "独自のJPAエンティティを追加するには、 `JpaEntityProviderFactory` と `JpaEntityProvider` "
-"を実装する必要があります。 `JpaEntityProvider` "
-"によって、カスタムJPAエンティティのリストを返し、liquibase変更履歴の場所とidを指定することができます。 "
-"実装サンプルは、以下の通りになります。"
+"を実装する必要があります。 `JpaEntityProvider` によって、カスタムJPAエンティティのリストを返し、Liquibase "
+"の変更履歴の場所とidを提供することができます。 実装サンプルは、以下の通りになります。"
 
 #. type: delimited block -
 #: source/server_development/topics/extensions.adoc:101
@@ -401,10 +396,10 @@ msgid ""
 "automatically updated at startup."
 msgstr ""
 "`getChangelogLocation` と `getFactoryId` "
-"のメソッドは、Liquibaseでエンティティを自動的に更新するのをサポートするために重要です。http://www.liquibase.org/[Liquibase]はデータベース・スキーマを更新するためのフレームワークです。これは{project_name}で内部的に使用され、DBスキーマを作成してバージョン間でDBスキーマを更新します。これを同じように使用して、エンティティの変更履歴を作成する必要があるかもしれません。独自のliquibaseの変更履歴のバージョニングは{project_name}のバージョンとは異なる独立したものであることに注意してください。つまり、新しい{project_name}バージョンへ更新した際、同時にスキーマを更新する必要はありません。また、その逆の場合でも、{project_name}バージョンを更新しなくてもスキーマを更新することができます。Liquibaseの更新は常にサーバー起動時に実行されるので、スキーマのDB更新のトリガーとなるには、新しい変更セットをliquibaseの変更履歴ファイルへ追加するだけです（上記のサンプルでは、これは"
-" `META-INF/example-changelog.xml` ファイルになります。これは同じJAR内でJPAエンティティと "
-"`ExampleJpaEntityProvider` "
-"として含まれているはずです）。これで次に、再起動します。起動時に、DBスキーマが自動的に更新されます。"
+"のメソッドは、Liquibaseによるエンティティの自動更新をサポートするために重要です。http://www.liquibase.org/[Liquibase]はデータベース・スキーマを更新するためのフレームワークです。これは{project_name}で内部的に使用され、DBスキーマを作成してバージョン間でDBスキーマを更新します。これを同じように使用して、エンティティの変更履歴を作成する必要があるかもしれません。独自のLiquibaseの変更履歴のバージョニングは{project_name}のバージョンとは異なる独立したものであることに注意してください。つまり、新しい{project_name}バージョンへ更新した際、同時にスキーマを更新する必要はありません。また、その逆の場合でも、{project_name}バージョンを更新しなくてもスキーマを更新することができます。Liquibaseの更新は常にサーバー起動時に実行されるので、新しい変更セットをLiquibaseの変更履歴ファイル（上記のサンプルでは、これは"
+" `META-INF/example-changelog.xml` "
+"ファイル（これは同じJAR内にJPAエンティティとして含まれていなければなりません）と `ExampleJpaEntityProvider` "
+"になります）へ追加して再起動するだけで、スキーマのDB更新のトリガーとなります。起動時に、DBスキーマが自動的に更新されます。"
 
 #. type: Plain text
 #: source/server_development/topics/extensions.adoc:145
@@ -421,5 +416,4 @@ msgstr ""
 msgid ""
 "Don't forget to always backup your database before doing any changes in the "
 "Liquibase changelog and triggering a DB update."
-msgstr ""
-"Liquibase変更履歴に変更を加えたりDBの更新をトリガーにする前に、必ずデータベースをバックアップすることを忘れないようにしてください。"
+msgstr "Liquibase変更履歴に変更を加えたりDBの更新をトリガーにする前に、必ずデータベースをバックアップするようにしてください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__extensions/ja_JP/index.html
