### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,7 +53,7 @@ msgstr "Windows"
 #: source/authorization_services/topics/hello-world-before-start.adoc:1
 #, no-wrap
 msgid "Before You Start"
-msgstr "はじめる前に"
+msgstr "始める前に"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/before.adoc:11

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -70,12 +70,10 @@ msgid ""
 "a number that will be added to the base value of every port opened by the "
 "{project_name} server."
 msgstr ""
-"このチュートリアルの操作をはじめる前に、{project_name}のインストールを完了し、<<_install-boot, "
-"インストールと起動>>のチュートリアルに沿って初期管理者ユーザーを作成する必要があります。これには注意事項があります。{project_name}サーバーと同じマシンで、別途{appserver_name}インスタンスを起動する必要があります。この別インスタンスではJava"
-" "
-"Servletアプリケーションを起動します。そのため、同じマシンで起動させる際にポートが競合しないように、異なるポートで{project_name}を起動する必要があります。コマンドラインで"
+"このチュートリアルの操作を始める前に、{project_name}のインストールを完了し、<<_install-boot, "
+"インストールと起動>>のチュートリアルに沿って初期管理者ユーザーを作成する必要があります。これには注意事項があります。{project_name}サーバーと同じマシンで、別途{appserver_name}インスタンスを起動する必要があります。この別インスタンスではJavaサーブレット・アプリケーションを起動します。そのため、同じマシンで起動させる際にポートが競合しないように、異なるポートで{project_name}を起動する必要があります。コマンドラインで"
 " `jboss.socket.binding.port-offset` "
-"システムプロパティを使います。当プロパティの値は、{project_name}サーバーで開いた全ポートの基準値に加算される数値です。"
+"システム・プロパティーを使います。当プロパティーの値は、{project_name}サーバーで開いた全ポートの基準値に加算される数値です。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/before.adoc:13


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
