### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po
@@ -1,30 +1,31 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:80
 #: source/authorization_services/topics/enforcer-overview.adoc:8
 msgid "image:images/pep-pattern-diagram.png[alt=\"PEP Overview\"]"
-msgstr ""
+msgstr "image:images/pep-pattern-diagram.png[alt=\"PEPの概要\"]"
 
 #. type: Title =
 #: source/authorization_services/topics/enforcer-overview.adoc:2
 #, no-wrap
 msgid "Policy Enforcers"
-msgstr ""
+msgstr "ポリシー・エンフォーサー"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-overview.adoc:7
@@ -36,3 +37,5 @@ msgid ""
 "RESTful API, and leverages OAuth2 authorization capabilities for fine-"
 "grained authorization using a centralized authorization server."
 msgstr ""
+"Policy Enforcement "
+"Point（PEP）は設計パターンなので、さまざまな方法で実装できます。{project_name}は、さまざまなプラットフォーム、環境、およびプログラミング言語に対してPEPを実装するために必要なすべての手段を提供します。{project_name}認可サービスは、RESTfulなAPIを提供し、集中認可サーバーを使用してきめ細かな認可を行うための、OAuth2認可機能を活用します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__enforcer-overview/ja_JP/index.html
