### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -103,7 +103,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Equivalent configuration using CLI commands:"
-msgstr "同じ設定でCLIコマンドを使用する場合は、以下のようになります。"
+msgstr "CLIコマンドを使用した同等の設定は以下になります。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr "IP制限"
 msgid ""
 "It is possible to restrict access to `/auth/admin` to only specific IP "
 "addresses."
-msgstr "`/auth/admin` へのアクセスを特定のIPアドレスだけに制限することは可能です。"
+msgstr "`/auth/admin` へのアクセスを特定のIPアドレスだけに制限することが可能です。"
 
 #. type: Plain text
 msgid ""
@@ -131,7 +131,7 @@ msgstr "ポート制限"
 msgid ""
 "It is possible to expose `/auth/admin` to a different port that is not "
 "exposed on the Internet."
-msgstr "`/auth/admin` をインターネットに公開されていない別のポートに公開することは可能です。"
+msgstr "`/auth/admin` をインターネットに公開されていない別のポートに公開することが可能です。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -1,0 +1,229 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Admin Endpoints and Console"
+msgstr "管理エンドポイントと管理コンソール"
+
+#. type: Plain text
+msgid ""
+"The {project_name} administrative REST API and the web console are exposed "
+"by default on the same port as non-admin usage. If you are exposing "
+"{project_name} on the Internet, we recommend not also exposing the admin "
+"endpoints on the Internet."
+msgstr ""
+"{project_name}管理REST "
+"APIとWebコンソールは、非管理用途と同じポートにデフォルトで公開されています。{project_name}をインターネットで公開している場合は、管理エンドポイントをインターネットに公開しないことをお勧めします。"
+
+#. type: Plain text
+msgid ""
+"This can be achieve either directly in {project_name} or with a proxy such "
+"as Apache or nginx."
+msgstr "これは、{project_name}で直接行うことも、Apacheやnginxなどのプロキシで行うこともできます。"
+
+#. type: Plain text
+msgid ""
+"For the proxy option please follow the documentation for the proxy. You need"
+" to control access to any requests to `/auth/admin`."
+msgstr ""
+"プロキシ・オプションについては、プロキシのマニュアルを参照してください。 `/auth/admin` へのリクエストのアクセスを制御する必要があります。"
+
+#. type: Plain text
+msgid ""
+"To achieve this directly in {project_name} there are a few options. This "
+"document covers two options, IP restriction and separate ports."
+msgstr ""
+"これを{project_name}で直接実現するには、いくつかのオプションがあります。このドキュメントでは、IP制限とポートの分離の2つのオプションについて説明します。"
+
+#. type: Title ====
+#, no-wrap
+msgid "IP Restriction"
+msgstr "IP制限"
+
+#. type: Plain text
+msgid ""
+"It is possible to restrict access to `/auth/admin` to only specific IP "
+"addresses."
+msgstr "`/auth/admin` へのアクセスを特定のIPアドレスだけに制限することは可能です。"
+
+#. type: Plain text
+msgid ""
+"The following example restricts access to `/auth/admin` to IP addresses in "
+"the range `10.0.0.1` to `10.0.0.255`."
+msgstr ""
+"次の例では、 `/auth/admin` へのアクセスを `10.0.0.1` から `10.0.0.255` の範囲のIPアドレスに制限しています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
+"    ...\n"
+"    <server name=\"default-server\">\n"
+"        ...\n"
+"        <host name=\"default-host\" alias=\"localhost\">\n"
+"            ...\n"
+"            <filter-ref name=\"ipAccess\"/>\n"
+"        </host>\n"
+"    </server>\n"
+"    <filters>\n"
+"        <expression-filter name=\"ipAccess\" expression=\"path-prefix('/auth/admin') -> ip-access-control(acl={'10.0.0.0/24 allow'})\"/>\n"
+"    </filters>\n"
+"    ...\n"
+"</subsystem>\n"
+msgstr ""
+"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
+"    ...\n"
+"    <server name=\"default-server\">\n"
+"        ...\n"
+"        <host name=\"default-host\" alias=\"localhost\">\n"
+"            ...\n"
+"            <filter-ref name=\"ipAccess\"/>\n"
+"        </host>\n"
+"    </server>\n"
+"    <filters>\n"
+"        <expression-filter name=\"ipAccess\" expression=\"path-prefix('/auth/admin') -> ip-access-control(acl={'10.0.0.0/24 allow'})\"/>\n"
+"    </filters>\n"
+"    ...\n"
+"</subsystem>\n"
+
+#. type: Plain text
+msgid "Equivalent configuration using CLI commands:"
+msgstr "同じ設定でCLIコマンドを使用する場合は、以下のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"/subsystem=undertow/configuration=filter/expression-filter=ipAccess:add(,expression=\"path-prefix[/auth/admin] -> ip-access-control(acl={'10.0.0.0/24 allow'})\")\n"
+"/subsystem=undertow/server=default-server/host=default-host/filter-ref=ipAccess:add()\n"
+msgstr ""
+"/subsystem=undertow/configuration=filter/expression-filter=ipAccess:add(,expression=\"path-prefix[/auth/admin] -> ip-access-control(acl={'10.0.0.0/24 allow'})\")\n"
+"/subsystem=undertow/server=default-server/host=default-host/filter-ref=ipAccess:add()\n"
+
+#. type: Plain text
+msgid ""
+"For IP restriction if you are using a proxy it is important to configure it "
+"correctly to make sure {project_name} receives the client IP address and not"
+" the proxy IP address"
+msgstr ""
+"IP制限において、プロキシを使用している場合は、プロキシのIPアドレスではなく、クライアントのIPアドレスで{project_name}が受け取るようにIPを正しく設定することが重要です。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Port Restriction"
+msgstr "ポート制限"
+
+#. type: Plain text
+msgid ""
+"It is possible to expose `/auth/admin` to a different port that is not "
+"exposed on the Internet."
+msgstr "`/auth/admin` をインターネットに公開されていない別のポートに公開することは可能です。"
+
+#. type: Plain text
+msgid ""
+"The following example exposes `/auth/admin` on port `8444` while not "
+"permitting access with the default port `8443`."
+msgstr ""
+"次の例では、 `/auth/admin` をポート` 8444` で公開しますが、デフォルトポート `8443` ではアクセスを許可しません。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
+"    ...\n"
+"    <server name=\"default-server\">\n"
+"        ...\n"
+"        <https-listener name=\"https\" socket-binding=\"https\" security-realm=\"ApplicationRealm\" enable-http2=\"true\"/>\n"
+"        <https-listener name=\"https-admin\" socket-binding=\"https-admin\" security-realm=\"ApplicationRealm\" enable-http2=\"true\"/>\n"
+"        <host name=\"default-host\" alias=\"localhost\">\n"
+"            ...\n"
+"            <filter-ref name=\"portAccess\"/>\n"
+"        </host>\n"
+"    </server>\n"
+"    <filters>\n"
+"        <expression-filter name=\"portAccess\" expression=\"path-prefix('/auth/admin') and not equals(%p, 8444) -> response-code(403)\"/>\n"
+"    </filters>\n"
+"    ...\n"
+"</subsystem>\n"
+msgstr ""
+"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
+"    ...\n"
+"    <server name=\"default-server\">\n"
+"        ...\n"
+"        <https-listener name=\"https\" socket-binding=\"https\" security-realm=\"ApplicationRealm\" enable-http2=\"true\"/>\n"
+"        <https-listener name=\"https-admin\" socket-binding=\"https-admin\" security-realm=\"ApplicationRealm\" enable-http2=\"true\"/>\n"
+"        <host name=\"default-host\" alias=\"localhost\">\n"
+"            ...\n"
+"            <filter-ref name=\"portAccess\"/>\n"
+"        </host>\n"
+"    </server>\n"
+"    <filters>\n"
+"        <expression-filter name=\"portAccess\" expression=\"path-prefix('/auth/admin') and not equals(%p, 8444) -> response-code(403)\"/>\n"
+"    </filters>\n"
+"    ...\n"
+"</subsystem>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "...\n"
+msgstr "...\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<socket-binding-group name=\"standard-sockets\" default-interface=\"public\" port-offset=\"${jboss.socket.binding.port-offset:0}\">\n"
+"    ...\n"
+"    <socket-binding name=\"https\" port=\"${jboss.https.port:8443}\"/>\n"
+"    <socket-binding name=\"https-admin\" port=\"${jboss.https.port:8444}\"/>\n"
+"    ...\n"
+"</socket-binding-group>\n"
+msgstr ""
+"<socket-binding-group name=\"standard-sockets\" default-interface=\"public\" port-offset=\"${jboss.socket.binding.port-offset:0}\">\n"
+"    ...\n"
+"    <socket-binding name=\"https\" port=\"${jboss.https.port:8443}\"/>\n"
+"    <socket-binding name=\"https-admin\" port=\"${jboss.https.port:8444}\"/>\n"
+"    ...\n"
+"</socket-binding-group>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"/socket-binding-group=standard-sockets/socket-binding=https-"
+"admin/:add(port=8444)\n"
+msgstr ""
+"/socket-binding-group=standard-sockets/socket-binding=https-"
+"admin/:add(port=8444)\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"/subsystem=undertow/server=default-server/https-listener=https-admin:add"
+"(socket-binding=https-admin, security-realm=ApplicationRealm, enable-"
+"http2=true)\n"
+msgstr ""
+"/subsystem=undertow/server=default-server/https-listener=https-admin:add"
+"(socket-binding=https-admin, security-realm=ApplicationRealm, enable-"
+"http2=true)\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"/subsystem=undertow/configuration=filter/expression-filter=portAccess:add(,expression=\"path-prefix('/auth/admin') and not equals(%p, 8444) -> response-code(403)\")\n"
+"/subsystem=undertow/server=default-server/host=default-host/filter-ref=portAccess:add()\n"
+msgstr ""
+"/subsystem=undertow/configuration=filter/expression-filter=portAccess:add(,expression=\"path-prefix('/auth/admin') and not equals(%p, 8444) -> response-code(403)\")\n"
+"/subsystem=undertow/server=default-server/host=default-host/filter-ref=portAccess:add()\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
