### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -1,25 +1,25 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Database Configuration"
+#, no-wrap
 msgid "JavaScript Integration"
-msgstr "データベース設定"
+msgstr "JavaScriptの統合"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:6
@@ -30,6 +30,7 @@ msgid ""
 "integrated to allow your client to obtain permissions from a {project_name} "
 "Server."
 msgstr ""
+"{project_name}サーバーには、ポリシー・エンフォーサーによって保護されたリソース・サーバーと対話するために使用できるJavaScriptライブラリが付属しています。このライブラリは{project_name}JavaScriptアダプターに基づいています。これを統合すると、クライアントは{project_name}サーバーからアクセス権を取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:8
@@ -37,18 +38,19 @@ msgid ""
 "You can obtain this library from a running a {project_name} Server instance "
 "by including the following `script` tag in your web page:"
 msgstr ""
+"実行中の{project_name}サーバーインスタンスからこのライブラリを入手するには、次の `script` タグをWebページに追加します。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:11
 msgid "<script src=\"http://.../auth/js/keycloak-authz.js\"></script>"
-msgstr ""
+msgstr "<script src=\"http://.../auth/js/keycloak-authz.js\"></script>"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:13
 msgid ""
 "Once you do that, you can create a `KeycloakAuthorization` instance as "
 "follows:"
-msgstr ""
+msgstr "これを実行すると、次のように `KeycloakAuthorization` インスタンスを作成できます。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:17
@@ -57,26 +59,34 @@ msgid ""
 "var keycloak = ... // obtain a Keycloak instance from keycloak.js library\n"
 "var authorization = new KeycloakAuthorization(keycloak);\n"
 msgstr ""
+"var keycloak = ... // obtain a Keycloak instance from keycloak.js library\n"
+"var authorization = new KeycloakAuthorization(keycloak);\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:19
 msgid "The *keycloak-authz.js* library provides two main features:"
-msgstr ""
+msgstr "*keycloak-authz.js* ライブラリには2つの主な機能があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:21
 msgid ""
-"Handle responses from a resource server protected by a <<_enforcer_overview, "
-"{project_name} Policy Enforcer>> and obtain a requesting party token (RPT) "
+"Handle responses from a resource server protected by a <<_enforcer_overview,"
+" {project_name} Policy Enforcer>> and obtain a requesting party token (RPT) "
 "with the necessary permissions to gain access to the protected resources on "
 "the resource server."
 msgstr ""
+"<<_enforcer_overview, "
+"{project_name}ポリシー・エンフォーサー>>によって保護されたリソース・サーバーからの応答を処理し、リソース・サーバー上の保護されたリソースにアクセスするために必要な権限を持つリクエスティング・パーティー・トークン（RPT）を取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:23
 #, no-wrap
-msgid "** In this case, the library can handle whatever authorization protocol the resource server is using: <<_service_entitlement_api, Entitlements>>.\n"
+msgid ""
+"** In this case, the library can handle whatever authorization protocol the "
+"resource server is using: <<_service_entitlement_api, Entitlements>>.\n"
 msgstr ""
+"** この場合、ライブラリは、リソース・サーバーが使用している認可プロトコル（<<_service_entitlement_api, "
+"エンタイトルメント>>）を処理できます。\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:25
@@ -84,6 +94,7 @@ msgid ""
 "Obtain permissions from a {project_name} Server using the "
 "<<_service_entitlement_api, Entitlement API>>."
 msgstr ""
+"<<_service_entitlement_api, エンタイトルメントAPI>>を使用して{project_name}サーバーから権限を取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:28
@@ -93,12 +104,13 @@ msgid ""
 "permissions your client can use as bearer tokens to access the protected "
 "resources on a resource server."
 msgstr ""
+"いずれの場合も、リソース・サーバーと{project_name}認可サービスの両方との対話を容易にし、クライアントがリソース・サーバー上の保護されたリソースにアクセスするベアラー・トークンとして使用できる権限を持つトークンを取得できます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:29
 #, no-wrap
 msgid "Handling Authorization Responses from a Resource Server"
-msgstr ""
+msgstr "リソース・サーバーからの認可応答の処理"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:34
@@ -110,14 +122,18 @@ msgid ""
 "protected resource, the resource server responds with a *401* status code "
 "and a `WWW-Authenticate` header."
 msgstr ""
+"リソース・サーバーがポリシー・エンフォーサーによって保護されている場合、リソース・サーバーは、ベアラー・トークンと一緒に持つ権限に基づいてクライアント要求に応答します。通常、保護されたリソースにアクセスするための権限がないベアラー・トークンを使用してリソース・サーバーにアクセスしようとすると、リソース・サーバーは"
+" *401* ステータスコードと `WWW-Authenticate` ヘッダーで応答します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:36
 msgid ""
 "The value of the `WWW-Authenticate` header depends on the authorization "
-"protocol in use by the resource server. Whatever protocol is in use, you can "
-"use a `KeycloakAuthorization` instance to handle responses as follows:"
+"protocol in use by the resource server. Whatever protocol is in use, you can"
+" use a `KeycloakAuthorization` instance to handle responses as follows:"
 msgstr ""
+"`WWW-Authenticate` ヘッダーの値は、リソース・サーバーで使用されている認可プロトコルによって異なります。使用中のプロトコルが何であれ、"
+" `KeycloakAuthorization` インスタンスを使用して次のように応答を処理できます。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:49
@@ -135,13 +151,24 @@ msgid ""
 "    // onError callback function. Called when the server responds unexpectedly\n"
 "});\n"
 msgstr ""
+"var wwwAuthenticateHeader = ... // extract WWW-Authenticate Header from the response in case of a 401 status code\n"
+"authorization.authorize(wwwAuthenticateHeader).then(function (rpt) {\n"
+"    // onGrant callback function.\n"
+"    // If authorization was successful you'll receive an RPT\n"
+"    // with the necessary permissions to access the resource server\n"
+"}, function () {\n"
+"    // onDeny callback function.\n"
+"    // Called when the authorization request is denied by the server\n"
+"}, function () {\n"
+"    // onError callback function. Called when the server responds unexpectedly\n"
+"});\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:52
 msgid ""
 "The `authorize` function is completely asynchronous and supports a few "
 "callback functions to receive notifications from the server:"
-msgstr ""
+msgstr "`authorize` 関数は完全に非同期で、サーバーからの通知を受け取るためのいくつかのコールバック関数をサポートしています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:54
@@ -150,15 +177,15 @@ msgid ""
 "`onGrant`: The first argument of the function. If authorization was "
 "successful and the server returned an RPT with the requested permissions, "
 "the callback receives the RPT."
-msgstr ""
+msgstr "`onGrant`: 関数の第1引数。認可が成功し、サーバーが要求された権限でRPTを返した場合、コールバックはRPTを受け取ります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:55
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:76
 msgid ""
-"`onDeny`: The second argument of the function. Only called if the server has "
-"denied the authorization request."
-msgstr ""
+"`onDeny`: The second argument of the function. Only called if the server has"
+" denied the authorization request."
+msgstr "`onDeny`: 関数の第2引数。サーバーが認可要求を拒否した場合にのみ呼び出されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:56
@@ -166,23 +193,24 @@ msgstr ""
 msgid ""
 "`onError`: The third argument of the function. Only called if the server "
 "responds unexpectedly."
-msgstr ""
+msgstr "`onError`: 関数の第3引数。サーバーが予期せず応答する場合にのみ呼び出されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:58
 msgid ""
-"Most applications should use the `onGrant` callback to retry a request after "
-"a 401 response. Subsequent requests should include the RPT as a bearer token "
-"for retries."
+"Most applications should use the `onGrant` callback to retry a request after"
+" a 401 response. Subsequent requests should include the RPT as a bearer "
+"token for retries."
 msgstr ""
+"ほとんどのアプリケーションは、 `onGrant` "
+"コールバックを使用して401応答後にリクエストをリトライする必要があります。以降のリクエストには、RPTをリトライのためのベアラー・トークンとして含める必要があります。"
 
 #. type: Title ==
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:59
 #: source/authorization_services/topics/service-entitlement-entitlement-api-aapi.adoc:35
-#, fuzzy, no-wrap
-#| msgid "Obtaining Assertion Attributes"
+#, no-wrap
 msgid "Obtaining Entitlements"
-msgstr "アサーション属性の取得"
+msgstr "エンタイトルメントの取得"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:62
@@ -190,6 +218,8 @@ msgid ""
 "The keycloak-authz.js library provides an `entitlement` function that you "
 "can use to obtain an RPT from the server using the Entitlement API."
 msgstr ""
+"keycloak-authz.jsライブラリには、エンタイトルメントAPIを使用してサーバーからRPTを取得するために使用できる "
+"`entitlement` 関数が用意されています。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:69
@@ -201,37 +231,43 @@ msgid ""
 "    // with the necessary permissions to access the resource server\n"
 "});\n"
 msgstr ""
+"authorization.entitlement('my-resource-server-id').then(function (rpt) {\n"
+"    // onGrant callback function.\n"
+"    // If authorization was successful you'll receive an RPT\n"
+"    // with the necessary permissions to access the resource server\n"
+"});\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:71
 msgid ""
 "When using the `entitlement` function, you must provide the _client_id_ of "
 "the resource server you want to access."
-msgstr ""
+msgstr "`entitlement` を使用する場合は、アクセスするリソース・サーバーの _client_id_ を指定する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:73
 msgid ""
 "The `entitlement` function is completely asynchronous and supports a few "
 "callback functions to receive notifications from the server:"
-msgstr ""
+msgstr "`entitlement` 関数は完全に非同期で、サーバーからの通知を受け取るためのコールバック関数をいくつかサポートしています。"
 
 #. type: Title ==
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:78
 #, no-wrap
 msgid "Obtaining the RPT"
-msgstr ""
+msgstr "RPTの取得"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:81
 msgid ""
-"If you have already obtained an RPT using any of the authorization functions "
-"provided by the library, you can always obtain the RPT as follows from the "
+"If you have already obtained an RPT using any of the authorization functions"
+" provided by the library, you can always obtain the RPT as follows from the "
 "authorization object (assuming that it has been initialized by one of the "
 "techniques shown earlier):"
 msgstr ""
+"ライブラリによって提供されている認可関数を使用してRPTをすでに取得している場合は、認可オブジェクトから次のようにRPTを得ることができます。（前述のいずれかの手法で初期化されているものとします）"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:84
 msgid "var rpt = authorization.rpt;"
-msgstr ""
+msgstr "var rpt = authorization.rpt;"

--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -30,7 +30,8 @@ msgid ""
 "integrated to allow your client to obtain permissions from a {project_name} "
 "Server."
 msgstr ""
-"{project_name}サーバーには、ポリシー・エンフォーサーによって保護されたリソース・サーバーと対話するために使用できるJavaScriptライブラリが付属しています。このライブラリは{project_name}JavaScriptアダプターに基づいています。これを統合すると、クライアントは{project_name}サーバーからアクセス権を取得できます。"
+"{project_name}サーバーには、ポリシー・エンフォーサーによって保護されたリソース・サーバーと対話するために使用できるJavaScriptライブラリが付属しています。このライブラリは{project_name}"
+" JavaScriptアダプターに基づいています。これを統合すると、クライアントは{project_name}サーバーからアクセス権を取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:8
@@ -38,7 +39,7 @@ msgid ""
 "You can obtain this library from a running a {project_name} Server instance "
 "by including the following `script` tag in your web page:"
 msgstr ""
-"実行中の{project_name}サーバーインスタンスからこのライブラリを入手するには、次の `script` タグをWebページに追加します。"
+"次の `script` タグをWebページに含めることで、実行中の{project_name}サーバー・インスタンスからこのライブラリを入手できます。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:11
@@ -76,7 +77,7 @@ msgid ""
 "the resource server."
 msgstr ""
 "<<_enforcer_overview, "
-"{project_name}ポリシー・エンフォーサー>>によって保護されたリソース・サーバーからの応答を処理し、リソース・サーバー上の保護されたリソースにアクセスするために必要な権限を持つリクエスティング・パーティー・トークン（RPT）を取得します。"
+"{project_name}ポリシー・エンフォーサー>>によって保護されたリソース・サーバーからのレスポンスを処理し、リソース・サーバー上の保護されたリソースにアクセスするために必要な権限を持つリクエスティング・パーティー・トークン（RPT）を取得します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:23
@@ -110,7 +111,7 @@ msgstr ""
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:29
 #, no-wrap
 msgid "Handling Authorization Responses from a Resource Server"
-msgstr "リソース・サーバーからの認可応答の処理"
+msgstr "リソース・サーバーからの認可レスポンスの処理"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:34
@@ -122,7 +123,8 @@ msgid ""
 "protected resource, the resource server responds with a *401* status code "
 "and a `WWW-Authenticate` header."
 msgstr ""
-"リソース・サーバーがポリシー・エンフォーサーによって保護されている場合、リソース・サーバーは、ベアラー・トークンと一緒に持つ権限に基づいてクライアント要求に応答します。通常、保護されたリソースにアクセスするための権限がないベアラー・トークンを使用してリソース・サーバーにアクセスしようとすると、リソース・サーバーは"
+"リソース・サーバーがポリシー・エンフォーサーによって保護されている場合、リソース・サーバーは、<<_enforcer_bearer, "
+"ベアラートークンベアラー・トークン>>とともに送信される権限に基づいてクライアント・リクエストに応答します。通常、保護されたリソースにアクセスするための権限がないベアラー・トークンを使用してリソース・サーバーにアクセスしようとすると、リソース・サーバーは"
 " *401* ステータスコードと `WWW-Authenticate` ヘッダーで応答します。"
 
 #. type: Plain text
@@ -133,7 +135,7 @@ msgid ""
 " use a `KeycloakAuthorization` instance to handle responses as follows:"
 msgstr ""
 "`WWW-Authenticate` ヘッダーの値は、リソース・サーバーで使用されている認可プロトコルによって異なります。使用中のプロトコルが何であれ、"
-" `KeycloakAuthorization` インスタンスを使用して次のように応答を処理できます。"
+" `KeycloakAuthorization` インスタンスを使用して次のようにレスポンスを処理できます。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:49
@@ -185,7 +187,7 @@ msgstr "`onGrant`: 関数の第1引数。認可が成功し、サーバーが要
 msgid ""
 "`onDeny`: The second argument of the function. Only called if the server has"
 " denied the authorization request."
-msgstr "`onDeny`: 関数の第2引数。サーバーが認可要求を拒否した場合にのみ呼び出されます。"
+msgstr "`onDeny`: 関数の第2引数。サーバーがリクエストを拒否した場合にのみ呼び出されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:56
@@ -265,7 +267,7 @@ msgid ""
 "authorization object (assuming that it has been initialized by one of the "
 "techniques shown earlier):"
 msgstr ""
-"ライブラリによって提供されている認可関数を使用してRPTをすでに取得している場合は、認可オブジェクトから次のようにRPTを得ることができます。（前述のいずれかの手法で初期化されているものとします）"
+"ライブラリによって提供されている認可関数を使用してRPTをすでに取得している場合は、認可オブジェクトから次のようにRPTを得ることができます（前述のいずれかの手法で初期化されているものとします）。"
 
 #. type: Code block
 #: source/authorization_services/topics/enforcer-js-adapter.adoc:84


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-js-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__enforcer-js-adapter/ja_JP/index.html
