### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
@@ -30,7 +30,7 @@ msgid ""
 "newer protocol (OIDC) instead of the older more mature protocol (SAML)."
 msgstr ""
 "OpenID "
-"ConnectとSAMLの選択は、古いより成熟したプロトコル(SAML)の代わりに新しいプロトコル(OIDC)を使用するだけの問題ではありません。"
+"ConnectとSAMLの選択は、古いより成熟したプロトコル（SAML）の代わりに新しいプロトコル（OIDC）を使用するだけの問題ではありません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/overview/supported-protocols.adoc:47


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml-vs-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-server_admin__topics__sso-protocols__saml-vs-oidc/ja_JP/index.html
