### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -49,7 +49,7 @@ msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr ""
-"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
+"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -15,24 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title =====
-#, no-wrap
-msgid "Required Per WAR Configuration"
-msgstr "WARごとに必要な設定"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
-msgstr ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -57,6 +39,11 @@ msgstr ""
 msgid "Adapter Installation"
 msgstr "アダプターのインストール"
 
+#. type: Title =====
+#, no-wrap
+msgid "Required Per WAR Configuration"
+msgstr "WARごとに必要な設定"
+
 #. type: Plain text
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
@@ -77,6 +64,19 @@ msgid ""
 msgstr ""
 "最後に、URLに対してロールベース制約を指定するために、 `login-config` "
 "と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
+msgstr ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -108,7 +108,7 @@ msgid ""
 "then have to provide some extra configuration in each WAR you deploy to "
 "Tomcat.  Let's go over these steps."
 msgstr ""
-"Tomcat 6、7、8にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 6、7、8 "
+"Tomcat 6、7、8にデプロイされたWARアプリケーションをセキュリティー保護するには、Keycloak Tomcat 6、7、8 "
 "アダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -55,7 +55,7 @@ msgstr ""
 msgid ""
 "Next you must create a `keycloak.json` adapter config file within the `WEB-"
 "INF` directory of your WAR."
-msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
+msgstr "次に、WARの `WEB-INF` ディレクトリーに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -126,8 +126,8 @@ msgid ""
 "Keycloak adapter is implemented as a Valve and valve code must reside in "
 "Tomcat's main lib/ directory."
 msgstr ""
-"アダプターの配布物をTomcatの `lib/` ディレクトリに解凍する必要があります。WEB-"
-"INF/libディレクトリ内にアダプターのjarを含めても動作しません！KeycloakアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリに存在する必要があります。"
+"アダプターの配布物をTomcatの `lib/` ディレクトリーに解凍する必要があります。WEB-"
+"INF/libディレクトリー内にアダプターのjarを含めても動作しません！KeycloakアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリーに存在する必要があります。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -63,7 +63,7 @@ msgid ""
 "security to specify role-base constraints on your URLs.  Here's an example:"
 msgstr ""
 "最後に、URLに対してロールベース制約を指定するために、 `login-config` "
-"と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
+"と標準のサーブレット・セキュリティーの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__tomcat-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
