### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po
@@ -17,11 +17,6 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "</beans>\n"
-msgstr "</beans>\n"
-
-#. type: delimited block -
-#, no-wrap
 msgid "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 msgstr "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 
@@ -41,7 +36,7 @@ msgstr ""
 #. type: Title =====
 #, no-wrap
 msgid "Securing an Apache CXF Endpoint on a Separate Jetty Engine"
-msgstr "独立したJettyエンジンでのApache CXFエンドポイントの保護"
+msgstr "独立したJettyエンジンでのApache CXFエンドポイントのセキュリティー保護"
 
 #. type: Plain text
 msgid ""
@@ -203,6 +198,11 @@ msgstr ""
 "    <jaxws:endpoint\n"
 "                    implementor=\"org.keycloak.example.ws.ProductImpl\"\n"
 "                    address=\"http://localhost:8282/ProductServiceCF\" depends-on=\"kc-cxf-endpoint\" />\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "</beans>\n"
+msgstr "</beans>\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__cxf-separate
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
