### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
@@ -253,7 +253,7 @@ msgstr ""
 msgid ""
 "The way to configure the integration mechanism depends on the Camel "
 "component for which you configure your RestDSL-defined routes."
-msgstr "統合メカニズムを設定する方法は、RestDSLで定義されたルートを設定するCamelコンポーネントによって異なります。"
+msgstr "統合機構を設定する方法は、RestDSLで定義されたルートを設定するCamelコンポーネントによって異なります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
@@ -34,10 +34,10 @@ msgid ""
 "roles, security constraint mappings, and {project_name} adapter "
 "configuration might differ slightly depending on your environment and needs."
 msgstr ""
-"`KeycloakJettyAuthenticator` とsecurityHandlerを追加し、適切なセキュリティ制約を注入することで、 "
+"`KeycloakJettyAuthenticator` とsecurityHandlerを追加し、適切なセキュリティー制約を注入することで、 "
 "http://camel.apache.org/jetty.html[camel-jetty]コンポーネントで実装されたApache "
-"Camelエンドポイントを保護できます。 `OSGI-INF/blueprint/blueprint.xml` "
-"ファイルを、以下のような設定でCamelアプリケーションに追加できます。ロール、セキュリティ制約のマッピング、および{project_name}アダプターの設定は、ご使用の環境と必要性により若干異なる場合があります。"
+"Camelエンドポイントをセキュリティー保護できます。 `OSGI-INF/blueprint/blueprint.xml` "
+"ファイルを、以下のような設定でCamelアプリケーションに追加できます。ロール、セキュリティー制約のマッピング、および{project_name}アダプターの設定は、使用する環境と必要性により若干異なる場合があります。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
@@ -22,7 +22,7 @@ msgstr "例："
 #. type: Title =====
 #, no-wrap
 msgid "Securing an Apache Camel Application"
-msgstr "Apache Camelアプリケーションのセキュリティ保護"
+msgstr "Apache Camelアプリケーションのセキュリティー保護"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__camel
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
