### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
@@ -34,7 +34,7 @@ msgstr "`/WEB-INF/web.xml` ファイルで、次のように必要なものを�
 
 #. type: Plain text
 msgid "security constraints in the <security-constraint> element"
-msgstr "<security-constraint>要素のセキュリティ制約"
+msgstr "<security-constraint>要素のセキュリティー制約"
 
 #. type: Plain text
 msgid "login configuration in the <login-config> element"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
@@ -22,7 +22,7 @@ msgstr "例："
 #. type: Title =====
 #, no-wrap
 msgid "Securing a Classic WAR Application"
-msgstr "クラシックWARアプリケーションのセキュリティ保護"
+msgstr "クラシックWARアプリケーションのセキュリティー保護"
 
 #. type: Plain text
 msgid "The needed steps to secure your WAR application are:"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
@@ -171,7 +171,7 @@ msgid ""
 "to make this file available externally as described in "
 "xref:config_external_adapter[Configuring the External Adapter]."
 msgstr ""
-"WARの `/WEB-INF/` ディレクトリ内に、新しいファイル `keycloak.json` "
+"WARの `/WEB-INF/` ディレクトリー内に、新しいファイル `keycloak.json` "
 "を作成します。この設定ファイルの形式は、<<_java_adapter_config,Javaアダプターの設定>>のセクションで説明しています。xref:config_external_adapter[外部アダプターの設定]で説明されているように、外部でこのファイルを使用することもできます。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
@@ -26,7 +26,7 @@ msgstr "クラシックWARアプリケーションのセキュリティー保護
 
 #. type: Plain text
 msgid "The needed steps to secure your WAR application are:"
-msgstr "WARアプリケーションを保護するために必要な手順は次のとおりです。"
+msgstr "WARアプリケーションをセキュリティー保護するために必要な手順は次のとおりです。"
 
 #. type: Plain text
 msgid "In the `/WEB-INF/web.xml` file, declare the necessary:"
@@ -42,7 +42,7 @@ msgstr "<login-config>要素のログイン設定"
 
 #. type: Plain text
 msgid "security roles in the <security-role> element."
-msgstr "<security-role>要素のセキュリティ・ロール。"
+msgstr "<security-role>要素のセキュリティー・ロール。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
@@ -171,8 +171,8 @@ msgid ""
 "to make this file available externally as described in "
 "xref:config_external_adapter[Configuring the External Adapter]."
 msgstr ""
-"WARの `/WEB-INF/` ディレクトリー内に、新しいファイル `keycloak.json` "
-"を作成します。この設定ファイルの形式は、<<_java_adapter_config,Javaアダプターの設定>>のセクションで説明しています。xref:config_external_adapter[外部アダプターの設定]で説明されているように、外部でこのファイルを使用することもできます。"
+"WARの `/WEB-INF/` ディレクトリー内に、新しい `keycloak.json` "
+"ファイルを作成します。この設定ファイルの形式は、<<_java_adapter_config,Javaアダプターの設定>>のセクションで説明しています。xref:config_external_adapter[外部アダプターの設定]で説明されているように、外部でこのファイルを使用することもできます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po
@@ -253,7 +253,7 @@ msgid ""
 "`<your_web_context>-keycloak.json`."
 msgstr ""
 "そのコンポーネントは、 `keycloak.config` または `karaf.etc` "
-"のjavaプロパティを使って基本フォルダーを検索し、設定を探します。そして、見つけたフォルダーの中で "
+"のjavaプロパティーを使って基本フォルダーを検索し、設定を探します。そして、見つけたフォルダーの中で "
 "`<your_web_context>-keycloak.json` というファイルを探します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/classic-war.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__classic-war
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
