### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,7 +53,7 @@ msgstr "エンタイトルメントAPIトークン"
 msgid ""
 "An entitlement API token (EAT) is a special OAuth2 access token with the "
 "scope *kc_entitlement*."
-msgstr "エンタイトルメントAPIトークン（EAT）は、スコープ *kc_entitlement* を持つ特別なOAuth2アクセス・トークンです。"
+msgstr "エンタイトルメントAPIトークン（EAT）は、スコープ *kc_entitlement* を持つ特別なOAuth2アクセストークンです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:8
@@ -64,9 +64,9 @@ msgid ""
 "_authorizaton_code_ grant type is used to authenticate a user and issue an "
 "OAuth2 access token to the client application acting on the user's behalf."
 msgstr ""
-"クライアント・アプリケーションは、他のOAuth2アクセス・トークンと同様に{project_name}からEATを取得できます。通常、クライアント・アプリケーションは、ユーザーが{project_name}で正常に認証された後にEATを取得します。デフォルトでは、"
+"クライアント・アプリケーションは、他のOAuth2アクセストークンと同様に{project_name}からEATを取得できます。通常、クライアント・アプリケーションは、ユーザーが{project_name}で正常に認証された後にEATを取得します。デフォルトでは、"
 " _authorization_code_ "
-"グラント・タイプは、ユーザーを認証に使用され、サーバーは代わりにクライアント・アプリケーションへのOAuth2アクセス・トークンを発行します。"
+"グラント・タイプは、ユーザーを認証に使用され、サーバーは代わりにクライアント・アプリケーションへのOAuth2アクセストークンを発行します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:10

--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -22,7 +23,7 @@ msgstr ""
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:20
 #: source/authorization_services/topics/service-rpt-token-introspection.adoc:43
 msgid "As a result, the server response is:"
-msgstr ""
+msgstr "その結果、サーバーの応答は次のようになります。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-authorization-whatis-obtain-aat.adoc:23
@@ -35,36 +36,44 @@ msgid ""
 "    -d 'username=${username}&password=${user_password}&grant_type=password' \\\n"
 "    \"http://localhost:8080/auth/realms/${realm_name}/protocol/openid-connect/token\"\n"
 msgstr ""
+"curl -X POST \\\n"
+"-H \"Authorization: Basic aGVsbG8td29ybGQtYXV0aHotc2VydmljZTpwYXNzd29yZA==\" \\\n"
+"-H \"Content-Type: application/x-www-form-urlencoded\" \\\n"
+"-d 'username=${username}&password=${user_password}&grant_type=password' \\\n"
+"\"http://localhost:8080/auth/realms/${realm_name}/protocol/openid-connect/token\"\n"
 
 #. type: Title =
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:2
 #, no-wrap
 msgid "Entitlement API Tokens"
-msgstr ""
+msgstr "エンタイトルメントAPIトークン"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:5
 msgid ""
 "An entitlement API token (EAT) is a special OAuth2 access token with the "
 "scope *kc_entitlement*."
-msgstr ""
+msgstr "エンタイトルメントAPIトークン（EAT）は、スコープ *kc_entitlement* を持つ特別なOAuth2アクセス・トークンです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:8
 msgid ""
 "Client applications can obtain an EAT from {project_name} like any other "
-"OAuth2 access token. Usually, client applications obtain EATs after the user "
-"is successfully authenticated in {project_name}. By default the "
+"OAuth2 access token. Usually, client applications obtain EATs after the user"
+" is successfully authenticated in {project_name}. By default the "
 "_authorizaton_code_ grant type is used to authenticate a user and issue an "
 "OAuth2 access token to the client application acting on the user's behalf."
 msgstr ""
+"クライアント・アプリケーションは、他のOAuth2アクセス・トークンと同様に{project_name}からEATを取得できます。通常、クライアント・アプリケーションは、ユーザーが{project_name}で正常に認証された後にEATを取得します。デフォルトでは、"
+" _authorizaton_code_ "
+"グラント・タイプは、ユーザーを認証し、ユーザーの代理として動作するクライアント・アプリケーションへのOAuth2アクセス・トークンを発行するために使用されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:10
 msgid ""
 "For demonstration purposes, the example below uses Resource Owner Password "
 "Credentials Grant Type to request an EAT:"
-msgstr ""
+msgstr "説明のために、以下の例では、リソース・オーナー・パスワード・クレデンシャル・グラント・タイプを使用してEATをリクエストしています。"
 
 #. type: Code block
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:32
@@ -81,16 +90,28 @@ msgid ""
 "  \"session_state\": \"3cad2afc-855b-47b7-8e4d-a21c66e312fb\"\n"
 "}\n"
 msgstr ""
+"{\n"
+"  \"access_token\": ${EAT},\n"
+"  \"expires_in\": 300,\n"
+"  \"refresh_expires_in\": 1800,\n"
+"  \"refresh_token\": ${refresh_token},\n"
+"  \"token_type\": \"bearer\",\n"
+"  \"id_token\": ${id_token},\n"
+"  \"not-before-policy\": 0,\n"
+"  \"session_state\": \"3cad2afc-855b-47b7-8e4d-a21c66e312fb\"\n"
+"}\n"
 
 #. type: Title ===
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:34
 #, no-wrap
 msgid "About the kc_entitlement scope"
-msgstr ""
+msgstr "kc_entitlementスコープについて"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:36
 msgid ""
-"The *kc_entitlement* scope can be created like any other _realm role_, or as "
-"a _client role_. Once created, grant this role to the users of your realm."
+"The *kc_entitlement* scope can be created like any other _realm role_, or as"
+" a _client role_. Once created, grant this role to the users of your realm."
 msgstr ""
+"*kc_entitlement* スコープは、他の _realm role_ と同じように作成することも、 _client role_ "
+"として作成することもできます。作成したら、レルムのユーザーにこのロールを与えます。"

--- a/i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,8 +65,8 @@ msgid ""
 "OAuth2 access token to the client application acting on the user's behalf."
 msgstr ""
 "クライアント・アプリケーションは、他のOAuth2アクセス・トークンと同様に{project_name}からEATを取得できます。通常、クライアント・アプリケーションは、ユーザーが{project_name}で正常に認証された後にEATを取得します。デフォルトでは、"
-" _authorizaton_code_ "
-"グラント・タイプは、ユーザーを認証し、ユーザーの代理として動作するクライアント・アプリケーションへのOAuth2アクセス・トークンを発行するために使用されます。"
+" _authorization_code_ "
+"グラント・タイプは、ユーザーを認証に使用され、サーバーは代わりにクライアント・アプリケーションへのOAuth2アクセス・トークンを発行します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/service-entitlement-whatis-obtain-eat.adoc:10


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-entitlement-whatis-obtain-eat.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-entitlement-whatis-obtain-eat
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__service-entitlement-whatis-obtain-eat/ja_JP/index.html
