### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -63,7 +63,7 @@ msgid ""
 "especially useful when combined with scripting."
 msgstr ""
 "設定変更は、手作業で編集するだけでなく、 _jboss-cli_ "
-"ツールを使用しコマンドを発行して行うこともできます。CLIを使用すると、サーバーをローカルまたはリモートで設定することもできます。スクリプティングと組み合わせると特に便利です。"
+"ツールでコマンドを発行して行うこともできます。CLIを使用すると、サーバーをローカルでもリモートでも設定することができます。スクリプティングと組み合わせると特に便利です。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:10

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -144,7 +144,7 @@ msgid ""
 " on how to make things more secure if you are uncomfortable with that setup."
 msgstr ""
 "ここでユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
-"を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]をご覧ください。"
+"を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。"
 
 #. type: Title ===
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:47

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -215,7 +215,7 @@ msgid ""
 "_Note: to connect to a remote server, you pass the `--connect` option as "
 "well.  Use the --help option for more details._"
 msgstr ""
-"_Note: リモートサーバーに接続するには `--connect` オプションも渡します。詳しくは、 --helpオプションをご覧ください。_"
+"_Note: リモートサーバーに接続するには、 `--connect` オプションも渡します。詳しくは、 --helpオプションを参照してください。_"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:81

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -161,8 +161,8 @@ msgid ""
 "requests.  To do this, first execute the `embed` command with the config "
 "file you wish to change."
 msgstr ""
-"サーバーがアクティブではない間にスタンドアロン・サーバーと同じマシン上にコマンドが発行された場合は、サーバーをCLIに組み込み、受信要求を許可しない特殊モードに変更することができます。これを行うには、まず、変更したい設定ファイルで"
-" `embed` コマンドを実行します。"
+"サーバーがアクティブではない間にスタンドアローン・サーバーと同じマシン上にコマンドが発行された場合は、サーバーをCLIに組み込み、受信要求を許可しない特殊モードに変更することができます。これを行うには、まず、変更したい設定ファイルで"
+" `embed-server` コマンドを実行します。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:54

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -168,7 +168,7 @@ msgstr ""
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:54
 #, no-wrap
 msgid "embed"
-msgstr "embed"
+msgstr "embed-server"
 
 #. type: delimited block -
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:59

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -247,7 +247,7 @@ msgid ""
 "with CLI commands in it.  Consider a simple script that turns off theme and "
 "template caching."
 msgstr ""
-"CLIには、さまざまなスクリプト機能があります。スクリプトはCLIコマンドを含む単なるテキストファイルです。テーマとテンプレートのキャッシュをオフにする簡単なスクリプトをみていきましょう。"
+"CLIには、さまざまなスクリプト機能があります。スクリプトはCLIコマンドを含む単なるテキストファイルです。テーマとテンプレートのキャッシュをオフにする簡単なスクリプトを見ていきましょう。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:90

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -195,7 +195,7 @@ msgid ""
 "formatting your CLI commands and learning about the options available.  The "
 "GUI can also retrieve server logs from a local or remote server."
 msgstr ""
-"CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションが起動します。GUIモードは、CLIコマンドの書式を設定したりオプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
+"CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションが起動します。GUIモードは、CLIコマンドの書式を設定したり、オプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:69

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -195,7 +195,7 @@ msgid ""
 "formatting your CLI commands and learning about the options available.  The "
 "GUI can also retrieve server logs from a local or remote server."
 msgstr ""
-"CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションを起動します。GUIモードは、CLIコマンドの書式を設定したりオプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
+"CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションが起動します。GUIモードは、CLIコマンドの書式を設定したりオプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
 
 #. type: Block title
 #: source/server_installation/topics/config-subsystem/start-cli.adoc:69


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
