### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -49,9 +49,9 @@ msgid ""
 "_org/postgresql/main_. Copy your database driver JAR into this directory and"
 " create an empty _module.xml_ file within it too."
 msgstr ""
-" {project_name}の配布物の _.../modules/_ "
+"{project_name}の配布物の _.../modules/_ "
 "ディレクトリ内で、モジュール定義を保持するディレクトリ構造を作成する必要があります。規約では、ディレクトリ構造の名前にJDBCドライバーのJavaパッケージ名を使用します。PostgreSQLの場合、"
-" _org/postgresql/main_  ディレクトリを作成します。このディレクトリにデータベースドライバーのJARをコピーし、その中に空の "
+" _org/postgresql/main_ ディレクトリを作成します。このディレクトリにデータベースドライバーのJARをコピーし、その中に空の "
 "_module.xml_ ファイルも作成します。"
 
 #. type: Block title


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__jdbc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
