### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -44,13 +44,13 @@ msgid ""
 " with a client ID so {project_name} can provide a login page, single sign-on"
 " (SSO) session management, and other services."
 msgstr ""
-"{project_name}を使用できるように、任意のアプリケーションのクライアント設定を作成または取得する必要があります。通常は、一意のホスト名でホストされる新しいアプリケーションごとに、新しいクライアントを設定します。アプリケーションが{project_name}と対話するとき、アプリケーションはクライアントIDで自身を識別し、{project_name}はログイン・ページ、シングル・サインオン（SSO）セッション管理、およびその他のサービスを提供できます。"
+"{project_name}を使用できるように、任意のアプリケーションのクライアント設定を作成または取得する必要があります。通常は、一意のホスト名でホストされる新しいアプリケーションごとに、新しいクライアントを設定します。アプリケーションが{project_name}と対話する際に、アプリケーションはクライアントIDで自身を識別し、{project_name}はログイン・ページ、シングル・サインオン（SSO）セッション管理、およびその他のサービスを提供できます。"
 
 #. type: Plain text
 msgid ""
 "You can configure application clients from a command line with the Client "
 "Registration CLI, and you can use it in shell scripts."
-msgstr "アプリケーション・クライアントは、クライアント登録CLIを使用してコマンド・ラインから設定できます（シェルスクリプトで使用できます）。"
+msgstr "アプリケーション・クライアントは、クライアント登録CLIを使用してコマンド・ラインから設定でき、シェルスクリプトで使用できます。"
 
 #. type: Plain text
 msgid ""
@@ -61,7 +61,7 @@ msgid ""
 msgstr ""
 "特定のユーザーが `クライアント登録CLI` "
 "を使用できるようにするため、通常、{project_name}管理者は管理コンソールを使って新しいユーザーを適切なロールで設定するか、クライアント登録REST"
-" APIへのアクセス権を与えるように新しいクライアントとクライアント・シークレットを設定します 。"
+" APIの権限を与えるように新しいクライアントとクライアント・シークレットを設定します 。"
 
 #. type: Title ===
 #, no-wrap
@@ -103,8 +103,8 @@ msgid ""
 "only or *create-client* to create new clients."
 msgstr ""
 "*Available Roles > manage-client* "
-"を選択して、クライアント管理パーミッションのフルセットを付与します。別のオプションは、 *view-clients* を読み取り専用に、または "
-"*create-client* を新しいクライアントを作成するために選択することです。"
+"を選択して、クライアント管理権限のフルセットを付与します。別の選択肢として、読み取り専用に *view-clients* "
+"を、または新しいクライアント作成用に *create-client* を選択します。"
 
 #. type: delimited block =
 msgid ""
@@ -112,7 +112,7 @@ msgid ""
 "without the use of <<_initial_access_token,Initial Access Token>> or "
 "<<_registration_access_token,Registration Access Token>>."
 msgstr ""
-"これらのパーミッションは、ユーザーに<<_initial_access_token初期アクセストークンまたは<<_registration_access_token,登録アクセストークン>>を使用せずに操作を実行できるようにします。"
+"これらの権限は、ユーザーに<<_initial_access_token,初期アクセス・トークンまたは<<_registration_access_token,登録アクセス・トークン>>を使用せずに操作を実行できるようにします。"
 
 #. type: Plain text
 msgid ""
@@ -121,9 +121,9 @@ msgid ""
 " but cannot use it without an Initial Access Token. Trying to perform any "
 "operations without a token results in a *403 Forbidden* error."
 msgstr ""
-"[command]`realm-management` ロールをユーザに割り当てることはできません。その場合、ユーザーはRegistration "
-"Client CLIでログインできますが、初期アクセストークンなしでは使用できません。トークンなしで操作を実行しようとすると、 *403 "
-"Forbidden* エラーが発生します。"
+"[command]`realm-management` "
+"ロールをユーザーに割り当てることはできません。その場合、ユーザーはクライアント登録CLIでログインできますが、初期アクセス・トークンなしでは使用できません。トークンなしで操作を実行しようとすると、"
+" *403 Forbidden* エラーが発生します。"
 
 #. type: Plain text
 msgid ""
@@ -132,7 +132,7 @@ msgid ""
 "menu."
 msgstr ""
 "管理者は、管理コンソールの *Realm Settings > Client Registration > Initial Access Token* "
-"メニューから初期アクセストークンを発行できます。"
+"メニューから初期アクセス・トークンを発行できます。"
 
 #. type: Title ===
 #, no-wrap
@@ -155,7 +155,7 @@ msgid ""
 " [filename]`Confidential` and selecting *Credentials > ClientId and Secret*."
 msgstr ""
 "クライアント [filename]`Access Type` を [filename]`Confidential` に設定し、 *Credentials"
-" > ClientId and Secret*を選択することで、セキュリティを強化してください。"
+" > ClientId and Secret* を選択することで、セキュリティを強化してください。"
 
 #. type: Plain text
 msgid ""
@@ -177,8 +177,8 @@ msgid ""
 "Specify which [filename]`clientId` to use (for example, [command]`--client "
 "reg-cli`) when running [command]`kcreg config credentials`."
 msgstr ""
-"[command]`kcreg config credentials` を実行するときに使用するには、 [filename]`clientId` "
-"（たとえば、 [command]`--client reg-cli` ）を指定します。"
+"[command]`kcreg config credentials` を実行する際に使用する [filename]`clientId` "
+"を指定します（たとえば、 [command]`--client reg-cli` ）。"
 
 #. type: Plain text
 msgid ""
@@ -186,8 +186,8 @@ msgid ""
 " the client by selecting a client to edit in the *Clients* section of the "
 "`Admin Console`."
 msgstr ""
-"`Admin Console` の *Clients* "
-"セクションで、編集するクライアントを選択することで、クライアントに関連付けられたサービス・アカウントを使用したい場合は、サービス・アカウントを有効にします。"
+"クライアントに関連付けられたサービス・アカウントを使用したい場合は、 `管理コンソール` の *Clients* "
+"セクションで編集するクライアントを選択することで、サービス・アカウントを有効にします。"
 
 #. type: Plain text
 msgid ""
@@ -226,8 +226,8 @@ msgid ""
 "directory. The Linux script is called [filename]`kcreg.sh`, and the Windows "
 "script is called [filename]`kcreg.bat`."
 msgstr ""
-"クライアント登録CLIは、Keycloakサーバー・ディストリビューション内にパッケージ化されています。実行スクリプトは [filename]`bin`"
-" ディレクトリにあります。Linuxスクリプトは [filename]`kcreg.sh` で、Windowsスクリプトは "
+"クライアント登録CLIは、Keycloakサーバーの配布物内にパッケージ化されています。実行スクリプトは [filename]`bin` "
+"ディレクトリにあります。Linuxスクリプトは [filename]`kcreg.sh` で、Windowsスクリプトは "
 "[filename]`kcreg.bat` です。"
 
 #. type: Plain text
@@ -240,11 +240,11 @@ msgstr ""
 
 #. type: Plain text
 msgid "For example, on:"
-msgstr "例えば"
+msgstr "以下に例を示します。"
 
 #. type: Plain text
 msgid "Linux:"
-msgstr "Linuxの場合"
+msgstr "Linuxの場合："
 
 #. type: delimited block -
 #, no-wrap
@@ -257,7 +257,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Windows:"
-msgstr "Windowsの場合"
+msgstr "Windowsの場合："
 
 #. type: delimited block -
 #, no-wrap
@@ -272,8 +272,7 @@ msgstr ""
 msgid ""
 "[filename]`KEYCLOAK_HOME` refers to a directory where the Keycloak Server "
 "distribution was unpacked."
-msgstr ""
-"[filename]`KEYCLOAK_HOME` は、Keycloakサーバー・ディストリビューションが解凍されたディレクトリを参照します。"
+msgstr "[filename]`KEYCLOAK_HOME` は、Keycloakサーバーの配布物が解凍されたディレクトリーを示します。"
 
 #. type: Title ===
 #, no-wrap
@@ -315,7 +314,7 @@ msgid ""
 "In a production environment, Keycloak has to be accessed with "
 "[filename]`https:` to avoid exposing tokens to network sniffers."
 msgstr ""
-"実稼働環境では、ネットワーク・スニファーへのトークンの公開を避けるため、 [filename]`https:` "
+"プロダクション環境では、ネットワーク・スニファーへのトークンの公開を避けるため、 [filename]`https:` "
 "でKeycloakにアクセスする必要があります。"
 
 #. type: Plain text
@@ -355,7 +354,7 @@ msgstr "ログイン"
 msgid ""
 "Specify a server endpoint URL and a realm when you log in with the Client "
 "Registration CLI."
-msgstr "クライアント登録CLIを使用してログインするときに、サーバーのエンドポイントURLとレルムを指定します。"
+msgstr "クライアント登録CLIを使用してログインする際は、サーバーのエンドポイントURLとレルムを指定します。"
 
 #. type: Plain text
 msgid ""
@@ -377,8 +376,8 @@ msgid ""
 "can create a single user in the [filename]`master` realm and add roles for "
 "managing clients in different realms."
 msgstr ""
-"ログイン方法にかかわらず、ログインするアカウントには、クライアント登録操作を実行するための適切な権限が必要です。master以外のレルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムに設定するか、単一のユーザーを"
-" [filename]`master` レルムに作成し、異なるレルムのクライアントを管理するロールを追加することができます。"
+"ログイン方法にかかわらず、ログインするアカウントには、クライアント登録操作を実行するための適切な権限が必要です。master以外のレルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムで設定するか、"
+" [filename]`master` レルムで1人のユーザーを作成して、異なるレルムのクライアントを管理するロールを追加します。"
 
 #. type: Plain text
 msgid ""
@@ -386,7 +385,7 @@ msgid ""
 "Console web interface or the Admin Client CLI to configure users. See "
 "link:{adminguide_link}[{adminguide_name}] for more details."
 msgstr ""
-"クライアント登録CLIでユーザーを設定することはできません。管理コンソールのWebインタフェースまたは管理クライアントCLIを使用して、ユーザを設定します。詳細については、link:{adminguide_link}[{adminguide_name}]を参照してください。"
+"クライアント登録CLIでユーザーを設定することはできません。管理コンソールのWebインターフェイスまたは管理クライアントCLIを使用して、ユーザを設定します。詳細については、link:{adminguide_link}[{adminguide_name}]を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -440,7 +439,7 @@ msgid ""
 msgstr ""
 "デフォルトでは、クライアント登録CLIは、ユーザーのホーム・ディレクトリー配下のデフォルトの場所に設定ファイル（ "
 "[filename]`./.keycloak/kcreg.config` ）を自動的に保存します。 [command]`--config` "
-"オプションを使うと、複数の認証済みセッションを並行して保存するために、別のファイルや場所を指すことができます。これは、単一のスレッドから単一の設定ファイルに結び付けられた操作を実行する最も安全な方法です。"
+"オプションを使うと別のファイルや場所を指すことができ、複数の認証済みセッションを並行して処理できます。1つのスレッドから1つの設定ファイルに結び付けられた操作を実行するのが最も安全な方法です。"
 
 #. type: delimited block =
 msgid ""
@@ -457,7 +456,7 @@ msgid ""
 "it is less convenient and requires more token requests to do so. Specify all"
 " authentication information with each [command]`kcreg` invocation."
 msgstr ""
-"利便性が低く、より多くのトークン・リクエストではありますが、すべてのコマンドで [command]`--no-config` "
+"利便性が低く、より多くのトークン要求が必要ではありますが、すべてのコマンドで [command]`--no-config` "
 "オプションを使用することで、設定ファイル内にシークレットを保存しないようにすることができます。各 [command]`kcreg` "
 "呼び出しごとにすべての認証情報を指定してください。"
 
@@ -475,7 +474,7 @@ msgid ""
 "The realm administrator can limit the maximum age of the Initial Access "
 "Token and the total number of clients that can be created with it."
 msgstr ""
-"使用したいKeycloakサーバーでアカウントを設定していない開発者は、クライアント登録CLIを使用できます。レルム管理者が開発者に初期アクセス・トークンを発行するときに可能です。これらのトークンの発行方法と配布方法は、レルム管理者が決定します。レルム管理者は、初期アクセストークンの最大経過時間と、初期アクセス・トークンを使用して作成できるクライアントの総数を制限できます。"
+"使用したいKeycloakサーバーで設定されたアカウントを持っていない開発者は、クライアント登録CLIを使用できます。レルム管理者が開発者に初期アクセス・トークンを発行することにより、開発者は使用することができます。これらのトークンの発行方法と配布方法は、レルム管理者が決定します。レルム管理者は、初期アクセス・トークンの最大経過時間と、初期アクセス・トークンを使用して作成できるクライアントの総数を制限できます。"
 
 #. type: Plain text
 msgid ""
@@ -575,7 +574,7 @@ msgid ""
 "it may contain, set any other attributes, and print the configuration to a "
 "standard output after successful creation."
 msgstr ""
-"次の例は、作成が成功した後にJSONファイルを読み込み、それに含まれる可能性のあるクライアントIDを上書きし、他の属性を設定し、標準出力に設定を出力する方法を示しています。"
+"次の例は、JSONファイルを読み込み、それに含まれるクライアントIDを上書きし、他の属性を設定し、作成が成功した後に標準出力に設定を出力する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -611,7 +610,7 @@ msgid ""
 "should not have any id fields in your template and should not specify them "
 "as arguments to the [command]`kcreg create` command."
 msgstr ""
-" [command]`kcreg attrs` "
+"[command]`kcreg attrs` "
 "を使って、利用可能な属性の一覧を取得できます。多くの設定属性の妥当性や一貫性はチェックされません。適切な値を指定する必要があります。また、テンプレートには"
 " `id` フィールドを持たせず、  [command]`kcreg create` の引数として指定しないことを忘れないでください。"
 
@@ -722,8 +721,7 @@ msgid ""
 "treating the JSON file as a full, new configuration, it should treat it as a"
 " set of attributes to be applied over the existing configuration."
 msgstr ""
-"適用される変更のみを含むファイルを使用することもできるので、引数として多すぎる値を指定する必要はありません。この場合、 "
-"[command]`--merge` "
+"適用される変更のみを含むファイルを使用することもできるので、引数に多くの値を指定する必要はありません。この場合、 [command]`--merge` "
 "をクライアント登録CLIに指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
 
 #. type: delimited block -
@@ -786,9 +784,9 @@ msgid ""
 "client without authenticating with an account that has *manage-clients* "
 "permissions."
 msgstr ""
-"[command]`--no-config` モードを使用して作成、読み込み、更新、削除（CRUD）操作を実行すると、 `クライアント登録CLI` "
-"は登録アクセス・トークンを処理できなくなります。その場合、クライアントのために最も最近発行された登録アクセス・トークンの追跡を失う可能性があり"
-"、'manage-clients'権限を持つアカウントで認証なしでは、そのクライアントでそれ以上のCRUD操作を実行することは不可能になります。"
+"[command]`--no-config` "
+"モードを使用して作成、読み込み、更新、削除（CRUD）操作を実行すると、クライアント登録CLIは登録アクセス・トークンを処理できなくなります。その場合、クライアントのために最も最近発行された登録アクセス・トークンの追跡を失う可能性があり、"
+" *manage-clients* 権限を持つアカウントで認証なしでは、そのクライアントでそれ以上のCRUD操作を実行することは不可能になります。"
 
 #. type: Plain text
 msgid ""
@@ -802,10 +800,10 @@ msgid ""
 "and have the Client Registration CLI automatically handle it for you from "
 "that point on."
 msgstr ""
-"アクセス権を持っている場合は、クライアント用に新しい登録アクセス・トークンを発行し、標準出力に出力するか、選択した設定ファイルに保存することができます。それ以外の場合は、レルム管理者にクライアントの新しい登録アクセス・トークンを発行して、それを送信するよう依頼する必要があります。その際は、"
+"権限を持っている場合は、クライアント用に新しい登録アクセス・トークンを発行し、標準出力に出力するか、選択した設定ファイルに保存することができます。それ以外の場合は、レルム管理者にクライアントの新しい登録アクセス・トークンを発行して、それを送信するよう依頼する必要があります。その際は、"
 " [command]`--token` オプションを使ってCRUDコマンドに渡すことができます。また、 [command]`kcreg config "
-"registration-token` コマンドを使って新しいトークンを設定ファイルに保存し、 `クライアント登録CLI` "
-"が自動的にそれを処理するようにすることもできます。"
+"registration-token` "
+"コマンドを使って新しいトークンを設定ファイルに保存し、クライアント登録CLIが自動的にそれを処理するようにすることもできます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -27,43 +27,41 @@ msgstr "クライアント登録CLI"
 
 #. type: Plain text
 msgid ""
-"`Client Registration CLI` is a command line interface tool for application "
-"developers to configure new clients in self-service manner when integrating "
-"with {project_name}. It is specifically designed to interact with "
-"{project_name} Client Registration REST endpoints."
+"The Client Registration CLI is a command-line interface (CLI) tool for "
+"application developers to configure new clients in a self-service manner "
+"when integrating with {project_name}. It is specifically designed to "
+"interact with {project_name} Client Registration REST endpoints."
 msgstr ""
-"`クライアント登録CLI` "
-"は、アプリケーション開発者が{project_name}と統合する際にセルフ・サービスで新しいクライアントを設定するためのコマンドライン・インターフェイス・ツールです。"
+"クライアント登録CLIは、アプリケーション開発者が{project_name}と統合する際にセルフ・サービスで新しいクライアントを設定するためのコマンドライン・インターフェイス（CLI）ツールです。"
 " これは、{project_name}クライアント登録RESTエンドポイントと対話するように特別に設計されています。"
 
 #. type: Plain text
 msgid ""
-"In order for any application to be able to use {project_name} it is "
-"necessary to create or obtain a client configuration. Usually a new client "
-"is configured for each new application hosted on a unique hostname. When "
-"application interacts with {project_name} it needs to identify itself with a"
-" `client_id` in order for {project_name} to be able to provide login page, "
-"SSO session management, and other services."
+"It is necessary to create or obtain a client configuration for any "
+"application to be able to use {project_name}. You usually configure a new "
+"client for each new application hosted on a unique host name. When an "
+"application interacts with {project_name}, the application identifies itself"
+" with a client ID so {project_name} can provide a login page, single sign-on"
+" (SSO) session management, and other services."
 msgstr ""
-"アプリケーションが{project_name}を使用できるようにするには、クライアントの設定を作成または取得する必要があります。通常、新しいクライアントは一意なホスト名でホストされる新しいアプリケーションごとに設定されます。アプリケーションが{project_name}と対話する際に、{project_name}がログインページ、SSOセッション管理、およびその他のサービスを提供できるようにするために、自身を"
-" `client_id` で識別する必要があります。"
+"{project_name}を使用できるように、任意のアプリケーションのクライアント設定を作成または取得する必要があります。通常は、一意のホスト名でホストされる新しいアプリケーションごとに、新しいクライアントを設定します。アプリケーションが{project_name}と対話するとき、アプリケーションはクライアントIDで自身を識別し、{project_name}はログイン・ページ、シングル・サインオン（SSO）セッション管理、およびその他のサービスを提供できます。"
 
 #. type: Plain text
 msgid ""
-"`Client Registration CLI` allows you to configure application clients from a"
-" command line, and can be used in shell scripts as well."
-msgstr ""
-"`クライアント登録CLI` では、コマンドラインからアプリケーション・クライアントを設定することができます。シェルスクリプトでも使用できます。"
+"You can configure application clients from a command line with the Client "
+"Registration CLI, and you can use it in shell scripts."
+msgstr "アプリケーション・クライアントは、クライアント登録CLIを使用してコマンド・ラインから設定できます（シェルスクリプトで使用できます）。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"To allow a particular user to use `Client Registration CLI` the {project_name} administrator will typically use `Admin Console` to configure\n"
-" a new user with proper roles, or configure a new client and client secret to grant access to `Client Registration REST API`.\n"
+"To allow a particular user to use `Client Registration CLI` the "
+"{project_name} administrator typically uses the Admin Console to configure a"
+" new user with proper roles or to configure a new client and client secret "
+"to grant access to the Client Registration REST API."
 msgstr ""
-"特定のユーザーが `クライアント登録CLI` を使用できるようにするため、通常、{project_name}管理者は `管理コンソール` "
-"を使って新しいユーザーを適切なロールで設定するか、`クライアント登録REST API` "
-"へのアクセス権を与えるように新しいクライアントとクライアント・シークレットを設定します 。\n"
+"特定のユーザーが `クライアント登録CLI` "
+"を使用できるようにするため、通常、{project_name}管理者は管理コンソールを使って新しいユーザーを適切なロールで設定するか、クライアント登録REST"
+" APIへのアクセス権を与えるように新しいクライアントとクライアント・シークレットを設定します 。"
 
 #. type: Title ===
 #, no-wrap
@@ -72,137 +70,181 @@ msgstr "クライアント登録CLIで使用するための新しい正規ユー
 
 #. type: Plain text
 msgid ""
-"Login as `admin` into `Admin Console` (e.g. "
-"`http://localhost:8080/auth/admin`). Select a realm you want to administer."
-"  If you want to use existing user, select that user for edit, otherwise "
-"create a new user. Go to `Role Mappings` tab. Under `Client Roles` select "
-"`realm-management` (if in master realm, select `NAME-realm` where NAME is "
-"name of the target realm - users in master realm can have access to any "
-"other realms).  Under `Available Roles` select `manage-client` for full set "
-"of client management permissions. Alternatively you can choose `view-"
-"clients` for read-only or `create-client` for ability to create new clients."
-"  These permissions grant user the capability to perform operations without "
-"the use of <<_initial_access_token,Initial Access Token>> or "
+"Log in to the Admin Console (for example, http://localhost:8080/auth/admin) "
+"as [command]`admin`."
+msgstr ""
+"管理コンソール（たとえば、 http://localhost:8080/auth/admin）に [command] `admin` "
+"としてログインします。"
+
+#. type: Plain text
+msgid "Select a realm to administer."
+msgstr "管理するレルムを選択します。"
+
+#. type: Plain text
+msgid ""
+"If you want to use an existing user, select that user to edit; otherwise, "
+"create a new user."
+msgstr "既存のユーザーを使用する場合は、編集するユーザーを選択します。それ以外の場合は、新しいユーザーを作成します。"
+
+#. type: Plain text
+msgid ""
+"Select *Role Mappings > Client Roles > realm-management*. If you are in the "
+"master realm, select *NAME-realm*, where `NAME` is the name of the target "
+"realm. You can grant access to any other realm to users in the master realm."
+msgstr ""
+"*Role Mappings > Client Roles > realm-management* を選択します。masterレルムにいる場合は"
+"、*NAME-realm* を選択します。ここで、 `NAME` "
+"はターゲット・レルムの名前です。masterレルム内のユーザーに他のレルムへのアクセス権を与えることができます。"
+
+#. type: Plain text
+msgid ""
+"Select *Available Roles > manage-client* to grant a full set of client "
+"management permissions. Another option is to choose *view-clients* for read-"
+"only or *create-client* to create new clients."
+msgstr ""
+"*Available Roles > manage-client* "
+"を選択して、クライアント管理パーミッションのフルセットを付与します。別のオプションは、 *view-clients* を読み取り専用に、または "
+"*create-client* を新しいクライアントを作成するために選択することです。"
+
+#. type: delimited block =
+msgid ""
+"These permissions grant the user the capability to perform operations "
+"without the use of <<_initial_access_token,Initial Access Token>> or "
 "<<_registration_access_token,Registration Access Token>>."
 msgstr ""
-"`管理コンソール` （例： `http://localhost:8080/auth/admin` ）に `admin` "
-"としてログインしてください。管理するレルムを選択します。既存のユーザーを使用する場合は、編集するユーザーを選択し、そうでない場合は新しいユーザーを作成します。"
-" `Role Mappings` のタブに行きます。 `Client Roles` の下で、 `realm-management` "
-"を選択します（masterレルムの場合、 `NAME-realm` "
-"を選択します。NAMEは対象のレルムの名前で、masterレルムのユーザーは他のレルムにアクセスできます）。 `Available Roles` "
-"で、クライアント管理権限のフルセットである `manage-client` を選択します。あるいは、読み取り専用の場合は `view-clients` "
-"を、新しいクライアントを作成する場合は ` create-client` "
-"を選択できます。これらの権限により、ユーザーは<<_initial_access_token,初期アクセス・トークン>>または<<_registration_access_token,登録アクセス・トークン>>を使用せずに操作を実行できるようになります。"
+"これらのパーミッションは、ユーザーに<<_initial_access_token初期アクセストークンまたは<<_registration_access_token,登録アクセストークン>>を使用せずに操作を実行できるようにします。"
 
 #. type: Plain text
 msgid ""
-"It's possible to not assign users any of `realm-management` roles. In that "
-"case user can still login with `Registration Client CLI` but will not be "
-"able to use it without being in possession of an `Initial Access Token`. "
-"Trying to perform any operations without it will result in `403 Forbidden` "
-"error."
+"It is possible to not assign any [command]`realm-management` roles to a "
+"user. In that case, a user can still log in with the Registration Client CLI"
+" but cannot use it without an Initial Access Token. Trying to perform any "
+"operations without a token results in a *403 Forbidden* error."
 msgstr ""
-"ユーザーに `realm-management` ロールを割り当てないことも可能です。その場合、ユーザーは `Registration Client "
-"CLI` でまだログインすることができますが、 `初期アクセス・トークン` "
-"を所有していなければ使用することはできません。それなしで何らかの操作を実行しようとすると `403 Forbidden` エラーが発生します。"
+"[command]`realm-management` ロールをユーザに割り当てることはできません。その場合、ユーザーはRegistration "
+"Client CLIでログインできますが、初期アクセストークンなしでは使用できません。トークンなしで操作を実行しようとすると、 *403 "
+"Forbidden* エラーが発生します。"
 
 #. type: Plain text
 msgid ""
-"Administrator can issue `Initial Access Tokens` from `Admin Console` by "
-"selecting `Client Registration` tab under `Realm Settings`, then `Initial "
-"Access Token` sub-tab."
+"The Administrator can issue Initial Access Tokens from the Admin Console "
+"through the *Realm Settings > Client Registration > Initial Access Token* "
+"menu."
 msgstr ""
-"管理者は、 `Realm Settings` の下の `Client Registration` タブを選択し、 `Initial Access "
-"Token` サブ・タブを選択することによって、管理コンソールから `初期アクセス・トークン` を発行することができます。"
+"管理者は、管理コンソールの *Realm Settings > Client Registration > Initial Access Token* "
+"メニューから初期アクセストークンを発行できます。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Configuring a client for use with Client Registration CLI"
-msgstr "クライアント登録CLIで使用するためのクライアント設定"
+msgid "Configuring a client for use with the Client Registration CLI"
+msgstr "クライアント登録CLIで使用するためのクライアントの設定"
 
 #. type: Plain text
 msgid ""
-"By default the `Client Registration CLI` identifies to the server as `admin-"
-"cli` client which is automatically configured for every new realm.  No "
-"additional client configuration is necessary when logging in with username. "
-"You may wish to strengthen security by configuring the client `Access Type` "
-"as `Confidential`, and under `Credentials` tab select `ClientId and Secret`."
-" When running `kcreg config credentials` you would then also have to provide"
-" a secret by using `--secret` option."
+"By default, the server recognizes the Client Registration CLI as the "
+"[filename]`admin-cli` client, which is configured automatically for every "
+"new realm. No additional client configuration is necessary when logging in "
+"with a user name."
 msgstr ""
-"デフォルトでは、 `クライアント登録CLI` はサーバーに `admin-cli` "
-"クライアントとして識別されます。これは新しいレルムごとに自動的に設定されます。ユーザー名でログインする場合、追加のクライアント設定は不要です。セキュリティを強化したい場合は、クライアントの"
-" `Access Type` を `Confidential` に設定し、 `Credentials` タブで `ClientId and "
-"Secret` を選択します。 `kcreg config credentials` を実行する際に、 ` --secret` "
-"オプションを使用してシークレットを提供する必要があります。"
+"デフォルトでは、サーバーはクライアント登録CLIを [filename]`admin-cli` "
+"クライアントとして認識します。これは新規レルムごとに自動的に設定されます。ユーザー名でログインする場合、追加のクライアント設定は必要ありません。"
 
 #. type: Plain text
 msgid ""
-"If you want to use a separate client configuration for `Registration Client "
-"CLI` then you can create a new client - you can call it `reg-cli` for "
-"example. When running `kcreg config credentials` you then need to specify "
-"which `clientId` to use e.g. `--client reg-cli`."
+"Strengthen the security by configuring the client [filename]`Access Type` as"
+" [filename]`Confidential` and selecting *Credentials > ClientId and Secret*."
 msgstr ""
-"`クライアント登録CLI` に対して別のクライアント設定を使いたい場合は、新しいクライアントを作成することができます。例えば、それを `reg-cli`"
-" と呼びます。 `kcreg config credentials` を実行する際は、 `--client reg-cli` のように、どの "
-"`clientId` を使用するかを指定する必要があります。"
+"クライアント [filename]`Access Type` を [filename]`Confidential` に設定し、 *Credentials"
+" > ClientId and Secret*を選択することで、セキュリティを強化してください。"
 
 #. type: Plain text
 msgid ""
-"If you want to use a service account associated with the client, you first "
-"need to enable service accounts. In `Admin Console` go to `Clients` section,"
-" and select a client for edit. Then under `Settings` change the `Access "
-"Type` to `Confidential`, and toggle `Service Accounts Enabled` setting to "
-"`On`. Make sure to `Save` the configuration."
+"Provide a secret when running [command]`kcreg config credentials` by using "
+"the [command]`--secret` option."
 msgstr ""
-"クライアントに関連付けられたサービス・アカウントを使用する場合は、まずサービス・アカウントを有効にする必要があります。 `管理コンソール` で "
-"`Clients` のセクションに行き、編集するクライアントを選択します。 次に、`Settings` の下で、 `Access Type` を "
-"`Confidential` に変更し、 `Service Accounts Enabled` を `On` に切り替えます。設定を `Save` "
-"することを忘れないでください。"
+"[command]`--secret` オプションを使用して、 [command]`kcreg config credentials` "
+"を実行する際にシークレットを提供してください。"
 
 #. type: Plain text
 msgid ""
-"Under `Credentials` tab you can choose to configure either `Client Id and "
-"Secret`, or `Signed JWT`."
-msgstr "`Credentials` タブで、`Client Id and Secret` か `Signed JWT` のどちらかを設定できます。"
-
-#. type: Plain text
-msgid ""
-"Having done that you can then omit specifying user during `kcreg config "
-"credentials`, and only provide client secret or keystore info."
+"Create a new client (for example, [filename]`reg-cli`) if you want to use a "
+"separate client configuration for the Registration Client CLI."
 msgstr ""
-"これを行うと、 `kcreg config credentials` "
-"の実行中にユーザーを指定することを省略し、クライアント・シークレットやキーストア情報のみを提供することができます。"
+"クライアント登録CLIに別のクライアント設定を使用したい場合は、新しいクライアントを作成します（たとえば、 [filename]`reg-cli` ）。"
+
+#. type: Plain text
+msgid ""
+"Specify which [filename]`clientId` to use (for example, [command]`--client "
+"reg-cli`) when running [command]`kcreg config credentials`."
+msgstr ""
+"[command]`kcreg config credentials` を実行するときに使用するには、 [filename]`clientId` "
+"（たとえば、 [command]`--client reg-cli` ）を指定します。"
+
+#. type: Plain text
+msgid ""
+"Enable service accounts if you want to use a service account associated with"
+" the client by selecting a client to edit in the *Clients* section of the "
+"`Admin Console`."
+msgstr ""
+"`Admin Console` の *Clients* "
+"セクションで、編集するクライアントを選択することで、クライアントに関連付けられたサービス・アカウントを使用したい場合は、サービス・アカウントを有効にします。"
+
+#. type: Plain text
+msgid ""
+"Under *Settings*, change the *Access Type* to *Confidential*, toggle the "
+"*Service Accounts Enabled* setting to *On*, and click [btn]`Save`."
+msgstr ""
+"*Settings* で、 *Access Type* を *Confidential* に変更し、 *Service Accounts "
+"Enabled* の設定を *On* に切り替え、 [btn]`Save` をクリックします。"
+
+#. type: delimited block =
+msgid ""
+"You can configure either [filename]`Client Id and Secret` or "
+"[filename]`Signed JWT` under the *Credentials* tab ."
+msgstr ""
+"*Credentials* タブの下で、 [filename]`Client Id and Secret` または [filename]`Signed "
+"JWT` のいずれかを設定できます。"
+
+#. type: Plain text
+msgid ""
+"With the service account enabled, you can omit specifying the user when "
+"running [command]`kcreg config credentials` and only provide the client "
+"secret or keystore information."
+msgstr ""
+"サービス・アカウントを有効にすると、 [command]`kcreg config credentials` "
+"を実行するときにユーザーを指定せずに、クライアント・シークレットまたはキーストア情報のみを提供することができます。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Installing Client Registration CLI"
+msgid "Installing the Client Registration CLI"
 msgstr "クライアント登録CLIのインストール"
 
 #. type: Plain text
 msgid ""
-"Client Registration CLI is packaged inside Keycloak Server distribution. You"
-" can find execution scripts inside `bin` directory."
+"The Client Registration CLI is packaged inside the Keycloak Server "
+"distribution. You can find execution scripts inside the [filename]`bin` "
+"directory. The Linux script is called [filename]`kcreg.sh`, and the Windows "
+"script is called [filename]`kcreg.bat`."
 msgstr ""
-"クライアント登録CLIは、{project_name}サーバーの配布物の中にパッケージされています。 `bin` "
-"ディレクトリ内に実行スクリプトがあります。"
+"クライアント登録CLIは、Keycloakサーバー・ディストリビューション内にパッケージ化されています。実行スクリプトは [filename]`bin`"
+" ディレクトリにあります。Linuxスクリプトは [filename]`kcreg.sh` で、Windowsスクリプトは "
+"[filename]`kcreg.bat` です。"
 
 #. type: Plain text
 msgid ""
-"The Linux script is called `kcreg.sh`, and the one for Windows is called "
-"`kcreg.bat`."
-msgstr "Linuxのスクリプトは `kcreg.sh` 、Windowsのスクリプトは `kcreg.bat` という名前です。"
-
-#. type: Plain text
-msgid ""
-"In order to setup the client for use from any location on the filesystem you"
-" may want to add Keycloak server directory to your PATH."
+"Add the Keycloak server directory to your [filename]`PATH` when setting up "
+"the client for use from any location on the file system ."
 msgstr ""
-"ファイルシステム上の任意の場所からクライアントを使用できるように設定するには、PATHにKeycloakサーバーのディレクトリを追加します。"
+"ファイル・システム上の任意の場所からクライアントを使用できるように設定するときは、Keycloakサーバーのディレクトリーを "
+"[filename]`PATH` に追加してください。"
 
 #. type: Plain text
-msgid "On Linux:"
-msgstr "Linuxの場合："
+msgid "For example, on:"
+msgstr "例えば"
+
+#. type: Plain text
+msgid "Linux:"
+msgstr "Linuxの場合"
 
 #. type: delimited block -
 #, no-wrap
@@ -214,8 +256,8 @@ msgstr ""
 "$ kcreg.sh\n"
 
 #. type: Plain text
-msgid "On Windows:"
-msgstr "Windowsの場合："
+msgid "Windows:"
+msgstr "Windowsの場合"
 
 #. type: delimited block -
 #, no-wrap
@@ -228,26 +270,23 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Where KEYCLOAK_HOME refers to a directory where Keycloak Server distribution"
-" was unpacked."
-msgstr "KEYCLOAK_HOMEは、Keycloakサーバーの配布物が解凍されたディレクトリを示します。"
+"[filename]`KEYCLOAK_HOME` refers to a directory where the Keycloak Server "
+"distribution was unpacked."
+msgstr ""
+"[filename]`KEYCLOAK_HOME` は、Keycloakサーバー・ディストリビューションが解凍されたディレクトリを参照します。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Using Client Registration CLI"
+msgid "Using the Client Registration CLI"
 msgstr "クライアント登録CLIの使用"
 
 #. type: Plain text
-msgid ""
-"First you need to start an authenticated session (i.e. logging in) by "
-"providing credentials. Then you perform operations on Client Registration "
-"REST endpoint."
-msgstr ""
-"まず、クレデンシャルを提供して認証されたセッション（つまりログイン）を開始する必要があります。次に、クライアント登録RESTエンドポイントで操作を実行します。"
+msgid "Start an authenticated session by logging in with your credentials."
+msgstr "クレデンシャルでログインして、認証されたセッションを開始します。"
 
 #. type: Plain text
-msgid "For example on Linux:"
-msgstr "たとえば、Linux の場合："
+msgid "Run commands on the [filename]`Client Registration REST` endpoint."
+msgstr "[filename]`Client Registration REST` エンドポイントでコマンドを実行します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -260,10 +299,6 @@ msgstr ""
 "$ kcreg.sh create -s clientId=my_client -s 'redirectUris=[\"http://localhost:8980/myapp/*\"]'\n"
 "$ kcreg.sh get my_client\n"
 
-#. type: Plain text
-msgid "Or on Windows:"
-msgstr "または、Windowsの場合："
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -275,17 +310,23 @@ msgstr ""
 "c:\\> kcreg create -s clientId=my_client -s \"redirectUris=[\\\"http://localhost:8980/myapp/*\\\"]\"\n"
 "c:\\> kcreg get my_client\n"
 
+#. type: delimited block =
+msgid ""
+"In a production environment, Keycloak has to be accessed with "
+"[filename]`https:` to avoid exposing tokens to network sniffers."
+msgstr ""
+"実稼働環境では、ネットワーク・スニファーへのトークンの公開を避けるため、 [filename]`https:` "
+"でKeycloakにアクセスする必要があります。"
+
 #. type: Plain text
 msgid ""
-"In a production environment Keycloak has to be accessed with `https:` to "
-"avoid exposing tokens to network sniffers. If server's certificate is not "
-"issued by one of the trusted CAs that are included in Java's default "
-"certificate truststore, you will need to prepare a truststore.jks file, and "
-"instruct `Client Registration CLI` to use it."
+"If a server's certificate is not issued by one of the trusted certificate "
+"authorities (CAs) that are included in Java's default certificate "
+"truststore, prepare a [filename]`truststore.jks` file and instruct the "
+"Client Registration CLI to use it."
 msgstr ""
-"プロダクション環境では、ネットワーク・スニファーでトークンの解読を避けるため、Keycloakには `https:` "
-"でアクセスする必要があります。サーバー証明書が、Javaのデフォルトの証明書トラスト・ストアに含まれている信頼されたCAのいずれかによって発行されていない場合は、"
-" `truststore.jks` ファイルを準備し、それを使用するように、 `クライアント登録CLI` に指示する必要があります。"
+"サーバーの証明書が、Javaのデフォルトの証明書トラスト・ストアーに含まれている信頼できる証明機関（CA）のいずれかによって発行されていない場合は、 "
+"[filename]`truststore.jks` ファイルを準備し、クライアント登録CLIに使用するよう指示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -307,60 +348,62 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Logging In"
+msgid "Logging in"
 msgstr "ログイン"
 
 #. type: Plain text
 msgid ""
-"When logging in with `Client Registration CLI` you specify a server endpoint"
-" url, and a realm. Then you specify a username or, alternatively, a client "
-"id, which will result in special service account being used. In the first "
-"case, a password for the specified user has to be used at login. In the "
-"latter case there is no user password - only client secret or a `Signed JWT`"
-" is used."
-msgstr ""
-"`クライアント登録CLI` "
-"でログインするときに、サーバーのエンドポイントURLとレルムを指定します。次に、ユーザー名、またはクライアントIDを指定します。これにより、特別なサービス・アカウントが使用されます。前者の場合、ログイン時に指定されたユーザーのパスワードを使用する必要があります。後者の場合、ユーザーのパスワードは使いません。クライアント・シークレットまたは"
-" `署名済みJWT` のみが使用されます。"
+"Specify a server endpoint URL and a realm when you log in with the Client "
+"Registration CLI."
+msgstr "クライアント登録CLIを使用してログインするときに、サーバーのエンドポイントURLとレルムを指定します。"
 
 #. type: Plain text
 msgid ""
-"Regardless of the method, the account that logs in needs proper permissions "
-"to be able to perform client registration operations. Keep in mind that any "
-"account in non-master realm can only have permissions to manage clients "
-"within the same realm.  If you need to manage different realms, you can "
-"either configure multiple users in different realms, or you can create a "
-"single user in `master` realm and add it roles for managing clients in "
-"different realms."
+"Specify a user name or a client id, which results in a special service "
+"account being used. When using a user name, you must use a password for the "
+"specified user. When using a client ID, you use a client secret or a "
+"[filename]`Signed JWT` instead of a password."
 msgstr ""
-"方法に関係なく、ログインするアカウントには、クライアント登録操作を実行できる適切な権限が必要です。非マスター・レルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムで設定するか、"
-" `master` レルムで1人のユーザーを作成して、異なるレルムのクライアントを管理するロールを追加します。"
+"ユーザー名またはクライアントIDを指定すると、特別なサービス・アカウントが使用されます。ユーザー名を使用する場合は、指定されたユーザーのパスワードを使用する必要があります。クライアントIDを使用する場合は、パスワードの代わりにクライアント・シークレットまたは"
+" [filename]`Signed JWT` を使用します。"
 
 #. type: Plain text
 msgid ""
-"`Client Registration CLI` by itself does not support configuring users, for "
-"that you would need to use `Admin Console` web interface or Admin Client CLI"
-" command line tool (see link:{adminguide_link}[{adminguide_name}] for more "
-"details)."
+"Regardless of the login method, the account that logs in needs proper "
+"permissions to be able to perform client registration operations. Keep in "
+"mind that any account in a non-master realm can only have permissions to "
+"manage clients within the same realm. If you need to manage different "
+"realms, you can either configure multiple users in different realms, or you "
+"can create a single user in the [filename]`master` realm and add roles for "
+"managing clients in different realms."
 msgstr ""
-"`クライアント登録CLI` "
-"自体はユーザーの設定をサポートしていません。そのためには、管理コンソールのWebインターフェイスまたは管理クライアントCLIコマンドライン・ツール（詳細はlink:{adminguide_link}[{adminguide_name}]）を使う必要があります。"
+"ログイン方法にかかわらず、ログインするアカウントには、クライアント登録操作を実行するための適切な権限が必要です。master以外のレルムのアカウントは、同じレルム内のクライアントを管理する権限しか持てません。異なるレルムを管理する必要がある場合は、複数のユーザーを異なるレルムに設定するか、単一のユーザーを"
+" [filename]`master` レルムに作成し、異なるレルムのクライアントを管理するロールを追加することができます。"
 
 #. type: Plain text
 msgid ""
-"When `kcreg` successfully logs in it receives authorization tokens and saves"
-" them into private config file so they can be used for subsequent "
-"invocations. See <<_working_with_alternative_configurations, next chapter>> "
-"for more info on configuration file."
+"You cannot configure users with the Client Registration CLI. Use the Admin "
+"Console web interface or the Admin Client CLI to configure users. See "
+"link:{adminguide_link}[{adminguide_name}] for more details."
 msgstr ""
-"`kcreg` "
-"が正常にログインすると、認可トークンを受け取り、それらをプライベート設定ファイルに保存して、後続の呼び出しに使用できるようにします。設定ファイルの詳細については、<<_working_with_alternative_configurations,"
-" 次の章>>を参照してください。"
+"クライアント登録CLIでユーザーを設定することはできません。管理コンソールのWebインタフェースまたは管理クライアントCLIを使用して、ユーザを設定します。詳細については、link:{adminguide_link}[{adminguide_name}]を参照してください。"
 
 #. type: Plain text
 msgid ""
-"See built-in help for more information on using `Client Registration CLI`."
-msgstr "`クライアント登録CLI` の使用方法の詳細については、組み込みのヘルプを参照してください。"
+"When [filename]`kcreg` successfully logs in, it receives authorization "
+"tokens and saves them in a private configuration file so the tokens can be "
+"used for subsequent invocations. See "
+"<<_working_with_alternative_configurations>> for more information on "
+"configuration files."
+msgstr ""
+"[filename]`kcreg` "
+"が正常にログインすると、認可トークンを受信してプライベート設定ファイルに保存し、その後の呼び出しでトークンを使用できるようにします。設定ファイルの詳細については、<<_working_with_alternative_configurations>>を参照してください。"
+
+#. type: Plain text
+msgid ""
+"See the built-in help for more information on using the Client Registration "
+"CLI."
+msgstr "クライアント登録CLIの使用方法の詳細については、組み込みのヘルプを参照してください。"
 
 #. type: delimited block -
 #, no-wrap
@@ -374,9 +417,11 @@ msgstr "c:\\> kcreg help\n"
 
 #. type: Plain text
 msgid ""
-"See `kcreg config credentials --help` for more information about starting an"
-" authenticated session."
-msgstr "認証されたセッションの開始についての詳細は、 `kcreg config credentials --help` を参照してください。"
+"See [filename]`kcreg config credentials --help` for more information about "
+"starting an authenticated session."
+msgstr ""
+"認証されたセッションの開始についての詳細は、 [filename]`kcreg config credentials --help` "
+"を参照してください。"
 
 #. type: Title ===
 #, no-wrap
@@ -385,39 +430,36 @@ msgstr "代替設定の使用"
 
 #. type: Plain text
 msgid ""
-"By default, `Client Registration CLI` automatically maintains a "
-"configuration file at a default location - `./.keycloak/kcreg.config` under "
-"user's home directory."
+"By default, the Client Registration CLI automatically maintains a "
+"configuration file at a default location, "
+"[filename]`./.keycloak/kcreg.config`, under the user's home directory. You "
+"can use the [command]`--config` option to point to a different file or "
+"location to mantain multiple authenticated sessions in parallel. It is the "
+"safest way to perform operations tied to a single configuration file from a "
+"single thread."
 msgstr ""
-"デフォルトで `クライアント登録CLI` は、ユーザーのホーム・ディレクトリの下にあるデフォルトの場所（ "
-"`./.keycloak/kcreg.config` ）に設定ファイルを自動的に保持します。"
+"デフォルトでは、クライアント登録CLIは、ユーザーのホーム・ディレクトリー配下のデフォルトの場所に設定ファイル（ "
+"[filename]`./.keycloak/kcreg.config` ）を自動的に保存します。 [command]`--config` "
+"オプションを使うと、複数の認証済みセッションを並行して保存するために、別のファイルや場所を指すことができます。これは、単一のスレッドから単一の設定ファイルに結び付けられた操作を実行する最も安全な方法です。"
+
+#. type: delimited block =
+msgid ""
+"Do not make the configuration file visible to other users on the system. The"
+" configuration file contains access tokens and secrets that should be kept "
+"private."
+msgstr ""
+"システム上の他のユーザーが設定ファイルを参照できないようにしてください。設定ファイルには、非公開にしておくべきアクセス・トークンとシークレットが含まれています。"
 
 #. type: Plain text
 msgid ""
-"You can always use `--config` option to point to a different file / "
-"location. This way you can mantain multiple authenticated sessions in "
-"parallel. It is safest to perform operations tied to a single config file "
-"from a single thread."
+"You might want to avoid storing secrets inside a configuration file by using"
+" the [command]`--no-config` option with all of your commands, even thought "
+"it is less convenient and requires more token requests to do so. Specify all"
+" authentication information with each [command]`kcreg` invocation."
 msgstr ""
-"`--config` "
-"オプションを使うと、いつでも別のファイル/場所を指すことができます。これにより、複数の認証済みセッションを並行して処理できます。1つのスレッドから1つの設定ファイルに結び付けられた操作を実行するのが最も安全です。"
-
-#. type: Plain text
-msgid ""
-"Make sure to not make the config file visible to other users on the system "
-"as it contains access tokens, and secrets that should be kept private."
-msgstr ""
-"アクセス・トークンとプライベートにしておかなければならないシークレットが含まれているため、設定ファイルをシステム上の他のユーザーには参照できないようにしてください。"
-
-#. type: Plain text
-msgid ""
-"You may want to avoid storing any secrets at all inside a config file for "
-"the price of less convenience and having to do more token requests.  In that"
-" case you can use `--no-config` option with all your commands. You will have"
-" to specify all authentication info with each `kcreg` invocation."
-msgstr ""
-"利便性が低く、さらにトークン要求をしなければならないために、設定ファイルの中にシークレットを保存することは避けたいかもしれません。その場合、すべてのコマンドで"
-" `--no-config` オプションを使用できます。 `kcreg` の呼び出しごとに、すべての認証情報を指定する必要があります。"
+"利便性が低く、より多くのトークン・リクエストではありますが、すべてのコマンドで [command]`--no-config` "
+"オプションを使用することで、設定ファイル内にシークレットを保存しないようにすることができます。各 [command]`kcreg` "
+"呼び出しごとにすべての認証情報を指定してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -426,29 +468,25 @@ msgstr "初期アクセス・トークンと登録アクセス・トークン"
 
 #. type: Plain text
 msgid ""
-"`Client Registration CLI` can be used by developers who don't have an "
-"account configured at Keycloak server they want to use.  That's possible "
-"when realm administrator issues developer an `Initial Access Token`. It is "
-"up to realm administrator to decide how to issue and distribute these "
-"tokens. Admin can limit Initial Access Token's maximum age, and a total "
-"number of clients that can be created with it. Many Initial Access Tokens "
-"can be created, and it's up to realm administrator to distribute them to "
-"application developers."
+"Developers who do not have an account configured at the Keycloak server they"
+" want to use can use the Client Registration CLI. That is possible when the "
+"realm administrator issues a developer an Initial Access Token. It is up to "
+"the realm administrator to decide how to issue and distribute these tokens. "
+"The realm administrator can limit the maximum age of the Initial Access "
+"Token and the total number of clients that can be created with it."
 msgstr ""
-"`クライアント登録CLI` は、使用したいKeycloakサーバーで設定されたアカウントを持っていない開発者が使用できます。レルム管理者が開発者に "
-"`初期アクセス・トークン` "
-"を発行することにより、開発者は使用することができます。トークンを発行して配布する方法を決定するのは、レルム管理者次第です。管理者は、初期アクセス・トークンの最大有効期間と作成できるクライアントの総数を制限できます。レルム管理者は、たくさんの初期アクセス・トークンを作成することができますが、それをアプリケーション開発者に配布するのはレルム管理者次第となります。"
+"使用したいKeycloakサーバーでアカウントを設定していない開発者は、クライアント登録CLIを使用できます。レルム管理者が開発者に初期アクセス・トークンを発行するときに可能です。これらのトークンの発行方法と配布方法は、レルム管理者が決定します。レルム管理者は、初期アクセストークンの最大経過時間と、初期アクセス・トークンを使用して作成できるクライアントの総数を制限できます。"
 
 #. type: Plain text
 msgid ""
-"Once a developer is in possession of Initial Access Token they can use it to"
-" create new clients without authenticating with `kcreg config credentials`. "
-"Rather, Initial Access Token can be stored in configuration, or specified as"
-" part of `kcreg create` command."
+"Once a developer has an Initial Access Token, the developer can use it to "
+"create new clients without authenticating with [command]`kcreg config "
+"credentials`. The Initial Access Token can be stored in the configuration "
+"file or specified as part of the [command]`kcreg create` command."
 msgstr ""
-"開発者が初期アクセス・トークンを所有すると、 `kcreg config credentials` "
-"で認証せずに新しいクライアントを作成できます。それどころか、初期アクセス・トークンは設定に保存することも、 `kcreg create` "
-"コマンドの一部として指定することもできます。"
+"開発者が初期アクセス・トークンを取得すると、開発者はこれを使用して、 [command]`kcreg config credentials` "
+"で認証せずに新しいクライアントを作成できます。初期アクセス・トークンは、設定ファイルに保存するか、 [command]`kcreg create` "
+"コマンドの一部として指定することができます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -484,61 +522,60 @@ msgstr "c:\\> kcreg create -s clientId=myclient -t %TOKEN%\n"
 
 #. type: Plain text
 msgid ""
-"When Initial Access Token is used, the server response will include a newly "
-"issued Registration Access Token.  Any subsequent operation for that client "
-"needs to be performed by authenticating with that token which is only valid "
-"for that client."
+"When using an Initial Access Token, the server response includes a newly "
+"issued Registration Access Token. Any subsequent operation for that client "
+"needs to be performed by authenticating with that token, which is only valid"
+" for that client."
 msgstr ""
-"初期アクセス・トークンが使用されると、サーバー・レスポンスに新たに発行された登録アクセス・トークンを含まれます。そのクライアントの後続の操作は、そのクライアントに対してのみ有効な登録アクセス・トークンで認証し、実行する必要があります。"
+"初期アクセス・トークンを使用する場合、サーバー・レスポンスには新しく発行された登録アクセス・トークンが含まれます。そのクライアントの後続の操作は、そのクライアントに対してのみ有効なトークンで認証することによって実行される必要があります。"
 
 #. type: Plain text
 msgid ""
-"`Client Registration CLI` automatically uses its private configuration file "
-"to save, and use this token with its associated client.  As long as the same"
-" configuration file is used for all client operations, the developer will "
-"not need to authenticate in order to read, update, or delete a client that "
-"was created this way."
+"The Client Registration CLI automatically uses its private configuration "
+"file to save and use this token with its associated client. As long as the "
+"same configuration file is used for all client operations, the developer "
+"does not need to authenticate to read, update, or delete a client that was "
+"created this way."
 msgstr ""
-"`クライアント登録CLI` "
-"は、自動的にプライベート設定ファイルを使用して保存し、このトークンを関連するクライアントと共に使用します。同じ設定ファイルがすべてのクライアント操作に使用されている限り、このように作成されたクライアントの読み取り、更新、削除を行うために、開発者は認証する必要はありません。"
+"クライアント登録CLIはプライベートな設定ファイルを自動的に使用して、このトークンを関連付けられたクライアントと共に保存して使用します。すべてのクライアント操作で同じ設定ファイルが使用されている限り、開発者はこのように作成されたクライアントの読み取り、更新、または削除をするために、認証する必要はありません。"
 
 #. type: Plain text
 msgid ""
-"You can read more about Initial Access and Registration Access Tokens in "
-"<<_client_registration,Client Registration chapter>>."
+"See <<_client_registration, Client Registration>> for more information about"
+" Initial Access and Registration Access Tokens."
 msgstr ""
-"初期アクセス・トークンと登録アクセス・トークンの詳細については、<<_client_registration,クライアント登録の章>>をご覧ください。"
+"初期アクセス・トークンおよび登録アクセス・トークンの詳細については、<<_client_registration,クライアント登録>>を参照してください。"
 
 #. type: Plain text
 msgid ""
-"See `kcreg config initial-token --help` and `kcreg config registration-token"
-" --help` for more information on how to configure them with `Client "
-"Registration CLI`."
+"Run the [command]`kcreg config initial-token --help` and [command]`kcreg "
+"config registration-token --help` commands for more information on how to "
+"configure tokens with the Client Registration CLI."
 msgstr ""
-"`クライアント登録CLI` で設定する方法の詳細については、 `kcreg config initial-token --help` と `kcreg "
-"config registration-token --help` を参照してください。"
+"クライアント登録CLIでトークンを設定する方法の詳細については、 [command]`kcreg config initial-token "
+"--help` と [command]`kcreg config registration-token --help` コマンドを実行してください。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Creating client configuration"
+msgid "Creating a client configuration"
 msgstr "クライアント設定の作成"
 
 #. type: Plain text
 msgid ""
-"After authenticating with credentials or configuring Initial Access Token, "
-"the first operation will usually be to create a new client."
-msgstr "クレデンシャルで認証したり、初期アクセス・トークンを設定した後に、通常は最初の操作で新しいクライアントを作成します。"
+"The first task after authenticating with credentials or configuring an "
+"Initial Access Token is usually to create a new client. Often you might want"
+" to use a prepared JSON file as a template and set or override some of the "
+"attributes."
+msgstr ""
+"クレデンシャルで認証したり、初期アクセス・トークンを設定した後の最初のタスクは、通常、新しいクライアントを作成することです。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定または上書きすることがよくあります。"
 
 #. type: Plain text
 msgid ""
-"We've seen the simplest create command already. Often we may want to use a "
-"prepared JSON file as a template and set / override some of the attributes. "
-"For example, here is how you read a JSON file, override any `clientId` it "
-"may contain, set any other attributes as well, and after successful creation"
-" print the configuration to standard output."
+"The following example shows how to read a JSON file, override any client id "
+"it may contain, set any other attributes, and print the configuration to a "
+"standard output after successful creation."
 msgstr ""
-"最もシンプルなcreateコマンドをすでに見てきました。準備されたJSONファイルをテンプレートとして使用し、いくつかの属性を設定/オーバーライドすることはよくあります。たとえば、JSONファイルを読み込み、含まれている"
-" `clientId` をオーバーライドし、他の属性も設定し、正常に作成した後に設定を標準出力に出力する方法があります。"
+"次の例は、作成が成功した後にJSONファイルを読み込み、それに含まれる可能性のあるクライアントIDを上書きし、他の属性を設定し、標準出力に設定を出力する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -559,33 +596,35 @@ msgstr ""
 "baseUrl=/myclient -s \"redirectUris=[\\\"/myclient/*\\\"]\" -o\n"
 
 #. type: Plain text
-msgid "See `kcreg create --help` for more information about `kcreg create`."
-msgstr "`kcreg create` の詳細については、 `kcreg create --help` を参照してください。"
+msgid ""
+"Run the [command]`kcreg create --help` for more information about the "
+"[command]`kcreg create` command."
+msgstr ""
+"[command]`kcreg create` コマンドの詳細については、 [command]`kcreg create --help` "
+"を実行してください。"
 
 #. type: Plain text
 msgid ""
-"You can use `kcreg attrs` to list available attributes. Keep in mind that "
-"many configuration attributes are not checked for validity or consistency. "
-"It is up to you to specify proper values. Also note that you should not have"
-" any `id` fields in your template and should not specify them as arguments "
-"to `kcreg create`."
+"You can use [command]`kcreg attrs` to list available attributes. Keep in "
+"mind that many configuration attributes are not checked for validity or "
+"consistency. It is up to you to specify proper values. Remember that you "
+"should not have any id fields in your template and should not specify them "
+"as arguments to the [command]`kcreg create` command."
 msgstr ""
-"`kcreg attrs` "
+" [command]`kcreg attrs` "
 "を使って、利用可能な属性の一覧を取得できます。多くの設定属性の妥当性や一貫性はチェックされません。適切な値を指定する必要があります。また、テンプレートには"
-" `id` フィールドを持たせず、 `kcreg create` の引数としても指定しないように注意してください。"
+" `id` フィールドを持たせず、  [command]`kcreg create` の引数として指定しないことを忘れないでください。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Retrieving client configuration"
+msgid "Retrieving a client configuration"
 msgstr "クライアント設定の取得"
 
 #. type: Plain text
-msgid "You can retrieve an existing client by using `kcreg get`."
-msgstr "既に存在するクライアントについては、 `kcreg get` を使用することで取得できます。"
-
-#. type: Plain text
-msgid "For example, on Linux:"
-msgstr "たとえば、Linux の場合："
+msgid ""
+"You can retrieve an existing client by using the [command]`kcreg get` "
+"command."
+msgstr "既に存在するクライアントについては、 [command]`kcreg get` コマンドを使用することで取得できます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -599,8 +638,8 @@ msgstr "C:\\> kcreg get myclient\n"
 
 #. type: Plain text
 msgid ""
-"You can also get client configuration as adapter configuration file which "
-"you can package with your web application."
+"You can also retrieve the client configuration as an adapter configuration "
+"file, which you can package with your web application."
 msgstr "また、Webアプリケーションとパッケージ化できるアダプター設定ファイルとして、クライアント設定を取得することもできます。"
 
 #. type: delimited block -
@@ -614,23 +653,28 @@ msgid "C:\\> kcreg get myclient -e install > keycloak.json\n"
 msgstr "C:\\> kcreg get myclient -e install > keycloak.json\n"
 
 #. type: Plain text
-msgid "See `kcreg get --help` for more information about `kcreg get`."
-msgstr "`kcreg get` の詳細については、 `kcreg get --help` を参照してください。"
+msgid ""
+"Run the [command]`kcreg get --help` command for more information about the "
+"[command]`kcreg get` command."
+msgstr ""
+"[command]`kcreg get` コマンドの詳細については、 [command]`kcreg get --help` "
+"コマンドを実行してください。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Modifying client configuration"
+msgid "Modifying a client configuration"
 msgstr "クライアント設定の更新"
 
 #. type: Plain text
-msgid "There are two modes of updating client configuration."
-msgstr "クライアント設定の更新には2つのモードがあります。"
+msgid "There are two methods for updating a client configuration."
+msgstr "クライアント設定の更新には2つの方法があります。"
 
 #. type: Plain text
 msgid ""
-"One is to submit a complete new state to the server after getting current "
-"configuration, saving it into a file, editing it, and posting it back."
-msgstr "1つは、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信する方法です。"
+"One method is to submit a complete new state to the server after getting the"
+" current configuration, saving it to a file, editing it, and posting it back"
+" to the server."
+msgstr "1つ目の方法は、現在の設定を取得してファイルに保存し、編集してから、新しい状態をサーバーにPOSTで送信する方法です。"
 
 #. type: delimited block -
 #, no-wrap
@@ -656,9 +700,9 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Another way is to fetch current client, set or delete fields on it, and post"
-" it back all in one single step."
-msgstr "別の方法は、現在のクライアントをフェッチし、そのフィールドを設定または削除し、POST送信するという全てを1つのステップで行う方法です。"
+"The second method fetches the current client, sets or deletes fields on it, "
+"and posts it back in one step."
+msgstr "2つ目の方法は、現在のクライアントをフェッチし、そのクライアント上のフィールドを設定または削除し、一度にPOSTで送信する方法です。"
 
 #. type: delimited block -
 #, no-wrap
@@ -672,15 +716,15 @@ msgstr "C:\\> kcreg update myclient -s enabled=false -d redirectUris\n"
 
 #. type: Plain text
 msgid ""
-"You can even use a file that only contains changes to be applied so you "
-"don't have to specify too many values as arguments.  In this case specify "
-"`--merge` to tell `Client Registration CLI` that rather than treating JSON "
-"file as full new configuration, it should treat it as a set of attributes to"
-" be applied over existing configuration."
+"You can also use a file that contains only changes to be applied so you do "
+"not have to specify too many values as arguments. In this case, specify "
+"[command]`--merge` to tell the Client Registration CLI that rather than "
+"treating the JSON file as a full, new configuration, it should treat it as a"
+" set of attributes to be applied over the existing configuration."
 msgstr ""
-"適用される変更のみを含むファイルを使用することもできるので、引数として多すぎる値を指定する必要はありません。この場合、 `--merge` を "
-"`クライアント登録CLI` "
-"に指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
+"適用される変更のみを含むファイルを使用することもできるので、引数として多すぎる値を指定する必要はありません。この場合、 "
+"[command]`--merge` "
+"をクライアント登録CLIに指定すると、JSONファイルは完全な新しい設定として扱われるのではなく、既存の設定に適用される属性のセットとして扱われます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -693,17 +737,21 @@ msgid "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 msgstr "C:\\> kcreg update myclient --merge -d redirectUris -f mychanges.json\n"
 
 #. type: Plain text
-msgid "See `kcreg update --help` for more information about `kcreg update`."
-msgstr "`kcreg update` の詳細については、 `kcreg update --help` を参照してください。"
+msgid ""
+"Run the [command]`kcreg update --help` command for more information about "
+"the [command]`kcreg update` command."
+msgstr ""
+"[command]`kcreg update` コマンドの詳細については、 [command]`kcreg update --help` "
+"コマンドを実行してください。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Deleting client configuration"
+msgid "Deleting a client configuration"
 msgstr "クライアント設定の削除"
 
 #. type: Plain text
-msgid "You may sometimes also need to delete a client."
-msgstr "クライアントを削除する必要がある場合もあります。"
+msgid "Use the following example to delete a client."
+msgstr "クライアントを削除するには、以下の例を使用します。 "
 
 #. type: delimited block -
 #, no-wrap
@@ -716,60 +764,71 @@ msgid "C:\\> kcreg delete myclient\n"
 msgstr "C:\\> kcreg delete myclient\n"
 
 #. type: Plain text
-msgid "See `kcreg delete --help` for more information about `kcreg delete`."
-msgstr "`kcreg delete` の詳細については、 `kcreg delete --help` を参照してください。"
+msgid ""
+"Run the [command]`kcreg delete --help` command for more information about "
+"the [command]`kcreg delete` command."
+msgstr ""
+"[command]`kcreg delete` コマンドの詳細については、 [command]`kcreg delete --help` "
+"コマンドを実行してください。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Refreshing Invalid Registration Access Tokens"
+msgid "Refreshing invalid Registration Access Tokens"
 msgstr "無効な登録アクセス・トークンのリフレッシュ"
 
 #. type: Plain text
 msgid ""
-"When performing a CRUD operation using `--no-config` mode, `Client "
-"Registration CLI` can no longer handle Registration Access Tokens for you.  "
-"In that case it is possible to lose track of most recently issued "
-"Registration Access Token for a client, which makes it impossible to perform"
-" any further CRUD operations on that client without authenticating with "
-"account that has 'manage-clients' permissions."
+"When performing a create, read, update, and delete (CRUD) operation using "
+"the [command]`--no-config` mode, the Client Registration CLI cannot handle "
+"Registration Access Tokens for you. In that case, it is possible to lose "
+"track of the most recently issued Registration Access Token for a client, "
+"which makes it impossible to perform any further CRUD operations on that "
+"client without authenticating with an account that has *manage-clients* "
+"permissions."
 msgstr ""
-"`--no-config` モードを使用してCRUD操作を実行すると、 `クライアント登録CLI` "
+"[command]`--no-config` モードを使用して作成、読み込み、更新、削除（CRUD）操作を実行すると、 `クライアント登録CLI` "
 "は登録アクセス・トークンを処理できなくなります。その場合、クライアントのために最も最近発行された登録アクセス・トークンの追跡を失う可能性があり"
 "、'manage-clients'権限を持つアカウントで認証なしでは、そのクライアントでそれ以上のCRUD操作を実行することは不可能になります。"
 
 #. type: Plain text
 msgid ""
 "If you have permissions, you can issue a new Registration Access Token for "
-"the client, and have it printed to stdout or saved to a config file of your "
-"choice. Otherwise you have to ask realm administrator to issue new "
-"Registration Access Token for your client, and send it to you. You can then "
-"pass it to any CRUD command via `--token` option. You can also use `kcreg "
-"config registration-token` command to save the new token in configuration "
-"file, and have `Client Registration CLI` automatically handle it for you "
-"from that point on."
+"the client and have it printed to a standard output or saved to a "
+"configuration file of your choice. Otherwise, you have to ask the realm "
+"administrator to issue a new Registration Access Token for your client and "
+"send it to you. You can then pass it to any CRUD command via the "
+"[command]`--token` option. You can also use the [command]`kcreg config "
+"registration-token` command to save the new token in a configuration file "
+"and have the Client Registration CLI automatically handle it for you from "
+"that point on."
 msgstr ""
 "アクセス権を持っている場合は、クライアント用に新しい登録アクセス・トークンを発行し、標準出力に出力するか、選択した設定ファイルに保存することができます。それ以外の場合は、レルム管理者にクライアントの新しい登録アクセス・トークンを発行して、それを送信するよう依頼する必要があります。その際は、"
-" `--token` オプションを使ってCRUDコマンドに渡すことができます。また、 `kcreg config registration-token`"
-" コマンドを使って新しいトークンを設定ファイルに保存し、 `クライアント登録CLI` が自動的にそれを処理するようにすることもできます。"
+" [command]`--token` オプションを使ってCRUDコマンドに渡すことができます。また、 [command]`kcreg config "
+"registration-token` コマンドを使って新しいトークンを設定ファイルに保存し、 `クライアント登録CLI` "
+"が自動的にそれを処理するようにすることもできます。"
 
 #. type: Plain text
 msgid ""
-"See `kcreg update-token --help` for more information about `kcreg update-"
-"token`."
-msgstr "`kcreg update-token` の詳細については、 `kcreg update-token --help` を参照してください。"
-
-#. type: Plain text
-msgid ""
-"Q: When logging in I get an error: `Parameter client_assertion_type is "
-"missing [invalid_client]`"
+"Run the [command]`kcreg update-token --help` command for more information "
+"about the [command]`kcreg update-token` command."
 msgstr ""
-"Q：ログインすると、次のエラーが表示されます： `Parameter client_assertion_type is missing "
-"[invalid_client]`"
+"[command]`kcreg update-token` コマンドの詳細については、 [command]`kcreg update-token "
+"--help` コマンドを実行してください。"
 
 #. type: Plain text
 msgid ""
-"A: Your client is configured with `Signed JWT` token credentials which means"
-" you have to use `--keystore` parameter when logging in."
+"Q: When logging in, I get an error: *Parameter client_assertion_type is "
+"missing [invalid_client]."
 msgstr ""
-"A：クライアントが `Signed JWT` のトークン・クレデンシャルで設定されています。つまり、ログイン時に `--keystore` "
+"Q：ログインすると、次のエラーが表示されます：*Parameter client_assertion_type is missing "
+"[invalid_client]"
+
+#. type: Plain text
+msgid ""
+"A: This error means your client is configured with [filename]`Signed JWT` "
+"token credentials, which means you have to use the [command]`--keystore` "
+"parameter when logging in."
+msgstr ""
+"A：このエラーメッセージは、クライアントが [filename]`Signed JWT` "
+"のトークン・クレデンシャルで設定されていることを意味します。つまり、ログイン時に [command]`--keystore` "
 "パラメータを使用する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration__client-registration-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__client-registration__client-registration-cli/ja_JP/index.html
