### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po
@@ -51,14 +51,14 @@ msgid ""
 "Unlike the other Keycloak Adapters, you should not configure your security "
 "in web.xml.  However, keycloak.json is still required."
 msgstr ""
-"他のKeycloakアダプターとは異なり、web.xmlにセキュリティを設定しないでください。ただし、 `keycloak.json` "
+"他のKeycloakアダプターとは異なり、web.xmlにセキュリティーを設定しないでください。ただし、 `keycloak.json` "
 "は依然として必要です。"
 
 #. type: Plain text
 msgid ""
 "Add Keycloak Spring Security adapter as a dependency to your Maven POM or "
 "Gradle build."
-msgstr "MavenのPOMまたはGradleのbuildに依存するKeycloak Spring Securityアダプターを追加してください。"
+msgstr "MavenのPOMまたはGradleのbuildに、依存するKeycloak Spring Securityアダプターを追加してください。"
 
 #. type: delimited block -
 #, no-wrap
@@ -84,7 +84,7 @@ msgstr "Spring Securityの設定"
 msgid ""
 "The Keycloak Spring Security adapter takes advantage of Spring Security's "
 "flexible security configuration syntax."
-msgstr "Keycloak Spring Securityアダプターは、Spring Securityの柔軟なセキュリティ設定構文を利用します。"
+msgstr "Keycloak Spring Securityアダプターは、Spring Securityの柔軟なセキュリティー設定構文を利用します。"
 
 #. type: Title ======
 #, no-wrap
@@ -98,9 +98,10 @@ msgid ""
 "The implementation allows customization by overriding methods.\n"
 "While its use is not required, it greatly simplifies your security context configuration.\n"
 msgstr ""
-"Keycloakは、 `KeycloakWebSecurityConfigurerAdapter` を、 https://docs.spring.io/spring-security/site/docs/4.0.x/apidocs/org/springframework/security/config/annotation/web/WebSecurityConfigurer.html[WebSecurityConfigurer]を作成するための便利な基本クラスとして提供します。\n"
-"この実装では、メソッドのオーバーライドによるカスタマイズが可能です。\n"
-"その使用は必須ではありませんが、セキュリティ・コンテキストの設定が大幅に簡素化されます。\n"
+"Keycloakは、https://docs.spring.io/spring-"
+"security/site/docs/4.0.x/apidocs/org/springframework/security/config/annotation/web/WebSecurityConfigurer.html[WebSecurityConfigurer]を作成するための便利な基本クラスとして、"
+" `KeycloakWebSecurityConfigurerAdapter` "
+"を提供します。この実装では、メソッドのオーバーライドによるカスタマイズが可能です。その使用は必須ではありませんが、セキュリティー・コンテキストの設定が大幅に簡素化されます。\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -209,7 +210,7 @@ msgstr ""
 "`@KeycloakConfiguration` アノテーションは、Spring "
 "Securityで{project_name}を統合するために必要なすべてのアノテーションを定義するメタ・データ・アノテーションです。複雑なSpring"
 " Securityの設定をする場合は、 `@KeycloakConfiguration` "
-"アノテーションを見て、独自のカスタム・メタ・アノテーションを作成してください。もしくは、{project_name}アダプター用の特定のSpringアノテーションを使用してください。"
+"アノテーションを参照して、独自のカスタム・メタ・アノテーションを作成してください。もしくは、{project_name}アダプター用の特定のSpringアノテーションを使用してください。"
 
 #. type: Title ======
 #, no-wrap
@@ -380,7 +381,7 @@ msgstr ""
 #. type: Title =====
 #, no-wrap
 msgid "Naming Security Roles"
-msgstr "セキュリティ・ロールの命名"
+msgstr "セキュリティー・ロールの命名"
 
 #. type: Plain text
 msgid ""
@@ -416,7 +417,7 @@ msgid ""
 "function correctly."
 msgstr ""
 "クライアント間の通信を簡素化するために、Keycloakはベアラー・トークン認証を処理するSpringの `RestTemplate` "
-"の拡張を提供します。この機能を有効にするには、セキュリティ設定で `KeycloakRestTemplate` "
+"の拡張を提供します。この機能を有効にするには、セキュリティー設定で `KeycloakRestTemplate` "
 "を追加する必要があります。正しく機能するには、プロトタイプとしてスコープを設定する必要があることに注意してください。"
 
 #. type: Plain text
@@ -609,7 +610,7 @@ msgid ""
 msgstr ""
 "Spring Bootは、フィルターBeanをWebアプリケーション・コンテキストに登録しようとします。そのため、Spring "
 "Boot環境でKeycloak Spring "
-"Securityアダプターを実行する場合は、Keycloakフィルターが2回登録されないように、セキュリティ設定に2つの "
+"Securityアダプターを実行する場合は、Keycloakフィルターが2回登録されないように、セキュリティー設定に2つの "
 "``FilterRegistrationBean`` を追加する必要があります。"
 
 #. type: delimited block -

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po
@@ -44,7 +44,7 @@ msgid ""
 msgstr ""
 "Spring "
 "SecurityとKeycloakでアプリケーションを保護するには、このアダプターをプロジェクトのdependencyに追加します。Spring "
-"Securityの設定ファイルにいくつか追加のBeanを用意し、パイプラインにKeycloakセキュリティ・フィルターを追加する必要があります。"
+"Securityの設定ファイルにいくつか追加のBeanを用意し、パイプラインにKeycloakセキュリティー・フィルターを追加する必要があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__spring-security-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
