### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
@@ -15,40 +15,33 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
-#: source/server_installation/topics/operating-mode/standalone.adoc:3
-#: source/server_installation/topics/clustering/booting.adoc:6
-#, no-wrap
-msgid "Standalone Mode"
-msgstr "スタンドアロン・モード"
-
 #. type: Title ===
-#: source/server_installation/topics/clustering/booting.adoc:2
 #, no-wrap
 msgid "Booting the Cluster"
 msgstr "クラスターの起動"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/booting.adoc:5
 msgid ""
 "Booting {project_name} in a cluster depends on your <<_operating-mode, "
 "operating mode>>"
 msgstr "クラスター内での{project_name}の起動は<<_operating-mode, 動作モード>>によって異なります。"
 
+#. type: Title ===
+#, no-wrap
+msgid "Standalone Mode"
+msgstr "スタンドアロン・モード"
+
 #. type: delimited block -
-#: source/server_installation/topics/clustering/booting.adoc:10
 #, no-wrap
 msgid "$ bin/standalone.sh --server-config=standalone-ha.xml\n"
 msgstr "$ bin/standalone.sh --server-config=standalone-ha.xml\n"
 
 #. type: Block title
-#: source/server_installation/topics/clustering/booting.adoc:12
 #, no-wrap
 msgid "Domain Mode"
 msgstr "ドメイン・モード"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/booting.adoc:17
 #, no-wrap
 msgid ""
 "$ bin/domain.sh --host-config=host-master.xml\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__booting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__clustering__booting/ja_JP/index.html
