### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-federation-mapper.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-federation-mapper.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-federation-mapper.ja_JP.po
@@ -23,7 +23,7 @@ msgid ""
 "For details on how to package and deploy a custom provider refer to the "
 "<<providers.adoc#providers,Service Provider Interfaces>> chapter."
 msgstr ""
-"カスタム・プロバイダーをパッケージ化してデプロイする方法の詳細については、<<providers.adoc#providers,サービス・プロバイダー・インタフェース>>の章を参照してください。"
+"カスタム・プロバイダーをパッケージ化してデプロイする方法の詳細については、<<providers.adoc#providers,サービス・プロバイダー・インターフェイス>>の章を参照してください。"
 
 #. type: Title ==
 #: source/server_development/topics/user-federation-mapper.adoc:2
@@ -45,8 +45,8 @@ msgid ""
 "mapper implementation. You will need to implement "
 "`UserFederationMapperFactory` interface."
 msgstr ""
-"より高度な用途の場合、独自のLDAPマッパーの実装を作成するか、既存のマッパー実装からサブクラス化することができます。  "
-"`UserFederationMapperFactory` インターフェースを実装する必要があります。"
+"より高度な用途の場合、独自のLDAPマッパーの実装を作成するか、既存のマッパー実装からサブクラス化することができます。 "
+"`UserFederationMapperFactory` インターフェイスを実装する必要があります。"
 
 #. type: Plain text
 #: source/server_development/topics/user-federation-mapper.adoc:11

--- a/i18n/po/ja_JP/server_development/topics/user-federation-mapper.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-federation-mapper.ja_JP.po
@@ -2,17 +2,17 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -23,18 +23,19 @@ msgid ""
 "For details on how to package and deploy a custom provider refer to the "
 "<<providers.adoc#providers,Service Provider Interfaces>> chapter."
 msgstr ""
+"カスタム・プロバイダーをパッケージ化してデプロイする方法の詳細については、<<providers.adoc#providers,サービス・プロバイダー・インタフェース>>の章を参照してください。"
 
 #. type: Title ==
 #: source/server_development/topics/user-federation-mapper.adoc:2
 #, no-wrap
 msgid "User Federation Mapper SPI"
-msgstr ""
+msgstr "ユーザー・フェデレーション・マッパーSPI"
 
 #. type: Title ===
 #: source/server_development/topics/user-federation-mapper.adoc:4
 #, no-wrap
 msgid "LDAP Mapper"
-msgstr ""
+msgstr "LDAPマッパー"
 
 #. type: Plain text
 #: source/server_development/topics/user-federation-mapper.adoc:8
@@ -44,14 +45,19 @@ msgid ""
 "mapper implementation. You will need to implement "
 "`UserFederationMapperFactory` interface."
 msgstr ""
+"より高度な用途の場合、独自のLDAPマッパーの実装を作成するか、既存のマッパー実装からサブクラス化することができます。  "
+"`UserFederationMapperFactory` インターフェースを実装する必要があります。"
 
 #. type: Plain text
 #: source/server_development/topics/user-federation-mapper.adoc:11
 msgid ""
 "In most cases, instead of creating `UserFederationMapperFactory` from "
-"scratch, you can create subclasses of `AbstractLDAPFederationMapperFactory`, "
-"which itself implements `UserFederationMapperFactory`."
+"scratch, you can create subclasses of `AbstractLDAPFederationMapperFactory`,"
+" which itself implements `UserFederationMapperFactory`."
 msgstr ""
+"ほとんどの場合、 `UserFederationMapperFactory` を最初から作成するのではなく、 "
+"`UserFederationMapperFactory` を実装する `AbstractLDAPFederationMapperFactory` "
+"のサブクラスを作成することができます。"
 
 #. type: Plain text
 #: source/server_development/topics/user-federation-mapper.adoc:14
@@ -60,3 +66,6 @@ msgid ""
 "`AbstractLDAPFederationMapper` (this mapper implementation will be returned "
 "by `YourAbstractLDAPFederationMapperFactorySubclass.createMapper` method)."
 msgstr ""
+"次に、 `AbstractLDAPFederationMapper` のサブクラスになるマッパー実装を作成する必要があります（このマッパー実装は "
+"`YourAbstractLDAPFederationMapperFactorySubclass.createMapper` "
+"メソッドによって返されます）。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-federation-mapper.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-federation-mapper
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__user-federation-mapper/ja_JP/index.html
