### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po
@@ -29,9 +29,9 @@ msgid ""
 "If you don't already have an account or don't know how to create applications go to https://www.openshift.com/        first.\n"
 "You can create the {project_name} instance either with the web tool or the command line tool, both approaches are described below.\n"
 msgstr ""
-"{project_name}は、OpenShiftで簡単に動作させるOpenShiftカートリッジを提供します。\n"
-"アカウントをまだ持っていない場合、またはアプリケーションの作成方法が分からない場合は、 https：//www.openshift.com/ を参照してください。\n"
-"Webツールまたはコマンドライン・ツールを使用して{project_name}インスタンスを作成することができます。両方のアプローチについては後述します。\n"
+"{project_name}は、OpenShiftで簡単に動作させるOpenShiftカートリッジを提供します。アカウントをまだ持っていない場合、またはアプリケーションの作成方法が分からない場合は、"
+" https：//www.openshift.com/ "
+"を参照してください。Webツールまたはコマンドライン・ツールを使用して{project_name}インスタンスを作成することができます。両方のアプローチについては後述します。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:12
@@ -40,8 +40,8 @@ msgid ""
 "It's important that immediately after creating a {project_name} instance you open the `Administration Console`            and login to reset the password.\n"
 "If this is not done anyone can easily gain admin rights to your {project_name} instance.\n"
 msgstr ""
-"{project_name}インスタンスを作成した直後に、 `Administration Console`を開き、ログインしてパスワードをリセットすることが重要です。\n"
-"これが行われていない場合、{project_name}インスタンスに対する管理者権限を簡単に得ることができます。\n"
+"{project_name}インスタンスを作成した直後に、 `Administration Console` "
+"を開き、ログインしてパスワードをリセットすることが重要です。これが行われていない場合、{project_name}インスタンスに対する管理者権限を簡単に得ることができます。\n"
 
 #. type: Title ===
 #: source/server_installation/topics/openshift.adoc:13
@@ -55,14 +55,14 @@ msgid ""
 "Open https://openshift.redhat.com/app/console/applications and click on `Add"
 " Application`."
 msgstr ""
-"https://openshift.redhat.com/app/console/applications を開き、 "
-"「アプリケーションの追加」をクリックしてください。"
+"https://openshift.redhat.com/app/console/applications を開き、 `Add Application`"
+" をクリックしてください。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:17
 msgid ""
 "Scroll down to the bottom of the page to find the `Code Anything` section."
-msgstr "ページの一番下までスクロールして、 `Code Anything`セクションを見つけてください。"
+msgstr "ページの一番下までスクロールして、 `Code Anything` セクションを探します。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:18
@@ -71,26 +71,26 @@ msgid ""
 "keycloak-cartridge` into the `URL to a cartridge definition` field and click"
 " on `Next`."
 msgstr ""
-"「URL to a cartridge definition」フィールドに `http://cartreflect-"
-"claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge` "
-"を挿入し、「次へ」をクリックします。"
+"`URL to a cartridge definition` フィールドに `http://cartreflect-"
+"claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge` を挿入し、 "
+"`Next` をクリックします。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:19
 msgid "Fill in the following form and click on `Create Application`."
-msgstr "次のフォームに記入し、「アプリケーションの作成」をクリックします。"
+msgstr "次のフォームに記入し、 `Create Application` をクリックします。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:20
 msgid "Click on `Continue to the application overview page`."
-msgstr "「アプリケーション概要ページへ進む」をクリックします。"
+msgstr "`Continue to the application overview page` をクリックします。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:21
 msgid ""
 "Under the list of applications you should find your {project_name} instance "
 "and the status should be `Started`."
-msgstr "アプリケーションのリストの下に{project_name}インスタンスがあり、ステータスは `Started`でなければなりません。"
+msgstr "アプリケーションのリストの下に{project_name}インスタンスがあり、ステータスは `Started` になっているはずです。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:22
@@ -131,8 +131,8 @@ msgid ""
 "Once the instance is created the rhc tool outputs details about it.  Open "
 "the returned `URL` in a browser to open the {project_name} servers homepage."
 msgstr ""
-"インスタンスが作成されると、rhcツールは詳細を出力します。 ブラウザーで返された "
-"`URL`を開き、{project_name}サーバのホームページを開きます。"
+"インスタンスが作成されると、rhcツールは詳細を出力します。 ブラウザーで返された `URL` "
+"を開き、{project_name}サーバーのホームページを開きます。"
 
 #. type: Title ===
 #: source/server_installation/topics/openshift.adoc:37
@@ -148,9 +148,9 @@ msgid ""
 "Console`.  Open that and log in using username `admin` and password `admin`."
 "  On the first login you are required to change the password."
 msgstr ""
-"{project_name}のサーバのホームページに{project_name}のロゴと `{project_name}へようこそ 'が表示されます。 "
-"`Administration Console`へのリンクもあります。 それを開き、ユーザー名 `admin`とパスワード` "
-"admin`を使ってログインしてください。 最初のログイン時にパスワードを変更する必要があります。"
+"{project_name}のサーバのホームページに{project_name}のロゴと `Welcome to {project_name}' "
+"が表示されます。 `Administration Console` へのリンクもあります。それを開き、ユーザー名 `admin` とパスワード "
+"`admin` を使ってログインしてください。最初のログイン時にパスワードを変更する必要があります。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:45
@@ -158,5 +158,5 @@ msgid ""
 "On OpenShift {project_name} has been configured to only accept requests over"
 " https.  If you try to use http you will be redirected to https."
 msgstr ""
-"On OpenShift {project_name}は、httpsを介した要求のみを受け入れるように設定されています。 "
-"httpを使用しようとすると、httpsにリダイレクトされます。"
+"On OpenShift "
+"{project_name}は、httpsを介した要求のみを受け入れるように設定されています。httpを使用しようとすると、httpsにリダイレクトされます。"

--- a/i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po
@@ -1,24 +1,25 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: wadahiro <wadahiro@gmail.com>\n"
-"Language-Team: Japanese\n"
-"Language: ja_JP\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: crowdin.com\n"
-"X-Crowdin-Project: keycloak-documentation-i18n\n"
-"X-Crowdin-Language: ja\n"
-"X-Crowdin-File: /develop/i18n/po/ja_JP/"
-"server_installation__topics__openshift.ja_JP.po\n"
 
 #. type: Title ==
 #: source/server_installation/topics/openshift.adoc:4
 #, no-wrap
 msgid "Running {project_name} Server on OpenShift"
-msgstr ""
+msgstr "OpenShift上の{project_name}サーバーの実行"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:9
@@ -28,6 +29,9 @@ msgid ""
 "If you don't already have an account or don't know how to create applications go to https://www.openshift.com/        first.\n"
 "You can create the {project_name} instance either with the web tool or the command line tool, both approaches are described below.\n"
 msgstr ""
+"{project_name}は、OpenShiftで簡単に動作させるOpenShiftカートリッジを提供します。\n"
+"アカウントをまだ持っていない場合、またはアプリケーションの作成方法が分からない場合は、 https：//www.openshift.com/ を参照してください。\n"
+"Webツールまたはコマンドライン・ツールを使用して{project_name}インスタンスを作成することができます。両方のアプローチについては後述します。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:12
@@ -36,107 +40,123 @@ msgid ""
 "It's important that immediately after creating a {project_name} instance you open the `Administration Console`            and login to reset the password.\n"
 "If this is not done anyone can easily gain admin rights to your {project_name} instance.\n"
 msgstr ""
+"{project_name}インスタンスを作成した直後に、 `Administration Console`を開き、ログインしてパスワードをリセットすることが重要です。\n"
+"これが行われていない場合、{project_name}インスタンスに対する管理者権限を簡単に得ることができます。\n"
 
 #. type: Title ===
 #: source/server_installation/topics/openshift.adoc:13
 #, no-wrap
 msgid "Create {project_name} instance with the web tool"
-msgstr ""
+msgstr "Webツールを使用して{project_name}インスタンスを作成する"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:16
 msgid ""
-"Open https://openshift.redhat.com/app/console/applications and click on `Add "
-"Application`."
+"Open https://openshift.redhat.com/app/console/applications and click on `Add"
+" Application`."
 msgstr ""
+"https://openshift.redhat.com/app/console/applications を開き、 "
+"「アプリケーションの追加」をクリックしてください。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:17
 msgid ""
 "Scroll down to the bottom of the page to find the `Code Anything` section."
-msgstr ""
+msgstr "ページの一番下までスクロールして、 `Code Anything`セクションを見つけてください。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:18
 msgid ""
 "Insert `http://cartreflect-claytondev.rhcloud.com/github/keycloak/openshift-"
-"keycloak-cartridge` into the `URL to a cartridge definition` field and click "
-"on `Next`."
+"keycloak-cartridge` into the `URL to a cartridge definition` field and click"
+" on `Next`."
 msgstr ""
+"「URL to a cartridge definition」フィールドに `http://cartreflect-"
+"claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge` "
+"を挿入し、「次へ」をクリックします。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:19
 msgid "Fill in the following form and click on `Create Application`."
-msgstr ""
+msgstr "次のフォームに記入し、「アプリケーションの作成」をクリックします。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:20
 msgid "Click on `Continue to the application overview page`."
-msgstr ""
+msgstr "「アプリケーション概要ページへ進む」をクリックします。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:21
 msgid ""
 "Under the list of applications you should find your {project_name} instance "
 "and the status should be `Started`."
-msgstr ""
+msgstr "アプリケーションのリストの下に{project_name}インスタンスがあり、ステータスは `Started`でなければなりません。"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:22
 msgid "Click on it to open the {project_name} servers homepage."
-msgstr ""
+msgstr "これをクリックすると、{project_name}サーバーのホームページが開きます。"
 
 #. type: Title ===
 #: source/server_installation/topics/openshift.adoc:23
 #, no-wrap
 msgid "Create {project_name} instance with the command-line tool"
-msgstr ""
+msgstr "コマンドラインツールを使用して{project_name}インスタンスを作成する"
 
 #. type: Plain text
 #: source/server_installation/topics/openshift.adoc:26
 msgid "Run the following command from a terminal:"
-msgstr ""
+msgstr "ターミナルから次のコマンドを実行します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/openshift.adoc:31
+#: source/server_installation/topics/openshift.adoc:30
 #, no-wrap
 msgid ""
-"rhc app create <APPLICATION NAME> http://cartreflect-claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge\n"
-"----\t\n"
+"rhc app create <APPLICATION NAME> http://cartreflect-"
+"claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge\n"
 msgstr ""
+"rhc app create <APPLICATION NAME> http://cartreflect-"
+"claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge\n"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/server_installation/topics/openshift.adoc:33
-#, no-wrap
-msgid ". Replace `<APPLICATION NAME>` with the name you want (for example {project_name}).\n"
-msgstr ""
-
-#. type: delimited block -
-#: source/server_installation/topics/openshift.adoc:36
-#, no-wrap
 msgid ""
-"Once the instance is created the rhc tool outputs details about it.\n"
-"Open the returned `URL` in a browser to open the {project_name} servers homepage.\n"
+"Replace `<APPLICATION NAME>` with the name you want (for example "
+"{project_name})."
+msgstr "`<APPLICATION NAME>` を任意の名前（例えば{project_name}）に置き換えてください。"
+
+#. type: Plain text
+#: source/server_installation/topics/openshift.adoc:36
+msgid ""
+"Once the instance is created the rhc tool outputs details about it.  Open "
+"the returned `URL` in a browser to open the {project_name} servers homepage."
 msgstr ""
+"インスタンスが作成されると、rhcツールは詳細を出力します。 ブラウザーで返された "
+"`URL`を開き、{project_name}サーバのホームページを開きます。"
 
 #. type: Title ===
 #: source/server_installation/topics/openshift.adoc:37
 #, no-wrap
 msgid "Next steps"
-msgstr ""
+msgstr "次のステップ"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/server_installation/topics/openshift.adoc:43
 msgid ""
 "The {project_name} servers homepage shows the {project_name} logo and "
 "`Welcome to {project_name}`.  There is also a link to the `Administration "
-"Console`.  Open that and log in using username `admin` and password "
-"`admin`.  On the first login you are required to change the password."
+"Console`.  Open that and log in using username `admin` and password `admin`."
+"  On the first login you are required to change the password."
 msgstr ""
+"{project_name}のサーバのホームページに{project_name}のロゴと `{project_name}へようこそ 'が表示されます。 "
+"`Administration Console`へのリンクもあります。 それを開き、ユーザー名 `admin`とパスワード` "
+"admin`を使ってログインしてください。 最初のログイン時にパスワードを変更する必要があります。"
 
-#. type: delimited block -
+#. type: Plain text
 #: source/server_installation/topics/openshift.adoc:45
 msgid ""
-"TIP: On OpenShift {project_name} has been configured to only accept requests "
-"over https.  If you try to use http you will be redirected to https."
+"On OpenShift {project_name} has been configured to only accept requests over"
+" https.  If you try to use http you will be redirected to https."
 msgstr ""
+"On OpenShift {project_name}は、httpsを介した要求のみを受け入れるように設定されています。 "
+"httpを使用しようとすると、httpsにリダイレクトされます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__openshift
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_installation__topics__openshift/ja_JP/index.html
