### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -26,7 +26,7 @@ msgstr "配布物のディレクトリー構造"
 msgid ""
 "This chapter walks you through the directory structure of the server "
 "distribution."
-msgstr "この章では、サーバー配布物のディレクトリ構造についてご説明します。"
+msgstr "この章では、サーバー配布物のディレクトリー構造についてご説明します。"
 
 #. type: Block title
 #: source/server_installation/topics/installation/directory-structure.adoc:6

--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -70,7 +70,7 @@ msgid ""
 "{project_name} in <<_domain-mode,domain mode>>."
 msgstr ""
 "{project_name}を<<_domain-"
-"mode,ドメイン・モード>>で実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
+"mode,ドメインモード>>で実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:17
@@ -96,7 +96,7 @@ msgid ""
 "  See the link:{developerguide_link}[{developerguide_name}] for more "
 "information on this."
 msgstr ""
-"Keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照ください。"
+"Keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:25
@@ -129,5 +129,5 @@ msgid ""
 "this."
 msgstr ""
 "このディレクトリーは、サーバーにより指定されたUI画面を表示するために使用されるhtml、スタイルシート、 "
-"javascriptファイルおよびイメージ画像が含まれています。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照ください。"
+"javascriptファイルおよびイメージ画像が含まれています。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 " "

--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_installation/topics/installation/directory-structure.adoc:2
 #, no-wrap
 msgid "Distribution Directory Structure"
-msgstr "配布物のディレクトリ構造"
+msgstr "配布物のディレクトリー構造"
 
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:5

--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -26,7 +26,7 @@ msgstr "配布物のディレクトリー構造"
 msgid ""
 "This chapter walks you through the directory structure of the server "
 "distribution."
-msgstr "この章では、サーバー配布物のディレクトリー構造についてご説明します。"
+msgstr "この章では、サーバー配布物のディレクトリー構造について説明します。"
 
 #. type: Block title
 #: source/server_installation/topics/installation/directory-structure.adoc:6
@@ -42,7 +42,7 @@ msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:10
 msgid "Let's examine the purpose of some of the directories:"
-msgstr "いくつかのディレクトリの目的について学んでいきましょう。"
+msgstr "いくつかのディレクトリーの目的について学んでいきましょう。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:11
@@ -70,7 +70,7 @@ msgid ""
 "{project_name} in <<_domain-mode,domain mode>>."
 msgstr ""
 "{project_name}を<<_domain-"
-"mode,ドメイン・モード>>で実行する場合の、設定ファイルとワーキング・ディレクトリが含まれています。"
+"mode,ドメイン・モード>>で実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:17
@@ -81,7 +81,7 @@ msgstr "_modules/_"
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:19
 msgid "These are all the Java libraries used by the server."
-msgstr "サーバー上で使用されるすべてのJavaライブラリです。"
+msgstr "サーバー上で使用されるすべてのJavaライブラリーです。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:21
@@ -96,7 +96,7 @@ msgid ""
 "  See the link:{developerguide_link}[{developerguide_name}] for more "
 "information on this."
 msgstr ""
-"keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]をご覧ください。"
+"Keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照ください。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:25
@@ -111,7 +111,7 @@ msgid ""
 "{project_name} in <<_standalone-mode,standalone mode>>."
 msgstr ""
 "<<_standalone-mode,standalone "
-"mode>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリは含まれません。"
+"mode>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリーは含まれません。"
 
 #. type: Labeled list
 #: source/server_installation/topics/installation/directory-structure.adoc:28
@@ -128,6 +128,6 @@ msgid ""
 "link:{developerguide_link}[{developerguide_name}] for more information on "
 "this."
 msgstr ""
-"このディレクトリは、サーバーにより指定されたUI画面を表示するために使用されるhtml、スタイルシート、 "
-"javascriptファイルおよびイメージ画像が含まれています。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることができます。詳しくは、link:{developerguide_link}[{developerguide_name}]をご覧ください。"
+"このディレクトリーは、サーバーにより指定されたUI画面を表示するために使用されるhtml、スタイルシート、 "
+"javascriptファイルおよびイメージ画像が含まれています。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照ください。"
 " "

--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -32,7 +32,7 @@ msgstr "この章では、サーバー配布物のディレクトリー構造に
 #: source/server_installation/topics/installation/directory-structure.adoc:6
 #, no-wrap
 msgid "distribution directory structure"
-msgstr "配布物のディレクトリ構造"
+msgstr "配布物のディレクトリー構造"
 
 #. type: Plain text
 #: source/server_installation/topics/installation/directory-structure.adoc:8


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__installation__directory-structure
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
