### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -1642,8 +1642,8 @@ msgid ""
 "To clear the caches, see "
 "{adminguide_clearcache_link}[{adminguide_clearcache_name}]."
 msgstr ""
-"キャッシュをクリアするには、{adminguide_clearcache_link} "
-"[{adminguide_clearcache_name}]を参照してください。"
+"キャッシュをクリアするには、 {adminguide_clearcache_link} [{adminguide_clearcache_name}] "
+"を参照してください。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -164,7 +164,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "For more details, see <<Modes>>."
-msgstr "詳細は、<<Modes>>を参照してください。"
+msgstr "詳細は、<<モード>>を参照してください。"
 
 #. type: Title ====
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -1475,9 +1475,8 @@ msgstr ""
 "**管理者による手作業** - 管理者は `jconsole` "
 "または他のツールを使用して、いくつかのJMX操作を実行することで、手動で特定のサイトをオフラインにすることができます。これは、特に停止が計画されている場合に役立ちます。"
 " `jconsole` またはCLIを使用すると、 `jdg1` サーバーに接続し、 `site2` "
-"をオフラインにすることができます。この詳細については、 https：//access.redhat.com/documentation/en-"
-"us/red_hat_jboss_data_grid/7.1/html/administration_and_configuration_guide/set_up_cross_datacenter_replication#taking_a_site_offline"
-" [JDGドキュメント] のリンクを参照してください。\n"
+"をオフラインにすることができます。この詳細については、 link:https://access.redhat.com/documentation/en-"
+"us/red_hat_jboss_data_grid/7.1/html/administration_and_configuration_guide/set_up_cross_datacenter_replication#taking_a_site_offline[JDGドキュメント]のリンクを参照してください。\n"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -1476,7 +1476,7 @@ msgstr ""
 "または他のツールを使用して、いくつかのJMX操作を実行することで、手動で特定のサイトをオフラインにすることができます。これは、特に停止が計画されている場合に役立ちます。"
 " `jconsole` またはCLIを使用すると、 `jdg1` サーバーに接続し、 `site2` "
 "をオフラインにすることができます。この詳細については、 link:https://access.redhat.com/documentation/en-"
-"us/red_hat_jboss_data_grid/7.1/html/administration_and_configuration_guide/set_up_cross_datacenter_replication#taking_a_site_offline[JDGドキュメント]のリンクを参照してください。\n"
+"us/red_hat_jboss_data_grid/7.1/html/administration_and_configuration_guide/set_up_cross_datacenter_replication#taking_a_site_offline[JDGドキュメント]を参照してください。\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
