### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -199,7 +199,7 @@ msgid ""
 "the blueprint configuration file."
 msgstr ""
 "プロジェクト内に `WEB-INF` "
-"ディレクトリ（プロジェクトがWebアプリケーションでない場合でも）を用意し、<<_fuse_adapter_classic_war,クラシックWARアプリケーション>>のセクションのように"
+"ディレクトリー（プロジェクトがWebアプリケーションでない場合でも）を用意し、<<_fuse_adapter_classic_war,クラシックWARアプリケーション>>のセクションのように"
 " `/WEB-INF/jetty-web.xml` と `/WEB-INF/keycloak.json` ファイルを作成する必要があります"
 "。security-constraintsがblueprint設定ファイルで宣言されているので、 `web.xml` ファイルは必要ありません。"
 

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -46,7 +46,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:3
 #, no-wrap
 msgid "Securing a Servlet Deployed as an OSGI Service"
-msgstr "OSGIサービスとしてデプロイされたサーブレットのセキュリティ保護"
+msgstr "OSGIサービスとしてデプロイされたサーブレットのセキュリティー保護"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:6

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -62,7 +62,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:8
 msgid ""
 "To secure your servlet with {project_name}, complete the following steps:"
-msgstr "{project_name}でサーブレットを保護するには、次の手順を実行します。"
+msgstr "{project_name}でサーブレットをセキュリティー保護するには、次の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:11

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -74,7 +74,7 @@ msgid ""
 "  An example configuration:"
 msgstr ""
 "{project_name}はPaxWebIntegrationServiceを提供します。これにより、jetty-"
-"web.xmlを注入し、アプリケーションのセキュリティ制約を設定できます。アプリケーション内の `OSGI-"
+"web.xmlを注入し、アプリケーションのセキュリティー制約を設定できます。アプリケーション内の `OSGI-"
 "INF/blueprint/blueprint.xml` "
 "ファイルでそのようなサービスを宣言する必要があります。サーブレットはそれに依存する必要があることに注意してください。設定例は次のとおりです。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__servlet-whiteboard
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
