### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
@@ -19,53 +20,53 @@ msgstr ""
 #: source/server_installation/topics/profiles.adoc:66
 #: source/authorization_services/topics/auth-services-architecture.adoc:84
 #: source/authorization_services/topics/service-overview.adoc:2
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Authorization Services"
-msgstr ""
-"#-#-#-#-#  service-overview.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"#-#-#-#-#  profiles.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"Authorization Servicesガイド"
+msgstr "認可サービス"
 
 #. type: Title =
 #: source/authorization_services/topics/auth-services-architecture.adoc:2
 #, no-wrap
 msgid "Architecture"
-msgstr ""
+msgstr "アーキテクチャー"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:5
 msgid ""
-"image:images/authz-arch-overview.png[alt=\"{project_name} AuthZ Architecture "
-"Overview\"]"
+"image:images/authz-arch-overview.png[alt=\"{project_name} AuthZ Architecture"
+" Overview\"]"
 msgstr ""
+"image:images/authz-arch-overview.png[alt=\"{project_name} AuthZアーキテクチャー概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:7
 msgid ""
-"From a design perspective, Authorization Services is based on a well-defined "
-"set of authorization patterns providing these capabilities:"
-msgstr ""
+"From a design perspective, Authorization Services is based on a well-defined"
+" set of authorization patterns providing these capabilities:"
+msgstr "設計の観点から、認可サービスは、明確に定義された認可パターンのセットに基づいて次の機能を提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:9
 #, no-wrap
 msgid "**Policy Administration Point (PAP)**\n"
-msgstr ""
+msgstr "**ポリシー管理ポイント（PAP）**\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:12
 msgid ""
 "Provides a set of UIs based on the {project_name} Administration Console to "
-"manage resource servers, resources, scopes, permissions, and policies.  Part "
-"of this is also accomplished remotely through the use of the "
+"manage resource servers, resources, scopes, permissions, and policies.  Part"
+" of this is also accomplished remotely through the use of the "
 "<<_service_protection_api, Protection API>>."
 msgstr ""
+"リソース・サーバー、リソース、スコープ、パーミッション、およびポリシーを管理するための{project_name}管理コンソールに基づいた一連のUIを提供します。このうちの一部は、<<_service_protection_api,"
+" 保護API>>を使用してリモートでも実現されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:15
 #, no-wrap
 msgid "**Policy Decision Point (PDP)**\n"
-msgstr ""
+msgstr "**ポリシー決定点（PDP）**\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:18
@@ -75,12 +76,14 @@ msgid ""
 "permissions being requested. Part of this is also accomplished remotely "
 "through the use of the <<_service_entitlement_api, Entitlement>> APIs."
 msgstr ""
+"認可要求が送信され、要求が許可されることでポリシーが評価される場所に配布可能なポリシー決定点を提供します。このうちの一部は、<<_service_entitlement_api,"
+" エンタイトルメント>>APIを使用してリモートでも実現されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:21
 #, no-wrap
 msgid "**Policy Enforcement Point (PEP)**\n"
-msgstr ""
+msgstr "**ポリシー実施ポイント（PEP）**\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:24
@@ -89,12 +92,14 @@ msgid ""
 "authorization decisions at the resource server side.  {project_name} "
 "provides some built-in <<_enforcer_overview, Policy Enforcers>>."
 msgstr ""
+"異なる環境に実装を提供し、リソース・サーバー側で実際に認可の決定を実施します。{project_name}には、組み込みの<<_enforcer_overview,"
+" ポリシー・エンフォーサー>>が用意されています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:27
 #, no-wrap
 msgid "**Policy Information Point (PIP)**\n"
-msgstr ""
+msgstr "**ポリシー情報ポイント（PIP）**\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:29
@@ -103,15 +108,13 @@ msgid ""
 "attributes from identities and runtime environment during the evaluation of "
 "authorization policies."
 msgstr ""
+"{project_name}認証サーバーに基づいているため、認可ポリシーの評価中にアイデンティティーとラインタイム環境から属性を取得できます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/auth-services-architecture.adoc:30
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "The Authorization Process"
-msgstr ""
-"#-#-#-#-#  service-overview.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"#-#-#-#-#  profiles.ja_JP.po (keycloak-documentation-i18n)  #-#-#-#-#\n"
-"Authorization Servicesガイド"
+msgstr "認可プロセス"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:33
@@ -119,52 +122,57 @@ msgid ""
 "Three main processes define the necessary steps to understand how to use "
 "{project_name} to enable fine-grained authorization to your applications:"
 msgstr ""
+"{project_name}を使用してアプリケーションにきめ細かな権限を与える方法を理解するために必要な手順を定義する3つの主要なプロセスは以下のとおりです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:35
 #: source/authorization_services/topics/auth-services-architecture.adoc:103
 #, no-wrap
 msgid "*Resource Management*\n"
-msgstr ""
+msgstr "*リソース管理*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:36
 #, no-wrap
 msgid "*Permission and Policy Management*\n"
-msgstr ""
+msgstr "*権限とポリシーの管理*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:37
 #, no-wrap
 msgid "*Policy Enforcement*\n"
-msgstr ""
+msgstr "*ポリシーの実施*\n"
 
 #. type: Title ===
 #: source/authorization_services/topics/auth-services-architecture.adoc:38
 #, no-wrap
 msgid "Resource Management"
-msgstr ""
+msgstr "リソース管理"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:41
 #, no-wrap
-msgid "*Resource Management* involves all the necessary steps to define what is being protected.\n"
-msgstr ""
+msgid ""
+"*Resource Management* involves all the necessary steps to define what is "
+"being protected.\n"
+msgstr "*リソース管理* には、何が保護されているかを定義するために必要なすべてのステップが含まれます。\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:43
 msgid ""
 "image:images/resource-mgmt-process.png[alt=\"Resource Management Overview\"]"
-msgstr ""
+msgstr "image:images/resource-mgmt-process.png[alt=\"リソース管理の概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:45
 msgid ""
 "First, you need to specify {project_name} what are you looking to protect, "
-"which usually represents a web application or a set of one or more services. "
-"For more information on resource servers see <<_overview_terminology, "
+"which usually represents a web application or a set of one or more services."
+" For more information on resource servers see <<_overview_terminology, "
 "Terminology>>."
 msgstr ""
+"まず、保護しようとしているものを{project_name}に指定する必要があります。これは通常、Webアプリケーションまたは1つ以上のサービスのセットを表します。リソース・サーバーの詳細については、<<_overview_terminology,"
+" 用語集>>を参照してください。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:47
@@ -174,11 +182,12 @@ msgid ""
 "resource server and start managing the resources and scopes you want to "
 "protect."
 msgstr ""
+"リソースサーバーは、{project_name}管理コンソールを使用して管理されます。そこで、登録されたクライアント・アプリケーションをリソース・サーバーとして有効にし、保護するリソースとスコープの管理を開始できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:49
 msgid "image:images/rs-r-scopes.png[alt=\"Resource Server Overview\"]"
-msgstr ""
+msgstr "image:images/rs-r-scopes.png[alt=\"リソースサーバの概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:51
@@ -187,6 +196,7 @@ msgid ""
 "system, an EJB, and so on. They can represent a group of resources (just "
 "like a Class in Java) or they can represent a single and specific resource."
 msgstr ""
+"リソースには、Webページ、RESTFulリソース、ファイルシステム内のファイル、EJBなどがあります。それらはリソースのグループ（Javaのクラスと同様）、または単一の特定のリソースを表すことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:53
@@ -198,6 +208,9 @@ msgid ""
 "customer), where only the owner is allowed to access some information or "
 "perform an operation."
 msgstr ""
+"例えば、すべての銀行口座を表す _Bank Account_ "
+"リソースを持ったとして、それを使用してすべての銀行口座に共通する認可ポリシーを定義することができます。ただし、 _Alice Account_ "
+"（顧客に属しているリソース・インスタンス）に対して特定のポリシーを定義したい場合は、所有者だけが情報にアクセスしたり、操作を実行することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:55
@@ -206,6 +219,8 @@ msgid ""
 "the <<_service_protection_api, Protection API>>. In the latter case, "
 "resource servers are able to manage their resources remotely."
 msgstr ""
+"リソースは、{project_name}管理コンソールまたは<<_service_protection_api, "
+"保護API>>を使用して管理できます。後者の場合、リソース・サーバーはリソースをリモートで管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:57
@@ -214,49 +229,54 @@ msgid ""
 "but they are not limited to that. You can also use scopes to represent one "
 "or more attributes within a resource."
 msgstr ""
+"スコープは、通常、リソースに対して実行できるアクションを表しますが、これに限定されるものではありません。スコープを使用して、リソース内の1つ以上の属性を表すこともできます。"
 
 #. type: Title ===
 #: source/authorization_services/topics/auth-services-architecture.adoc:58
 #, no-wrap
 msgid "Permission and Policy Management"
-msgstr ""
+msgstr "権限とポリシーの管理"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:61
 msgid ""
-"Once you have defined your resource server and all the resources you want to "
-"protect, you must set up permissions and policies."
-msgstr ""
+"Once you have defined your resource server and all the resources you want to"
+" protect, you must set up permissions and policies."
+msgstr "リソース・サーバーと保護するすべてのリソースを定義したら、権限とポリシーを設定する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:63
 msgid ""
 "This process involves all the necessary steps to actually define the "
 "security and access requirements that govern your resources."
-msgstr ""
+msgstr "このプロセスには、リソースを管理するセキュリティおよびアクセス要件を実際に定義するために必要なすべての手順が含まれます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:65
 msgid ""
 "image:images/policy-mgmt-process.png[alt=\"Permission and Policy Management "
 "Overview\"]"
-msgstr ""
+msgstr "image:images/policy-mgmt-process.png[alt=\"アクセス許可とポリシー管理の概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:67
 msgid ""
 "Policies define the conditions that must be satisfied to access or perform "
 "operations on something (resource or scope), but they are not tied to what "
-"they are protecting. They are generic and can be reused to build permissions "
-"or even more complex policies."
+"they are protecting. They are generic and can be reused to build permissions"
+" or even more complex policies."
 msgstr ""
+"ポリシーは、何か（リソースまたはスコープ）へのアクセスや操作を実行するために満たす条件を定義しますが、保護しているものと結びついていません。これらは一般的なもので、権限やさらに複雑なポリシーを構築するために再利用することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:69
 msgid ""
 "For instance,to allow access to a group of resources only for users granted "
-"with a role \"User Premium,\"\" you can use RBAC (Role-based Access Control)."
+"with a role \"User Premium,\"\" you can use RBAC (Role-based Access "
+"Control)."
 msgstr ""
+"例えば、ロール\"User "
+"Premium\"で付与されたユーザーに対してのみリソースのグループにアクセスするには、RBAC（ロールベースのアクセス・コントロール）を使用できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:71
@@ -266,6 +286,8 @@ msgid ""
 "can even create policies based on rules written using JavaScript or JBoss "
 "Drools."
 msgstr ""
+"{project_name}には、最も一般的なアクセス・コントロール機構をカバーするいくつかの組み込みのポリシー・タイプ（およびそれぞれのポリシー・プロバイダー）が用意されています。JavaScriptやJBoss"
+" Droolsを使用して作成されたルールに基づいてポリシーを作成することもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:74
@@ -275,24 +297,35 @@ msgid ""
 "Here you specify what you want to protect (resource or scope) and the "
 "policies that must be satisfied to grant or deny permission."
 msgstr ""
+"ポリシーを定義したら、パーミッションの定義を開始できます。パーミッションは、保護しているリソースと結合されます。ここでは、保護する対象（リソースまたはスコープ）と、パーミッションを許可または拒否するために満たす必要のあるポリシーを指定します。"
 
 #. type: Title ===
 #: source/authorization_services/topics/auth-services-architecture.adoc:75
 #, no-wrap
 msgid "Policy Enforcement"
-msgstr ""
+msgstr "ポリシー実施"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:78
 #, no-wrap
-msgid "*Policy Enforcement* involves the necessary steps to actually enforce authorization decisions to a resource server. This is achieved by enabling a *Policy Enforcement Point* or PEP at the resource server that is capable of communicating with the authorization server, ask for authorization data and control access to protected resources based on the decisions and permissions returned by the server.\n"
+msgid ""
+"*Policy Enforcement* involves the necessary steps to actually enforce "
+"authorization decisions to a resource server. This is achieved by enabling a"
+" *Policy Enforcement Point* or PEP at the resource server that is capable of"
+" communicating with the authorization server, ask for authorization data and"
+" control access to protected resources based on the decisions and "
+"permissions returned by the server.\n"
 msgstr ""
+"*Policy Enforcement* "
+"には、リソース・サーバーへの認可の決定を実際に実施するために必要な手順が含まれます。これは、認可サーバーと通信できるリソース・サーバーで *Policy"
+" Enforcement Point* "
+"またはPEPを有効にし、サーバーによって返された決定とパーミッションに基づいて認可データを要求し、保護されたリソースへのアクセスを制御することによって実現されます。\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:80
 #: source/authorization_services/topics/enforcer-overview.adoc:8
 msgid "image:images/pep-pattern-diagram.png[alt=\"PEP Overview\"]"
-msgstr ""
+msgstr "image:images/pep-pattern-diagram.png[alt=\"PEPの概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:82
@@ -301,61 +334,66 @@ msgid ""
 "Enforcers>> implementations that you can use to protect your applications "
 "depending on the platform they are running on."
 msgstr ""
+"{project_name}には、実行中のプラットフォームに応じてアプリケーションを保護するために使用できる組み込みの<<_enforcer_overview,"
+" ポリシー・エンフォーサー>>実装がいくつか用意されています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:87
 msgid "Authorization services consist of the following RESTFul APIs:"
-msgstr ""
+msgstr "認可サービスは以下のRESTFul APIで構成されています。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:89
 #, no-wrap
 msgid "*Protection API*\n"
-msgstr ""
+msgstr "*保護API*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:90
-#, fuzzy, no-wrap
-#| msgid "Authentication"
+#, no-wrap
 msgid "*Authorization API*\n"
-msgstr "認証"
+msgstr "*認可API*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:91
 #, no-wrap
 msgid "*Entitlement API*\n"
-msgstr ""
+msgstr "*エンタイトルメントAPI*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:93
 msgid ""
 "Each of these services provides a specific API covering the different steps "
 "involved in the authorization process."
-msgstr ""
+msgstr "これらの各サービスは、認可プロセスに関わるさまざまなステップをカバーする特定のAPIを提供します。"
 
 #. type: Title =
 #: source/authorization_services/topics/auth-services-architecture.adoc:94
 #: source/authorization_services/topics/service-protection-protection-api.adoc:2
 #, no-wrap
 msgid "Protection API"
-msgstr ""
+msgstr "保護API"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:99
 msgid ""
-"The *Protection API* is a https://kantarainitiative.org/confluence/display/"
-"uma/UMA+1.0+Core+Protocol[UMA-compliant] endpoint providing a small set of "
-"operations for resource servers to help them manage their resources and "
-"scopes. Only resource servers are allowed to access this API, which also "
-"requires a *uma_protection* scope."
+"The *Protection API* is a "
+"https://kantarainitiative.org/confluence/display/uma/UMA+1.0+Core+Protocol"
+"[UMA-compliant] endpoint providing a small set of operations for resource "
+"servers to help them manage their resources and scopes. Only resource "
+"servers are allowed to access this API, which also requires a "
+"*uma_protection* scope."
 msgstr ""
+"保護APIは、リソース・サーバーがリソースとスコープを管理するのに役立つ細かい一連の操作を提供する、 "
+"https://kantarainitiative.org/confluence/display/uma/UMA+1.0+Core+Protocol[UMA準拠]"
+" のエンドポイントです。リソース・サーバーだけがこのAPIにアクセスできますが、 *uma_protection* スコープも必要です。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:101
 msgid ""
 "The operations provided by the Protection API can be organized in two main "
 "groups:"
-msgstr ""
+msgstr "保護APIによって提供される操作は、次の2つの主要なグループに分けられます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:108
@@ -367,26 +405,32 @@ msgid ""
 "** Find All\n"
 "** Find with filters (for example, search by name, type, or URI)\n"
 msgstr ""
+"** リソースの作成\n"
+"** リソースの削除\n"
+"** IDで検索\n"
+"** 全検索\n"
+"** フィルタで検索（例えば、名前、タイプ、またはURIで検索）\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:109
 #, no-wrap
 msgid "*Permission Management*\n"
-msgstr ""
+msgstr "*権限管理*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:110
 #, no-wrap
 msgid "** Issue Permission Tickets\n"
-msgstr ""
+msgstr "** パーミッション・チケットの発行\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:113
 msgid ""
-"By default, Remote Resource Management is enabled. You can change that using "
-"the {project_name} Administration Console and only allow resource management "
-"through the console."
+"By default, Remote Resource Management is enabled. You can change that using"
+" the {project_name} Administration Console and only allow resource "
+"management through the console."
 msgstr ""
+"デフォルトでは、リモート・リソース管理が有効になっています。{project_name}管理コンソールを使用して変更することができ、コンソールからのリソース管理のみを許可します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:115
@@ -398,62 +442,68 @@ msgid ""
 "token with all permissions granted during the evaluation of the permissions "
 "and policies associated with the resources and scopes being requested."
 msgstr ""
+"UMAプロトコルを使用する場合、保護APIによるパーミッション・チケットの発行は、認可プロセス全体の重要な部分です。次のセクションで説明するように、これらはクライアントによって要求されたパーミッションを表し、要求されているリソースとスコープに関連付けられたパーミッションとポリシーの評価中に付与されたすべての権限を持つ最終トークンを取得するためにサーバーに送信されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:117
 msgid "For more information, see <<_service_protection_api, Protection API>>."
-msgstr ""
+msgstr "より詳細な情報は<<_service_protection_api, 保護API>>を参照してください。"
 
 #. type: Title =
 #: source/authorization_services/topics/auth-services-architecture.adoc:118
 #: source/authorization_services/topics/service-authorization-authorization-api.adoc:2
-#, fuzzy, no-wrap
-#| msgid "Authentication"
+#, no-wrap
 msgid "Authorization API"
-msgstr "認証"
+msgstr "認可API"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:121
 msgid ""
-"The Authorization API is also a https://kantarainitiative.org/confluence/"
-"display/uma/UMA+1.0+Core+Protocol[UMA-compliant] endpoint providing a single "
-"operation that exchanges an Access Token and "
-"<<_overview_terminology_permission_ticket, Permission Ticket>> with a "
-"Requesting Party Token (RPT)."
+"The Authorization API is also a "
+"https://kantarainitiative.org/confluence/display/uma/UMA+1.0+Core+Protocol"
+"[UMA-compliant] endpoint providing a single operation that exchanges an "
+"Access Token and <<_overview_terminology_permission_ticket, Permission "
+"Ticket>> with a Requesting Party Token (RPT)."
 msgstr ""
+"認可APIは、アクセス・トークンと<<_overview_terminology_permission_ticket, "
+"パーミッション・チケット>>をリクエスティング・パーティー・トークン（RPT）と交換する単一の操作を提供する "
+"https://kantarainitiative.org/confluence/display/uma/UMA+1.0+Core+Protocol[UMA準拠]"
+" のエンドポイントです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:123
 msgid ""
-"The RPT contains all permissions granted to a client and can be used to call "
-"a resource server to get access to its protected resources."
+"The RPT contains all permissions granted to a client and can be used to call"
+" a resource server to get access to its protected resources."
 msgstr ""
+"RPTには、クライアントに付与されたすべてのパーミッションが含まれており、保護されたリソースにアクセスするためにリソース・サーバーを呼び出すのに使用できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:126
 msgid ""
-"When requesting an RPT you can also provide a previously issued RPT. In this "
-"case, the resulting RPT will consist of the union of the permissions from "
+"When requesting an RPT you can also provide a previously issued RPT. In this"
+" case, the resulting RPT will consist of the union of the permissions from "
 "the previous RPT and the new ones within a permission ticket."
 msgstr ""
+"RPTを要求する際には、以前に発行したRPTを提供することもできます。この場合、結果として得られるRPTは、以前のRPTのパーミッショとパーミッション・チケット内の新しいパーミッションの結合で構成されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:128
 msgid "image:images/authz-calls.png[alt=\"Authorization API Overview\"]"
-msgstr ""
+msgstr "image:images/authz-calls.png[alt=\"認可APIの概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:130
 msgid ""
 "For more information, see <<_service_authorization_api, Authorization API>>."
-msgstr ""
+msgstr "詳細については、<<_service_authorization_api, 認可API>>を参照してください。"
 
 #. type: Title =
 #: source/authorization_services/topics/auth-services-architecture.adoc:131
 #: source/authorization_services/topics/service-entitlement-entitlement-api.adoc:2
 #, no-wrap
 msgid "Entitlement API"
-msgstr ""
+msgstr "エンタイトルメントAPI"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:134
@@ -461,6 +511,7 @@ msgid ""
 "The Entitlement API provides a 1-legged protocol to issue RPTs. Unlike the "
 "Authorization API, the Entitlement API only expects an access token."
 msgstr ""
+"エンタイトルメントAPIは、RPTを発行するための1-leggedプロトコルを提供します。認可APIとは異なり、エンタイトルメントAPIはアクセス・トークンのみを要求します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:137
@@ -469,13 +520,15 @@ msgid ""
 "(based on the resources managed by a given resource server) or just the "
 "entitlements for a set of one or more resources."
 msgstr ""
+"このAPIから、ユーザー（特定のリソース・サーバーによって管理されるリソースに基づいた）のすべてのエンタイトルメントまたはパーミッション、または1つ以上のリソースのセットに対するエンタイトルメントのみを取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:139
 msgid "image:images/entitlement-calls.png[alt=\"Entitlement API Overview\"]"
-msgstr ""
+msgstr "image:images/entitlement-calls.png[alt=\"エンタイトルメントAPIの概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:140
-msgid "For more information see <<_service_entitlement_api, Entitlement API>>."
-msgstr ""
+msgid ""
+"For more information see <<_service_entitlement_api, Entitlement API>>."
+msgstr "より詳細な情報は<<_service_entitlement_api, エンタイトルAPI>>を参照してください。"

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
@@ -59,8 +59,8 @@ msgid ""
 " of this is also accomplished remotely through the use of the "
 "<<_service_protection_api, Protection API>>."
 msgstr ""
-"リソース・サーバー、リソース、スコープ、パーミッション、およびポリシーを管理するための{project_name}管理コンソールに基づいた一連のUIを提供します。このうちの一部は、<<_service_protection_api,"
-" 保護API>>を使用してリモートでも実現されます。"
+"リソースサーバー、リソース、スコープ、パーミッション、およびポリシーを管理するための{project_name}管理コンソールに基づいたUIのセットを提供します。このうちの一部は、<<_service_protection_api,"
+" 保護API>>を使用してリモートでも実現できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:15
@@ -76,7 +76,7 @@ msgid ""
 "permissions being requested. Part of this is also accomplished remotely "
 "through the use of the <<_service_entitlement_api, Entitlement>> APIs."
 msgstr ""
-"認可要求が送信され、要求が許可されることでポリシーが評価される場所に配布可能なポリシー決定点を提供します。このうちの一部は、<<_service_entitlement_api,"
+"認可リクエストが送信され、リクエストが許可されることでポリシーが評価される場所に配布可能なポリシー決定点を提供します。このうちの一部は、<<_service_entitlement_api,"
 " エンタイトルメント>>APIを使用してリモートでも実現されます。"
 
 #. type: Plain text
@@ -92,7 +92,7 @@ msgid ""
 "authorization decisions at the resource server side.  {project_name} "
 "provides some built-in <<_enforcer_overview, Policy Enforcers>>."
 msgstr ""
-"異なる環境に実装を提供し、リソース・サーバー側で実際に認可の決定を実施します。{project_name}には、組み込みの<<_enforcer_overview,"
+"異なる環境に実装を提供し、リソースサーバー側で実際に認可の決定を実施します。{project_name}には、組み込みの<<_enforcer_overview,"
 " ポリシー・エンフォーサー>>が用意されています。"
 
 #. type: Plain text
@@ -107,8 +107,7 @@ msgid ""
 "Being based on {project_name} Authentication Server, you can obtain "
 "attributes from identities and runtime environment during the evaluation of "
 "authorization policies."
-msgstr ""
-"{project_name}認証サーバーに基づいているため、認可ポリシーの評価中にアイデンティティーとラインタイム環境から属性を取得できます。"
+msgstr "{project_name}認証サーバーに基づいて、認可ポリシーの評価中にアイデンティティーとラインタイム環境から属性を取得できます。"
 
 #. type: Title ==
 #: source/authorization_services/topics/auth-services-architecture.adoc:30
@@ -122,7 +121,7 @@ msgid ""
 "Three main processes define the necessary steps to understand how to use "
 "{project_name} to enable fine-grained authorization to your applications:"
 msgstr ""
-"{project_name}を使用してアプリケーションにきめ細かな権限を与える方法を理解するために必要な手順を定義する3つの主要なプロセスは以下のとおりです。"
+"{project_name}を使用してアプリケーションにきめ細かな権限を与える方法を、理解するために必要な手順を定義する3つの主要なプロセスは、以下のとおりです。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:35
@@ -135,7 +134,7 @@ msgstr "*リソース管理*\n"
 #: source/authorization_services/topics/auth-services-architecture.adoc:36
 #, no-wrap
 msgid "*Permission and Policy Management*\n"
-msgstr "*権限とポリシーの管理*\n"
+msgstr "*パーミッションとポリシーの管理*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:37
@@ -182,7 +181,7 @@ msgid ""
 "resource server and start managing the resources and scopes you want to "
 "protect."
 msgstr ""
-"リソースサーバーは、{project_name}管理コンソールを使用して管理されます。そこで、登録されたクライアント・アプリケーションをリソース・サーバーとして有効にし、保護するリソースとスコープの管理を開始できます。"
+"リソース・サーバーは、{project_name}管理コンソールを使用して管理されます。そこで、登録されたクライアント・アプリケーションをリソース・サーバーとして有効にし、保護するリソースとスコープの管理を開始できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:49
@@ -210,7 +209,7 @@ msgid ""
 msgstr ""
 "例えば、すべての銀行口座を表す _Bank Account_ "
 "リソースを持ったとして、それを使用してすべての銀行口座に共通する認可ポリシーを定義することができます。ただし、 _Alice Account_ "
-"（顧客に属しているリソース・インスタンス）に対して特定のポリシーを定義したい場合は、所有者だけが情報にアクセスしたり、操作を実行することができます。"
+"（顧客に属しているリソース・インスタンス）に対して特定のポリシーを定義したい場合は、オーナーだけが情報にアクセスしたり、操作を実行することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:55
@@ -220,7 +219,7 @@ msgid ""
 "resource servers are able to manage their resources remotely."
 msgstr ""
 "リソースは、{project_name}管理コンソールまたは<<_service_protection_api, "
-"保護API>>を使用して管理できます。後者の場合、リソース・サーバーはリソースをリモートで管理できます。"
+"保護API>>を使用して管理できます。後者の場合、リソースサーバーはリソースをリモートで管理できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:57
@@ -242,7 +241,7 @@ msgstr "権限とポリシーの管理"
 msgid ""
 "Once you have defined your resource server and all the resources you want to"
 " protect, you must set up permissions and policies."
-msgstr "リソース・サーバーと保護するすべてのリソースを定義したら、権限とポリシーを設定する必要があります。"
+msgstr "リソースサーバーと保護するすべてのリソースを定義したら、パーミッションとポリシーを設定する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:63
@@ -256,7 +255,7 @@ msgstr "このプロセスには、リソースを管理するセキュリティ
 msgid ""
 "image:images/policy-mgmt-process.png[alt=\"Permission and Policy Management "
 "Overview\"]"
-msgstr "image:images/policy-mgmt-process.png[alt=\"アクセス許可とポリシー管理の概要\"]"
+msgstr "image:images/policy-mgmt-process.png[alt=\"パーミッションとポリシー管理の概要\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:67
@@ -266,7 +265,7 @@ msgid ""
 "they are protecting. They are generic and can be reused to build permissions"
 " or even more complex policies."
 msgstr ""
-"ポリシーは、何か（リソースまたはスコープ）へのアクセスや操作を実行するために満たす条件を定義しますが、保護しているものと結びついていません。これらは一般的なもので、権限やさらに複雑なポリシーを構築するために再利用することができます。"
+"ポリシーは、何か（リソースまたはスコープ）へのアクセスや操作を実行するために満たす条件を定義しますが、保護しているものとは結びついていません。これらは一般的なもので、パーミッションやさらに複雑なポリシーを構築するために再利用することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:69
@@ -276,7 +275,7 @@ msgid ""
 "Control)."
 msgstr ""
 "例えば、ロール\"User "
-"Premium\"で付与されたユーザーに対してのみリソースのグループにアクセスするには、RBAC（ロールベースのアクセス・コントロール）を使用できます。"
+"Premium\"が付与されたユーザーに対してのみリソースのグループへのアクセスを許可するために、RBAC（ロールベースのアクセス・コントロール）を使用できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:71
@@ -317,8 +316,8 @@ msgid ""
 "permissions returned by the server.\n"
 msgstr ""
 "*Policy Enforcement* "
-"には、リソース・サーバーへの認可の決定を実際に実施するために必要な手順が含まれます。これは、認可サーバーと通信できるリソース・サーバーで *Policy"
-" Enforcement Point* "
+"には、リソースサーバーへの認可の決定を実際に実施するために必要な手順が含まれます。これは、認可サーバーと通信できるリソース・サーバーで *Policy "
+"Enforcement Point* "
 "またはPEPを有効にし、サーバーによって返された決定とパーミッションに基づいて認可データを要求し、保護されたリソースへのアクセスを制御することによって実現されます。\n"
 
 #. type: Plain text
@@ -384,9 +383,9 @@ msgid ""
 "servers are allowed to access this API, which also requires a "
 "*uma_protection* scope."
 msgstr ""
-"保護APIは、リソース・サーバーがリソースとスコープを管理するのに役立つ細かい一連の操作を提供する、 "
+"保護APIは、リソースサーバーがリソースとスコープを管理するのに役立つ細かい一連の操作を提供する、 "
 "https://kantarainitiative.org/confluence/display/uma/UMA+1.0+Core+Protocol[UMA準拠]"
-" のエンドポイントです。リソース・サーバーだけがこのAPIにアクセスできますが、 *uma_protection* スコープも必要です。"
+" のエンドポイントです。リソースサーバーだけがこのAPIにアクセスできますが、 *uma_protection* スコープも必要です。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:101
@@ -415,7 +414,7 @@ msgstr ""
 #: source/authorization_services/topics/auth-services-architecture.adoc:109
 #, no-wrap
 msgid "*Permission Management*\n"
-msgstr "*権限管理*\n"
+msgstr "*パーミッション管理*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:110
@@ -430,7 +429,7 @@ msgid ""
 " the {project_name} Administration Console and only allow resource "
 "management through the console."
 msgstr ""
-"デフォルトでは、リモート・リソース管理が有効になっています。{project_name}管理コンソールを使用して変更することができ、コンソールからのリソース管理のみを許可します。"
+"デフォルトでは、リモートリソース管理が有効になっています。{project_name}管理コンソールを使用して変更することができ、コンソールからのリソース管理のみを許可できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:115
@@ -442,7 +441,7 @@ msgid ""
 "token with all permissions granted during the evaluation of the permissions "
 "and policies associated with the resources and scopes being requested."
 msgstr ""
-"UMAプロトコルを使用する場合、保護APIによるパーミッション・チケットの発行は、認可プロセス全体の重要な部分です。次のセクションで説明するように、これらはクライアントによって要求されたパーミッションを表し、要求されているリソースとスコープに関連付けられたパーミッションとポリシーの評価中に付与されたすべての権限を持つ最終トークンを取得するためにサーバーに送信されます。"
+"UMAプロトコルを使用する場合、保護APIによるパーミッション・チケットの発行は、認可プロセス全体の重要な部分です。次のセクションで説明するように、これらはクライアントによって要求されたパーミッションを表し、要求されているリソースとスコープに関連付けられたパーミッションとポリシーの評価中に付与されたすべてのパーミッションを持つ最終的なトークンを取得するためにサーバーに送信されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:117
@@ -476,7 +475,7 @@ msgid ""
 "The RPT contains all permissions granted to a client and can be used to call"
 " a resource server to get access to its protected resources."
 msgstr ""
-"RPTには、クライアントに付与されたすべてのパーミッションが含まれており、保護されたリソースにアクセスするためにリソース・サーバーを呼び出すのに使用できます。"
+"RPTには、クライアントに付与されたすべてのパーミッションが含まれており、保護されたリソースにアクセスするためにリソースサーバーを呼び出す目的で使用できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:126
@@ -485,7 +484,7 @@ msgid ""
 " case, the resulting RPT will consist of the union of the permissions from "
 "the previous RPT and the new ones within a permission ticket."
 msgstr ""
-"RPTを要求する際には、以前に発行したRPTを提供することもできます。この場合、結果として得られるRPTは、以前のRPTのパーミッショとパーミッション・チケット内の新しいパーミッションの結合で構成されます。"
+"RPTを要求する際に、以前に発行したRPTを提供することもできます。この場合、結果として得られるRPTは、以前のRPTのパーミッショとパーミッション・チケット内の新しいパーミッションの結合で構成されます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:128
@@ -511,7 +510,7 @@ msgid ""
 "The Entitlement API provides a 1-legged protocol to issue RPTs. Unlike the "
 "Authorization API, the Entitlement API only expects an access token."
 msgstr ""
-"エンタイトルメントAPIは、RPTを発行するための1-leggedプロトコルを提供します。認可APIとは異なり、エンタイトルメントAPIはアクセス・トークンのみを要求します。"
+"エンタイトルメントAPIは、RPTを発行するための1-leggedプロトコルを提供します。認可APIとは異なり、エンタイトルメントAPIはアクセストークンのみを要求します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:137
@@ -520,7 +519,7 @@ msgid ""
 "(based on the resources managed by a given resource server) or just the "
 "entitlements for a set of one or more resources."
 msgstr ""
-"このAPIから、ユーザー（特定のリソース・サーバーによって管理されるリソースに基づいた）のすべてのエンタイトルメントまたはパーミッション、または1つ以上のリソースのセットに対するエンタイトルメントのみを取得できます。"
+"このAPIから、ユーザー（特定のリソースサーバーによって管理されるリソースに基づいた）のすべてのエンタイトルメントまたはパーミッション、または1つ以上のリソースのセットに対するエンタイトルメントのみを取得できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/auth-services-architecture.adoc:139


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-architecture
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__auth-services-architecture/ja_JP/index.html
