### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-whatis-obtain-pat.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-whatis-obtain-pat.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-whatis-obtain-pat.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgid ""
 " account."
 msgstr ""
 "*保護APIトークン* （PAT）は、 *uma_protection* "
-"として定義されたスコープを持つ特殊なOAuth2アクセス・トークンです。リソース・サーバーを作成すると、{project_name}は対応するクライアント・アプリケーションのロール"
+"として定義されたスコープを持つ特殊なOAuth2アクセストークンです。リソースサーバーを作成すると、{project_name}は対応するクライアント・アプリケーションのロール"
 " _uma_protection_ を自動的に作成し、クライアントのサービス・アカウントに関連付けます。"
 
 #. type: Block title
@@ -50,7 +50,7 @@ msgid ""
 "Resource servers can obtain a PAT from {project_name} like any other OAuth2 "
 "access token. For example, using curl:"
 msgstr ""
-"リソース・サーバーは、{project_name}から他のOAuth2アクセス・トークンと同様にPATを取得できます。例えば、curlを使用します。"
+"リソースサーバーは、{project_name}から他のOAuth2アクセストークンと同様にPATを取得できます。たとえば、次のようにcurlを使用します。"
 
 #. type: Code block
 #, no-wrap
@@ -72,7 +72,7 @@ msgid ""
 "the following:"
 msgstr ""
 "上記の例では、 *client_credentials* "
-"グラント・タイプを使用してサーバーからPATを取得しています。その結果、サーバーは次のような応答を返します。"
+"グラントタイプを使用してサーバーからPATを取得しています。その結果、サーバーは次のような応答を返します。"
 
 #. type: Code block
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-whatis-obtain-pat.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-whatis-obtain-pat.ja_JP.po
@@ -1,76 +1,80 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:2
 #, no-wrap
 msgid "What is a PAT and How to Obtain It"
-msgstr ""
+msgstr "PATとは何か、そしてそれをどのように取得するか"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:6
 msgid ""
-"A *protection API token* (PAT) is a special OAuth2 access token with a scope "
-"defined as *uma_protection*. When you create a resource server, "
+"A *protection API token* (PAT) is a special OAuth2 access token with a scope"
+" defined as *uma_protection*. When you create a resource server, "
 "{project_name} automatically creates a role, _uma_protection_, for the "
-"corresponding client application and associates it with the client's service "
-"account."
+"corresponding client application and associates it with the client's service"
+" account."
 msgstr ""
+"*保護APIトークン* （PAT）は、 *uma_protection* "
+"として定義されたスコープを持つ特殊なOAuth2アクセス・トークンです。リソース・サーバーを作成すると、{project_name}は対応するクライアント・アプリケーションのロール"
+" _uma_protection_ を自動的に作成し、クライアントのサービス・アカウントに関連付けます。"
 
 #. type: Block title
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:7
 #, no-wrap
 msgid "Service Account granted with *uma_protection* role"
-msgstr ""
+msgstr "*uma_protection* ロールで付与されたサービス・アカウント"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:9
 msgid ""
 "image:{project_images}/service/rs-uma-protection-role.png[alt=\"Service "
 "Account granted with uma_protection role\"]"
 msgstr ""
+"image:{project_images}/service/rs-uma-protection-"
+"role.png[alt=\"uma_protectionロールで付与されたサービス・アカウント\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:11
 msgid ""
 "Resource servers can obtain a PAT from {project_name} like any other OAuth2 "
 "access token. For example, using curl:"
 msgstr ""
+"リソース・サーバーは、{project_name}から他のOAuth2アクセス・トークンと同様にPATを取得できます。例えば、curlを使用します。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:18
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
-"    -H \"Authorization: Basic aGVsbG8td29ybGQtYXV0aHotc2VydmljZTpwYXNzd29yZA==\" \\\n"
 "    -H \"Content-Type: application/x-www-form-urlencoded\" \\\n"
-"    -d 'grant_type=client_credentials' \\\n"
+"    -d 'grant_type=client_credentials&client_id=${client_id}&client_secret=${client_secret}' \\\n"
 "    \"http://localhost:8080/auth/realms/${realm_name}/protocol/openid-connect/token\"\n"
 msgstr ""
+"curl -X POST \\\n"
+" -H \"Content-Type: application/x-www-form-urlencoded\" \\\n"
+" -d 'grant_type=client_credentials&client_id=${client_id}&client_secret=${client_secret}' \\\n"
+" \"http://localhost:8080/auth/realms/${realm_name}/protocol/openid-connect/token\"\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:21
 msgid ""
 "The example above is using the *client_credentials* grant type to obtain a "
 "PAT from the server. As a result, the server returns a response similar to "
 "the following:"
 msgstr ""
+"上記の例では、 *client_credentials* "
+"グラント・タイプを使用してサーバーからPATを取得しています。その結果、サーバーは次のような応答を返します。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:33
 #, no-wrap
 msgid ""
 "{\n"
@@ -84,12 +88,24 @@ msgid ""
 "  \"session_state\": \"ccea4a55-9aec-4024-b11c-44f6f168439e\"\n"
 "}\n"
 msgstr ""
+"{\n"
+" \"access_token\": ${PAT},\n"
+" \"expires_in\": 300,\n"
+" \"refresh_expires_in\": 1800,\n"
+" \"refresh_token\": ${refresh_token},\n"
+" \"token_type\": \"bearer\",\n"
+" \"id_token\": ${id_token},\n"
+" \"not-before-policy\": 0,\n"
+" \"session_state\": \"ccea4a55-9aec-4024-b11c-44f6f168439e\"\n"
+"}\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-whatis-obtain-pat.adoc:37
 msgid ""
 "{project_name} can authenticate your client application in different ways. "
 "For simplicity, the *client_credentials* grant type is used here, which "
 "requires a _client_id_ and a _client_secret_. You can choose to use any "
 "supported authentication method."
 msgstr ""
+"{project_name}は、さまざまな方法でクライアント・アプリケーションを認証できます。わかりやすくするため、ここでは "
+"*client_credentials* グラント・タイプが使用されています。これには _client_id_ と _client_secret_ "
+"が必要です。サポートされている認証方法の使用を選択することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-whatis-obtain-pat.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-whatis-obtain-pat
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-protection-whatis-obtain-pat/ja_JP/index.html
