### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <pro00011@partner.nri.co.jp>, 2018\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -89,7 +89,7 @@ msgstr "*Logic*\n"
 msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
-msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, Logic>>。"
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-client-policy.adoc:21
@@ -99,7 +99,7 @@ msgstr "他の条件が評価された後に適用する、このポリシーの
 #: source/authorization_services/topics/policy-time-policy.adoc:21
 #: source/authorization_services/topics/policy-user-policy.adoc:21
 msgid "A string containing details about this policy."
-msgstr "このポリシーに関する詳細情報を含む文字列"
+msgstr "このポリシーに関する詳細情報を含む文字列。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-group-policy.adoc:17
@@ -124,7 +124,8 @@ msgstr "ロール・ベース・ポリシー"
 msgid ""
 "You can use this type of policy to define conditions for your permissions "
 "where a set of one or more roles is permitted to access an object."
-msgstr "このポリシーは、1つ以上のロールが、ある対象へアクセスすることを可能にする条件を定義するために使うことができます。"
+msgstr ""
+"1つ以上のロールの集合がオブジェクトへのアクセスを許可されるパーミッションの条件を定義するために、このタイプのポリシーを使用することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:7
@@ -136,7 +137,7 @@ msgid ""
 "You can also combine required and non-required roles, regardless of whether "
 "they are realm or client roles."
 msgstr ""
-"デフォルトでは、このポリシーに追加されたロールは、必須として指定せず、アクセスを要求するユーザーにこれらのロールのいずれかが付与されている場合に、ポリシーはアクセスを許可します。ただし、特定のロールを適用する場合は、<<_policy_rbac_required,"
+"デフォルトでは、このポリシーに追加されたロールは、必須として指定されず、アクセスを要求するユーザーにこれらのロールのいずれかが付与されている場合に、ポリシーはアクセスを許可します。ただし、特定のロールを適用する場合は、<<_policy_rbac_required,"
 " 必須>>として特定のロールを指定できます。レルムまたはクライアントのロールにかかわらず、必須ロールと必須ではないロールを組み合わせることもできます。"
 
 #. type: Plain text
@@ -180,7 +181,7 @@ msgstr "*Realm Roles*\n"
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:29
 msgid "Specifies which *realm* roles are permitted by this policy."
-msgstr "このポリシーによってどの *realm* ロールが許可されるかを指定します。"
+msgstr "このポリシーによって、どの *realm* ロールが許可されるかを指定します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:31

--- a/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
@@ -137,8 +137,9 @@ msgid ""
 "You can also combine required and non-required roles, regardless of whether "
 "they are realm or client roles."
 msgstr ""
-"デフォルトでは、このポリシーに追加されたロールは、必須として指定されず、アクセスを要求するユーザーにこれらのロールのいずれかが付与されている場合に、ポリシーはアクセスを許可します。ただし、特定のロールを適用する場合は、<<_policy_rbac_required,"
-" 必須>>として特定のロールを指定できます。レルムまたはクライアントのロールにかかわらず、必須ロールと必須ではないロールを組み合わせることもできます。"
+"デフォルトでは、このポリシーに追加されたロールは、Requiredとして指定されず、アクセスを要求するユーザーにこれらのロールのいずれかが付与されている場合に、ポリシーはアクセスを許可します。ただし、特定のロールを強制したい場合は、<<_policy_rbac_required,"
+" "
+"Required>>として特定のロールを指定できます。レルムまたはクライアントのロールにかかわらず、RequiredのロールとRequiredではないロールを組み合わせることもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:9

--- a/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <pro00011@partner.nri.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -29,7 +30,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-create.adoc:15
 #, no-wrap
 msgid "*Name*\n"
-msgstr ""
+msgstr "*Name*\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-oidc.adoc:43
@@ -45,7 +46,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-user-policy.adoc:19
 #, no-wrap
 msgid "*Description*\n"
-msgstr ""
+msgstr "*Description*\n"
 
 #. type: Title ==
 #: source/authorization_services/topics/permission-create-resource.adoc:11
@@ -59,10 +60,9 @@ msgstr ""
 #: source/authorization_services/topics/policy-time-policy.adoc:11
 #: source/authorization_services/topics/policy-user-policy.adoc:11
 #: source/authorization_services/topics/service-client-api.adoc:21
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Configuration"
-msgstr "ドメイン設定"
+msgstr "設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:39
@@ -75,7 +75,7 @@ msgstr "ドメイン設定"
 #: source/authorization_services/topics/policy-user-policy.adoc:27
 #, no-wrap
 msgid "*Logic*\n"
-msgstr ""
+msgstr "*Logic*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:41
@@ -89,7 +89,7 @@ msgstr ""
 msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
-msgstr ""
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, Logic>>。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-client-policy.adoc:21
@@ -99,7 +99,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-time-policy.adoc:21
 #: source/authorization_services/topics/policy-user-policy.adoc:21
 msgid "A string containing details about this policy."
-msgstr ""
+msgstr "このポリシーに関する詳細情報を含む文字列"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-group-policy.adoc:17
@@ -107,85 +107,86 @@ msgstr ""
 #: source/authorization_services/topics/policy-role-policy.adoc:21
 #: source/authorization_services/topics/policy-time-policy.adoc:17
 msgid ""
-"A human-readable and unique string describing the policy. A best practice is "
-"to use names that are closely related to your business and security "
+"A human-readable and unique string describing the policy. A best practice is"
+" to use names that are closely related to your business and security "
 "requirements, so you can identify them more easily."
 msgstr ""
+"ポリシーを説明する、人が判読可能で一意の文字列。ベストプラクティスは、ビジネス要件とセキュリティ要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
 
 #. type: Title =
 #: source/authorization_services/topics/policy-role-policy.adoc:2
 #, no-wrap
 msgid "Role-Based Policy"
-msgstr ""
+msgstr "ロール・ベース・ポリシー"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:5
 msgid ""
 "You can use this type of policy to define conditions for your permissions "
 "where a set of one or more roles is permitted to access an object."
-msgstr ""
+msgstr "このポリシーは、1つ以上のロールが、ある対象へアクセスすることを可能にする条件を定義するために使うことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:7
 msgid ""
-"By default, roles added to this policy are not specified as required and the "
-"policy will grant access if the user requesting access has been granted any "
-"of these roles. However, you can specify a specific role as "
+"By default, roles added to this policy are not specified as required and the"
+" policy will grant access if the user requesting access has been granted any"
+" of these roles. However, you can specify a specific role as "
 "<<_policy_rbac_required, required>> if you want to enforce a specific role. "
 "You can also combine required and non-required roles, regardless of whether "
 "they are realm or client roles."
 msgstr ""
+"デフォルトでは、このポリシーに追加されたロールは、必須として指定せず、アクセスを要求するユーザーにこれらのロールのいずれかが付与されている場合に、ポリシーはアクセスを許可します。ただし、特定のロールを適用する場合は、<<_policy_rbac_required,"
+" 必須>>として特定のロールを指定できます。レルムまたはクライアントのロールにかかわらず、必須ロールと必須ではないロールを組み合わせることもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:9
 msgid ""
 "Role policies can be useful when you need more restricted role-based access "
 "control (RBAC), where specific roles must be enforced to grant access to an "
-"object. For instance, you can enforce that a user must consent to allowing a "
-"client application (which is acting on the user's behalf) to access the "
+"object. For instance, you can enforce that a user must consent to allowing a"
+" client application (which is acting on the user's behalf) to access the "
 "user's resources. You can use {project_name} Client Scope Mapping to enable "
 "consent pages or even enforce clients to explicitly provide a scope when "
 "obtaining access tokens from a {project_name} server."
 msgstr ""
+"ロールのポリシーは、オブジェクトへのアクセスを許可するのに特定のロールを強制する必要がある、より限定されたロールベースのアクセス・コントロール（RBAC）が必要な場合に役立ちます。例えば、ユーザーがクライアント・アプリケーション（ユーザーの代理として動作している）がユーザーのリソースにアクセスできるようにするのにユーザーが同意する必要があることを強制できます。{project_name}クライアント・スコープ・マッピングを使用して同意ページを有効にしたり、{project_name}サーバーからアクセス・トークンを取得するときに明示的にスコープを指定したりすることもできます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:11
 msgid ""
-"To create a new role-based policy, select *Role* in the dropdown list in the "
-"upper right corner of the policy listing."
-msgstr ""
+"To create a new role-based policy, select *Role* in the dropdown list in the"
+" upper right corner of the policy listing."
+msgstr "新しいロール・ベース・ポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウンリストから *Role* を選択します。"
 
 #. type: Block title
 #: source/authorization_services/topics/policy-role-policy.adoc:12
 #, no-wrap
 msgid "Add Role-Based Policy"
-msgstr ""
+msgstr "ロール・ベース・ポリシーの追加"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:14
-#, fuzzy
-#| msgid "image:{project_images}/create-realm.png[]"
 msgid ""
 "image:{project_images}/policy/create-role.png[alt=\"Add Role-Based Policy\"]"
-msgstr "image:{project_images}/create-realm.png[]"
+msgstr "image:{project_images}/policy/create-role.png[alt=\"ロール・ベース・ポリシーの追加\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:27
 #, no-wrap
 msgid "*Realm Roles*\n"
-msgstr ""
+msgstr "*Realm Roles*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:29
 msgid "Specifies which *realm* roles are permitted by this policy."
-msgstr ""
+msgstr "このポリシーによってどの *realm* ロールが許可されるかを指定します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:31
-#, fuzzy, no-wrap
-#| msgid "Clients"
+#, no-wrap
 msgid "*Client Roles*\n"
-msgstr "クライアント"
+msgstr "*Client Roles*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-role-policy.adoc:33
@@ -193,3 +194,4 @@ msgid ""
 "Specifies which *client* roles are permitted by this policy. To enable this "
 "field must first select a `Client`."
 msgstr ""
+"このポリシーで許可される *client* ロールを指定します。このフィールドを有効にするには、最初に `Client` を選択する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-role-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__policy-role-policy/ja_JP/index.html
