### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -27,7 +27,7 @@ msgid ""
 "authentication step via the system browser."
 msgstr ""
 "{project_name}は、システム・ブラウザーを介して認証ステップを実行することによって、 `KeycloakInstalled` "
-"アダプターを介してデスクトップ（例えば、Swing、JavaFX）またはCLIアプリケーションのセキュリティ保護をサポートします。"
+"アダプターを介したデスクトップ（例えば、Swing、JavaFX）またはCLIアプリケーションのセキュリティー保護をサポートします。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -60,9 +60,9 @@ msgid ""
 "{project_name} login pages to login when the `loginDesktop()` method is "
 "called on the `KeycloakInstalled` object."
 msgstr ""
-"`desktop` バリアントでユーザーを認証するために、`KeycloakInstalled` アダプターは 、`KeycloakInstalled`"
-" オブジェクトの `loginDesktop()` "
-"メソッドが呼び出されたとき、ログインするためにユーザーが通常の{project_name}ログイン・ページを使用しているブラウザーのウィンドウを開きます。"
+"`desktop` バリアントを使用してユーザーを認証するために、 `KeycloakInstalled` "
+"アダプターはデスクトップ・ブラウザーのウィンドウを開きます。ここで `KeycloakInstalled` オブジェクトに対して "
+"`loginDesktop()` メソッドが呼び出されると、ユーザーは通常の{project_name}ログインページを使用してログインします。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -136,9 +136,8 @@ msgid ""
 "with `Standard Flow Enabled` and pass:[http://localhost:*] as an allowed "
 "`Valid Redirect URI`."
 msgstr ""
-"アプリケーションは、 `public` なOpenID Connectクライアントが `Standard Flow Enabled` "
-"として設定され、許可される `Valid Redirect URI` "
-"としてpass:[http://localhost:*]が設定される必要があります。"
+"アプリケーションは、 `Standard Flow Enabled` で `public` なOpenID Connectクライアントであり、許可される"
+" `Valid Redirect URI` としてpass:[http://localhost:*]が設定される必要があります。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__installed-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
