### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -215,8 +215,8 @@ msgid ""
 "obtain one for free at http://www.cacert.org[cacert.org].  You'll have to do"
 " a little set up first before doing this though."
 msgstr ""
-"第三者署名証明書が必要だが用意していない場合、http://www.cacert.org[cacert.org]で無料で取得することができます。しかしこの方法で取得する前に、少し設定が必要になります。"
-" "
+"第三者署名証明書が必要だが用意していない場合、 http://www.cacert.org[cacert.org] "
+"で無料で取得することができます。しかしこの方法で取得する前に、少し設定が必要になります。 "
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:70


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
