### PR TITLE
Fix site index.html deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
       - run:
           name: deply to s3
           command: |
-            aws s3 sync ~/repo/site/ s3://keycloak-documentation/
+            [ "$CIRCLE_BRANCH" = "master" ] && aws s3 sync ~/repo/site/ s3://keycloak-documentation/
+            cp -r ~/repo/site/* ~/repo/translated/dist/
             aws s3 sync ~/repo/translated/dist/ s3://keycloak-documentation/$CIRCLE_BRANCH/ --delete
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
           name: deply to s3
           command: |
             [ "$CIRCLE_BRANCH" = "master" ] && aws s3 sync ~/repo/site/ s3://keycloak-documentation/
+            sed -i -e "s|/master/|/|g" ~/repo/site/index.html
             cp -r ~/repo/site/* ~/repo/translated/dist/
             aws s3 sync ~/repo/translated/dist/ s3://keycloak-documentation/$CIRCLE_BRANCH/ --delete
 


### PR DESCRIPTION
Fix #523.

* Root index.html for the site should be deployed when master branch is pushed.
* Add deploying branch specific index.html under the branch-top directory.