### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -103,7 +103,7 @@ msgstr "*Logic*\n"
 msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
-msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, Logic>>。"
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
 
 #. type: Title =
 #: source/authorization_services/topics/policy-drools-policy.adoc:2
@@ -121,7 +121,7 @@ msgid ""
 "<<_policy_evaluation_api, Evaluation API>>."
 msgstr ""
 "このタイプのポリシーでは、ルール評価環境である http://www.drools.org[Drools] "
-"を使用してパーミッションの条件を定義できます。これは{project_name}でサポートされている _Rule-Based_ "
+"を使用してパーミッションの条件を定義できます。これは{project_name}でサポートされている _ルールベース_ "
 "のポリシー・タイプの1つであり、<<_policy_evaluation_api, 評価API>>に基づいたポリシーを柔軟に作成できます。"
 
 #. type: Plain text
@@ -130,9 +130,7 @@ msgstr ""
 msgid ""
 "To create a new Rule-based policy, in the dropdown list in the right upper corner of the policy listing,\n"
 " select *Rule*.\n"
-msgstr ""
-"新しいルールベースのポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウンリストで、\n"
-"*ルール*を選択します。\n"
+msgstr "新しいルールベースのポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウンリストで、*ルール*を選択します。\n"
 
 #. type: Block title
 #: source/authorization_services/topics/policy-drools-policy.adoc:10
@@ -215,7 +213,7 @@ msgstr "*Module*\n"
 msgid ""
 "The module used by this policy. You must provide a module to select a "
 "specific session from which rules will be loaded."
-msgstr "このポリシーで使用されるモジュール。 ルールをロードする特定のセッションを選択するためのモジュールを提供する必要があります。"
+msgstr "このポリシーで使用されるモジュール。ルールがロードされる特定のセッションを選択するためのモジュールを提供する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:45
@@ -228,7 +226,7 @@ msgstr "*Session*\n"
 msgid ""
 "The session used by this policy. The session provides all the rules to "
 "evaluate when processing the policy."
-msgstr "このポリシーで使用されるセッション。 セッションは、ポリシーの処理時に評価するすべてのルールを提供します。"
+msgstr "このポリシーで使用されるセッション。セッションは、ポリシーの処理時に評価するすべてのルールを提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:49
@@ -286,7 +284,7 @@ msgid ""
 "You can even use another variant of ABAC to obtain attributes from the "
 "identity and define a condition accordingly:"
 msgstr ""
-"IDから属性を取得し、それに応じて条件を定義するために、ABAC（属性ベースのアクセス・コントロール）の別のバリアントを使用することもできます。"
+"アイデンティティから属性を取得し、それに応じて条件を定義するために、ABAC（属性ベースのアクセス・コントロール）の別のバリアントを使用することもできます。"
 
 #. type: Code block
 #: source/authorization_services/topics/policy-drools-policy.adoc:90
@@ -323,5 +321,5 @@ msgid ""
 "`org.keycloak.authorization.policy.evaluation.Evaluation` interface, see "
 "<<_policy_evaluation_api, Evaluation API>>."
 msgstr ""
-"`org.keycloak.authorization.policy.evaluation.Evaluation`インターフェイスからアクセスできるものの詳細については、<<"
-" _ policy_evaluation_api、Evaluation API >>を参照してください。"
+"`org.keycloak.authorization.policy.evaluation.Evaluation` "
+"インターフェイスからアクセスできるものの詳細については、<< _ policy_evaluation_api, 評価 API >>を参照してください。"

--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -1,17 +1,18 @@
-# Japanese translations for keycloak-documentation-i18n package
-# Copyright (C) 2017 Nomura Research Institute, Ltd.
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
-# Automatically generated, 2017.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: keycloak-documentation-i18n  \n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"Language: ja\n"
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: n.watanabe <nwatanabe.ase@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
@@ -29,7 +30,7 @@ msgstr ""
 #: source/authorization_services/topics/resource-create.adoc:15
 #, no-wrap
 msgid "*Name*\n"
-msgstr ""
+msgstr "*Name*\n"
 
 #. type: Plain text
 #: source/server_admin/topics/clients/client-oidc.adoc:43
@@ -45,16 +46,15 @@ msgstr ""
 #: source/authorization_services/topics/policy-user-policy.adoc:19
 #, no-wrap
 msgid "*Description*\n"
-msgstr ""
+msgstr "*Description*\n"
 
 #. type: Title ==
 #: source/authorization_services/topics/example-overview.adoc:2
 #: source/authorization_services/topics/policy-drools-policy.adoc:56
 #: source/authorization_services/topics/policy-js-policy.adoc:31
-#, fuzzy, no-wrap
-#| msgid "Example using CURL"
+#, no-wrap
 msgid "Examples"
-msgstr "CURLを使用した例"
+msgstr "サンプル"
 
 #. type: Title ==
 #: source/authorization_services/topics/permission-create-resource.adoc:11
@@ -68,16 +68,15 @@ msgstr "CURLを使用した例"
 #: source/authorization_services/topics/policy-time-policy.adoc:11
 #: source/authorization_services/topics/policy-user-policy.adoc:11
 #: source/authorization_services/topics/service-client-api.adoc:21
-#, fuzzy, no-wrap
-#| msgid "Domain Configuration"
+#, no-wrap
 msgid "Configuration"
-msgstr "ドメイン設定"
+msgstr "設定"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:29
 #: source/authorization_services/topics/policy-drools-policy.adoc:23
 msgid "A string with more details about this policy."
-msgstr ""
+msgstr "このポリシーの詳細を示す文字列。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:39
@@ -90,7 +89,7 @@ msgstr ""
 #: source/authorization_services/topics/policy-user-policy.adoc:27
 #, no-wrap
 msgid "*Logic*\n"
-msgstr ""
+msgstr "*Logic*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-aggregated-policy.adoc:41
@@ -104,23 +103,26 @@ msgstr ""
 msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
-msgstr ""
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, Logic>>。"
 
 #. type: Title =
 #: source/authorization_services/topics/policy-drools-policy.adoc:2
 #, no-wrap
 msgid "Rule-Based Policy"
-msgstr ""
+msgstr "ルールベースのポリシー"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:6
 msgid ""
 "With this type of policy you can define conditions for your permissions "
-"using http://www.drools.org[Drools], which is a rule evaluation environment. "
-"It is one of the _Rule-Based_ policy types supported by {project_name}, and "
-"provides flexibility to write any policy based on the "
+"using http://www.drools.org[Drools], which is a rule evaluation environment."
+" It is one of the _Rule-Based_ policy types supported by {project_name}, and"
+" provides flexibility to write any policy based on the "
 "<<_policy_evaluation_api, Evaluation API>>."
 msgstr ""
+"このタイプのポリシーでは、ルール評価環境である http://www.drools.org[Drools] "
+"を使用してパーミッションの条件を定義できます。これは{project_name}でサポートされている _Rule-Based_ "
+"のポリシー・タイプの1つであり、<<_policy_evaluation_api, 評価API>>に基づいたポリシーを柔軟に作成できます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:9
@@ -129,20 +131,19 @@ msgid ""
 "To create a new Rule-based policy, in the dropdown list in the right upper corner of the policy listing,\n"
 " select *Rule*.\n"
 msgstr ""
+"新しいルールベースのポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウンリストで、\n"
+"*ルール*を選択します。\n"
 
 #. type: Block title
 #: source/authorization_services/topics/policy-drools-policy.adoc:10
 #, no-wrap
 msgid "Add Rule Policy"
-msgstr ""
+msgstr "ルールポリシーの追加"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:12
-#, fuzzy
-#| msgid "image:{project_images}/create-realm.png[]"
-msgid ""
-"image:{project_images}/policy/create-drools.png[alt=\"Add Rule Policy\"]"
-msgstr "image:{project_images}/create-realm.png[]"
+msgid "image:{project_images}/policy/create-drools.png[alt=\"Add Rule Policy\"]"
+msgstr "image:{project_images}/policy/create-drools.png[alt=\"ルールポリシーを追加\"]"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:19
@@ -152,12 +153,13 @@ msgid ""
 "security requirements, so you can identify them more easily and also know "
 "what they actually mean."
 msgstr ""
+"ポリシーを説明する、人が判読可能な一意の文字列。ビジネス要件とセキュリティ要件に密接に関連する名前を使用することを強くお勧めします。そうすることで簡単に識別することができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:25
 #, no-wrap
 msgid "*Policy Maven Artifact*\n"
-msgstr ""
+msgstr "*Policy Maven Artifact*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:27
@@ -166,78 +168,78 @@ msgid ""
 "rules are defined. Once you have provided the GAV, you can click *Resolve* "
 "to load both *Module* and *Session* fields."
 msgstr ""
+"ルールが定義されているアーティファクトを指し示すMavenのグループID-アーティファクトID-バージョン（GAV）。GAVを提供したら、 "
+"*Resolve* をクリックして、 *Module* と *Session* フィールドの両方を読み込むことができます。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:29
 #, no-wrap
 msgid "** Group Id\n"
-msgstr ""
+msgstr "** Group Id\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:31
 msgid "The groupId of the artifact."
-msgstr ""
+msgstr "アーティファクトのgroupId。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:33
 #, no-wrap
 msgid "** Artifact Id\n"
-msgstr ""
+msgstr "** Artifact Id\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:35
 msgid "The artifactId of the artifact."
-msgstr ""
+msgstr "アーティファクトのartifactId。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:37
 #, no-wrap
 msgid "** Version\n"
-msgstr ""
+msgstr "** Version\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:39
 msgid "The version of the artifact."
-msgstr ""
+msgstr "アーティファクトのバージョン。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:41
-#, fuzzy, no-wrap
-#| msgid "Module XML"
+#, no-wrap
 msgid "*Module*\n"
-msgstr "モジュールXML"
+msgstr "*Module*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:43
 msgid ""
 "The module used by this policy. You must provide a module to select a "
 "specific session from which rules will be loaded."
-msgstr ""
+msgstr "このポリシーで使用されるモジュール。 ルールをロードする特定のセッションを選択するためのモジュールを提供する必要があります。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:45
 #, no-wrap
 msgid "*Session*\n"
-msgstr ""
+msgstr "*Session*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:47
 msgid ""
 "The session used by this policy. The session provides all the rules to "
 "evaluate when processing the policy."
-msgstr ""
+msgstr "このポリシーで使用されるセッション。 セッションは、ポリシーの処理時に評価するすべてのルールを提供します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:49
-#, fuzzy, no-wrap
-#| msgid "Update Password"
+#, no-wrap
 msgid "*Update Period*\n"
-msgstr "パスワードの更新"
+msgstr "*Update Period*\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:51
 msgid "Specifies an interval for scanning for artifact updates."
-msgstr ""
+msgstr "アーティファクトの更新をスキャンする間隔を指定します。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:60
@@ -246,6 +248,7 @@ msgid ""
 "access control (ABAC) to define a condition that evaluates to a GRANT only "
 "if the authenticated user is the owner of the requested resource:"
 msgstr ""
+"認証されたユーザーがリクエストされたリソースのオーナーである場合にのみ、GRANTに評価される条件を定義するために属性ベースのアクセス・コントロール（ABAC）を使用するDroolsベースのポリシーの簡単な例を次に示します。"
 
 #. type: Code block
 #: source/authorization_services/topics/policy-drools-policy.adoc:74
@@ -264,6 +267,18 @@ msgid ""
 "        $evaluation.grant();\n"
 "end\n"
 msgstr ""
+"import org.keycloak.authorization.policy.evaluation.Evaluation;\n"
+"rule \"Authorize Resource Owner\"\n"
+"    dialect \"mvel\"\n"
+"    when\n"
+"       $evaluation : Evaluation(\n"
+"           $identity: context.identity,\n"
+"           $permission: permission,\n"
+"           $permission.resource != null && $permission.resource.owner.equals($identity.id)\n"
+"       )\n"
+"    then\n"
+"        $evaluation.grant();\n"
+"end\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:77
@@ -271,6 +286,7 @@ msgid ""
 "You can even use another variant of ABAC to obtain attributes from the "
 "identity and define a condition accordingly:"
 msgstr ""
+"IDから属性を取得し、それに応じて条件を定義するために、ABAC（属性ベースのアクセス・コントロール）の別のバリアントを使用することもできます。"
 
 #. type: Code block
 #: source/authorization_services/topics/policy-drools-policy.adoc:90
@@ -288,11 +304,24 @@ msgid ""
 "        $evaluation.grant();\n"
 "end\n"
 msgstr ""
+"import org.keycloak.authorization.policy.evaluation.Evaluation;\n"
+"rule \"Authorize Using Identity Information\"\n"
+"    dialect \"mvel\"\n"
+"    when\n"
+"       $evaluation : Evaluation(\n"
+"           $identity: context.identity,\n"
+"           identity.attributes.containsValue(\"someAttribute\", \"you_can_access\")\n"
+"       )\n"
+"    then\n"
+"        $evaluation.grant();\n"
+"end\n"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:92
 msgid ""
-"For more information about what you can access from the `org.keycloak."
-"authorization.policy.evaluation.Evaluation` interface, see "
+"For more information about what you can access from the "
+"`org.keycloak.authorization.policy.evaluation.Evaluation` interface, see "
 "<<_policy_evaluation_api, Evaluation API>>."
 msgstr ""
+"`org.keycloak.authorization.policy.evaluation.Evaluation`インターフェイスからアクセスできるものの詳細については、<<"
+" _ policy_evaluation_api、Evaluation API >>を参照してください。"

--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: n.watanabe <nwatanabe.ase@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -130,7 +130,7 @@ msgstr ""
 msgid ""
 "To create a new Rule-based policy, in the dropdown list in the right upper corner of the policy listing,\n"
 " select *Rule*.\n"
-msgstr "新しいルールベースのポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウンリストで、*ルール*を選択します。\n"
+msgstr "新しいルールベースのポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウン・リストで、 *Rule* を選択します。\n"
 
 #. type: Block title
 #: source/authorization_services/topics/policy-drools-policy.adoc:10
@@ -166,7 +166,7 @@ msgid ""
 "rules are defined. Once you have provided the GAV, you can click *Resolve* "
 "to load both *Module* and *Session* fields."
 msgstr ""
-"ルールが定義されているアーティファクトを指し示すMavenのグループID-アーティファクトID-バージョン（GAV）。GAVを提供したら、 "
+"ルールが定義されているアーティファクトを指し示すMavenのgroupId-artifactId-version（GAV）。GAVを提供したら、 "
 "*Resolve* をクリックして、 *Module* と *Session* フィールドの両方を読み込むことができます。"
 
 #. type: Plain text
@@ -200,7 +200,7 @@ msgstr "** Version\n"
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:39
 msgid "The version of the artifact."
-msgstr "アーティファクトのバージョン。"
+msgstr "アーティファクトのversion。"
 
 #. type: Plain text
 #: source/authorization_services/topics/policy-drools-policy.adoc:41


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-drools-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-authorization_services__topics__policy-drools-policy/ja_JP/index.html
