### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,22 +16,18 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/upgrading/topics/install_new_version.adoc:10
-#: source/upgrading/topics/prep_migration.adoc:10
 msgid ""
 "Prior to applying the upgrade, handle any open transactions and delete the "
 "data/tx-object-store/ transaction directory."
 msgstr ""
-"アップグレードする前に、オープンしているトランザクションを処理し、data/tx-object-store/トランザクション・ディレクトリを削除します。"
+"アップグレードする前に、開いているトランザクションを処理し、data/tx-object-store/トランザクション・ディレクトリを削除します。"
 
 #. type: Title ==
-#: source/upgrading/topics/prep_migration.adoc:3
 #, no-wrap
 msgid "Preparing for Upgrading"
 msgstr "アップグレードする準備"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:8
 msgid ""
 "Before you upgrade, be aware of the order in which you need to perform the "
 "upgrade steps. Also note potential issues that can occur within the upgrade "
@@ -42,12 +38,10 @@ msgstr ""
 " "
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:11
 msgid "Back up the old installation (configuration, themes, and so on)."
 msgstr "古いインストール（設定、テーマなど）をバックアップします。"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:13
 msgid ""
 "Back up the database. For detailed information on how to back up the "
 "database, see the documentation for the relational database you’re using."
@@ -55,12 +49,10 @@ msgstr ""
 "データベースをバックアップします。データベースのバックアップの仕方について、詳しくは、使用しているデータベースの関連ドキュメントを参照ください。"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:14
 msgid "Upgrade {project_name} server."
 msgstr "{project_name}サーバーのアップグレード"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:16
 msgid ""
 "Testing the upgrade in a non-production environment first, to prevent any "
 "installation issues from being exposed in production, is a best practice."
@@ -68,27 +60,23 @@ msgstr ""
 "プロダクション環境でインストールの問題に直面しないように、まずは非プロダクション環境でアップグレードのテストをすることがベストプラクティスです。"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:17
 msgid ""
 "Be aware that after the upgrade the database will no longer be compatible "
 "with the old server"
 msgstr "アップグレード後、データベースは古いサーバーとの互換性がなくなることに注意してください。"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:18
 msgid ""
 "Ensure the upgraded server is functional before upgrading adapters in "
 "production."
 msgstr "プロダクション環境でアダプターをアップグレードする前に、アップグレードしたサーバーが機能していることを確認してください。"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:19
 msgid ""
 "If you need to revert the upgrade, first restore the old installation, and "
 "then restore the database from the backup copy."
 msgstr "アップグレードを元に戻す必要がある場合は、まず古いインストールを復元してから、バックアップのコピーからデータベースを復元します。"
 
 #. type: Plain text
-#: source/upgrading/topics/prep_migration.adoc:20
 msgid "Upgrade the adapters."
 msgstr "アダプターをアップグレードします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__prep_migration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-upgrading__topics__prep_migration/ja_JP/index.html
