### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
@@ -44,8 +44,7 @@ msgid ""
 "ability to understand how to map repository names and permissions to the "
 "OAuth scope mechanism."
 msgstr ""
-"link:https://docs.docker.com/registry/spec/auth/[Docker Registry V2 "
-"Authentciation]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}がこのプロトコルを実装することで、{project_name}認証サーバーをDockerクライアントがレジストリーに対して認証することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装として扱われるのを防ぐための方法があります。最大の偏りには、リクエストとレスポンスのための非常に特殊なJSON形式と、リポジトリー名とパーミッションをOAuthスコープ・メカニズムにマップする方法を理解する機能が含まれています。"
+"link:https://docs.docker.com/registry/spec/auth/[Dockerレジストリーv2認証]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}がこのプロトコルを実装することで、{project_name}認証サーバーをDockerクライアントがレジストリーに対して認証することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装として扱われるのを防ぐための方法があります。最大の偏りには、リクエストとレスポンスのための非常に特殊なJSON形式と、リポジトリー名とパーミッションをOAuthスコープ・メカニズムにマップする方法を理解する機能が含まれています。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/docker.adoc:9
@@ -68,7 +67,7 @@ msgstr ""
 #: source/server_admin/topics/sso-protocols/docker.adoc:13
 msgid ""
 "This flow assumes that a `docker login` command has already been performed"
-msgstr "このフローは、 `docker login` コマンドが既に実行されていることを前提としています"
+msgstr "このフローは、 `docker login` コマンドが既に実行されていることを前提としています。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:15
@@ -90,9 +89,9 @@ msgid ""
 " a link:https://tools.ietf.org/html/rfc2617[HTTP Basic Authentication] "
 "request to the {project_name} authentication server."
 msgstr ""
-"Dockerクライアントは、Dockerレジストリーからの401レスポンスに基づいて認証リクエストを作成します。クライアントはlink:https://tools.ietf.org/html/rfc2617[HTTP"
-" Basic Authentication] request to the {project_name}認証サーバーの一部として、(以前に実行された "
-"`docker login` コマンドで)ローカルにキャッシュされた証明書を使用します。"
+"Dockerクライアントは、Dockerレジストリーからの401レスポンスに基づいて認証リクエストを作成します。クライアントは、{project_name}認証サーバーへのlink:https://tools.ietf.org/html/rfc2617[HTTP"
+" Basic Authentication]リクエストの一部として、（以前に実行された `docker login` "
+"コマンドから）ローカルにキャッシュされたクレデンシャルを使用します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:17
@@ -122,7 +121,7 @@ msgstr ""
 #: source/server_admin/topics/sso-protocols/docker.adoc:20
 #, no-wrap
 msgid "{project_name} Docker Registry v2 Authentication Server URI Endpoints"
-msgstr "{project_name} Docker Registry v2認証サーバーのURIエンドポイント"
+msgstr "{project_name} Dockerレジストリーv2認証サーバーのURIエンドポイント"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:23

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
@@ -2,32 +2,33 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
 #: source/securing_apps/topics/docker/docker-overview.adoc:5
 #: source/server_admin/topics/sso-protocols/docker.adoc:6
 msgid ""
-"Docker authentication is disabled by default. To enable see link:"
-"{installguide_profile_link}[{installguide_profile_name}]."
+"Docker authentication is disabled by default. To enable see "
+"link:{installguide_profile_link}[{installguide_profile_name}]."
 msgstr ""
+"Docker認証はデフォルトで無効です。有効にするには、link:{installguide_profile_link}[{installguide_profile_name}]を参照してください。"
 
 #. type: Title ===
 #: source/server_admin/topics/sso-protocols/docker.adoc:3
 #, no-wrap
 msgid "Docker Registry v2 Authentication"
-msgstr ""
+msgstr "Dockerレジストリーv2認証"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:8
@@ -38,17 +39,19 @@ msgid ""
 "for a {project_name} authentication server to be used by a Docker client to "
 "authenticate against a registry.  While this protocol uses fairly standard "
 "token and signature mechanisms, it has a few wrinkles that prevent it from "
-"being treated as a true OIDC implementation.  The largest deviations include "
-"a very specific JSON format for requests and responses as well as the "
+"being treated as a true OIDC implementation.  The largest deviations include"
+" a very specific JSON format for requests and responses as well as the "
 "ability to understand how to map repository names and permissions to the "
 "OAuth scope mechanism."
 msgstr ""
+"link:https://docs.docker.com/registry/spec/auth/[Docker Registry V2 "
+"Authentciation]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}がこのプロトコルを実装することで、{project_name}認証サーバーをDockerクライアントがレジストリーに対して認証することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装として扱われるのを防ぐための方法があります。最大の偏りには、リクエストとレスポンスのための非常に特殊なJSON形式と、リポジトリー名とパーミッションをOAuthスコープ・メカニズムにマップする方法を理解する機能が含まれています。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/docker.adoc:9
 #, no-wrap
 msgid "Docker Auth Flow"
-msgstr ""
+msgstr "Docker認証フロー"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:11
@@ -58,12 +61,14 @@ msgid ""
 "summary will be given below from the perspective of they {project_name} "
 "authentication server."
 msgstr ""
+"link:https://docs.docker.com/registry/spec/auth/token/[Docker API "
+"documentation]はこのプロセスを最もよく説明していますが、{project_name}認証サーバーの観点から簡単な要約を以下に示します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:13
 msgid ""
 "This flow assumes that a `docker login` command has already been performed"
-msgstr ""
+msgstr "このフローは、 `docker login` コマンドが既に実行されていることを前提としています"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:15
@@ -71,26 +76,30 @@ msgid ""
 "The flow begins when the Docker client requests a resource from the Docker "
 "registry.  If the resource is protected and no auth token is present in the "
 "request, the Docker registry server will respond to the client with a 401 + "
-"some information on required permissions and where to find the authorization "
-"server."
+"some information on required permissions and where to find the authorization"
+" server."
 msgstr ""
+"DockerクライアントがDockerレジストリーからリソースを要求すると、フローが開始されます。リソースが保護されており、リクエストに認証トークンが存在しない場合、Dockerレジストリー・サーバーは、必要なパーミッションに関する情報と認可サーバーの場所を401でクライアントに応答します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:16
 msgid ""
 "The Docker client will construct an authentication request based on the 401 "
 "response from the Docker registry.  The client will then use the locally "
-"cached credentials (from a previously run `docker login` command) as part of "
-"a link:https://tools.ietf.org/html/rfc2617[HTTP Basic Authentication] "
+"cached credentials (from a previously run `docker login` command) as part of"
+" a link:https://tools.ietf.org/html/rfc2617[HTTP Basic Authentication] "
 "request to the {project_name} authentication server."
 msgstr ""
+"Dockerクライアントは、Dockerレジストリーからの401レスポンスに基づいて認証リクエストを作成します。クライアントはlink:https://tools.ietf.org/html/rfc2617[HTTP"
+" Basic Authentication] request to the {project_name}認証サーバーの一部として、(以前に実行された "
+"`docker login` コマンドで)ローカルにキャッシュされた証明書を使用します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:17
 msgid ""
 "The {project_name} authentication server will attempt to authenticate the "
 "user and return a JSON body containing an OAuth-style Bearer token."
-msgstr ""
+msgstr "{project_name}認証サーバーはユーザーを認証し、OAuth形式のベアラー・トークンを含むJSON本体を返します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:18
@@ -98,28 +107,32 @@ msgid ""
 "The Docker client will get the bearer token from the JSON response and use "
 "it in the Authorization header to request the protected resource."
 msgstr ""
+"Dockerクライアントは、JSONレスポンスからベアラー・トークンを取得し、Authorizationヘッダーでベアラー・トークンを使用して、保護されたリソースを要求します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:19
 msgid ""
-"When the Docker registry recieves the new request for the protected resource "
-"with the token from the {project_name} server, the registry validates the "
+"When the Docker registry recieves the new request for the protected resource"
+" with the token from the {project_name} server, the registry validates the "
 "token and grants access to the requested resource (if appropriate)."
 msgstr ""
+"Dockerレジストリーが保護されたリソースへの新しいリクエストを{project_name}サーバーからのトークンとともに受信すると、Dockerレジストリーはトークンを検証し、必要に応じてリソースへのアクセスを許可します。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/docker.adoc:20
 #, no-wrap
 msgid "{project_name} Docker Registry v2 Authentication Server URI Endpoints"
-msgstr ""
+msgstr "{project_name} Docker Registry v2認証サーバーのURIエンドポイント"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:23
 msgid ""
 "{project_name} really only has one endpoint for all Docker auth v2 requests."
-msgstr ""
+msgstr "{project_name}は、すべてのDocker認証v2リクエストに対して、実際には1つのエンドポイントしか持っていません。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:25
-msgid "`http(s)://authserver.host/auth/realms/{realm-name}/protocol/docker-v2`"
+msgid ""
+"`http(s)://authserver.host/auth/realms/{realm-name}/protocol/docker-v2`"
 msgstr ""
+"`http(s)://authserver.host/auth/realms/{realm-name}/protocol/docker-v2`"

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,7 +44,7 @@ msgid ""
 "ability to understand how to map repository names and permissions to the "
 "OAuth scope mechanism."
 msgstr ""
-"link:https://docs.docker.com/registry/spec/auth/[Dockerレジストリーv2認証]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}がこのプロトコルを実装することで、{project_name}認証サーバーをDockerクライアントがレジストリーに対して認証することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装として扱われるのを防ぐための方法があります。最大の偏りには、リクエストとレスポンスのための非常に特殊なJSON形式と、リポジトリー名とパーミッションをOAuthスコープ・メカニズムにマップする方法を理解する機能が含まれています。"
+"link:https://docs.docker.com/registry/spec/auth/[Dockerレジストリーv2認証]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}はこのプロトコルを実装しており、Dockerクライアントがレジストリーに対しての認証に{project_name}認証サーバーを使用することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装としては扱うことができない問題点があります。最大の問題点は、リクエストとレスポンスが非常に特殊なJSON形式であり、リポジトリー名とパーミッションをOAuthのスコープ・メカニズムにマップする方法を理解する必要がある点です。"
 
 #. type: Title ====
 #: source/server_admin/topics/sso-protocols/docker.adoc:9
@@ -98,7 +98,7 @@ msgstr ""
 msgid ""
 "The {project_name} authentication server will attempt to authenticate the "
 "user and return a JSON body containing an OAuth-style Bearer token."
-msgstr "{project_name}認証サーバーはユーザーを認証し、OAuth形式のベアラー・トークンを含むJSON本体を返します。"
+msgstr "{project_name}認証サーバーはユーザーを認証し、OAuth形式のベアラートークンを含むJSON本体を返します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:18
@@ -106,7 +106,7 @@ msgid ""
 "The Docker client will get the bearer token from the JSON response and use "
 "it in the Authorization header to request the protected resource."
 msgstr ""
-"Dockerクライアントは、JSONレスポンスからベアラー・トークンを取得し、Authorizationヘッダーでベアラー・トークンを使用して、保護されたリソースを要求します。"
+"Dockerクライアントは、JSONレスポンスからベアラートークンを取得し、Authorizationヘッダーでベアラートークンを使用して、保護されたリソースを要求します。"
 
 #. type: Plain text
 #: source/server_admin/topics/sso-protocols/docker.adoc:19


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__docker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sso-protocols__docker/ja_JP/index.html
