### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: KojiNose <knose.dev@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -108,13 +108,13 @@ msgstr "*Decision Strategy*\n"
 msgid ""
 "The <<_permission_decision_strategies, Decision Strategy>> for this "
 "permission."
-msgstr "パーミッションのための<<_permission_decision_strategies, 戦略的意思決定>>"
+msgstr "パーミッションのための<<_permission_decision_strategies, 決定戦略>>"
 
 #. type: Title =
 #: source/authorization_services/topics/permission-create-scope.adoc:2
 #, no-wrap
 msgid "Creating Scope-Based Permissions"
-msgstr "スコープ・ベースのパーミッションの作成"
+msgstr "スコープベースのパーミッションの作成"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:5
@@ -126,7 +126,7 @@ msgid ""
 "granularity when defining the permissions that govern your resources and the"
 " actions that can be performed on them."
 msgstr ""
-"スコープ・ベースのパーミッションは、1つ以上の認可ポリシーのセットを使用して保護する1つ以上のスコープのセットを定義します。リソース・ベースのパーミッションとは異なり、このパーミッションのタイプを使用して、リソースだけでなく、それに関連付けられたスコープのパーミッションを作成し、リソースを管理するパーミッションとそれらに対して実行可能なアクションを定義する際に、より詳細な情報を提供します。"
+"スコープベースのパーミッションは、1つ以上の認可ポリシーのセットを使用して保護する1つ以上のスコープのセットを定義します。リソースベースのパーミッションとは異なり、このパーミッションのタイプを使用して、リソースだけでなく、それに関連付けられたスコープのパーミッションを作成し、リソースを管理するパーミッションとそれらに対して実行可能なアクションを定義する際に、より詳細な情報を提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:7
@@ -134,14 +134,14 @@ msgid ""
 "To create a new scope-based permission, select *Scope-based* in the dropdown"
 " list in the upper right corner of the permission listing."
 msgstr ""
-"新しいスコープ・ベースのパーミッションを作成するには、パーミッション・リストの右上隅にあるドロップダウン・リストで *Scope-based* "
+"新しいスコープベースのパーミッションを作成するには、パーミッション・リストの右上隅にあるドロップダウン・リストで *Scope-based* "
 "を選択します。"
 
 #. type: Block title
 #: source/authorization_services/topics/permission-create-scope.adoc:8
 #, no-wrap
 msgid "Add Scope-Based Permission"
-msgstr "スコープ・ベースのパーミッションの追加"
+msgstr "スコープベースのパーミッションの追加"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:10
@@ -150,7 +150,7 @@ msgid ""
 "Permission\"]"
 msgstr ""
 "image:{project_images}/permission/create-"
-"scope.png[alt=\"スコープ・ベースのパーミッションの追加\"]"
+"scope.png[alt=\"スコープベースのパーミッションの追加\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:23

--- a/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: KojiNose <knose.dev@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -92,7 +92,7 @@ msgstr "*Apply Policy*\n"
 #: source/authorization_services/topics/permission-create-resource.adoc:38
 #: source/authorization_services/topics/permission-create-scope.adoc:33
 msgid "Defines a set of one or more policies to associate with a permission."
-msgstr "パーミッションに関連付ける1つまた複数のポリシーのセットを定義します。"
+msgstr "パーミッションに関連付ける1つ以上のポリシーのセットを定義します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:40
@@ -114,7 +114,7 @@ msgstr "パーミッションのための<<_permission_decision_strategies, 戦�
 #: source/authorization_services/topics/permission-create-scope.adoc:2
 #, no-wrap
 msgid "Creating Scope-Based Permissions"
-msgstr "スコープ・ベースの権限の作成"
+msgstr "スコープ・ベースのパーミッションの作成"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:5
@@ -126,7 +126,7 @@ msgid ""
 "granularity when defining the permissions that govern your resources and the"
 " actions that can be performed on them."
 msgstr ""
-"スコープ・ベースのパーミッションは、1つまたは複数の認可ポリシーのセットを使用して保護する1つ以上のスコープのセットを定義します。リソース・ベースのパーミッションとは異なり、このパーミッションのタイプを使用して、リソースだけでなく、それに関連付けられたスコープの権限を作成し、リソースを管理する権限とそれらに対して実行可能なアクションを定義する際に、より詳細な情報を提供します。"
+"スコープ・ベースのパーミッションは、1つ以上の認可ポリシーのセットを使用して保護する1つ以上のスコープのセットを定義します。リソース・ベースのパーミッションとは異なり、このパーミッションのタイプを使用して、リソースだけでなく、それに関連付けられたスコープのパーミッションを作成し、リソースを管理するパーミッションとそれらに対して実行可能なアクションを定義する際に、より詳細な情報を提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:7
@@ -177,4 +177,4 @@ msgstr "*Scopes*\n"
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:29
 msgid "Defines a set of one or more scopes to protect."
-msgstr "保護する1つまたは複数のスコープのセットを定義します。"
+msgstr "保護する1つ以上のスコープのセットを定義します。"

--- a/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: KojiNose <knose.dev@gmail.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -29,7 +30,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-create.adoc:15
 #, no-wrap
 msgid "*Name*\n"
-msgstr ""
+msgstr "*Name*\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-oidc.adoc:43
@@ -45,7 +46,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-user-policy.adoc:19
 #, no-wrap
 msgid "*Description*\n"
-msgstr ""
+msgstr "*Description*\n"
 
 #. type: Title ==
 #: source/authorization_services/topics/permission-create-resource.adoc:11
@@ -59,10 +60,9 @@ msgstr ""
 #: source/authorization_services/topics/policy-time-policy.adoc:11
 #: source/authorization_services/topics/policy-user-policy.adoc:11
 #: source/authorization_services/topics/service-client-api.adoc:21
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Configuration"
-msgstr "ドメイン設定"
+msgstr "設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:17
@@ -72,12 +72,13 @@ msgid ""
 "practice is to use names that are closely related to your business and "
 "security requirements, so you can identify them more easily."
 msgstr ""
+"権限を説明する、人が判別可能で一意の文字列。ベストプラクティスは、ビジネス要件とセキュリティ要件に密接に関連する名前を使用することすることです。そうすることで簡単に識別することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:21
 #: source/authorization_services/topics/permission-create-scope.adoc:21
 msgid "A string containing details about this permission."
-msgstr ""
+msgstr "パーミッションに関する詳細を含む文字列。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:36
@@ -85,13 +86,13 @@ msgstr ""
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:31
 #, no-wrap
 msgid "*Apply Policy*\n"
-msgstr ""
+msgstr "*Apply Policy*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:38
 #: source/authorization_services/topics/permission-create-scope.adoc:33
 msgid "Defines a set of one or more policies to associate with a permission."
-msgstr ""
+msgstr "パーミッションに関連付ける1つまた複数のポリシーのセットを定義します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:40
@@ -99,7 +100,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:35
 #, no-wrap
 msgid "*Decision Strategy*\n"
-msgstr ""
+msgstr "*Decision Strategy*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-resource.adoc:41
@@ -107,61 +108,63 @@ msgstr ""
 msgid ""
 "The <<_permission_decision_strategies, Decision Strategy>> for this "
 "permission."
-msgstr ""
+msgstr "パーミッションのための<<_permission_decision_strategies, 戦略的意思決定>>"
 
 #. type: Title =
 #: source/authorization_services/topics/permission-create-scope.adoc:2
 #, no-wrap
 msgid "Creating Scope-Based Permissions"
-msgstr ""
+msgstr "スコープ・ベースの権限の作成"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:5
 msgid ""
 "A scope-based permission defines a set of one or more scopes to protect "
 "using a set of one or more authorization policies. Unlike resource-based "
-"permissions, you can use this permission type to create permissions not only "
-"for a resource, but also for the scopes associated with it, providing more "
-"granularity when defining the permissions that govern your resources and the "
-"actions that can be performed on them."
+"permissions, you can use this permission type to create permissions not only"
+" for a resource, but also for the scopes associated with it, providing more "
+"granularity when defining the permissions that govern your resources and the"
+" actions that can be performed on them."
 msgstr ""
+"スコープ・ベースのパーミッションは、1つまたは複数の認可ポリシーのセットを使用して保護する1つ以上のスコープのセットを定義します。リソース・ベースのパーミッションとは異なり、このパーミッションのタイプを使用して、リソースだけでなく、それに関連付けられたスコープの権限を作成し、リソースを管理する権限とそれらに対して実行可能なアクションを定義する際に、より詳細な情報を提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:7
 msgid ""
-"To create a new scope-based permission, select *Scope-based* in the dropdown "
-"list in the upper right corner of the permission listing."
+"To create a new scope-based permission, select *Scope-based* in the dropdown"
+" list in the upper right corner of the permission listing."
 msgstr ""
+"新しいスコープ・ベースのパーミッションを作成するには、パーミッション・リストの右上隅にあるドロップダウン・リストで *Scope-based* "
+"を選択します。"
 
 #. type: Block title
 #: source/authorization_services/topics/permission-create-scope.adoc:8
 #, no-wrap
 msgid "Add Scope-Based Permission"
-msgstr ""
+msgstr "スコープ・ベースのパーミッションの追加"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:10
-#, fuzzy
-#| msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgid ""
 "image:{project_images}/permission/create-scope.png[alt=\"Add Scope-Based "
 "Permission\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
+msgstr ""
+"image:{project_images}/permission/create-"
+"scope.png[alt=\"スコープ・ベースのパーミッションの追加\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:23
 #: source/authorization_services/topics/resource-server-enable-authorization.adoc:21
-#, fuzzy, no-wrap
-#| msgid "resource"
+#, no-wrap
 msgid "*Resource*\n"
-msgstr "resource"
+msgstr "*Resource*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:25
 msgid ""
-"Restricts the scopes to those associated with the selected resource. If none "
-"is selected, all scopes are available."
-msgstr ""
+"Restricts the scopes to those associated with the selected resource. If none"
+" is selected, all scopes are available."
+msgstr "選択したリソースに関連付けられているものにスコープを制限します。選択されていない場合は、すべてのスコープを使用できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:27
@@ -169,9 +172,9 @@ msgstr ""
 #: source/authorization_services/topics/resource-create.adoc:31
 #, no-wrap
 msgid "*Scopes*\n"
-msgstr ""
+msgstr "*Scopes*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/permission-create-scope.adoc:29
 msgid "Defines a set of one or more scopes to protect."
-msgstr ""
+msgstr "保護する1つまたは複数のスコープのセットを定義します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__permission-create-scope
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__permission-create-scope/ja_JP/index.html
