### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
@@ -2,46 +2,50 @@
 # Copyright (C) YEAR Nomura Research Institute, Ltd.
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/"
-"teams/79437/ja_JP/)\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
 #: source/server_development/topics/user-storage/cache.adoc:2
 #, no-wrap
 msgid "User Caches"
-msgstr ""
+msgstr "ユーザー・キャッシュ"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:8
 msgid ""
-"When a user is loaded by ID, username, or email queries it is cached. When a "
-"user is cached, it iterates through the entire `UserModel` interface and "
+"When a user is loaded by ID, username, or email queries it is cached. When a"
+" user is cached, it iterates through the entire `UserModel` interface and "
 "pulls this information to a local in-memory-only cache. In a cluster, this "
 "cache is still local, but it becomes an invalidation cache. When a user is "
 "modified, it is evicted. This eviction event is propagated to the entire "
 "cluster so that the other nodes' user cache is also invalidated."
 msgstr ""
+"ID、ユーザー名、または電子メールのクエリーによってユーザーが読み込まれると、キャッシュされます。ユーザーがキャッシュされると、それは "
+"`UserModel` インタフェース全体を反復し、この情報をローカルのメモリー内専用キャッシュに保持します。 "
+"クラスターでは、このキャッシュはまだローカルですが、無効化キャッシュになります。ユーザーが変更されると、キャッシュは削除されます。このエビクション・イベントはクラスター全体に伝播され、他のノードのユーザー・キャッシュも無効になります。"
 
 #. type: Title ====
 #: source/server_development/topics/user-storage/cache.adoc:9
 #, no-wrap
 msgid "Managing the user cache"
-msgstr ""
+msgstr "ユーザー・キャッシュの管理"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:12
-msgid "You can access the user cache by calling `KeycloakSession.userCache()`."
-msgstr ""
+msgid ""
+"You can access the user cache by calling `KeycloakSession.userCache()`."
+msgstr "`KeycloakSession.userCache()` を呼び出すことで、ユーザー・キャッシュにアクセスできます。"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:28
@@ -61,6 +65,19 @@ msgid ""
 "     */\n"
 "    void evict(RealmModel realm, UserModel user);\n"
 msgstr ""
+"/**\n"
+" * All these methods effect an entire cluster of Keycloak instances.\n"
+" *\n"
+" * @author <a href=\"mailto:bill@burkecentral.com\">Bill Burke</a>\n"
+" * @version $Revision: 1 $\n"
+" */\n"
+"public interface UserCache extends UserProvider {\n"
+"    /**\n"
+"     * Evict user from cache.\n"
+"     *\n"
+"     * @param user\n"
+"     */\n"
+"    void evict(RealmModel realm, UserModel user);\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:35
@@ -73,6 +90,12 @@ msgid ""
 "     */\n"
 "    void evict(RealmModel realm);\n"
 msgstr ""
+"    /**\n"
+"     * Evict users of a specific realm\n"
+"     *\n"
+"     * @param realm\n"
+"     */\n"
+"    void evict(RealmModel realm);\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:42
@@ -85,27 +108,36 @@ msgid ""
 "    void clear();\n"
 "}\n"
 msgstr ""
+"    /**\n"
+"     * Clear cache entirely.\n"
+"     *\n"
+"     */\n"
+"    void clear();\n"
+"}\n"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:45
 msgid ""
-"There are methods for evicting specific users, users contained in a specific "
-"realm, or the entire cache."
-msgstr ""
+"There are methods for evicting specific users, users contained in a specific"
+" realm, or the entire cache."
+msgstr "特定のユーザー、特定のレルムに含まれるユーザー、またはキャッシュ全体を削除する方法があります。"
 
 #. type: Title ====
 #: source/server_development/topics/user-storage/cache.adoc:46
 #, no-wrap
 msgid "OnUserCache Callback Interface"
-msgstr ""
+msgstr "OnUserCacheコールバック・インターフェイス"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:50
 msgid ""
 "You might want to cache additional information that is specific to your "
-"provider implementation. The User Storage SPI has a callback whenever a user "
-"is cached: `org.keycloak.models.cache.OnUserCache`."
+"provider implementation. The User Storage SPI has a callback whenever a user"
+" is cached: `org.keycloak.models.cache.OnUserCache`."
 msgstr ""
+"プロバイダーの実装に固有の追加情報をキャッシュすることができます。User Storage "
+"SPIには、ユーザーがキャッシュされるたびにコールバックがあります（ `org.keycloak.models.cache.OnUserCache` "
+"）。"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:56
@@ -115,6 +147,9 @@ msgid ""
 "    void onCache(RealmModel realm, CachedUserModel user, UserModel delegate);\n"
 "}\n"
 msgstr ""
+"public interface OnUserCache {\n"
+"    void onCache(RealmModel realm, CachedUserModel user, UserModel delegate);\n"
+"}\n"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:61
@@ -124,12 +159,15 @@ msgid ""
 "returned by your provider. The `CachedUserModel` is an expanded `UserModel` "
 "interface.  This is the instance that is cached locally in local storage."
 msgstr ""
+"このコールバックが必要な場合、プロバイダー・クラスはこのインターフェイスを実装する必要があります。 `UserModel` "
+"デリゲート・パラメーターはプロバイダーから返された` UserModel`インスタンスです。 `CachedUserModel` は拡張された "
+"`UserModel` インターフェースです。これは、ローカル・ストレージにローカルでキャッシュされるインスタンスです。"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:65
 #, no-wrap
 msgid "public interface CachedUserModel extends UserModel {\n"
-msgstr ""
+msgstr "public interface CachedUserModel extends UserModel {\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:72
@@ -142,12 +180,18 @@ msgid ""
 "     */\n"
 "    UserModel getDelegateForUpdate();\n"
 msgstr ""
+"    /**\n"
+"     * Invalidates the cache for this user and returns a delegate that represents the actual data provider\n"
+"     *\n"
+"     * @return\n"
+"     */\n"
+"    UserModel getDelegateForUpdate();\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:74
 #, no-wrap
 msgid "    boolean isMarkedForEviction();\n"
-msgstr ""
+msgstr "    boolean isMarkedForEviction();\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:80
@@ -159,6 +203,11 @@ msgid ""
 "     */\n"
 "    void invalidate();\n"
 msgstr ""
+"    /**\n"
+"     * Invalidate the cache for this model\n"
+"     *\n"
+"     */\n"
+"    void invalidate();\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:87
@@ -171,6 +220,12 @@ msgid ""
 "     */\n"
 "    long getCacheTimestamp();\n"
 msgstr ""
+"    /**\n"
+"     * When was the model was loaded from database.\n"
+"     *\n"
+"     * @return\n"
+"     */\n"
+"    long getCacheTimestamp();\n"
 
 #. type: delimited block -
 #: source/server_development/topics/user-storage/cache.adoc:95
@@ -184,28 +239,40 @@ msgid ""
 "    ConcurrentHashMap getCachedWith();\n"
 "}\n"
 msgstr ""
+"    /**\n"
+"     * Returns a map that contains custom things that are cached along with this model.  You can write to this map.\n"
+"     *\n"
+"     * @return\n"
+"     */\n"
+"    ConcurrentHashMap getCachedWith();\n"
+"}\n"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:99
 msgid ""
-"This `CachedUserModel` interface allows you to evict the user from the cache "
-"and get the provider `UserModel` instance.  The `getCachedWith()` method "
+"This `CachedUserModel` interface allows you to evict the user from the cache"
+" and get the provider `UserModel` instance.  The `getCachedWith()` method "
 "returns a map that allows you to cache additional information pertaining to "
 "the user. For example, credentials are not part of the `UserModel` "
-"interface. If you wanted to cache credentials in memory, you would implement "
-"`OnUserCache` and cache your user's credentials using the `getCachedWith()` "
-"method."
+"interface. If you wanted to cache credentials in memory, you would implement"
+" `OnUserCache` and cache your user's credentials using the `getCachedWith()`"
+" method."
 msgstr ""
+"この `CachedUserModel` インターフェイスは、キャッシュからユーザーを削除し、プロバイダーの `UserModel` "
+"インスタンスを取得することを可能にします。 `getCachedWith()` "
+"メソッドは、ユーザーに関する追加情報をキャッシュするためのマップを返します。たとえば、クレデンシャルは "
+"`UserModel`インターフェイスの一部ではありません。メモリにクレデンシャルをキャッシュしたい場合は、 `OnUserCache` "
+"を実装し、`getCachedWith()` メソッドを使ってユーザーのクレデンシャルをキャッシュします。"
 
 #. type: Title ====
 #: source/server_development/topics/user-storage/cache.adoc:100
 #, no-wrap
 msgid "Cache Policies"
-msgstr ""
+msgstr "キャッシュ・ポリシー"
 
 #. type: Plain text
 #: source/server_development/topics/user-storage/cache.adoc:103
 msgid ""
 "On the administration console management page for your user storage "
 "provider, you can specify a unique cache policy."
-msgstr ""
+msgstr "管理コンソールのユーザー・ストレージ・プロバイダーの管理ページで、一意なキャッシュ・ポリシーを指定できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_development__topics__user-storage__cache/ja_JP/index.html
