### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +37,7 @@ msgid ""
 "classpath and the dependencies those JARs have on other modules. They are "
 "pretty simple to set up."
 msgstr ""
-"RDBMS用のJDBCドライバーJARを検索してダウンロードします。このドライバーを使用する前に、モジュールにパッケージしてサーバーにインストールする必要があります。モジュールによって、{project_name}クラスパスにロードされるJAR、およびこれらのJARが他のモジュール上に持つ依存関係が定義されます。設定は非常に簡単です。"
+"RDBMS用のJDBCドライバーのJARを検索してダウンロードします。このドライバーを使用する前に、モジュールにパッケージ化してサーバーにインストールする必要があります。モジュールによって、{project_name}のクラスパスにロードされるJAR、およびこれらのJARが他のモジュールに持つ依存関係が定義されます。設定は非常に簡単です。"
 
 #. type: Plain text
 #: source/server_installation/topics/database/jdbc.adoc:7

--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -207,7 +207,7 @@ msgid ""
 " the driver's Java class.  Here's an example of installing PostgreSQL driver"
 " that lives in the module example defined earlier in this chapter."
 msgstr ""
-"`drivers` XMLブロック内で、追加のJDBCドライバーを宣言する必要があります。それに `name` "
+"`drivers` のXMLブロック内で、追加のJDBCドライバーを宣言する必要があります。それに `name` "
 "を付けて、必要時に選択できるようにします。ドライバーのJAR用に以前作成した `module` パッケージを指す、 `module` "
 "属性を指定します。最後に、ドライバーのJavaクラスを指定します。サンプルとして、この章で以前定義したモジュールのサンプル内にある、PostgreSQLドライバーをインストールすると下記のとおりになります。"
 

--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -162,7 +162,7 @@ msgid ""
 "the H2 JDBC driver. This is where you'll declare the JDBC driver for your "
 "external database."
 msgstr ""
-"プロファイル内で、 `datasources` サブシステム内の `drivers` XMLブロックを検索すると、H2 "
+"プロファイル内で、 `datasources` サブシステム内の `drivers` のXMLブロックを検索すると、H2 "
 "JDBCドライバー用に宣言された定義済みのドライバーが見つかります。ここで、外部データベース用のJDBCドライバーを宣言します。"
 
 #. type: Block title

--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -50,8 +50,8 @@ msgid ""
 " create an empty _module.xml_ file within it too."
 msgstr ""
 "{project_name}の配布物の _.../modules/_ "
-"ディレクトリ内で、モジュール定義を保持するディレクトリ構造を作成する必要があります。規約では、ディレクトリ構造の名前にJDBCドライバーのJavaパッケージ名を使用します。PostgreSQLの場合、"
-" _org/postgresql/main_ ディレクトリを作成します。このディレクトリにデータベースドライバーのJARをコピーし、その中に空の "
+"ディレクトリー内で、モジュール定義を保持するディレクトリー構造を作成する必要があります。規約では、ディレクトリー構造の名前にJDBCドライバーのJavaパッケージ名を使用します。PostgreSQLの場合、"
+" _org/postgresql/main_ ディレクトリーを作成します。このディレクトリーにデータベース・ドライバーのJARをコピーし、その中に空の "
 "_module.xml_ ファイルも作成します。"
 
 #. type: Block title

--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -58,7 +58,7 @@ msgstr ""
 #: source/server_installation/topics/database/jdbc.adoc:8
 #, no-wrap
 msgid "Module Directory"
-msgstr "モジュールディレクトリ"
+msgstr "モジュール・ディレクトリー"
 
 #. type: Plain text
 #: source/server_installation/topics/database/jdbc.adoc:10

--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -125,7 +125,7 @@ msgid ""
 "the normal dependencies that any JDBC driver JAR would have."
 msgstr ""
 "モジュール名は、モジュールのディレクトリ構造と一致する必要があります。したがって、 _org/postgresql_ は "
-"`org.postgresql` にマッピングされます。ドライバーのJARファイル名は、 `resource-root path` "
+"`org.postgresql` にマッピングされます。ドライバーのJARファイル名は、 `resource-root` の `path` "
 "の属性によって指定される必要があります。残りの部分は、JDBCドライバーのJARが持つ通常の依存関係になります。"
 
 #. type: Title ===


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__jdbc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
