### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
@@ -46,7 +46,7 @@ msgid ""
 "be inconvenient and you may also want to select the realm based on something"
 " else than context-path."
 msgstr ""
-"さまざまなコンテキスト・パスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。しかし、これは不便かもしれませんし"
+"さまざまなコンテキストパスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。しかし、これは不便かもしれませんし"
 "、context-path以外のものに基づいてレルムを選択することもできます。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
@@ -46,8 +46,7 @@ msgid ""
 "be inconvenient and you may also want to select the realm based on something"
 " else than context-path."
 msgstr ""
-"さまざまなコンテキストパスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。しかし、これは不便かもしれませんし"
-"、context-path以外のものに基づいてレルムを選択することもできます。"
+"さまざまなコンテキストパスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。しかし、これは不便かもしれませんし、コンテキストパス以外のものに基づいてレルムを選択するようにできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:13

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po
@@ -46,8 +46,8 @@ msgid ""
 "be inconvenient and you may also want to select the realm based on something"
 " else than context-path."
 msgstr ""
-"さまざまなコンテキスト・パスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。 "
-"しかし、これは不便かもしれませんし、context-path以外のものに基づいてレルムを選択することもできます。"
+"さまざまなコンテキスト・パスに異なるアダプター設定ファイルをデプロイして、WARの複数のインスタンスを作成することができます。しかし、これは不便かもしれませんし"
+"、context-path以外のものに基づいてレルムを選択することもできます。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/multi-tenancy.adoc:13


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/multi-tenancy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__multi-tenancy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
