### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -143,8 +143,8 @@ msgid ""
 "link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more details"
 " on how to make things more secure if you are uncomfortable with that setup."
 msgstr ""
-"ユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
-"を実行中のスタンドアロン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイルの許可がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
+"ここでユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
+"を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
 
 #. type: Title ===
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:47

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -63,7 +63,7 @@ msgid ""
 "especially useful when combined with scripting."
 msgstr ""
 "設定変更は、手作業で編集するだけでなく、 _jboss-cli_ "
-"toolツールを使用しコマンドを発行して行うこともできます。CLIを使用すると、サーバーをローカルまたはリモートで設定することもできます。スクリプティングと組み合わせると特に便利です。"
+"ツールを使用しコマンドを発行して行うこともできます。CLIを使用すると、サーバーをローカルまたはリモートで設定することもできます。スクリプティングと組み合わせると特に便利です。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:10
@@ -88,7 +88,7 @@ msgstr "> ...\\bin\\jboss-cli.bat\n"
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:24
 #: source/server_installation/topics/manage.adoc:28
 msgid "This will bring you to a prompt like this:"
-msgstr "これを実行すると、以下のようなプロンプトが表示されます。"
+msgstr "これを実行すると、以下のようにプロンプトが表示されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:25


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
