### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po
@@ -1,32 +1,32 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Client Registration Policies"
+#, no-wrap
 msgid "Evaluating and Testing Policies"
-msgstr "クライアント登録ポリシー"
+msgstr "ポリシーの評価とテスト"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:5
 msgid ""
 "When designing your policies, you can simulate authorization requests to "
 "test how your policies are being evaluated."
-msgstr ""
+msgstr "ポリシーを設計する際に、認可要求をシミュレートして、ポリシーの評価方法をテストすることができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:7
@@ -35,66 +35,73 @@ msgid ""
 "when editing a resource server. There you can specify different inputs to "
 "simulate real authorization requests and test the effect of your policies."
 msgstr ""
+"リソース・サーバーを編集するときに `Evaluate` "
+"タブをクリックすると、ポリシー評価ツールにアクセスできます。そこで、さまざまな入力を指定して、実際の認可要求をシミュレートし、ポリシーの効果をテストすることができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:9
 msgid ""
-"image:{project_images}/policy-evaluation-tool/policy-evaluation-tool.png[alt="
-"\"Policy Evaluation Tool\"]"
+"image:{project_images}/policy-evaluation-tool/policy-evaluation-"
+"tool.png[alt=\"Policy Evaluation Tool\"]"
 msgstr ""
+"image:{project_images}/policy-evaluation-tool/policy-evaluation-"
+"tool.png[alt=\"ポリシー評価ツール\"]"
 
 #. type: Title ==
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:10
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Providing Identity Information"
-msgstr "ドメイン設定"
+msgstr "アイデンティティー情報の提供"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:13
 msgid ""
 "The *Identity Information* filters can be used to specify the user "
 "requesting permissions."
-msgstr ""
+msgstr "*Identity Information* フィルターを使用して、アクセス権を要求するユーザーを指定できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:15
 msgid ""
 "You can also click *Entitlement* to obtain all permissions for the user you "
 "selected."
-msgstr ""
+msgstr "*Entitlement* をクリックして、選択したユーザーのすべての権限を取得することもできます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:16
 #, no-wrap
 msgid "Providing Contextual Information"
-msgstr ""
+msgstr "コンテキスト情報の提供"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:19
 msgid ""
 "The *Contextual Information* filters can be used to define additional "
-"attributes to the evaluation context, so that policies can obtain these same "
-"attributes."
+"attributes to the evaluation context, so that policies can obtain these same"
+" attributes."
 msgstr ""
+"*Contextual Information* "
+"フィルターを使用して、評価コンテキストに追加の属性を定義し、ポリシーがこれらの同じ属性を取得できるようにすることができます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:20
-#, fuzzy, no-wrap
-#| msgid "Client Registration"
+#, no-wrap
 msgid "Providing the Permissions"
-msgstr "クライアントの登録"
+msgstr "権限の提供"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:24
 msgid ""
-"The *Permissions* filters can be used to build an authorization request. You "
-"can request permissions for a set of one or more resources and scopes. If "
-"you want to simulate authorization requests based on all protected resources "
-"and scopes, click *Add* without specifying any `Resources` or `Scopes`."
+"The *Permissions* filters can be used to build an authorization request. You"
+" can request permissions for a set of one or more resources and scopes. If "
+"you want to simulate authorization requests based on all protected resources"
+" and scopes, click *Add* without specifying any `Resources` or `Scopes`."
 msgstr ""
+"*Permissions* "
+"フィルターを使用して、認可要求を作成できます。１つまたは複数のリソースとスコープのセットに対するアクセス許可を要求できます。すべての保護されたリソースとスコープに基づいて認可リクエストをシミュレートする場合は、"
+" `Resources` または `Scopes` を指定せずに *Add* をクリックします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:25
 msgid "When you've specified your desired values, click *Evaluate*."
-msgstr ""
+msgstr "目的の値を指定したら、 *Evaluate* をクリックします。"

--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +26,7 @@ msgstr "ポリシーの評価とテスト"
 msgid ""
 "When designing your policies, you can simulate authorization requests to "
 "test how your policies are being evaluated."
-msgstr "ポリシーを設計する際に、認可要求をシミュレートして、ポリシーの評価方法をテストすることができます。"
+msgstr "ポリシーを設計する際に、認可リクエストをシミュレートして、ポリシーの評価方法をテストすることができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:7
@@ -36,7 +36,7 @@ msgid ""
 "simulate real authorization requests and test the effect of your policies."
 msgstr ""
 "リソース・サーバーを編集するときに `Evaluate` "
-"タブをクリックすると、ポリシー評価ツールにアクセスできます。そこで、さまざまな入力を指定して、実際の認可要求をシミュレートし、ポリシーの効果をテストすることができます。"
+"タブをクリックすると、ポリシー評価ツールにアクセスできます。そこで、さまざまな入力を指定して、実際の認可リクエストをシミュレートし、ポリシーの効果をテストすることができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:9
@@ -58,14 +58,14 @@ msgstr "アイデンティティー情報の提供"
 msgid ""
 "The *Identity Information* filters can be used to specify the user "
 "requesting permissions."
-msgstr "*Identity Information* フィルターを使用して、アクセス権を要求するユーザーを指定できます。"
+msgstr "*Identity Information* フィルターを使用して、パーミッションを要求するユーザーを指定できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:15
 msgid ""
 "You can also click *Entitlement* to obtain all permissions for the user you "
 "selected."
-msgstr "*Entitlement* をクリックして、選択したユーザーのすべての権限を取得することもできます。"
+msgstr "*Entitlement* をクリックして、選択したユーザーのすべてのパーミッションを取得することもできます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:16
@@ -87,7 +87,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:20
 #, no-wrap
 msgid "Providing the Permissions"
-msgstr "権限の提供"
+msgstr "パーミッションの提供"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:24
@@ -98,7 +98,7 @@ msgid ""
 " and scopes, click *Add* without specifying any `Resources` or `Scopes`."
 msgstr ""
 "*Permissions* "
-"フィルターを使用して、認可要求を作成できます。１つまたは複数のリソースとスコープのセットに対するアクセス許可を要求できます。すべての保護されたリソースとスコープに基づいて認可リクエストをシミュレートする場合は、"
+"フィルターを使用して、認可リクエストを作成できます。1つ以上のリソースとスコープのセットに対するパーミッションを要求できます。すべての保護されたリソースとスコープに基づいて認可リクエストをシミュレートする場合は、"
 " `Resources` または `Scopes` を指定せずに *Add* をクリックします。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-evaluation-tool-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__policy-evaluation-tool-overview/ja_JP/index.html
