### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -30,6 +30,19 @@ msgstr "Wildfly 11"
 msgid "Any other server but Wildfly 11"
 msgstr "Wildfly 11以外の他のサーバー"
 
+#. type: Title =====
+#, no-wrap
+msgid "JBoss SSO"
+msgstr "JBoss SSO"
+
+#. type: Plain text
+msgid ""
+"{appserver_name} has built-in support for single sign-on for web "
+"applications deployed to the same {appserver_name} instance. This should not"
+" be enabled when using {project_name}."
+msgstr ""
+"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。これは、{project_name}を使用しているときは有効にしないでください。"
+
 #. type: Plain text
 msgid ""
 "Each adapter is a separate download on the {project_name} download site."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation/ja_JP/index.html
