### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -23,7 +23,7 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くおすすめします。\n"
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くお勧めします。\n"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:10

--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,7 +50,7 @@ msgstr "all requests"
 #: source/server_installation/topics/network/https.adoc:19
 #: source/server_admin/topics/realms/ssl.adoc:28
 msgid "{project_name} requires SSL for all IP addresses."
-msgstr "{project_name}では、すべてのIPアドレスに対してSSLが必要です。"
+msgstr "{project_name}はすべてのIPアドレスに対してSSLを要求します。"
 
 #. type: Block title
 #: source/server_admin/topics/login-settings/forgot-password.adoc:7

--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +23,7 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーの代わりにリバースプロキシ上のいずれかでSSLを有効にすることを強くお勧めします。\n"
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くおすすめします。\n"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:10


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
