### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -44,7 +44,9 @@ msgid ""
 "Tip: Google provides some more information about this approach on at "
 "https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]."
 msgstr ""
-"Tip：Googleはhttps://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]で、このアプローチに関する情報を提供しています。"
+"Tip：Googleは "
+"https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]"
+" で、このアプローチに関する情報を提供しています。"
 
 #. type: Title =====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__installed-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
