### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
@@ -29,9 +29,9 @@ msgid ""
 msgstr ""
 "アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
 "に設定する必要があります。 "
-"Webアプリケーションの未認証のユーザーをKeycloakログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
-" `401` ステータスコードを送信します。 Keycloakは、 `X-Requested-With` 、 `SOAPAction` 、 "
-"`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。 デフォルト値は _false_ です。"
+"Webアプリケーションの未認証のユーザーをKeycloakのログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPまたはRESTクライアントにはHTTPの"
+" `401` ステータスコードを送信します。Keycloakは、 `X-Requested-With` 、 `SOAPAction` 、 "
+"`Accept` のような典型的なヘッダに基づいて、SOAPまたはRESTクライアントを自動検出します。デフォルト値は _false_ です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:18


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/translate-securing_apps__topics__saml__java__general-config__sp_element/ja_JP/index.html
