### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgstr "リソースの管理"
 msgid ""
 "Resource servers can manage their resources remotely using a UMA-compliant "
 "endpoint."
-msgstr "リソース・サーバーは、UMA準拠のエンドポイントを使用して、リモートでリソースを管理できます。"
+msgstr "リソースサーバーは、UMA準拠のエンドポイントを使用して、リモートでリソースを管理できます。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:8
@@ -50,31 +50,31 @@ msgstr "このエンドポイントは、以下の概要を説明した登録操
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:13
 #: source/authorization_services/topics/service-protection-resources-api.adoc:13
 msgid "Create resource set description: POST /resource_set"
-msgstr "リソース・セットの内容を作成する: POST /resource_set"
+msgstr "リソースセットの説明を作成する: POST /resource_set"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:14
 #: source/authorization_services/topics/service-protection-resources-api.adoc:14
 msgid "Read resource set description: GET /resource_set/{_id}"
-msgstr "リソース・セットの内容を読み込む: GET /resource_set/{_id}"
+msgstr "リソースセットの説明を読み込む: GET /resource_set/{_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:15
 #: source/authorization_services/topics/service-protection-resources-api.adoc:15
 msgid "Update resource set description: PUT /resource_set/{_id}"
-msgstr "リソース・セットの内容を更新する: PUT /resource_set/{_id}"
+msgstr "リソースセットの説明を更新する: PUT /resource_set/{_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:16
 #: source/authorization_services/topics/service-protection-resources-api.adoc:16
 msgid "Delete resource set description: DELETE /resource_set/{_id}"
-msgstr "リソース・セットの内容を削除する: DELETE /resource_set/{_id}"
+msgstr "リソースセットの説明を削除する: DELETE /resource_set/{_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:17
 #: source/authorization_services/topics/service-protection-resources-api.adoc:17
 msgid "List resource set descriptions: GET /resource_set"
-msgstr "リソース・セットの内容を表示する: GET /resource_set"
+msgstr "リソースセットの説明を表示する: GET /resource_set"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:18
@@ -82,7 +82,7 @@ msgstr "リソース・セットの内容を表示する: GET /resource_set"
 msgid ""
 "List resource set descriptions using a filter: GET "
 "/resource_set?filter=${filter}"
-msgstr "フィルターを使用して、リソース・セットの内容を表示する: GET /resource_set?filter=${filter}"
+msgstr "フィルターを使用して、リソースセットの説明を表示する: GET /resource_set?filter=${filter}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:19
@@ -93,4 +93,4 @@ msgid ""
 "v1_0_1.html[UMA Resource Set Registration]."
 msgstr ""
 "各操作の規約の詳細については、 https://docs.kantarainitiative.org/uma/rec-oauth-resource-"
-"reg-v1_0_1.html[UMAリソース・セットの登録] を参照してください。"
+"reg-v1_0_1.html[UMAリソースセットの登録] を参照してください。"

--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api.ja_JP.po
@@ -1,26 +1,26 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:2
 #: source/authorization_services/topics/service-protection-resources-api.adoc:2
-#, fuzzy, no-wrap
-#| msgid "signRequest"
+#, no-wrap
 msgid "Managing Resources"
-msgstr "signRequest"
+msgstr "リソースの管理"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:5
@@ -28,17 +28,15 @@ msgstr "signRequest"
 msgid ""
 "Resource servers can manage their resources remotely using a UMA-compliant "
 "endpoint."
-msgstr ""
+msgstr "リソース・サーバーは、UMA準拠のエンドポイントを使用して、リモートでリソースを管理できます。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:8
 #: source/authorization_services/topics/service-protection-resources-api.adoc:8
-#, fuzzy
-#| msgid "http://localhost:8080/auth/realms/demo/account"
 msgid ""
-"http://${host}:${port}/auth/realms/${realm_name}/authz/protection/"
-"resource_set"
-msgstr "http://localhost:8080/auth/realms/demo/account"
+"http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set"
+msgstr ""
+"http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:11
@@ -46,51 +44,53 @@ msgstr "http://localhost:8080/auth/realms/demo/account"
 msgid ""
 "This endpoint provides registration operations outlined as follows (entire "
 "path omitted for clarity):"
-msgstr ""
+msgstr "このエンドポイントは、以下の概要を説明した登録操作を提供します（明確にするため、パス全体が省略されています）。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:13
 #: source/authorization_services/topics/service-protection-resources-api.adoc:13
 msgid "Create resource set description: POST /resource_set"
-msgstr ""
+msgstr "リソース・セットの内容を作成する: POST /resource_set"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:14
 #: source/authorization_services/topics/service-protection-resources-api.adoc:14
 msgid "Read resource set description: GET /resource_set/{_id}"
-msgstr ""
+msgstr "リソース・セットの内容を読み込む: GET /resource_set/{_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:15
 #: source/authorization_services/topics/service-protection-resources-api.adoc:15
 msgid "Update resource set description: PUT /resource_set/{_id}"
-msgstr ""
+msgstr "リソース・セットの内容を更新する: PUT /resource_set/{_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:16
 #: source/authorization_services/topics/service-protection-resources-api.adoc:16
 msgid "Delete resource set description: DELETE /resource_set/{_id}"
-msgstr ""
+msgstr "リソース・セットの内容を削除する: DELETE /resource_set/{_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:17
 #: source/authorization_services/topics/service-protection-resources-api.adoc:17
 msgid "List resource set descriptions: GET /resource_set"
-msgstr ""
+msgstr "リソース・セットの内容を表示する: GET /resource_set"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:18
 #: source/authorization_services/topics/service-protection-resources-api.adoc:18
 msgid ""
-"List resource set descriptions using a filter: GET /resource_set?filter="
-"${filter}"
-msgstr ""
+"List resource set descriptions using a filter: GET "
+"/resource_set?filter=${filter}"
+msgstr "フィルターを使用して、リソース・セットの内容を表示する: GET /resource_set?filter=${filter}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-protection-resources-api-papi.adoc:19
 #: source/authorization_services/topics/service-protection-resources-api.adoc:19
 msgid ""
 "For more information about the contract for each of these operations, see "
-"https://docs.kantarainitiative.org/uma/rec-oauth-resource-reg-v1_0_1."
-"html[UMA Resource Set Registration]."
+"https://docs.kantarainitiative.org/uma/rec-oauth-resource-reg-"
+"v1_0_1.html[UMA Resource Set Registration]."
 msgstr ""
+"各操作の規約の詳細については、 https://docs.kantarainitiative.org/uma/rec-oauth-resource-"
+"reg-v1_0_1.html[UMAリソース・セットの登録] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-resources-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-protection-resources-api/ja_JP/index.html
