### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -43,9 +43,10 @@ msgid ""
 "JavaScript apps — the goal was to be flexible enough to integrate with "
 "frameworks like https://expressjs.com/[Express.js]."
 msgstr ""
-"{project_name}は、サーバー・サイドのJavaScriptアプリケーションを保護するために、 "
-"https://github.com/senchalabs/connect[Connect]の上に構築されたNode.jsアダプターを提供します。目標は、"
-" https://expressjs.com/[Express.js]などのフレームワークと統合するのに十分な柔軟性を得ることです。"
+"{project_name}は、サーバーサイドのJavaScriptアプリケーションを保護するために、 "
+"https://github.com/senchalabs/connect[Connect] "
+"の上に構築されたNode.jsアダプターを提供します。目標は、 https://expressjs.com/[Express.js] "
+"などのフレームワークと統合するのに十分な柔軟性を得ることです。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:9
@@ -54,9 +55,9 @@ msgid ""
 "/keycloak-connect[ {project_name} organization] and the source is available "
 "at https://github.com/keycloak/keycloak-nodejs-connect[GitHub]."
 msgstr ""
-"ライブラリは https://www.npmjs.com/package/keycloak-"
-"connect[{project_name}から直接ダウンロードすることができ、ソースは https://github.com/keycloak"
-"/keycloak-nodejs-connect[GitHub]で利用可能です。"
+"ライブラリーは https://www.npmjs.com/package/keycloak-connect[{project_name} "
+"organization] から直接ダウンロードすることができ、ソースは https://github.com/keycloak/keycloak-"
+"nodejs-connect[GitHub] で利用可能です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:12
@@ -87,7 +88,7 @@ msgid ""
 "Assuming you've already installed https://nodejs.org[Node.js], create a "
 "folder for your application:"
 msgstr ""
-"すでに https://nodejs.org[Node.js]がインストールされていると仮定して、アプリケーション用のフォルダーを作成します。"
+"すでに https://nodejs.org[Node.js] がインストールされていると仮定して、アプリケーション用のフォルダーを作成します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:20
@@ -224,8 +225,8 @@ msgid ""
 "`store` parameter, passing in the actual session store that `express-"
 "session` is using."
 msgstr ""
-"認証のために、Webセッションを使用してサーバー・サイドの状態を管理する場合は、少なくとも `store` パラメータで `Keycloak(...)`"
-" を初期化し、実際のセッション・ストアで `express-session` 使用する必要があります。"
+"認証のために、Webセッションを使用してサーバーサイドの状態を管理する場合は、少なくとも `store` パラメータで `Keycloak(...)` "
+"を初期化し、実際のセッションストアで `express-session` 使用する必要があります。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:94
@@ -247,7 +248,7 @@ msgstr "    var keycloak = new Keycloak({ store: memoryStore });\n"
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:97
 #, no-wrap
 msgid "Passing a custom scope value"
-msgstr "カスタム・スコープ値を渡す"
+msgstr "カスタムスコープ値を渡す"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:100
@@ -317,7 +318,7 @@ msgstr "    app.get( '/complain', keycloak.protect(), complaintHandler );\n"
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:126
 #, no-wrap
 msgid "Role-based authorization"
-msgstr "ロール・ベースの認可"
+msgstr "ロールベースの認可"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:129
@@ -350,7 +351,7 @@ msgstr ""
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:141
 msgid "To secure a resource with a realm role:"
-msgstr "レルム・ロールを使用してリソースを保護するには次のようにします。"
+msgstr "レルムロールを使用してリソースを保護するには次のようにします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/nodejs-adapter.adoc:144


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
