### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgid ""
 "  Note that in all but the first example, we use the wildcard path `**` to "
 "mean you should substitute or the path to the keycloak-server subsystem."
 msgstr ""
-"ここでは、設定タスクおよびそれらをCLIコマンドで実行する方法についてご説明します。代入すべきという意味で、またはkeycloak-"
+"ここでは、設定タスクおよびそれらをCLIコマンドで実行する方法について説明します。代入すべきという意味で、またはkeycloak-"
 "serverサブシステムという意味でワイルドカード・パス `**` を使用しています。その点はご注意ください。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
@@ -34,7 +34,7 @@ msgstr ""
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:9
 msgid "For standalone, this just means:"
-msgstr "スタンドアロンの場合、これは単に以下の意味になります。"
+msgstr "スタンドアローンの場合、これは単に以下の意味になります。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:11

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
@@ -29,7 +29,7 @@ msgid ""
 "mean you should substitute or the path to the keycloak-server subsystem."
 msgstr ""
 "ここでは、設定タスクおよびそれらをCLIコマンドで実行する方法について説明します。代入すべきという意味で、またはkeycloak-"
-"serverサブシステムという意味でワイルドカード・パス `**` を使用しています。その点はご注意ください。"
+"serverサブシステムという意味でワイルドカード・パス `**` を使用しています。その点は注意してください。"
 
 #. type: Plain text
 #: source/server_installation/topics/config-subsystem/cli-recipes.adoc:9


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__cli-recipes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
