### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
@@ -1,18 +1,19 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/server_installation__topics__config-"
-"subsystem__configure-spi-providers.ja_JP.po\n"
 
 #. type: Title ===
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:3
@@ -27,8 +28,7 @@ msgid ""
 "context with that setting.  However, it is useful to understand the format "
 "used to declare settings on SPI providers."
 msgstr ""
-"各設定の詳細については、その設定と関連する別の箇所でご説明します。ただし、SPI"
-"プロバイダー設定の宣言に使用される形式について学ぶことをおすすめします。"
+"各設定の詳細については、その設定と関連する別の箇所でご説明します。ただし、SPIプロバイダー設定の宣言に使用される形式について学ぶことをおすすめします。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:13
@@ -38,9 +38,8 @@ msgid ""
 "allowed to swap out implementations of each SPI.  An implementation of an "
 "SPI is known as a _provider_."
 msgstr ""
-"{project_name}は、柔軟性に優れた、高度なモジュールシステムです。50以上のサー"
-"ビス・プロバイダー・インターフェイス、いわゆるSPIs、があり、各SPIの実装をス"
-"ワップアウトすることができます。SPIの実装は _provider_ によって行われます。"
+"{project_name}は、柔軟性に優れた、高度なモジュールシステムです。50以上のサービス・プロバイダー・インターフェイス（いわゆるSPI）があり、各SPIの実装を交換することができます。SPIの実装は"
+" _provider_ によって行われます。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:16
@@ -90,22 +89,19 @@ msgid ""
 "how it will treat this setting.  Some SPIs allow more than one provider and "
 "some do not.  So `default-provider` can help the SPI to choose."
 msgstr ""
-"ここでは、SPI `myspi` に2つのプロバイダーが定義されています。 `default-"
-"provider` は `myprovider` と表示されています。しかし、この設定をどのように処"
-"理するかは、SPIが決定します。SPIによって複数のプロバイダーを許可するものもあ"
-"れば、そうでないものもあります。だからこそ `default-provider` によりSPIは決定"
-"しやすくなります。"
+"ここでは、SPI `myspi` に2つのプロバイダーが定義されています。 `default-provider` は `myprovider` "
+"と表示されています。しかし、この設定をどのように処理するかはSPIが決定します。SPIによって複数のプロバイダーを許可するものもあれば、そうでないものもあります。そのため、"
+" `default-provider`はSPIの選択の手助けになります。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:40
 msgid ""
 "Also notice that each provider defines its own set of configuration "
-"properties.  The fact that both providers above have a property called `foo` "
-"is just a coincidence."
+"properties.  The fact that both providers above have a property called `foo`"
+" is just a coincidence."
 msgstr ""
-"また、各プロバイダーが独自の設定プロパティを定義することについてもご注意くだ"
-"さい。上記の両方のプロバイダーが `foo` というプロパティをもっている点は単なる"
-"偶然です。"
+"また、各プロバイダーが独自の設定プロパティを定義することについてもご注意ください。上記の両方のプロバイダーが `foo` "
+"というプロパティをもっている点は単なる偶然です。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:43
@@ -114,9 +110,8 @@ msgid ""
 "there is one exception.  Consider the `jpa` provider for the `eventStore` "
 "API:"
 msgstr ""
-"プロパティ値のタイプはそれぞれプロバイダーによって解釈されます。ただし、1つ例"
-"外があります。 `eventStore` アプリケーションプログラミング・インタフェース、"
-"いわゆるAPI、の `jpa` プロバイダーについて確認してみましょう。"
+"プロパティ値のタイプはそれぞれプロバイダーによって解釈されます。ただし、1つ例外があります。 `eventStore` APIの `jpa` "
+"プロバイダーについて確認してみましょう。"
 
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:53
@@ -143,15 +138,14 @@ msgstr ""
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:58
 msgid ""
-"We see that the value begins and ends with square brackets.  That means that "
-"the value will be passed to the provider as a list.  In this example, the "
+"We see that the value begins and ends with square brackets.  That means that"
+" the value will be passed to the provider as a list.  In this example, the "
 "system will pass the provider a list with two element values _EVENT1_ and "
 "_EVENT2_. To add more values to the list, just separate each list element "
 "with a comma. Unfortunately, you do need to escape the quotes surrounding "
 "each list element with `\\&quot;`."
 msgstr ""
-"この値は角括弧で始まり、角括弧で終わることがわかります。これは、値がリストと"
-"してプロバイダーに渡されることを意味します。このサンプルでは、2つの要素値 "
-"_EVENT1_ と _EVENT2_ のリストはシステムからプロバイダーに渡されます。リストに"
-"値を追加するには、各リスト要素をコンマで区切ります。残念ながら、各リスト要素"
-"を囲む引用符を `\\&quot;` にエスケープする必要があります。"
+"この値は角括弧で始まり、角括弧で終わることがわかります。これは、値がリストとしてプロバイダーに渡されることを意味します。このサンプルでは、2つの要素値 "
+"_EVENT1_ と _EVENT2_ "
+"のリストはシステムからプロバイダーに渡されます。リストに値を追加するには、各リスト要素をカンマで区切ります。残念ながら、各リスト要素を囲む引用符を "
+"`\\&quot;` にエスケープする必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__configure-spi-providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__config-subsystem__configure-spi-providers/ja_JP/index.html
