### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -59,7 +59,7 @@ msgstr ""
 "利用レルムの{project_name}管理コンソールにクライアントを作成します。たとえば、{project_name}の `demo` "
 "レルムでクライアント `hawtio-client` を作成し、アクセス・タイプとして `public` を指定し、Hawtio: "
 "\\http://localhost:8181/hawtio/*を指すリダイレクトURIを指定します。また、対応するWeb "
-"Origin（この場合は、\\http://localhost:8181)）も設定する必要があります。"
+"Origin（この場合は、\\http://localhost:8181）も設定する必要があります。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:20


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__hawtio
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
