### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
@@ -56,7 +56,7 @@ msgid ""
 " or 7 depending on your Red Hat Enterprise Linux version."
 msgstr ""
 "Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
-"7.0リポジトリをサブスクライブします。Red Hat Enterprise "
+"7.0リポジトリーをサブスクライブします。Red Hat Enterprise "
 "Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
 
 #. type: delimited block -
@@ -466,7 +466,7 @@ msgstr "このセクションでは、直接WARパッケージ内に設定を追
 msgid ""
 "The first thing you must do is create a `keycloak.json` adapter "
 "configuration file within the `WEB-INF` directory of your WAR."
-msgstr "まず、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
+msgstr "まず、WARの `WEB-INF` ディレクトリーに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -481,7 +481,7 @@ msgid ""
 "your URLs."
 msgstr ""
 "次に、 `web.xml` 内の `auth-method` を `KEYCLOAK` "
-"に設定する必要があります。また、標準のサーブレット・セキュリティを使用して、URLのロール・ベース制約を指定する必要があります。"
+"に設定する必要があります。また、標準のサーブレット・セキュリティーを使用して、URLのロール・ベース制約を指定する必要があります。"
 
 #. type: Plain text
 msgid "Here's an example:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
