### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -50,7 +50,7 @@ msgstr ""
 #. type: Title =====
 #, no-wrap
 msgid "Required Per WAR Configuration"
-msgstr "WAR設定ごとに必要"
+msgstr "WARごとに必要な設定"
 
 #. type: Title ====
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -235,8 +235,8 @@ msgid ""
 "yourwar.xml.  Jetty should pick it up.  In this mode, you'll have to declare"
 " keycloak.json configuration directly within the xml file."
 msgstr ""
-"keycloakでWARを保護するために、WARをオープンする必要はありません。代わりに、yourwar"
-".xmlという名前でwebappsディレクトリにjetty-"
+"KeycloakでWARをセキュリティー保護するために、WARをオープンする必要はありません。代わりに、yourwar"
+".xmlという名前でwebappsディレクトリーにjetty-"
 "web.xmlファイルを作成します。Jettyはそれをピックアップします。このモードでは、keycloak.jsonの設定をxmlファイル内で直接宣言する必要があります。"
 
 #. type: Plain text
@@ -245,7 +245,7 @@ msgid ""
 "security to specify role-base constraints on your URLs.  Here's an example:"
 msgstr ""
 "最後に、URLに対してロールベース制約を指定するために、 `login-config` "
-"と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
+"と標準のサーブレット・セキュリティーの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -104,7 +104,7 @@ msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr ""
-"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティ保護する方法について説明します。"
+"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -15,24 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title =====
-#, no-wrap
-msgid "Required Per WAR Configuration"
-msgstr "WAR設定ごとに必要"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
-msgstr ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -65,6 +47,11 @@ msgid ""
 msgstr ""
 "アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
+#. type: Title =====
+#, no-wrap
+msgid "Required Per WAR Configuration"
+msgstr "WAR設定ごとに必要"
+
 #. type: Title ====
 #, no-wrap
 msgid "Jetty 9.x Adapters"
@@ -90,8 +77,8 @@ msgid ""
 msgstr ""
 "Jetty 9.x用の配布物をJetty "
 "9.xのlink:https://www.eclipse.org/jetty/documentation/current/startup-base-"
-"and-home.html[base directory]に解凍する必要があります。WEB-"
-"INF/libディレクトリ内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base`です。"
+"and-home.html[baseディレクトリー]に解凍する必要があります。WEB-"
+"INF/libディレクトリー内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base` です。"
 
 #. type: delimited block -
 #, no-wrap
@@ -259,6 +246,19 @@ msgid ""
 msgstr ""
 "最後に、URLに対してロールベース制約を指定するために、 `login-config` "
 "と標準のサーブレット・セキュリティの両方を指定する必要があります。例を次に示します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
+msgstr ""
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -144,7 +144,7 @@ msgstr ""
 msgid ""
 "Next you must create a `keycloak.json` adapter config file within the `WEB-"
 "INF` directory of your WAR."
-msgstr "次に、WARの `WEB-INF` ディレクトリに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
+msgstr "次に、WARの `WEB-INF` ディレクトリーに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jetty9-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
