### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
@@ -19,23 +20,22 @@ msgstr ""
 #: source/server_installation/topics/profiles.adoc:66
 #: source/authorization_services/topics/auth-services-architecture.adoc:84
 #: source/authorization_services/topics/service-overview.adoc:2
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Authorization Services"
-msgstr ""
-"#-#-#-#-#  service-overview.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"#-#-#-#-#  profiles.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"Authorization Servicesガイド"
+msgstr "認可サービス"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-overview.adoc:5
 msgid ""
 "{project_name} Authorization Services are based on OAuth2's User-Managed "
 "Access (UMA) Profile."
-msgstr ""
+msgstr "{project_name}認可サービスは、OAuth2のUser-Managed Access（UMA）プロファイルに基づいています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-overview.adoc:7
 msgid ""
-"This section describes the different RESTful endpoints that you can interact "
-"with to enable fine-grained authorization for your applications and services."
+"This section describes the different RESTful endpoints that you can interact"
+" with to enable fine-grained authorization for your applications and "
+"services."
 msgstr ""
+"このセクションでは、アプリケーションとサービスのきめ細かな認可を可能にするために対話できる、さまざまなRESTfulエンドポイントについて説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-overview/ja_JP/index.html
