### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/getting_started/topics/first-realm/user.adoc:13
 #: source/authorization_services/topics/hello-world-create-realm.adoc:20
 msgid "On the right side of the empty user list, click *Add User*."
-msgstr "空のユーザーリストの右側にある *Add User* をクリックします。"
+msgstr "空のユーザー・リストの右側にある *Add User* をクリックします。"
 
 #. type: Block title
 #: source/getting_started/topics/first-realm/user.adoc:15
@@ -40,7 +40,7 @@ msgstr "レルムとユーザーの作成"
 msgid ""
 "The first step is to create a realm and a user in that realm. The realm "
 "consists of:"
-msgstr "最初のステップは、その領域にレルムとユーザーを作成することです。レルムは次のように構成されています。"
+msgstr "最初のステップは、そのレルムにレルムとユーザーを作成することです。レルムは次のように構成されています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:7
@@ -53,7 +53,8 @@ msgid ""
 "A single client application, which then becomes a <<_overview_terminology, "
 "resource server>> for which you need to enable authorization services."
 msgstr ""
-"単一のクライアント・アプリケーション。認可サービスを使用可能にする<<_overview_terminology, リソース・サーバー>>になります。"
+"単一のクライアント・アプリケーション。認可サービスを有効にする必要がある<<_overview_terminology, "
+"リソースサーバー>>になります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:11
@@ -134,8 +135,8 @@ msgid ""
 "Complete the *New Password* and *Password Confirmation* fields with a "
 "password and click the *Temporary* switch to *OFF*."
 msgstr ""
-"*New Password* と *Password Confirmation* フィールドを入力し、 *Temporary* を *OFF* "
-"に切り替えます。"
+"*New Password* と *Password Confirmation* フィールドにパスワードを入力し、 *Temporary* を "
+"*OFF* に切り替えます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:34

--- a/i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -30,8 +31,7 @@ msgstr "ユーザーの追加"
 
 #. type: Title =
 #: source/authorization_services/topics/hello-world-create-realm.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Creating a Realm and User"
+#, no-wrap
 msgid "Creating a Realm and a User"
 msgstr "レルムとユーザーの作成"
 
@@ -40,12 +40,12 @@ msgstr "レルムとユーザーの作成"
 msgid ""
 "The first step is to create a realm and a user in that realm. The realm "
 "consists of:"
-msgstr ""
+msgstr "最初のステップは、その領域にレルムとユーザーを作成することです。レルムは次のように構成されています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:7
 msgid "A single user"
-msgstr ""
+msgstr "単一のユーザー"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:9
@@ -53,87 +53,80 @@ msgid ""
 "A single client application, which then becomes a <<_overview_terminology, "
 "resource server>> for which you need to enable authorization services."
 msgstr ""
+"単一のクライアント・アプリケーション。認可サービスを使用可能にする<<_overview_terminology, リソース・サーバー>>になります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:11
-#, fuzzy
-#| msgid "To create a new realm, complete the following steps:"
 msgid "To create a realm and a user complete the following steps:"
-msgstr "新規レルムを作成するには、以下の手順に従います。"
+msgstr "レルムとユーザーを作成するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:13
 msgid ""
-"Create a realm with a name *hello-world-authz*. Once created, a page similar "
-"to the following is displayed:"
-msgstr ""
+"Create a realm with a name *hello-world-authz*. Once created, a page similar"
+" to the following is displayed:"
+msgstr "*hello-world-authz* という名前のレルムを作成します。作成されると、次のようなページが表示されます。"
 
 #. type: Block title
 #: source/authorization_services/topics/hello-world-create-realm.adoc:14
 #, no-wrap
 msgid "Realm hello-world-authz"
-msgstr ""
+msgstr "hello-world-authzレルム"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:16
 msgid ""
-"image:{project_images}/getting-started/hello-world/create-realm.png[alt="
-"\"Realm hello-world-authz\"]"
+"image:{project_images}/getting-started/hello-world/create-"
+"realm.png[alt=\"Realm hello-world-authz\"]"
 msgstr ""
+"image:{project_images}/getting-started/hello-world/create-realm.png[alt"
+"=\"hello-world-authzレルム\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:18
-#, fuzzy
-#| msgid "In the left menu bar click *Users*. The user list page opens."
 msgid ""
 "Create a user for your newly created realm. Click *Users*. The user list "
 "page opens."
-msgstr ""
-"左メニューバーで *Users* をクリックします。ユーザーリストページが開きます。"
+msgstr "新しく作成したレルムのユーザーを作成します。 *Users* をクリックします。ユーザー・リストのページが開きます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:23
 msgid ""
 "To create a new user, complete the *Username*, *Email*, *First Name*, and "
-"*Last Name* fields.  Click the *User Enabled* switch to *On*, and then click "
-"*Save*."
+"*Last Name* fields.  Click the *User Enabled* switch to *On*, and then click"
+" *Save*."
 msgstr ""
+"新しいユーザーを作成するには、 *Username* 、 *Email* 、 *First Name* 、 *Last Name* "
+"フィールドを入力します。 *User Enabled* を *On* に切り替えて、 *Save* をクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:26
-#, fuzzy
-#| msgid "image:{project_images}/client-install-selected.png[]"
 msgid ""
-"image:{project_images}/getting-started/hello-world/create-user.png[alt=\"Add "
-"User\"]"
-msgstr "image:{project_images}/client-install-selected.png[]"
+"image:{project_images}/getting-started/hello-world/create-user.png[alt=\"Add"
+" User\"]"
+msgstr ""
+"image:{project_images}/getting-started/hello-world/create-"
+"user.png[alt=\"ユーザーの追加\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:28
-#, fuzzy
-#| msgid ""
-#| "The next step is to define a temporary password for your new user. Click "
-#| "the *Credentials* tab."
 msgid "Set a password for the user by clicking the *Credentials* tab."
-msgstr ""
-"次に、新規ユーザーの仮パスワードを設定します。*Credentials* タブをクリックし"
-"ます。"
+msgstr "*Credentials* タブをクリックして、ユーザーのパスワードを設定します。"
 
 #. type: Block title
 #: source/authorization_services/topics/hello-world-create-realm.adoc:29
-#, fuzzy, no-wrap
-#| msgid "Set Temporary Password"
+#, no-wrap
 msgid "Set User Password"
-msgstr "仮パスワードの設定"
+msgstr "ユーザーのパスワード設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:31
-#, fuzzy
-#| msgid "image:{project_images}/client-install-selected.png[]"
 msgid ""
-"image:{project_images}/getting-started/hello-world/reset-user-pwd.png[alt="
-"\"Set User Password\"]"
-msgstr "image:{project_images}/client-install-selected.png[]"
+"image:{project_images}/getting-started/hello-world/reset-user-"
+"pwd.png[alt=\"Set User Password\"]"
+msgstr ""
+"image:{project_images}/getting-started/hello-world/reset-user-"
+"pwd.png[alt=\"ユーザーのパスワード設定\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:33
@@ -141,14 +134,10 @@ msgid ""
 "Complete the *New Password* and *Password Confirmation* fields with a "
 "password and click the *Temporary* switch to *OFF*."
 msgstr ""
+"*New Password* と *Password Confirmation* フィールドを入力し、 *Temporary* を *OFF* "
+"に切り替えます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:34
-#, fuzzy
-#| msgid ""
-#| "Click *Reset Password* to reset the user password to the new one you "
-#| "specified."
 msgid "Click *Reset Password* to set the user's password."
-msgstr ""
-"ユーザーパスワードを指定した新しいパスワードにリセットするには、*Reset "
-"Password* をクリックします。"
+msgstr "*Reset Password* をクリックして、ユーザーのパスワードを設定します。"

--- a/i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/getting_started/topics/first-realm/user.adoc:13
 #: source/authorization_services/topics/hello-world-create-realm.adoc:20
 msgid "On the right side of the empty user list, click *Add User*."
-msgstr "空のユーザー・リストの右側にある *Add User* をクリックします。"
+msgstr "空のユーザーリストの右側にある *Add User* をクリックします。"
 
 #. type: Block title
 #: source/getting_started/topics/first-realm/user.adoc:15
@@ -88,7 +88,7 @@ msgstr ""
 msgid ""
 "Create a user for your newly created realm. Click *Users*. The user list "
 "page opens."
-msgstr "新しく作成したレルムのユーザーを作成します。 *Users* をクリックします。ユーザー・リストのページが開きます。"
+msgstr "新しく作成したレルムのユーザーを作成します。 *Users* をクリックします。ユーザーリストのページが開きます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/hello-world-create-realm.adoc:23


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/hello-world-create-realm.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__hello-world-create-realm
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__hello-world-create-realm/ja_JP/index.html
