### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,14 +30,15 @@ msgid ""
 " the evaluation of all permissions and authorization policies associated "
 "with the resources being requested."
 msgstr ""
-"エンタイトルメントAPIは、サーバーから認可データを取得するための1-leggedプロトコルを提供します。ここで、認可データは、要求されているリソースに関連するすべての権限および認可ポリシーの評価の結果を表します。"
+"エンタイトルメントAPIは、サーバーから認可データを取得するための1-leggedプロトコルを提供します。ここで、認可データは、要求されているリソースに関連するすべてのパーミッションおよび認可ポリシーの評価の結果を表します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:8
 msgid ""
 "Unlike the _Authorization API_, the Entitlement API is not UMA-compliant and"
 " does not require permission tickets."
-msgstr "_Authorization API_ とは異なり、エンタイトルメントAPIはUMA準拠ではなく、アクセス許可チケットを必要としません。"
+msgstr ""
+"_Authorization API_ とは異なり、エンタイトルメントAPIはUMA準拠ではなく、パーミッション・チケットを必要としません。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:10
@@ -47,4 +48,4 @@ msgid ""
 "token is able to obtain the necessary authorization data on behalf of its "
 "users."
 msgstr ""
-"このAPIの目的は、有効なOAuth2アクセス・トークンを所有しているクライアントが、ユーザーに代わって必要な認可データを取得できる、認可データを取得するためのより軽量なAPIを提供することです。"
+"このAPIの目的は、有効なOAuth2アクセストークンを所有しているクライアントが、ユーザーに代わって必要な認可データを取得できる、認可データを取得するためのより軽量なAPIを提供することです。"

--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
@@ -19,23 +20,24 @@ msgstr ""
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:2
 #, no-wrap
 msgid "Entitlement API"
-msgstr ""
+msgstr "エンタイトルメントAPI"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:6
 msgid ""
-"The Entitlement API provides a 1-legged protocol for obtaining authorization "
-"data from the server, where the authorization data represents the result of "
-"the evaluation of all permissions and authorization policies associated with "
-"the resources being requested."
+"The Entitlement API provides a 1-legged protocol for obtaining authorization"
+" data from the server, where the authorization data represents the result of"
+" the evaluation of all permissions and authorization policies associated "
+"with the resources being requested."
 msgstr ""
+"エンタイトルメントAPIは、サーバーから認可データを取得するための1-leggedプロトコルを提供します。ここで、認可データは、要求されているリソースに関連するすべての権限および認可ポリシーの評価の結果を表します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:8
 msgid ""
-"Unlike the _Authorization API_, the Entitlement API is not UMA-compliant and "
-"does not require permission tickets."
-msgstr ""
+"Unlike the _Authorization API_, the Entitlement API is not UMA-compliant and"
+" does not require permission tickets."
+msgstr "_Authorization API_ とは異なり、エンタイトルメントAPIはUMA準拠ではなく、アクセス許可チケットを必要としません。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:10
@@ -45,3 +47,4 @@ msgid ""
 "token is able to obtain the necessary authorization data on behalf of its "
 "users."
 msgstr ""
+"このAPIの目的は、有効なOAuth2アクセス・トークンを所有しているクライアントが、ユーザーに代わって必要な認可データを取得できる、認可データを取得するためのより軽量なAPIを提供することです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-entitlement-entitlement-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-entitlement-entitlement-api/ja_JP/index.html
