### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
@@ -37,7 +37,7 @@ msgid ""
 "permissions. The required permissions are described in "
 "{adminguide_link}[{adminguide_name}]."
 msgstr ""
-"APIを呼び出すには、適切な権限を持つアクセス・トークンを取得する必要があります。必要な権限については "
+"APIを呼び出すには、適切な権限を持つアクセストークンを取得する必要があります。必要な権限については "
 "{adminguide_link}[{adminguide_name}] を参照してください。"
 
 #. type: Plain text
@@ -48,11 +48,11 @@ msgid ""
 msgstr ""
 "トークンは、{project_name}を使用したアプリケーションへの認証を有効にすることで取得できます。 "
 "{adapterguide_link}[{adapterguide_name}] "
-"を参照ください。また、ダイレクト・アクセス・グラントを使用しても、アクセス・トークンを取得できます。"
+"を参照してください。また、ダイレクト・アクセス・グラントを使用しても、アクセストークンを取得できます。"
 
 #. type: Plain text
 msgid "For complete documentation see {apidocs_link}[{apidocs_name}]."
-msgstr "完全なドキュメントについては、 {apidocs_link}[{apidocs_name}] を参照ください。"
+msgstr "完全なドキュメントについては、 {apidocs_link}[{apidocs_name}] を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -60,7 +60,7 @@ msgid ""
 " password `password`:"
 msgstr ""
 "ユーザー名 `admin` とパスワード `password` を使用して、以下の通り、 `master` "
-"レルム内のユーザー用にアクセス・トークンを取得します。"
+"レルム内のユーザー用にアクセストークンを取得します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -163,4 +163,4 @@ msgstr ""
 msgid ""
 "Complete Javadoc for the admin client is available at "
 "{apidocs_link}[{apidocs_name}]."
-msgstr "管理クライアントの完全なJavaのドキュメントは、 {apidocs_link}[{apidocs_name}] を参照ください。"
+msgstr "管理クライアントの完全なJavaのドキュメントは、 {apidocs_link}[{apidocs_name}] を参照してください。"

--- a/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
@@ -38,7 +38,7 @@ msgid ""
 "{adminguide_link}[{adminguide_name}]."
 msgstr ""
 "APIを呼び出すには、適切な権限を持つアクセス・トークンを取得する必要があります。必要な権限については "
-"{adminguide_link}[{adminguide_name}] を参照ください。"
+"{adminguide_link}[{adminguide_name}] を参照してください。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po
@@ -20,18 +20,7 @@ msgstr ""
 msgid "Example using CURL"
 msgstr "CURLを使用した例"
 
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"import org.keycloak.admin.client.Keycloak;\n"
-"import org.keycloak.representations.idm.RealmRepresentation;\n"
-"...\n"
-msgstr ""
-"import org.keycloak.admin.client.Keycloak;\n"
-"import org.keycloak.representations.idm.RealmRepresentation;\n"
-"...\n"
-
-#. type: Title ==
+#. type: Title ===
 #, no-wrap
 msgid "Admin REST API"
 msgstr "管理REST API"
@@ -48,7 +37,8 @@ msgid ""
 "permissions. The required permissions are described in "
 "{adminguide_link}[{adminguide_name}]."
 msgstr ""
-"APIを呼び出すには、適切な権限を持つアクセス・トークンを取得する必要があります。必要な権限については{adminguide_link}[{adminguide_name}]を参照ください。"
+"APIを呼び出すには、適切な権限を持つアクセス・トークンを取得する必要があります。必要な権限については "
+"{adminguide_link}[{adminguide_name}] を参照ください。"
 
 #. type: Plain text
 msgid ""
@@ -56,11 +46,13 @@ msgid ""
 "{project_name}; see the {adapterguide_link}[{adapterguide_name}]. You can "
 "also use direct access grant to obtain an access token."
 msgstr ""
-"トークンは、{project_name}を使用したアプリケーションへの認証を有効にすることで取得できます。{adapterguide_link}[{adapterguide_name}]を参照ください。また、ダイレクト・アクセス・グラントを使用しても、アクセス・トークンを取得できます。"
+"トークンは、{project_name}を使用したアプリケーションへの認証を有効にすることで取得できます。 "
+"{adapterguide_link}[{adapterguide_name}] "
+"を参照ください。また、ダイレクト・アクセス・グラントを使用しても、アクセス・トークンを取得できます。"
 
 #. type: Plain text
 msgid "For complete documentation see {apidocs_link}[{apidocs_name}]."
-msgstr "完全なドキュメントについては、{apidocs_link}[{apidocs_name}]を参照ください。"
+msgstr "完全なドキュメントについては、 {apidocs_link}[{apidocs_name}] を参照ください。"
 
 #. type: Plain text
 msgid ""
@@ -140,6 +132,17 @@ msgstr "次の例は、Javaクライアント・ライブラリーを使用し�
 #. type: delimited block -
 #, no-wrap
 msgid ""
+"import org.keycloak.admin.client.Keycloak;\n"
+"import org.keycloak.representations.idm.RealmRepresentation;\n"
+"...\n"
+msgstr ""
+"import org.keycloak.admin.client.Keycloak;\n"
+"import org.keycloak.representations.idm.RealmRepresentation;\n"
+"...\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
 "Keycloak keycloak = Keycloak.getInstance(\n"
 "    \"http://localhost:8080/auth\",\n"
 "    \"master\",\n"
@@ -160,4 +163,4 @@ msgstr ""
 msgid ""
 "Complete Javadoc for the admin client is available at "
 "{apidocs_link}[{apidocs_name}]."
-msgstr "管理クライアントの完全なJavaのドキュメントは、{apidocs_link}[{apidocs_name}]を参照ください。"
+msgstr "管理クライアントの完全なJavaのドキュメントは、 {apidocs_link}[{apidocs_name}] を参照ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/admin-rest-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__admin-rest-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
