### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,10 +29,10 @@ msgid ""
 "_standalone/configuration_ directory of the application server instance on "
 "which your application is deployed."
 msgstr ""
-"いまインストールページからXMLテンプレートをコピーしたところですが、これを _standalone.xml_ "
+"今インストールページからXMLテンプレートをコピーしたところですが、これを _standalone.xml_ "
 "ファイルにペーストする必要があります。_standalone.xml_ "
 "ファイルはアプリケーションをデプロイしたアプリケーション・サーバー・インスタンスの _standalone/configuration_ "
-"ディレクトリにあります。"
+"ディレクトリーにあります。"
 
 #. type: Plain text
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:8

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
@@ -69,7 +69,7 @@ msgstr ""
 msgid ""
 "Within the <subsystem> element, paste in the template. It will look "
 "something like this:"
-msgstr "<subsystem> エレメントの要素内で、テンプレートを貼り付けます。そうすると、以下のようになります。"
+msgstr "<subsystem> 要素内で、テンプレートを貼り付けます。そうすると、以下のようになります。"
 
 #. type: delimited block -
 #: source/getting_started/topics/secure-jboss-app/subsystem.adoc:35


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
