### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -54,8 +54,8 @@ msgid ""
 "grained authorization, click the *Authorization Enabled* switch to *ON* and "
 "click *Save*."
 msgstr ""
-"OIDCクライアント・アプリケーションをリソース・サーバーに変えて、きめ細かい認可を有効にするには、 *Authorization Enabled* を"
-" *ON* にして *Save* をクリックします。"
+"OIDCクライアント・アプリケーションをリソースサーバーに変えて、きめ細かい認可を有効にするには、 *Authorization Enabled* を "
+"*ON* にして *Save* をクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:8
@@ -81,7 +81,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-server-import-config.adoc:16
 #, no-wrap
 msgid "Resource Server Settings"
-msgstr "リソース・サーバーの設定"
+msgstr "リソースサーバーの設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:13
@@ -91,7 +91,7 @@ msgid ""
 "Server Settings\"]"
 msgstr ""
 "image:{project_images}/resource-server/authz-"
-"settings.png[alt=\"リソース・サーバーの設定\"]"
+"settings.png[alt=\"リソースサーバーの設定\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:15
@@ -115,7 +115,7 @@ msgid ""
 "General settings for your resource server. For more details about this page "
 "see the xref:resource_server_settings[Resource Server Settings] section."
 msgstr ""
-"リソース・サーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソース・サーバーの設定]のセクションを参照してください。"
+"リソースサーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソースサーバーの設定]のセクションを参照してください。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:23
@@ -186,7 +186,7 @@ msgid ""
 "On the Resource Server Settings page, you can configure the policy "
 "enforcement mode, allow remote resource management, and export the "
 "authorization configuration settings."
-msgstr "リソース・サーバー設定ページでは、ポリシーの強制モードの設定や、リモート・リソース管理の許可、認可構成の設定のエクスポートができます。"
+msgstr "リソースサーバー設定ページでは、ポリシーの強制モードの設定や、リモートリソース管理の許可、認可構成の設定のエクスポートができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:46
@@ -236,8 +236,7 @@ msgstr "*Allow Remote Resource Management*\n"
 msgid ""
 "Specifies whether resources can be managed remotely by the resource server. "
 "If false, resources can be managed only from the administration console."
-msgstr ""
-"リソース・サーバーによってリソースをリモート管理できるかどうかを指定します。falseの場合、リソースは管理コンソールからのみ管理できます。"
+msgstr "リソースサーバーによってリソースをリモート管理できるかどうかを指定します。falseの場合、リソースは管理コンソールからのみ管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:67
@@ -254,4 +253,4 @@ msgid ""
 "protected resources, scopes, permissions, and policies."
 msgstr ""
 "認可構成の設定をJSONファイルにエクスポートできます。 *Export* "
-"をクリックするとダウンロード用のJSON設定がすべて表示されます。設定ファイルには、リソース・サーバーに対して定義されているすべてのもの（保護されたリソース、スコープ、アクセス許可、およびポリシー）が含まれています。"
+"をクリックするとダウンロード用のJSON設定がすべて表示されます。設定ファイルには、リソースサーバーに対して定義されているすべてのもの（保護されたリソース、スコープ、アクセス許可、およびポリシー）が含まれています。"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -21,7 +22,7 @@ msgstr ""
 msgid ""
 "(default mode) Requests are denied by default even when there is no policy "
 "associated with a given resource."
-msgstr ""
+msgstr "（デフォルトモード）特定のリソースに関連付けられたポリシーがない場合でも、デフォルトで要求は拒否されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:88
@@ -29,26 +30,22 @@ msgstr ""
 msgid ""
 "Requests are allowed even when there is no policy associated with a given "
 "resource."
-msgstr ""
+msgstr "特定のリソースに関連付けられたポリシーがない場合でも、要求は許可されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/hello-world-create-resource-server.adoc:2
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:2
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:6
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Enabling Authorization Services"
-msgstr ""
-"#-#-#-#-#  service-overview.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"#-#-#-#-#  profiles.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"Authorization Servicesガイド"
+msgstr "認可サービスの有効化"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:23
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:21
-#, fuzzy, no-wrap
-#| msgid "resource"
+#, no-wrap
 msgid "*Resource*\n"
-msgstr "resource"
+msgstr "*Resource*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:5
@@ -57,22 +54,24 @@ msgid ""
 "grained authorization, click the *Authorization Enabled* switch to *ON* and "
 "click *Save*."
 msgstr ""
+"OIDCクライアント・アプリケーションをリソース・サーバーに変えて、きめ細かい認可を有効にするには、 *Authorization Enabled* を"
+" *ON* にして *Save* をクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:8
-#, fuzzy
-#| msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgid ""
-"image:{project_images}/resource-server/client-enable-authz.png[alt="
-"\"Enabling Authorization Services\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
+"image:{project_images}/resource-server/client-enable-"
+"authz.png[alt=\"Enabling Authorization Services\"]"
+msgstr ""
+"image:{project_images}/resource-server/client-enable-"
+"authz.png[alt=\"認可サービスの有効化\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:10
 msgid ""
 "A new Authorization tab is displayed for this client. Click the "
 "*Authorization* tab and a page similar to the following is displayed:"
-msgstr ""
+msgstr "クライアントに新しい認可タブが表示されます。 *Authorization* タブをクリックすると、次のようなページが表示されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:11
@@ -80,7 +79,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-server-import-config.adoc:16
 #, no-wrap
 msgid "Resource Server Settings"
-msgstr ""
+msgstr "リソース・サーバーの設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:13
@@ -89,21 +88,24 @@ msgid ""
 "image:{project_images}/resource-server/authz-settings.png[alt=\"Resource "
 "Server Settings\"]"
 msgstr ""
+"image:{project_images}/resource-server/authz-"
+"settings.png[alt=\"リソース・サーバーの設定\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:15
 msgid ""
 "The Authorization tab contains additional sub-tabs covering the different "
-"steps that you must follow to actually protect your application's resources. "
-"Each tab is covered separately by a specific topic in this documentation. "
+"steps that you must follow to actually protect your application's resources."
+" Each tab is covered separately by a specific topic in this documentation. "
 "But here is a quick description about each one:"
 msgstr ""
+"Authorizationタブには、アプリケーションのリソースを実際に保護するために従わなければならないさまざまなステップを補う追加のサブタブが含まれています。各タブは、このドキュメントの特定のトピックで個別に補足されています。ここではそれぞれについて簡単に説明します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:17
 #, no-wrap
 msgid "*Settings*\n"
-msgstr ""
+msgstr "*Settings*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:19
@@ -111,57 +113,60 @@ msgid ""
 "General settings for your resource server. For more details about this page "
 "see the xref:resource_server_settings[Resource Server Settings] section."
 msgstr ""
+"リソース・サーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソース・サーバーの設定]セクションを参照してください。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:23
 msgid ""
 "From this page, you can manage your application's <<_resource_overview, "
 "resources>>."
-msgstr ""
+msgstr "このページから、アプリケーションの<<_resource_overview, リソース>>を管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:25
 #, no-wrap
 msgid "*Scope*\n"
-msgstr ""
+msgstr "*Scope*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:27
 msgid "From this page, you can manage <<_resource_overview, scopes>>."
-msgstr ""
+msgstr "このページから、<<_resource_overview, スコープ>>を管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:29
 #, no-wrap
 msgid "*Policies*\n"
-msgstr ""
+msgstr "*Policies*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:31
 msgid ""
 "From this page, you can manage <<_policy_overview, authorization policies>> "
 "and define the conditions that must be met to grant a permission."
-msgstr ""
+msgstr "このページから、<<_policy_overview, 認可ポリシー>>を管理し、許可を得るために必要な条件を定義することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:33
 #, no-wrap
 msgid "*Permissions*\n"
-msgstr ""
+msgstr "*Permissions*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:35
 msgid ""
-"From this page, you can manage the <<_permission_overview, permissions>> for "
-"your protected resources and scopes by linking them with the policies you "
+"From this page, you can manage the <<_permission_overview, permissions>> for"
+" your protected resources and scopes by linking them with the policies you "
 "created."
 msgstr ""
+"このページから、保護されたリソースとスコープの<<_permission_overview, "
+"権限>>を、作成したポリシーとリンクさせることにより管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:37
 #, no-wrap
 msgid "*Evaluate*\n"
-msgstr ""
+msgstr "*Evaluate*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:39
@@ -170,6 +175,8 @@ msgid ""
 "authorization requests>> and view the result of the evaluation of the "
 "permissions and authorization policies you have defined."
 msgstr ""
+"このページでは、<<_policy_evaluation_overview, "
+"認可リクエストのシミュレート>>、および定義した権限と認可ポリシーの評価結果を表示できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:44
@@ -177,50 +184,50 @@ msgid ""
 "On the Resource Server Settings page, you can configure the policy "
 "enforcement mode, allow remote resource management, and export the "
 "authorization configuration settings."
-msgstr ""
+msgstr "リソース・サーバー設定ページでは、ポリシーの強制モードを設定、リモート・リソース管理を許可、認可構成の設定をエクスポートできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:46
 #, no-wrap
 msgid "*Policy Enforcement Mode*\n"
-msgstr ""
+msgstr "*Policy Enforcement Mode*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:48
 msgid ""
 "Specifies how policies are enforced when processing authorization requests "
 "sent to the server."
-msgstr ""
+msgstr "サーバーに送信された認可要求を処理するときに、ポリシーがどのように強制されるかを指定します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:50
 #, no-wrap
 msgid "** *Enforcing*\n"
-msgstr ""
+msgstr "** *Enforcing*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:54
 #, no-wrap
 msgid "** *Permissive*\n"
-msgstr ""
+msgstr "** *Permissive*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:58
 #, no-wrap
 msgid "** *Disabled*\n"
-msgstr ""
+msgstr "** *Disabled*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:60
 msgid ""
 "Disables the evaluation of all policies and allows access to all resources."
-msgstr ""
+msgstr "すべてのポリシーの評価を無効にし、すべてのリソースへのアクセスを許可します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:62
 #, no-wrap
 msgid "*Allow Remote Resource Management*\n"
-msgstr ""
+msgstr "*Allow Remote Resource Management*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:64
@@ -228,12 +235,13 @@ msgid ""
 "Specifies whether resources can be managed remotely by the resource server. "
 "If false, resources can be managed only from the administration console."
 msgstr ""
+"リソース・サーバーによってリソースをリモート管理できるかどうかを指定します。falseの場合、リソースは管理コンソールからのみ管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:67
 #, no-wrap
 msgid "*Export Settings*\n"
-msgstr ""
+msgstr "*Export Settings*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:68
@@ -243,3 +251,5 @@ msgid ""
 "configuration file contains everything defined for a resource server: "
 "protected resources, scopes, permissions, and policies."
 msgstr ""
+"認証構成の設定をJSONファイルにエクスポートできます。 *Export* "
+"をクリックするとダウンロード用のJSON設定がすべて表示されます。設定ファイルには、リソース・サーバーに対して定義されているすべてのもの（保護されたリソース、スコープ、アクセス許可、およびポリシー）が含まれています。"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -71,7 +71,9 @@ msgstr ""
 msgid ""
 "A new Authorization tab is displayed for this client. Click the "
 "*Authorization* tab and a page similar to the following is displayed:"
-msgstr "クライアントに新しい認可タブが表示されます。 *Authorization* タブをクリックすると、次のようなページが表示されます。"
+msgstr ""
+"クライアントに新しいAuthorizationタブが表示されます。 *Authorization* "
+"タブをクリックすると、次のようなページが表示されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:11
@@ -113,7 +115,7 @@ msgid ""
 "General settings for your resource server. For more details about this page "
 "see the xref:resource_server_settings[Resource Server Settings] section."
 msgstr ""
-"リソース・サーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソース・サーバーの設定]セクションを参照してください。"
+"リソース・サーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソース・サーバーの設定]のセクションを参照してください。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:23
@@ -184,7 +186,7 @@ msgid ""
 "On the Resource Server Settings page, you can configure the policy "
 "enforcement mode, allow remote resource management, and export the "
 "authorization configuration settings."
-msgstr "リソース・サーバー設定ページでは、ポリシーの強制モードを設定、リモート・リソース管理を許可、認可構成の設定をエクスポートできます。"
+msgstr "リソース・サーバー設定ページでは、ポリシーの強制モードの設定や、リモート・リソース管理の許可、認可構成の設定のエクスポートができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:46
@@ -251,5 +253,5 @@ msgid ""
 "configuration file contains everything defined for a resource server: "
 "protected resources, scopes, permissions, and policies."
 msgstr ""
-"認証構成の設定をJSONファイルにエクスポートできます。 *Export* "
+"認可構成の設定をJSONファイルにエクスポートできます。 *Export* "
 "をクリックするとダウンロード用のJSON設定がすべて表示されます。設定ファイルには、リソース・サーバーに対して定義されているすべてのもの（保護されたリソース、スコープ、アクセス許可、およびポリシー）が含まれています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-enable-authorization
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__resource-server-enable-authorization/ja_JP/index.html
