### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -15,48 +15,31 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Title =====
+#, no-wrap
+msgid "Adapter Installation"
+msgstr "アダプターのインストール"
+
 #. type: Block title
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:95
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:113
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:56
 #, no-wrap
 msgid "Wildfly 11"
 msgstr "Wildfly 11"
 
 #. type: Block title
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:102
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:120
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:63
 #, no-wrap
 msgid "Any other server but Wildfly 11"
 msgstr "Wildfly 11以外の他のサーバー"
 
-#. type: Title =====
-#: source/securing_apps/topics/oidc/java/jetty8-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/spring-boot-adapter.adoc:8
-#: source/securing_apps/topics/oidc/java/spring-security-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:10
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:40
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.adoc:3
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:3
-#, no-wrap
-msgid "Adapter Installation"
-msgstr "アダプターのインストール"
-
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:6
 msgid ""
 "Each adapter is a separate download on the {project_name} download site."
 msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:9
 msgid "Install on Wildfly 9 or 10, 11 or JBoss EAP 7:"
 msgstr "Wildfly 9、10、11、またはJBoss EAP 7へのインストールは次のとおりです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:15
 #, no-wrap
 msgid ""
 "$ cd $WILDFLY_HOME\n"
@@ -66,13 +49,10 @@ msgstr ""
 "$ unzip keycloak-saml-wildfly-adapter-dist.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:21
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:31
 msgid "Install on JBoss EAP 6.x:"
 msgstr "JBoss EAP 6.xへのインストールは次のとおりです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:26
 #, no-wrap
 msgid ""
 "$ cd $JBOSS_HOME\n"
@@ -82,7 +62,6 @@ msgstr ""
 "$ unzip keycloak-saml-eap6-adapter-dist.zip\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:36
 #, no-wrap
 msgid ""
 "$ cd $JBOSS_HOME\n"
@@ -92,12 +71,10 @@ msgstr ""
 "$ unzip rh-sso-saml-eap6-adapter.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:39
 msgid "Install on JBoss EAP 7.x:"
 msgstr "JBoss EAP 7.xへのインストールは次のとおりです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:44
 #, no-wrap
 msgid ""
 "$ cd $JBOSS_HOME\n"
@@ -107,7 +84,6 @@ msgstr ""
 "$ unzip rh-sso-saml-eap7-adapter.zip\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:49
 msgid ""
 "These zip files create new JBoss Modules specific to the Wildfly/JBoss EAP "
 "SAML Adapter within your Wildfly or JBoss EAP distro."
@@ -116,7 +92,6 @@ msgstr ""
 "SAMLアダプターに固有の新しいJBossモジュールを作成します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:51
 msgid ""
 "After adding the modules, you must then enable the {project_name} SAML "
 "Subsystem within your app server's server configuration: `domain.xml` or "
@@ -126,14 +101,12 @@ msgstr ""
 "内にある{project_name} SAMLサブシステムを有効にする必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:54
 msgid ""
 "There is a CLI script that will help you modify your server configuration.  "
 "Start the server and run the script from the server's bin directory:"
 msgstr "サーバー設定の変更に役立つCLIスクリプトがあります。サーバーを起動し、サーバーの `bin` ディレクトリからスクリプトを実行します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:60
 #, no-wrap
 msgid "$ ./bin/jboss-cli.sh --file=adapter-elytron-install-saml.cli\n"
 msgstr ""
@@ -141,7 +114,6 @@ msgstr ""
 "$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:69
 #, no-wrap
 msgid ""
 "$ cd $JBOSS_HOME/bin\n"
@@ -151,20 +123,17 @@ msgstr ""
 "$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:71
 msgid ""
 "The script will add the extension, subsystem, and optional security-domain "
 "as described below."
 msgstr "スクリプトは、以下に説明するように、extension、subsystem、オプションでsecurity-domainを追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:75
 #, no-wrap
 msgid "<server xmlns=\"urn:jboss:domain:1.4\">\n"
 msgstr "<server xmlns=\"urn:jboss:domain:1.4\">\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:80
 #, no-wrap
 msgid ""
 "    <extensions>\n"
@@ -178,7 +147,6 @@ msgstr ""
 "    </extensions>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:85
 #, no-wrap
 msgid ""
 "    <profile>\n"
@@ -192,7 +160,6 @@ msgstr ""
 "    </profile>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:90
 msgid ""
 "The `keycloak` security domain should be used with EJBs and other components"
 " when you need the security context created in the secured web tier to be "
@@ -203,7 +170,6 @@ msgstr ""
 "`keycloak` セキュリティ・ドメインをEJBなどのコンポーネントとともに使用する必要があります。それ以外の場合、この設定はオプションです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:105
 #, no-wrap
 msgid ""
 "<server xmlns=\"urn:jboss:domain:1.4\">\n"
@@ -231,7 +197,6 @@ msgstr ""
 "    </security-domains>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:109
 msgid ""
 "For example, if you have a JAX-RS service that is an EJB within your WEB-"
 "INF/classes directory, you'll want to annotate it with the `@SecurityDomain`"
@@ -241,7 +206,6 @@ msgstr ""
 "`@SecurityDomain` アノテーションを付けます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:115
 #, no-wrap
 msgid ""
 "import org.jboss.ejb3.annotation.SecurityDomain;\n"
@@ -251,7 +215,6 @@ msgstr ""
 "import org.jboss.resteasy.annotations.cache.NoCache;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:124
 #, no-wrap
 msgid ""
 "import javax.annotation.security.RolesAllowed;\n"
@@ -273,7 +236,6 @@ msgstr ""
 "import java.util.List;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:129
 #, no-wrap
 msgid ""
 "@Path(\"customers\")\n"
@@ -287,7 +249,6 @@ msgstr ""
 "public class CustomerService {\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:132
 #, no-wrap
 msgid ""
 "    @EJB\n"
@@ -297,7 +258,6 @@ msgstr ""
 "    CustomerDB db;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:141
 #, no-wrap
 msgid ""
 "    @GET\n"
@@ -319,7 +279,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.adoc:145
 msgid ""
 "We hope to improve our integration in the future so that you don't have to "
 "specify the `@SecurityDomain` annotation when you want to propagate a "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation/ja_JP/index.html
