### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
@@ -55,7 +55,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:14
 msgid ""
 "Or, it is available in secure and insecure requests in the HttpSession:"
-msgstr "または、セキュア・セキュアでないリクエストでは以下のように `HttpSession` からセキュリティ・コンテキストを利用できます。"
+msgstr "または、セキュアでないリクエストでは以下のように `HttpSession` からセキュリティー・コンテキストを利用できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:19

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:1
 #, no-wrap
 msgid "Security Context"
-msgstr "セキュリティ・コンテキスト"
+msgstr "セキュリティー・コンテキスト"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:5

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
@@ -38,7 +38,8 @@ msgid ""
 "In servlet environments it is available in secured invocations as an "
 "attribute in HttpServletRequest:"
 msgstr ""
-"サーブレット環境では、セキュアな呼び出しで `HttpServletRequest` の属性として以下のようにセキュリティ・コンテキストを利用できます。"
+"サーブレット環境では、セキュアな呼び出しで `HttpServletRequest` "
+"の属性として以下のようにセキュリティー・コンテキストを利用できます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/adapter-context.adoc:11


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__adapter-context
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
