### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po
@@ -151,9 +151,9 @@ msgid ""
 " not use together with `forceAuthentication` as they are opposite. This "
 "setting is _OPTIONAL_.  Default value is `false`."
 msgstr ""
-"SAMLクライアントは、IdPにログインしていなくても、ユーザーに認証を要求しないようにすることができます。その場合は、 "
-"`true`に設定してください。 `forceAuthentication` と反対の設定なため一緒に使用しないでください。この設定は "
-"_OPTIONAL_ です。デフォルト値は `false` です。"
+"SAMLクライアントは、IdPにログインしていなくても、ユーザーに認証を要求しないようにすることができます。その場合は、 `true` "
+"に設定してください。 `forceAuthentication` と反対の設定なため一緒に使用しないでください。この設定は _OPTIONAL_ "
+"です。デフォルト値は `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:48


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
