### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/fuse-admin.adoc:3
 #, no-wrap
 msgid "Securing Fuse Administration Services"
-msgstr "Fuse管理サービスのセキュリティ保護"
+msgstr "Fuse管理サービスのセキュリティー保護"
 
 #. type: Title ======
 #: source/securing_apps/topics/oidc/java/fuse/fuse-admin.adoc:5

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po
@@ -218,7 +218,7 @@ msgid ""
 "jmxRealm property to:"
 msgstr ""
 "`$FUSE_HOME/etc/org.apache.karaf.management.cfg` ファイルで、 `jmxRealm` "
-"プロパティを次のように変更します。"
+"プロパティーを次のように変更します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/fuse-admin.adoc:72

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po
@@ -62,7 +62,7 @@ msgid ""
 "In the `$FUSE_HOME/etc/org.apache.karaf.shell.cfg` file, update or specify "
 "this property:"
 msgstr ""
-"`$FUSE_HOME/etc/org.apache.karaf.shell.cfg` ファイルで、次のとおりにこのプロパティを更新または指定します。"
+"`$FUSE_HOME/etc/org.apache.karaf.shell.cfg` ファイルで、次のとおりにこのプロパティーを更新または指定します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/fuse-admin.adoc:21


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/fuse-admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__fuse-admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
