### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,15 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Attribute :installguide_profile_name:
-#: source/server_installation/topics/profiles.adoc:3
-#: source/topics/templates/document-attributes-community.adoc:32
-#: source/topics/templates/document-attributes-product.adoc:32
 #, no-wrap
 msgid "Profiles"
 msgstr "プロファイル"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:8
 msgid ""
 "{project_name} has a single profile, community, that enables most features "
 "by default, including features that are considered less mature. It is "
@@ -33,112 +29,71 @@ msgstr ""
 "{project_name}には、成熟度が低いと考えられる機能を含め、デフォルトですべての機能を有効にするcommunityプロファイルがあります。ただし、個々の機能を無効にすることは可能です。"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:10
-#: source/server_installation/topics/profiles.adoc:57
 msgid "The features that can be enabled and disabled are:"
 msgstr "有効および無効にできる機能は、以下のとおりです。"
 
 #. type: Named 'cols' AttributeList argument for style 'cols'
-#: source/server_installation/topics/profiles.adoc:11
-#: source/server_installation/topics/profiles.adoc:58
 #, no-wrap
 msgid "3*"
 msgstr "3*"
 
 #. type: Labeled list
-#: source/server_installation/topics/profiles.adoc:14
-#: source/server_installation/topics/profiles.adoc:61
-#: source/server_admin/topics/clients/client-saml.adoc:38
 #, no-wrap
 msgid "Name"
 msgstr "名前"
 
 #. type: Labeled list
-#: source/server_installation/topics/profiles.adoc:15
-#: source/server_installation/topics/profiles.adoc:62
-#: source/server_admin/topics/clients/client-saml.adoc:43
 #, no-wrap
 msgid "Description"
 msgstr "説明"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:16
-#: source/server_installation/topics/profiles.adoc:63
 msgid "Enabled by default"
 msgstr "デフォルトで有効"
 
 #. type: Labeled list
-#: source/server_installation/topics/profiles.adoc:18
-#: source/server_installation/topics/profiles.adoc:65
-#: source/server_admin/topics/overview/concepts.adoc:12
 #, no-wrap
 msgid "authorization"
 msgstr "authorization"
 
 #. type: Title =
-#: source/server_installation/topics/profiles.adoc:19
-#: source/server_installation/topics/profiles.adoc:66
-#: source/authorization_services/topics/auth-services-architecture.adoc:84
-#: source/authorization_services/topics/service-overview.adoc:2
 #, no-wrap
 msgid "Authorization Services"
 msgstr "認可サービス"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:20
-#: source/server_installation/topics/profiles.adoc:28
-#: source/server_installation/topics/profiles.adoc:32
-#: source/server_installation/topics/profiles.adoc:75
 msgid "Yes"
 msgstr "Yes"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:22
-#: source/server_installation/topics/profiles.adoc:69
 msgid "docker"
 msgstr "docker"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:23
-#: source/server_installation/topics/profiles.adoc:70
 msgid "Docker Registry protocol"
 msgstr "Dockerレジストリーのプロトコル"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:24
-#: source/server_installation/topics/profiles.adoc:67
-#: source/server_installation/topics/profiles.adoc:71
-#: source/server_installation/topics/profiles.adoc:79
 msgid "No"
 msgstr "No"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:26
-#: source/server_installation/topics/profiles.adoc:73
-#: source/server_admin/topics/admin-console-permissions/per-realm.adoc:23
 msgid "impersonation"
 msgstr "impersonation"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:27
-#: source/server_installation/topics/profiles.adoc:74
 msgid "Ability for admins to impersonate users"
 msgstr "管理者がユーザーに成り代わる機能"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:30
-#: source/server_installation/topics/profiles.adoc:77
 msgid "script"
 msgstr "script"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:31
-#: source/server_installation/topics/profiles.adoc:78
 msgid "Write custom authenticators using JavaScript"
 msgstr "Javaスクリプトを使用したカスタム認証の記述"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:39
 msgid ""
 "{project_name} has two profiles, product and preview. The product profile is"
 " enabled by default, which disables some tech preview features. To enable "
@@ -148,18 +103,15 @@ msgstr ""
 "{project_name}には、productとpreviewの2プロファイルがあります。productプロファイルはデフォルトで有効になっていて、テクニカル・プレビュー機能を無効にします。この機能を有効にするには、previewプロファイルに切り替えるか、個別機能を有効にします。"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:41
 msgid "To enable the preview profile start the server with:"
 msgstr "previewプロファイルを有効にするには、以下のようにサーバーを起動します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/profiles.adoc:45
 #, no-wrap
 msgid "bin/standalone.sh|bat -Dkeycloak.profile=preview\n"
 msgstr "bin/standalone.sh|bat -Dkeycloak.profile=preview\n"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:50
 msgid ""
 "You can set this permanently by creating the file "
 "`standalone/configuration/profile.properties` (or `domain/servers/server-"
@@ -171,27 +123,22 @@ msgstr ""
 "）ファイルを作成することにより、これを永続的に設定することができます。以下をファイルに追加します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/profiles.adoc:54
 #, no-wrap
 msgid "profile=preview\n"
 msgstr "profile=preview\n"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:83
 msgid "To enable a specific feature start the server with:"
 msgstr "特定の機能を有効にするには、以下のようにサーバーを起動します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/profiles.adoc:87
-#: source/server_installation/topics/profiles.adoc:96
 #, no-wrap
 msgid ""
-"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled\n"
 msgstr ""
-"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled\n"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:90
 msgid ""
 "For example to enable Docker use "
 "`-Dkeycloak.profile.feature.docker=enabled`."
@@ -199,12 +146,17 @@ msgstr ""
 "サンプルとして、Dockerを有効にするには `-Dkeycloak.profile.feature.docker=enabled` を使用します。"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:92
 msgid "To disable a specific feature start the server with:"
 msgstr "特定の機能を無効にするには、以下のようにサーバーを起動します。"
 
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
+msgstr ""
+"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=disabled\n"
+
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:99
 msgid ""
 "For example to disable Impersonation use "
 "`-Dkeycloak.profile.feature.impersonation=disabled`."
@@ -213,27 +165,22 @@ msgstr ""
 " を使用します。"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:101
-#: source/server_installation/topics/profiles.adoc:118
 msgid ""
 "You can set this permanently in the `profile.properties` file by adding:"
 msgstr "`profile.properties` ファイルに以下を追加することにより、永続的に設定することができます。"
 
 #. type: delimited block -
-#: source/server_installation/topics/profiles.adoc:105
 #, no-wrap
 msgid "feature.impersonation=disabled\n"
 msgstr "feature.impersonation=disabled\n"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:109
 msgid ""
 "To enable a specific feature without enabling the full preview profile you "
 "can start the server with:"
 msgstr "previewプロファイルを有効にするのではなく、特定の機能のみ有効にするには、以下のようにサーバーを起動します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/profiles.adoc:113
 #, no-wrap
 msgid ""
 "bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
@@ -241,7 +188,6 @@ msgstr ""
 "bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
 
 #. type: Plain text
-#: source/server_installation/topics/profiles.adoc:116
 msgid ""
 "For example to enable Authorization Services use "
 "`-Dkeycloak.profile.feature.authorization=enabled`."
@@ -250,7 +196,6 @@ msgstr ""
 "を使用します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/profiles.adoc:122
 #, no-wrap
 msgid "feature.authorization=enabled\n"
 msgstr "feature.authorization=enabled\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__profiles/ja_JP/index.html
