### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po
@@ -97,9 +97,10 @@ msgid ""
 "\\http://myhost.com/myapp is the base URL of your client application. This "
 "URL can be used by {project_name} (see below)."
 msgstr ""
-"クライアント・アプリケーションが開始されると、\\http://myhost.com/myapp/k_jwksのようなURLを使った https"
-"://self-issued.info/docs/draft-ietf-jose-json-web-"
-"key.html[JWKS]形式の公開鍵のダウンロードが許可されます。\\http://myhost.com/myappはクライアント・アプリケーションのベースURLであることを前提としています。このURLは{project_name}により使用されます（下記参照）。"
+"クライアント・アプリケーションが開始されると、 \\http://myhost.com/myapp/k_jwks のようなURLを使った https"
+"://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWKS] "
+"形式の公開鍵のダウンロードが許可されます。 \\http://myhost.com/myapp "
+"はクライアント・アプリケーションのベースURLであることを前提としています。このURLは{project_name}により使用されます（下記参照）。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/client-authentication.adoc:29
@@ -141,7 +142,8 @@ msgstr ""
 "\\http://myhost.com/myapp/k_jwks "
 "のようなURLです（詳細は上記を参照）。クライアントはいつでもキーをローテーションさせることができるので、このオプションは最も柔軟です。{project_name}は、設定を変更することなく、必要なときに常に新しいキーをダウンロードします。より正確には、{project_name}は、未知の"
 " `kid`  （Key ID）で署名されたトークンを見ると、新しい鍵をダウンロードします。 ** "
-"クライアントの公開鍵または証明書を、PEM形式、JWK形式、またはキーストアからアップロードします。このオプションを使用すると、公開鍵はハードコードされるので、クライアントが新しい鍵ペアを生成するときに変更する必要があります。独自のキーストアがない場合は、{project_name}管理コンソールから独自のキーストアを生成することもできます。{project_name}管理コンソールの設定方法の詳細については、{adminguide_link}[{adminguide_name}]を参照してください。"
+"クライアントの公開鍵または証明書を、PEM形式、JWK形式、またはキーストアからアップロードします。このオプションを使用すると、公開鍵はハードコードされるので、クライアントが新しい鍵ペアを生成するときに変更する必要があります。独自のキーストアがない場合は、{project_name}管理コンソールから独自のキーストアを生成することもできます。{project_name}管理コンソールの設定方法の詳細については、"
+" {adminguide_link}[{adminguide_name}] を参照してください。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/client-authentication.adoc:38


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__client-authentication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
