### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
@@ -1,24 +1,25 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/policy-evaluation-api.adoc:2
 #, no-wrap
 msgid "Policy Evaluation API"
-msgstr ""
+msgstr "ポリシー評価API"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:5
@@ -27,39 +28,44 @@ msgid ""
 "{project_name} provides an Evaluation API that provides useful information "
 "to help determine whether a permission should be granted."
 msgstr ""
+"JavaScriptまたはJBoss "
+"Droolsを使用してルールベースのポリシーを作成する場合、{project_name}は、アクセス許可を与える必要があるかどうかを判断するのに役立つ情報を提供する評価APIを提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:7
 msgid ""
 "This API consists of a few interfaces that provides you access to "
 "information such as:"
-msgstr ""
+msgstr "このAPIは、次のような情報へのアクセスを提供するいくつかのインターフェイスで構成されています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:9
 msgid "The permission being requested"
-msgstr ""
+msgstr "要求しているパーミッション"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:10
 msgid ""
 "The identity that is requesting the permission, from which you can obtain "
 "claims/attributes"
-msgstr ""
+msgstr "クレーム/属性を取得できるパーミッションを要求しているアイデンティティー"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:11
 msgid ""
 "Runtime environment and any other attribute associated with the execution "
 "context"
-msgstr ""
+msgstr "ランタイム環境および実行コンテキストに関連付けられたその他の属性"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:13
 msgid ""
-"The main interface is *org.keycloak.authorization.policy.evaluation."
-"Evaluation*, which defines the following contract:"
+"The main interface is "
+"*org.keycloak.authorization.policy.evaluation.Evaluation*, which defines the"
+" following contract:"
 msgstr ""
+"主なインタフェースは *org.keycloak.authorization.policy.evaluation.Evaluation* "
+"で、次のコントラクトを定義します。"
 
 #. type: Code block
 #: source/authorization_services/topics/policy-evaluation-api.adoc:41
@@ -92,6 +98,32 @@ msgid ""
 "    void deny();\n"
 "}\n"
 msgstr ""
+"public interface Evaluation {\n"
+"\n"
+"    /**\n"
+"     * Returns the {@link ResourcePermission} to be evaluated.\n"
+"     *\n"
+"     * @return the permission to be evaluated\n"
+"     */\n"
+"    ResourcePermission getPermission();\n"
+"\n"
+"    /**\n"
+"     * Returns the {@link EvaluationContext}. Which provides access to the whole evaluation runtime context.\n"
+"     *\n"
+"     * @return the evaluation context\n"
+"     */\n"
+"    EvaluationContext getContext();\n"
+"\n"
+"    /**\n"
+"     * Grants the requested permission to the caller.\n"
+"     */\n"
+"    void grant();\n"
+"\n"
+"    /**\n"
+"     * Denies the requested permission.\n"
+"     */\n"
+"    void deny();\n"
+"}\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:44
@@ -100,36 +132,41 @@ msgid ""
 "`Evaluation` instance before evaluating any policy. This instance is then "
 "passed to each policy to determine whether access is *GRANT* or *DENY*."
 msgstr ""
+"認証リクエストを処理する際、{project_name}は、ポリシーを評価する前に `Evaluation` "
+"インスタンスを作成します。このインスタンスは、各ポリシーに渡され、アクセスが *GRANT* か *DENY* かを判断します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:46
 msgid ""
 "Policies determine this by invoking the `grant()` or `deny()` methods on an "
-"`Evaluation` instance. By default, the state of the `Evaluation` instance is "
-"denied, which means that your policies must explicitly invoke the `grant()` "
-"method to indicate to the policy evaluation engine that permission should be "
-"granted."
+"`Evaluation` instance. By default, the state of the `Evaluation` instance is"
+" denied, which means that your policies must explicitly invoke the `grant()`"
+" method to indicate to the policy evaluation engine that permission should "
+"be granted."
 msgstr ""
+"ポリシーは、評価インスタンスで `grant()` または `deny()` "
+"メソッドを呼び出すことでこれを判断します。デフォルトでは、評価インスタンスの状態は拒否されています。つまり、ポリシーが明示的に `grant()` "
+"メソッドを呼び出してポリシー評価エンジンに許可を与える必要があることを示す必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:48
 msgid ""
-"For more information about the Evaluation API see the {apidocs_link}"
-"[JavaDocs]."
-msgstr ""
+"For more information about the Evaluation API see the "
+"{apidocs_link}[JavaDocs]."
+msgstr "評価APIの詳細については、{apidocs_link}[JavaDocs]を参照してください。"
 
 #. type: Title ==
 #: source/authorization_services/topics/policy-evaluation-api.adoc:49
 #, no-wrap
 msgid "The Evaluation Context"
-msgstr ""
+msgstr "評価コンテキスト"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:52
 msgid ""
 "The evaluation context provides useful information to policies during their "
 "evaluation."
-msgstr ""
+msgstr "評価コンテキストは、評価中にポリシーに有用な情報を提供します。"
 
 #. type: Code block
 #: source/authorization_services/topics/policy-evaluation-api.adoc:70
@@ -152,33 +189,51 @@ msgid ""
 "    Attributes getAttributes();\n"
 "}\n"
 msgstr ""
+"public interface EvaluationContext {\n"
+"\n"
+"    /**\n"
+"     * Returns the {@link Identity} that represents an entity (person or non-person) to which the permissions must be granted, or not.\n"
+"     *\n"
+"     * @return the identity to which the permissions must be granted, or not\n"
+"     */\n"
+"    Identity getIdentity();\n"
+"\n"
+"    /**\n"
+"     * Returns all attributes within the current execution and runtime environment.\n"
+"     *\n"
+"     * @return the attributes within the current execution and runtime environment\n"
+"     */\n"
+"    Attributes getAttributes();\n"
+"}\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:73
 msgid "From this interface, policies can obtain:"
-msgstr ""
+msgstr "このインターフェイスから、ポリシーは以下を取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:75
-#, fuzzy
-#| msgid "Authentication"
 msgid "The authenticated `Identity`"
-msgstr "認証"
+msgstr "認証された `Identity`"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:76
 msgid "Information about the execution context and runtime environment"
-msgstr ""
+msgstr "実行コンテキストとランタイム環境に関する情報"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:80
 msgid ""
-"The `Identity` is built based on the OAuth2 Access Token that was sent along "
-"with the authorization request, and this construct has access to all claims "
-"extracted from the original token. For example, if you are using a _Protocol "
-"Mapper_ to include a custom claim in a OAuth2 Access Token you can also "
-"access this claim from a policy and use it to build your conditions."
+"The `Identity` is built based on the OAuth2 Access Token that was sent along"
+" with the authorization request, and this construct has access to all claims"
+" extracted from the original token. For example, if you are using a "
+"_Protocol Mapper_ to include a custom claim in a OAuth2 Access Token you can"
+" also access this claim from a policy and use it to build your conditions."
 msgstr ""
+"`Identity`  "
+"は、認可リクエストとともに送信されたOAuth2アクセス・トークンに基づいて作成され、このコンストラクトはオリジナルのトークンから抽出されたすべてのクレームにアクセスできます。例えば、"
+" _Protocol Mapper_ "
+"を使用してカスタム・クレームをOAuth2アクセス・トークンに含める場合、ポリシーからこのクレームにアクセスして、条件を作成することもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:82
@@ -187,43 +242,44 @@ msgid ""
 "the execution and runtime environments. For now, there only a few built-in "
 "attributes."
 msgstr ""
+"`EvaluationContext` "
+"は、実行およびランタイム環境の両方に関連する属性へのアクセスも提供します。今のところ、いくつかの組み込み属性しかありません。"
 
 #. type: Block title
 #: source/authorization_services/topics/policy-evaluation-api.adoc:83
 #, no-wrap
 msgid "Execution and Runtime Attributes"
-msgstr ""
+msgstr "実行およびランタイム属性"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:86
-#, fuzzy
 msgid "Name |Description | Type"
-msgstr "|=== |名前|説明 |デフォルトで有効"
+msgstr "名前 |説明 | タイプ"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:88
 msgid "kc.time.date_time"
-msgstr ""
+msgstr "kc.time.date_time"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:89
 msgid "Current date and time"
-msgstr ""
+msgstr "現在の日付と時刻"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:90
 msgid "String. Format `MM/dd/yyyy hh:mm:ss`"
-msgstr ""
+msgstr "文字列。フォーマット `MM/dd/yyyy hh:mm:ss`"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:92
 msgid "kc.client.network.ip_address"
-msgstr ""
+msgstr "kc.client.network.ip_address"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:93
 msgid "IPv4 address of the client"
-msgstr ""
+msgstr "クライアントのIPv4アドレス"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:94
@@ -231,59 +287,49 @@ msgstr ""
 #: source/authorization_services/topics/policy-evaluation-api.adoc:102
 #: source/authorization_services/topics/policy-evaluation-api.adoc:110
 msgid "String"
-msgstr ""
+msgstr "String"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:96
 msgid "kc.client.network.host"
-msgstr ""
+msgstr "kc.client.network.host"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:97
-#, fuzzy
-#| msgid "Clients"
 msgid "Client's host name"
-msgstr "クライアント"
+msgstr "クライアントのホスト名"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:100
-#, fuzzy
-#| msgid "Add Client"
 msgid "kc.client.id"
-msgstr "クライアントの追加"
+msgstr "kc.client.id"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:101
-#, fuzzy
-#| msgid "Add Client"
 msgid "The client id"
-msgstr "クライアントの追加"
+msgstr "クライアントID"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:104
-#, fuzzy
-#| msgid "clientKeystore"
 msgid "kc.client.user_agent"
-msgstr "clientKeystore"
+msgstr "kc.client.user_agent"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:105
 msgid "The value of the 'User-Agent' HTTP header"
-msgstr ""
+msgstr "'User-Agent' HTTPヘッダーの値"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:106
 msgid "String[]"
-msgstr ""
+msgstr "String[]"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:108
 msgid "kc.realm.name"
-msgstr ""
+msgstr "kc.realm.name"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:109
-#, fuzzy
-#| msgid "JNDI name of the dataSource"
 msgid "The name of the realm"
-msgstr "データソースのJNDI名"
+msgstr "レルムの名前"

--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgid ""
 "to help determine whether a permission should be granted."
 msgstr ""
 "JavaScriptまたはJBoss "
-"Droolsを使用してルールベースのポリシーを作成する場合、{project_name}は、アクセス許可を与える必要があるかどうかを判断するのに役立つ情報を提供する評価APIを提供します。"
+"Droolsを使用してルールベースのポリシーを作成する場合、{project_name}は、パーミッションを与える必要があるかどうかを判断するのに役立つ情報を提供する評価APIを提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:7
@@ -144,9 +144,9 @@ msgid ""
 " method to indicate to the policy evaluation engine that permission should "
 "be granted."
 msgstr ""
-"ポリシーは、評価インスタンスで `grant()` または `deny()` "
-"メソッドを呼び出すことでこれを判断します。デフォルトでは、評価インスタンスの状態は拒否されています。つまり、ポリシーが明示的に `grant()` "
-"メソッドを呼び出してポリシー評価エンジンに許可を与える必要があることを示す必要があります。"
+"ポリシーは、 `Evaluation` インスタンスで `grant()` または `deny()` "
+"メソッドを呼び出すことでこれを判断します。デフォルトでは、 `Evaluation` インスタンスの状態は拒否されています。つまり、ポリシーが明示的に "
+"`grant()` メソッドを呼び出してポリシー評価エンジンに許可を与える必要があることを示す必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:48
@@ -249,7 +249,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-evaluation-api.adoc:83
 #, no-wrap
 msgid "Execution and Runtime Attributes"
-msgstr "実行およびランタイム属性"
+msgstr "実行属性およびランタイム属性"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:86
@@ -269,7 +269,7 @@ msgstr "現在の日付と時刻"
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:90
 msgid "String. Format `MM/dd/yyyy hh:mm:ss`"
-msgstr "文字列。フォーマット `MM/dd/yyyy hh:mm:ss`"
+msgstr "String。フォーマット `MM/dd/yyyy hh:mm:ss`"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-evaluation-api.adoc:92


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-evaluation-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__policy-evaluation-api/ja_JP/index.html
