### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,21 +15,17 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ==
-#: source/securing_apps/topics/overview/supported-platforms.adoc:3
-#: source/securing_apps/topics/overview/supported-protocols.adoc:5
-#: source/securing_apps/topics/oidc/oidc-overview.adoc:1
+#. type: Title ====
 #, no-wrap
 msgid "OpenID Connect"
 msgstr "OpenID Connect"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/oidc-overview.adoc:4
 msgid ""
 "This section describes how you can secure applications and services with "
 "OpenID Connect using either {project_name} adapters or generic OpenID "
 "Connect Resource Provider libraries."
 msgstr ""
 "このセクションでは、{project_name}アダプターまたは汎用OpenID "
-"Connectリソース・プロバイダーのライブラリを使用して、アプリケーションとサービスをOpenID "
-"Connectでセキュリティ保護する方法について説明します。"
+"Connectリソース・プロバイダーのライブラリーを使用して、アプリケーションとサービスをOpenID "
+"Connectでセキュリティー保護する方法について説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
