### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,7 +20,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-server-import-config.adoc:9
 #, no-wrap
 msgid "Permissions"
-msgstr "権限"
+msgstr "パーミッション"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:8
@@ -35,7 +35,7 @@ msgstr "ポリシー"
 #: source/authorization_services/topics/resource-server-import-config.adoc:16
 #, no-wrap
 msgid "Resource Server Settings"
-msgstr "リソース・サーバーの設定"
+msgstr "リソースサーバーの設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:13
@@ -45,7 +45,7 @@ msgid ""
 "Server Settings\"]"
 msgstr ""
 "image:{project_images}/resource-server/authz-"
-"settings.png[alt=\"リソース・サーバーの設定\"]"
+"settings.png[alt=\"リソースサーバーの設定\"]"
 
 #. type: Title =
 #: source/authorization_services/topics/resource-server-import-config.adoc:2
@@ -63,7 +63,7 @@ msgid ""
 " update an existing configuration. The configuration file contains "
 "definitions for:"
 msgstr ""
-"リソース・サーバー（またはクライアント）の構成設定をエクスポートおよびダウンロードできます。また、リソース・サーバーの既存の設定ファイルをインポートすることもできます。設定ファイルのインポートとエクスポートは、リソース・サーバーの初期設定を作成したり、既存の設定を更新する場合に役立ちます。設定ファイルには次の定義が含まれています。"
+"リソースサーバー（またはクライアント）の構成設定をエクスポートおよびダウンロードできます。また、リソースサーバーの既存の設定ファイルをインポートすることもできます。設定ファイルのインポートとエクスポートは、リソースサーバーの初期設定を作成したり、既存の設定を更新する場合に役立ちます。設定ファイルには次の定義が含まれています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:7
@@ -112,8 +112,8 @@ msgid ""
 "area, from which you can copy and paste. You can also click *Download* to "
 "download the configuration file and save it."
 msgstr ""
-"設定ファイルはJSON形式でエクスポートされ、テキスト・エリアに表示されます。そこからコピーして貼り付けることができます。 また、 *Download*"
-" をクリックし、設定ファイルをダウンロードして保存することもできます。"
+"設定ファイルはJSON形式でエクスポートされ、テキストエリアに表示されます。そこからコピーして貼り付けることができます。 また、 *Download* "
+"をクリックし、設定ファイルをダウンロードして保存することもできます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/resource-server-import-config.adoc:26
@@ -127,4 +127,4 @@ msgid ""
 "To import a configuration file for a resource server, click *Select file* to"
 " select a file containing the configuration you want to import."
 msgstr ""
-"リソース・サーバーの設定ファイルをインポートするには、 *Select file* をクリックして、インポートしたい設定ファイルを選択します。"
+"リソースサーバーの設定ファイルをインポートするには、 *Select file* をクリックして、インポートしたい設定ファイルを選択します。"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -19,14 +20,14 @@ msgstr ""
 #: source/authorization_services/topics/resource-server-import-config.adoc:9
 #, no-wrap
 msgid "Permissions"
-msgstr ""
+msgstr "権限"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-overview.adoc:8
 #: source/authorization_services/topics/resource-server-import-config.adoc:8
 #, no-wrap
 msgid "Policies"
-msgstr ""
+msgstr "ポリシー"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:11
@@ -34,7 +35,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-server-import-config.adoc:16
 #, no-wrap
 msgid "Resource Server Settings"
-msgstr ""
+msgstr "リソース・サーバーの設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:13
@@ -43,68 +44,66 @@ msgid ""
 "image:{project_images}/resource-server/authz-settings.png[alt=\"Resource "
 "Server Settings\"]"
 msgstr ""
+"image:{project_images}/resource-server/authz-"
+"settings.png[alt=\"リソース・サーバーの設定\"]"
 
 #. type: Title =
 #: source/authorization_services/topics/resource-server-import-config.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Standalone Configuration"
+#, no-wrap
 msgid "Export and Import Authorization Configuration"
-msgstr "スタンドアロン設定"
+msgstr "エクスポートおよびインポート権限の設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:5
 msgid ""
-"The configuration settings for a resource server (or client) can be exported "
-"and downloaded. You can also import an existing configuration file for a "
+"The configuration settings for a resource server (or client) can be exported"
+" and downloaded. You can also import an existing configuration file for a "
 "resource server. Importing and exporting a configuration file is helpful "
-"when you want to create an initial configuration for a resource server or to "
-"update an existing configuration. The configuration file contains "
+"when you want to create an initial configuration for a resource server or to"
+" update an existing configuration. The configuration file contains "
 "definitions for:"
 msgstr ""
+"リソース・サーバー（またはクライアント）の構成設定をエクスポートおよびダウンロードできます。また、リソース・サーバーの既存の設定ファイルをインポートすることもできます。設定ファイルのインポートとエクスポートは、リソース・サーバーの初期設定を作成したり、既存の設定を更新する場合に役立ちます。設定ファイルには次の定義が含まれています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:7
 msgid "Protected resources and scopes"
-msgstr ""
+msgstr "保護されたリソースとスコープ"
 
 #. type: Title ==
 #: source/authorization_services/topics/resource-server-import-config.adoc:10
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Exporting a Configuration File"
-msgstr "ドメイン設定"
+msgstr "設定ファイルのエクスポート"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:13
-#, fuzzy
-#| msgid "To create a new realm, complete the following steps:"
 msgid "To export a configuration file, complete the following steps:"
-msgstr "新規レルムを作成するには、以下の手順に従います。"
+msgstr "設定ファイルをエクスポートするには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:15
 msgid "Navigate to the *Resource Server Settings* page."
-msgstr ""
+msgstr "*Resource Server Settings* ページに移動します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:20
 msgid "On this page, in the Export Settings section, click *Export*."
-msgstr ""
+msgstr "このページのエクスポート設定のセクションで、 *Export* をクリックします。"
 
 #. type: Block title
 #: source/authorization_services/topics/resource-server-import-config.adoc:21
 #, no-wrap
 msgid "Export Settings"
-msgstr ""
+msgstr "エクスポートの設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:23
-#, fuzzy
-#| msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgid ""
-"image:{project_images}/resource-server/authz-export.png[alt=\"Export Settings"
-"\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
+"image:{project_images}/resource-server/authz-export.png[alt=\"Export "
+"Settings\"]"
+msgstr ""
+"image:{project_images}/resource-server/authz-export.png[alt=\"エクスポートの設定\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:25
@@ -113,17 +112,19 @@ msgid ""
 "area, from which you can copy and paste. You can also click *Download* to "
 "download the configuration file and save it."
 msgstr ""
+"設定ファイルはJSON形式でエクスポートされ、テキスト・エリアに表示されます。そこからコピーして貼り付けることができます。 また、*Download* "
+"をクリックし、設定ファイルをダウンロードして保存することもできます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/resource-server-import-config.adoc:26
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Importing a Configuration File"
-msgstr "ドメイン設定"
+msgstr "設定ファイルのインポート"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:28
 msgid ""
-"To import a configuration file for a resource server, click *Select file* to "
-"select a file containing the configuration you want to import."
+"To import a configuration file for a resource server, click *Select file* to"
+" select a file containing the configuration you want to import."
 msgstr ""
+"リソース・サーバーの設定ファイルをインポートするには、 *Select file* をクリックして、インポートしたい設定ファイルを選択します。"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,7 +51,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-server-import-config.adoc:2
 #, no-wrap
 msgid "Export and Import Authorization Configuration"
-msgstr "エクスポートおよびインポート権限の設定"
+msgstr "認可設定のエクスポートおよびインポート"
 
 #. type: Plain text
 #: source/authorization_services/topics/resource-server-import-config.adoc:5
@@ -112,8 +112,8 @@ msgid ""
 "area, from which you can copy and paste. You can also click *Download* to "
 "download the configuration file and save it."
 msgstr ""
-"設定ファイルはJSON形式でエクスポートされ、テキスト・エリアに表示されます。そこからコピーして貼り付けることができます。 また、*Download* "
-"をクリックし、設定ファイルをダウンロードして保存することもできます。"
+"設定ファイルはJSON形式でエクスポートされ、テキスト・エリアに表示されます。そこからコピーして貼り付けることができます。 また、 *Download*"
+" をクリックし、設定ファイルをダウンロードして保存することもできます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/resource-server-import-config.adoc:26


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-import-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__resource-server-import-config/ja_JP/index.html
