### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -51,7 +51,7 @@ msgid ""
 "work with earlier versions of Fuse."
 msgstr ""
 "サポートされているFuseのバージョンは{fuseVersion}のみです。以前のバージョンのFuseを使用している場合、一部の機能が正しく動作しない可能性があります。特に、"
-" http://hawt.io [Hawtio]との統合は、Fuseの以前のバージョンでは機能しません。"
+" http://hawt.io[Hawtio] との統合は、Fuseの以前のバージョンでは機能しません。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:15


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
