### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api-aapi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api-aapi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api-aapi.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,13 +74,13 @@ msgid ""
 "and permissions managed by a specific resource server."
 msgstr ""
 "{project_name}で<<_overview_terminology_resource_server, "
-"リソース・サーバー>>として機能するクライアント・アプリケーションを識別するために、上記の **client_id** "
-"パラメーターを指定する必要があります。評価の範囲を特定のリソース・サーバーによって管理されるリソース、スコープおよび権限に制限するには、クライアント識別子を指定する必要があります。"
+"リソースサーバー>>として機能するクライアント・アプリケーションを識別するために、上記の **client_id** "
+"パラメーターを指定する必要があります。評価の範囲を特定のリソースサーバーによって管理されるリソース、スコープおよび権限に制限するには、クライアント識別子を指定する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:18
 msgid "The Entitlement API comes in two flavors:"
-msgstr "エンタイトルメントAPIは2種類あります。"
+msgstr "エンタイトルメントAPIには次の2種類があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:21
@@ -90,7 +90,7 @@ msgid ""
 "managed by the resource server itself."
 msgstr ""
 "HTTP **GET** "
-"を使用して、特定のユーザーが所有するリソース、および（または）リソース・サーバー自体が所有、管理する一般的なリソースに基づいてすべてのエンタイトルメントを取得します。"
+"を使用して、特定のユーザーが所有するリソース、および（または）リソースサーバー自体が所有、管理する一般的なリソースに基づくすべてのエンタイトルメントを取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:23
@@ -99,7 +99,7 @@ msgid ""
 "or more resources and scopes sent along with an entitlement request."
 msgstr ""
 "HTTP **POST** "
-"を使用して、エンタイトルメントのリクエストと共に送信される1つまたは複数のリソースとスコープのセットに基づいてエンタイトルメントを取得します。"
+"を使用して、エンタイトルメントのリクエストと共に送信される1つ以上のリソースとスコープのセットに基づくエンタイトルメントを取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:28
@@ -111,8 +111,8 @@ msgid ""
 "the **POST** method is recommended."
 msgstr ""
 "どちらを使用するかは、ユースケースと{project_name}に登録したリソースの量によって異なります。 **GET** "
-"は、サーバーからの資格を取得する簡単な方法を提供しますが、ユーザーに関連するリソースが多すぎる場合には、適切ではない可能性があります。この場合は、 "
-"**POST** メソッドが推奨されます。"
+"は、サーバーからのエンタイトルメントを取得する簡単な方法を提供しますが、ユーザーに関連するリソースが多すぎる場合には、適切ではない可能性があります。この場合は、"
+" **POST** メソッドが推奨されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:31
@@ -141,7 +141,7 @@ msgid ""
 "The easiest way to obtain entitlements for a specific user is using an HTTP "
 "GET request. For example, using curl:"
 msgstr ""
-"特定のユーザーのエンタイトルメントを取得する最も簡単な方法は、HTTP GETリクエストを使用することです。 例えば、curlを使用します。"
+"特定のユーザーのエンタイトルメントを取得する最も簡単な方法は、HTTP GETリクエストを使用することです。たとえば、次のようにcurlを使用します。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:43
@@ -205,7 +205,7 @@ msgid ""
 "other hand, *Alice Bank Account* is a resource where user *alice* is the owner. The same goes for *Bob Bank Account* which is owned by a different user, *bob*.\n"
 msgstr ""
 "*Main Page* "
-"はアプリケーションの共通リソースで、リソース・サーバー自体が所有しています。アプリケーションのランディングページまたはメインページを表します。一方、 "
+"はアプリケーションの共通リソースで、リソースサーバー自体が所有しています。アプリケーションのランディング・ページまたはメインページを表します。一方、 "
 "*Alice Bank Account* は、ユーザー *alice* が所有者であるリソースです。別のユーザー *bob* が所有している *Bob "
 "Bank Account* についても同様です。\n"
 
@@ -232,7 +232,7 @@ msgid ""
 "You can also use the entitlements endpoint to obtain a user's entitlements "
 "for a set of one or more resources. For example, using curl:"
 msgstr ""
-"エンタイトルメント・エンドポイントを使用して、1つまたは複数のリソースのセットに対するユーザーのエンタイトルメントを取得することもできます。例えば、curlを使用します。"
+"エンタイトルメント・エンドポイントを使用して、1つ以上のリソースのセットに対するユーザーのエンタイトルメントを取得することもできます。たとえば、次のようにcurlを使用します。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:78
@@ -267,7 +267,7 @@ msgstr ""
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:92
 msgid ""
 "You can also specify the scopes you want to access. For example, using curl:"
-msgstr "アクセスするスコープを指定することもできます。 例えば、curlを使用します。"
+msgstr "アクセスするスコープを指定することもできます。たとえば、次のようにcurlを使用します。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:104
@@ -285,12 +285,12 @@ msgid ""
 "}' \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"
 msgstr ""
 "curl -X POST -H \"Authorization: Bearer ${access_token}\" -d '{\n"
-" \"permissions\" : [\n"
-" {\n"
-" \"resource_set_name\" : \"Alice Bank Account\",\n"
-" \"scopes\" : [\n"
-" \"withdraw\"\n"
-" ]\n"
-" }\n"
-" ]\n"
+"    \"permissions\" : [\n"
+"        {\n"
+"            \"resource_set_name\" : \"Alice Bank Account\",\n"
+"            \"scopes\" : [\n"
+"                \"withdraw\"\n"
+"            ]\n"
+"        }\n"
+"    ]\n"
 "}' \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"

--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api-aapi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api-aapi.ja_JP.po
@@ -1,26 +1,26 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:59
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:35
-#, fuzzy, no-wrap
-#| msgid "Obtaining Assertion Attributes"
+#, no-wrap
 msgid "Obtaining Entitlements"
-msgstr "アサーション属性の取得"
+msgstr "エンタイトルメントの取得"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-authorization-authorization-api-aapi.adoc:29
@@ -30,39 +30,39 @@ msgstr "アサーション属性の取得"
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:20
 #: source/authorization_services/topics/service-rpt-token-introspection.adoc:43
 msgid "As a result, the server response is:"
-msgstr ""
+msgstr "その結果、サーバーの応答は次のようになります。"
 
 #. type: Title =
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:2
 #, no-wrap
 msgid "Requesting Entitlements"
-msgstr ""
+msgstr "エンタイトルメントの要求"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:7
 msgid ""
-"Client applications can use a specific endpoint to obtain a special security "
-"token called a <<_service_rpt_overview, Requesting Party Token (RPT)>>.  "
-"This token consists of all the entitlements (or permissions) for a user as a "
-"result of the evaluation of the permissions and authorization policies "
+"Client applications can use a specific endpoint to obtain a special security"
+" token called a <<_service_rpt_overview, Requesting Party Token (RPT)>>.  "
+"This token consists of all the entitlements (or permissions) for a user as a"
+" result of the evaluation of the permissions and authorization policies "
 "associated with the resources being requested.  With an RPT, client "
 "applications can gain access to protected resources at the resource server."
 msgstr ""
+"クライアント・アプリケーションは、特定のエンドポイントを使用して、<<_service_rpt_overview, "
+"リクエスティング・パーティー・トークン（RPT）>>と呼ばれる特別なセキュリティ・トークンを取得できます。このトークンは、要求されているリソースに関連する権限および認可ポリシーの評価の結果として、ユーザーのすべてのエンタイトルメント（または権限）で構成されます。RPTを使用すると、クライアント・アプリケーションはリソース・サーバーで保護されたリソースにアクセスできます。"
 
 #. type: Block title
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:8
 #, no-wrap
 msgid "Entitlement API Endpoint"
-msgstr ""
+msgstr "エンタイトルメントAPIエンドポイント"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:11
-#, fuzzy
-#| msgid "http://localhost:8080/auth/realms/demo/account"
 msgid ""
-"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/"
-"{client_id}"
-msgstr "http://localhost:8080/auth/realms/demo/account"
+"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}"
+msgstr ""
+"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:16
@@ -73,11 +73,14 @@ msgid ""
 "in order to restrict the scope of the evaluation to the resources, scopes "
 "and permissions managed by a specific resource server."
 msgstr ""
+"{project_name}で<<_overview_terminology_resource_server, "
+"リソース・サーバー>>として機能するクライアント・アプリケーションを識別するために、上記の **client_id** "
+"パラメーターを指定する必要があります。評価の範囲を特定のリソース・サーバーによって管理されるリソース、スコープおよび権限に制限するには、クライアント識別子を指定する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:18
 msgid "The Entitlement API comes in two flavors:"
-msgstr ""
+msgstr "エンタイトルメントAPIは2種類あります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:21
@@ -86,6 +89,8 @@ msgid ""
 "resources owned by a specific user or/and general resources owned and "
 "managed by the resource server itself."
 msgstr ""
+"HTTP **GET** "
+"を使用して、特定のユーザーが所有するリソース、および（または）リソース・サーバー自体が所有、管理する一般的なリソースに基づいてすべてのエンタイトルメントを取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:23
@@ -93,16 +98,21 @@ msgid ""
 "Using HTTP **POST** in order to obtain entitlements based on a a set of one "
 "or more resources and scopes sent along with an entitlement request."
 msgstr ""
+"HTTP **POST** "
+"を使用して、エンタイトルメントのリクエストと共に送信される1つまたは複数のリソースとスコープのセットに基づいてエンタイトルメントを取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:28
 msgid ""
 "Using one or another depends on your use case and how much resources you "
 "have registered in {project_name}. Although the **GET** variant provides an "
-"easy way to obtain entitlements from the server, it might not be appropriate "
-"in case you have too much resources associated with an user. In this case, "
+"easy way to obtain entitlements from the server, it might not be appropriate"
+" in case you have too much resources associated with an user. In this case, "
 "the **POST** method is recommended."
 msgstr ""
+"どちらを使用するかは、ユースケースと{project_name}に登録したリソースの量によって異なります。 **GET** "
+"は、サーバーからの資格を取得する簡単な方法を提供しますが、ユーザーに関連するリソースが多すぎる場合には、適切ではない可能性があります。この場合は、 "
+"**POST** メソッドが推奨されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:31
@@ -113,6 +123,8 @@ msgid ""
 "access token must be sent as a bearer token using an HTTP "
 "```Authorization``` header."
 msgstr ""
+"エンタイトルメントAPIエンドポイントは、ユーザーの識別情報を表すリクエスト内のアクセス・トークンと、ユーザーの代理として認可データにアクセスするための同意を期待します。アクセス・トークンは、HTTP"
+" ```Authorization``` ヘッダーを使用してベアラー・トークンとして送信する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:34
@@ -120,6 +132,8 @@ msgid ""
 "After successfully invoking the Entitlement API endpoint, you will get a "
 "<<_service_rpt_overview, RPT>> with all permissions granted by the server."
 msgstr ""
+"エンタイトルメントAPIエンドポイントを正常に呼び出すと、サーバーによって付与されたすべての権限を持つ<<_service_rpt_overview, "
+"RPT>>が取得されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:38
@@ -127,6 +141,7 @@ msgid ""
 "The easiest way to obtain entitlements for a specific user is using an HTTP "
 "GET request. For example, using curl:"
 msgstr ""
+"特定のユーザーのエンタイトルメントを取得する最も簡単な方法は、HTTP GETリクエストを使用することです。 例えば、curlを使用します。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:43
@@ -136,6 +151,9 @@ msgid ""
 "    -H \"Authorization: Bearer ${access_token}\" \\\n"
 "    \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"
 msgstr ""
+"curl -X GET \\\n"
+" -H \"Authorization: Bearer ${access_token}\" \\\n"
+" \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:51
@@ -146,34 +164,38 @@ msgid ""
 "  \"rpt\": ${RPT}\n"
 "}\n"
 msgstr ""
+"{\n"
+" \"rpt\": ${RPT}\n"
+"}\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:55
 msgid ""
 "Using this method to obtain entitlements, the server responds to the "
 "requesting client with *all* entitlements for a user, based on the "
-"evaluation of the permissions and authorization policies associated with the "
-"resources owned by the user or the resource server itself. For instance, "
+"evaluation of the permissions and authorization policies associated with the"
+" resources owned by the user or the resource server itself. For instance, "
 "suppose you have permissions defined in {project_name} for the following "
 "resources:"
 msgstr ""
+"このメソッドを使用してエンタイトルメントを取得すると、サーバーは、ユーザーまたはリソース・サーバー自体が所有するリソースに関連付けられている権限および認可ポリシーの評価に基づいて、ユーザーの"
+" *すべて* "
+"のエンタイトルメントを要求元のクライアントに応答します。例えば、次のリソースの{project_name}で定義されている権限があるとします。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:57
-#, fuzzy
-#| msgid "Login Page"
 msgid "Main Page"
-msgstr "ログインページ"
+msgstr "Main Page"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:58
 msgid "Alice Bank Account"
-msgstr ""
+msgstr "Alice Bank Account"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:59
 msgid "Bob Bank Account"
-msgstr ""
+msgstr "Bob Bank Account"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:62
@@ -182,6 +204,10 @@ msgid ""
 "*Main Page* is a common resource in your application and owned by the resource server itself, it represents a landing or main page in your application. On the\n"
 "other hand, *Alice Bank Account* is a resource where user *alice* is the owner. The same goes for *Bob Bank Account* which is owned by a different user, *bob*.\n"
 msgstr ""
+"*Main Page* "
+"はアプリケーションの共通リソースで、リソース・サーバー自体が所有しています。アプリケーションのランディングページまたはメインページを表します。一方、 "
+"*Alice Bank Account* は、ユーザー *alice* が所有者であるリソースです。別のユーザー *bob* が所有している *Bob "
+"Bank Account* についても同様です。\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:65
@@ -191,12 +217,14 @@ msgid ""
 "Bank Account*. Giving you back a RPT (if permissions were actually granted) "
 "with a set of permissions representing these resources."
 msgstr ""
+"ユーザー *alice* のエンタイトルメントを取得するとき、サーバーはリソースの *Main Page* と *Alice Bank Account*"
+" に関連するすべての権限を評価します。これらのリソースを表す権限のセットを使用してRPT（実際に権限が与えられた場合）を返します。"
 
 #. type: Title ==
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:66
 #, no-wrap
 msgid "Obtaining Entitlements for a Specific Set of Resources"
-msgstr ""
+msgstr "特定のリソースのセットに対するエンタイトルメントの取得"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:69
@@ -204,6 +232,7 @@ msgid ""
 "You can also use the entitlements endpoint to obtain a user's entitlements "
 "for a set of one or more resources. For example, using curl:"
 msgstr ""
+"エンタイトルメント・エンドポイントを使用して、1つまたは複数のリソースのセットに対するユーザーのエンタイトルメントを取得することもできます。例えば、curlを使用します。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:78
@@ -217,6 +246,13 @@ msgid ""
 "    ]\n"
 "}' \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"
 msgstr ""
+"curl -X POST -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${access_token}\" -d '{\n"
+" \"permissions\" : [\n"
+" {\n"
+" \"resource_set_name\" : \"Alice Bank Account\"\n"
+" }\n"
+" ]\n"
+"}' \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:90
@@ -225,12 +261,13 @@ msgid ""
 "permissions granted during the evaluation of the permissions and "
 "authorization policies associated with the resources being requested."
 msgstr ""
+"GETバージョンとは異なり、サーバーは、要求されているリソースに関連付けられている権限および許可ポリシーの評価中に付与された権限を保持するRPTで応答します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:92
 msgid ""
 "You can also specify the scopes you want to access. For example, using curl:"
-msgstr ""
+msgstr "アクセスするスコープを指定することもできます。 例えば、curlを使用します。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:104
@@ -247,3 +284,13 @@ msgid ""
 "    ]\n"
 "}' \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"
 msgstr ""
+"curl -X POST -H \"Authorization: Bearer ${access_token}\" -d '{\n"
+" \"permissions\" : [\n"
+" {\n"
+" \"resource_set_name\" : \"Alice Bank Account\",\n"
+" \"scopes\" : [\n"
+" \"withdraw\"\n"
+" ]\n"
+" }\n"
+" ]\n"
+"}' \"http://${host}:${port}/auth/realms/${realm_name}/authz/entitlement/{client_id}\"\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-entitlement-entitlement-api-aapi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-entitlement-entitlement-api-aapi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-entitlement-entitlement-api-aapi/ja_JP/index.html
