### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -31,7 +31,7 @@ msgstr "{project_name}を使用して、Hawtio管理コンソールをセキュ�
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:8
 msgid "Add these properties to the `$FUSE_HOME/etc/system.properties` file:"
-msgstr "これらのプロパティを `$FUSE_HOME/etc/system.properties` ファイルに追加します。"
+msgstr "これらのプロパティーを `$FUSE_HOME/etc/system.properties` ファイルに追加します。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:15

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -26,7 +26,7 @@ msgstr "Hawtio管理コンソールのセキュリティー保護"
 msgid ""
 "To secure the Hawtio Administration Console with {project_name}, complete "
 "the following steps:"
-msgstr "{project_name}を使用して、Hawtio管理コンソールをセキュリティ保護するには、以下の手順を実行します。"
+msgstr "{project_name}を使用して、Hawtio管理コンソールをセキュリティー保護するには、以下の手順を実行します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:8

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -159,7 +159,7 @@ msgstr ""
 msgid ""
 "Go to http://localhost:8181/hawtio and log in as a user from your "
 "{project_name} realm."
-msgstr "http://localhost:8181/hawtioに移動し、{project_name}のレルムからユーザーとしてログインします。"
+msgstr "http://localhost:8181/hawtio に移動し、{project_name}のレルムからユーザーとしてログインします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:58

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -71,11 +71,11 @@ msgid ""
 " created in the previous step. This file is used by the client (Hawtio "
 "Javascript application) side."
 msgstr ""
-"`$FUSE_HOME/etc` ディレクトリに `keycloak-hawtio-client.json` "
+"`$FUSE_HOME/etc` ディレクトリーに `keycloak-hawtio-client.json` "
 "ファイルを作成します。このファイルは、以下の例のような内容で作成します。{project_name}環境に応じて、 `realm` 、 "
-"`resource` 、 `auth-server-url` の各プロパティを変更してください。 `resource` "
-"プロパティは前のステップで作成されたクライアントを指し示さなければなりません。このファイルは、クライアント（Hawtio "
-"Javascriptアプリケーション）側で使用されます。"
+"`resource` 、 `auth-server-url` の各プロパティーを変更してください。 `resource` "
+"プロパティーは前のステップで作成されたクライアントを指し示さなければなりません。このファイルは、クライアント（Hawtio "
+"JavaScriptアプリケーション）側で使用されます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:30

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:3
 #, no-wrap
 msgid "Securing the Hawtio Administration Console"
-msgstr "Hawtio管理コンソールのセキュリティ保護"
+msgstr "Hawtio管理コンソールのセキュリティー保護"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:6

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -175,7 +175,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:59
 #, no-wrap
 msgid "Securing Hawtio on {fuseHawtioEAPVersion}"
-msgstr "{fuseHawtioEAPVersion}上のHawtioのセキュリティ保護"
+msgstr "{fuseHawtioEAPVersion}上のHawtioのセキュリティー保護"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:62
@@ -190,7 +190,7 @@ msgid ""
 "Set up {project_name} as described in the previous section, Securing the "
 "Hawtio Administration Console. It is assumed that:"
 msgstr ""
-"前のセクション（Hawtio管理コンソールをセキュリティ保護する）で説明したように、{project_name}を設定します。次のように仮定します。"
+"前のセクション（Hawtio管理コンソールをセキュリティー保護する）で説明したように、{project_name}を設定します。次のように仮定します。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:65
@@ -356,4 +356,5 @@ msgid ""
 "Access Hawtio at http://localhost:8181/hawtio. It is secured by "
 "{project_name}."
 msgstr ""
-"Hawtio（http://localhost:8181/hawtio）へアクセスして下さい。 {project_name}によって保護されています。"
+"Hawtio（http://localhost:8181/hawtio）へアクセスして下さい。 "
+"{project_name}によってセキュリティー保護されています。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -106,9 +106,9 @@ msgid ""
 "environment. This file is used by the adapters on the server (JAAS Login "
 "module) side."
 msgstr ""
-"`$FUSE_HOME/etc` ディレクトリに `keycloak-hawtio.json` "
+"`$FUSE_HOME/etc` ディレクトリーに `keycloak-hawtio.json` "
 "ファイルを作成します。このファイルは、以下の例のような内容です。{project_name}の環境に応じて `realm` と `auth-"
-"server-url` プロパティを変更してください。このファイルは、サーバー（JAASログイン・モジュール）側のアダプターによって使用されます。"
+"server-url` プロパティーを変更してください。このファイルは、サーバー（JAASログイン・モジュール）側のアダプターによって使用されます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:45


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__hawtio
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
