### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
@@ -36,7 +36,7 @@ msgstr ""
 "{project_name}の初期認可エンドポイント・リクエストは、さまざまなパラメーターをサポートしています。ほとんどのパラメータは "
 "http://openid.net/specs/openid-connect-core-"
 "1_0.html#AuthorizationEndpoint[OIDC仕様] "
-"に記述されています。一部のパラメーターは、アダプターの設定に基づいて、アダプターにより自動的に追加されます。ただし、呼び出しごとに追加できるパラメータもいくつかあります。保護されたアプリケーションURIにアクセスすると、特定のパラメーターは{project_name}認可エンドポイントにフォワードされます。"
+"に記述されています。一部のパラメーターは、アダプターの設定に基づいて、アダプターにより自動的に追加されます。ただし、呼び出しごとに追加できるパラメーターもいくつかあります。保護されたアプリケーションURIにアクセスすると、特定のパラメーターは{project_name}認可エンドポイントにフォワードされます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:10
@@ -44,7 +44,7 @@ msgid ""
 "For example, if you request an offline token, then you can open the secured "
 "application URI with the `scope` parameter like:"
 msgstr ""
-"たとえば、オフライントークンを要求する場合、以下のように `scope` パラメータを使用して保護されたアプリケーションのURIにアクセスできます。"
+"たとえば、オフライン・トークンを要求する場合、以下のように `scope` パラメーターを使用して保護されたアプリケーションのURIにアクセスできます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:14
@@ -57,7 +57,7 @@ msgstr "http://myappserver/mysecuredapp?scope=offline_access\n"
 msgid ""
 "and the parameter `scope=offline_access` will be automatically forwarded to "
 "the {project_name} authorization endpoint."
-msgstr "パラメータ `scope=offline_access` が自動的に{project_name}認可エンドポイントにフォワードされます。"
+msgstr "パラメーター `scope=offline_access` が自動的に{project_name}認可エンドポイントにフォワードされます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:19
@@ -101,7 +101,7 @@ msgid ""
 "more information see the `Identity Brokering` section in "
 "link:{adminguide_link}[{adminguide_name}]."
 msgstr ""
-"ほとんどのパラメータは http://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[OIDC仕様] に記載されています。唯一の例外はパラメータ `kc_idp_hint` "
+"ほとんどのパラメーターは http://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthorizationEndpoint[OIDC仕様] に記載されています。唯一の例外はパラメーター `kc_idp_hint` "
 "です。これは{project_name}固有で、自動的に使用するアイデンティティー・プロバイダーの名前を含んでいます。詳細はlink:{adminguide_link}[{adminguide_name}]の"
 " `アイデンティティー・ブローカリング` のセクションを参照してください。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
@@ -44,7 +44,7 @@ msgid ""
 "For example, if you request an offline token, then you can open the secured "
 "application URI with the `scope` parameter like:"
 msgstr ""
-"たとえば、オフライン・トークンを要求する場合、以下のように `scope` パラメーターを使用して保護されたアプリケーションのURIにアクセスできます。"
+"たとえば、オフライントークンを要求する場合、以下のように `scope` パラメーターを使用して保護されたアプリケーションのURIにアクセスできます。"
 
 #. type: delimited block -
 #: source/securing_apps/topics/oidc/java/params_forwarding.adoc:14


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__params_forwarding
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
