### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -153,7 +153,7 @@ msgstr ""
 msgid ""
 "For more information about the Evaluation API see the "
 "{apidocs_link}[JavaDocs]."
-msgstr "評価APIの詳細については、{apidocs_link}[JavaDocs]を参照してください。"
+msgstr "評価APIの詳細については、 {apidocs_link}[JavaDocs] を参照してください。"
 
 #. type: Title ==
 #: source/authorization_services/topics/policy-evaluation-api.adoc:49


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-evaluation-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
