### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
@@ -29,14 +30,13 @@ msgstr "クライアント"
 #: source/authorization_services/topics/resource-server-create-client.adoc:27
 #, no-wrap
 msgid "Client Settings"
-msgstr ""
+msgstr "クライアントの設定"
 
 #. type: Title =
 #: source/authorization_services/topics/resource-server-create-client.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Creating a Client Application"
-msgstr "ドメイン設定"
+msgstr "クライアント・アプリケーションの作成"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:5
@@ -44,78 +44,69 @@ msgid ""
 "The first step to enable {project_name} Authorization Services is to create "
 "the client application that you want to turn into a resource server."
 msgstr ""
+"{project_name}認可サービスを有効にするための最初の手順は、リソース・サーバーにするクライアント・アプリケーションを作成することです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:7
-#, fuzzy
-#| msgid "To create a new realm, complete the following steps:"
 msgid "To create a client application, complete the following steps:"
-msgstr "新規レルムを作成するには、以下の手順に従います。"
+msgstr "クライアント・アプリケーションを作成するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:9
-#, fuzzy
-#| msgid "Clients"
 msgid "Click *Clients*."
-msgstr "クライアント"
+msgstr "*Clients* をクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:12
-#, fuzzy
-#| msgid "image:{project_images}/add-client.png[]"
 msgid "image:{project_images}/resource-server/client-list.png[alt=\"Clients\"]"
-msgstr "image:{project_images}/add-client.png[]"
+msgstr "image:{project_images}/resource-server/client-list.png[alt=\"クライアント\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:14
-#, fuzzy
-#| msgid "On the right click *Create*."
 msgid "On this page, click *Create*."
-msgstr "右側にある *Create* をクリックします。"
+msgstr "このページで、 *Create* をクリックします。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-server-create-client.adoc:15
-#, fuzzy, no-wrap
-#| msgid "Create Realm"
+#, no-wrap
 msgid "Create Client"
-msgstr "レルムの作成"
+msgstr "クライアントの作成"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:17
-#, fuzzy
-#| msgid "image:{project_images}/add-client.png[]"
 msgid ""
-"image:{project_images}/resource-server/client-create.png[alt=\"Create Client"
-"\"]"
-msgstr "image:{project_images}/add-client.png[]"
+"image:{project_images}/resource-server/client-create.png[alt=\"Create "
+"Client\"]"
+msgstr ""
+"image:{project_images}/resource-server/client-create.png[alt=\"クライアントの作成\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:19
 msgid "Type the `Client ID` of the client. For example, _my-resource-server_."
-msgstr ""
+msgstr "クライアントの `Client ID` を入力します。例では、 _my-resource-server_ とします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:20
 msgid "Type the `Root URL` for your application. For example:"
-msgstr ""
+msgstr "アプリケーションの `Root URL` を入力します。例になります。"
 
 #. type: Code block
 #: source/authorization_services/topics/resource-server-create-client.adoc:23
 msgid "http://${host}:${port}/my-resource-server"
-msgstr ""
+msgstr "http://${host}:${port}/my-resource-server"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:26
 msgid ""
 "Click *Save*. The client is created and the client Settings page opens. A "
 "page similar to the following is displayed:"
-msgstr ""
+msgstr "*Save* をクリックします。クライアントが作成され、クライアントの設定ページが開きます。次のようなページが表示されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:28
-#, fuzzy
-#| msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgid ""
 "image:{project_images}/resource-server/client-enable-authz.png[alt=\"Client "
 "Settings\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
+msgstr ""
+"image:{project_images}/resource-server/client-enable-"
+"authz.png[alt=\"クライアントの設定\"]"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
@@ -44,7 +44,7 @@ msgid ""
 "The first step to enable {project_name} Authorization Services is to create "
 "the client application that you want to turn into a resource server."
 msgstr ""
-"{project_name}認可サービスを有効にするための最初の手順は、リソース・サーバーにするクライアント・アプリケーションを作成することです。"
+"{project_name}認可サービスを有効にするための最初の手順は、リソースサーバーにするクライアント・アプリケーションを作成することです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:7

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -83,12 +83,12 @@ msgstr ""
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:19
 msgid "Type the `Client ID` of the client. For example, _my-resource-server_."
-msgstr "クライアントの `Client ID` を入力します。例では、 _my-resource-server_ とします。"
+msgstr "クライアントの `Client ID` を入力します。例えば、 _my-resource-server_ 。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-create-client.adoc:20
 msgid "Type the `Root URL` for your application. For example:"
-msgstr "アプリケーションの `Root URL` を入力します。例になります。"
+msgstr "アプリケーションの `Root URL` を入力します。例えば"
 
 #. type: Code block
 #: source/authorization_services/topics/resource-server-create-client.adoc:23


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-create-client
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__resource-server-create-client/ja_JP/index.html
