### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -26,8 +26,8 @@ msgid ""
 " `false`."
 msgstr ""
 "{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
-"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、 本番環境では "
-"*決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、プロダクション環境では"
+" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
 #: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:164

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -137,8 +137,8 @@ msgid ""
 msgstr ""
 "{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
 "に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。 "
-"SSL証明書の検証が一部無効となるため、この設定は開発時にのみ使用すべきで、本番環境では *決して使用してはいけません* 。これは _OPTIONAL_"
-" です。デフォルトは `false` です。"
+"SSL証明書の検証が一部無効となるため、この設定は開発時にのみ使用すべきで、プロダクション環境では *決して使用してはいけません* 。これは "
+"_OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:52


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_httpclient_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
