### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
@@ -109,7 +109,7 @@ msgid ""
 " on how to make things more secure if you are uncomfortable with that setup."
 msgstr ""
 "ここでユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
-"を実行中のスタンドアロン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
+"を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
 
 #. type: Title ==
 #: source/server_installation/topics/manage.adoc:3


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__manage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
