### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -108,7 +108,7 @@ msgid ""
 "traffic for you, you'll need to enable HTTPS for the {project_name} server."
 "  This involves"
 msgstr ""
-"HTTPSトラフィックを処理するためにリバースプロキシまたはロードバランサーを使用していない場合、{project_name}サーバー用にHTTPSを有効にする必要があります。これには下記が含まれます。"
+"HTTPSトラフィックを処理するためにリバース・プロキシーまたはロードバランサーを使用していない場合、{project_name}サーバー用にHTTPSを有効にする必要があります。これには下記が含まれます。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:28
@@ -152,7 +152,7 @@ msgid ""
 "available to test a {project_name} deployment so you'll need to generate a "
 "self-signed one using the `keytool` utility that comes with the Java JDK."
 msgstr ""
-"開発段階で、{project_name}の構成をテストするための第三者署名証明書を用意していない場合、Java JDKに付属する `keytool` "
+"開発段階で、{project_name}の配備をテストするための第三者署名証明書を用意していない場合、Java JDKに付属する `keytool` "
 "ユーティリティーを使用して自己署名証明書を生成する必要があります。"
 
 #. type: delimited block -
@@ -205,8 +205,8 @@ msgid ""
 "the `keytool` command in."
 msgstr ""
 "`What is your first and last name ?` という質問にはサーバーをインストールしたマシンのDNS名を答えてください。 "
-"テスト目的なので、 `localhost` を使用します。このコマンドを実行すると、 `keytool` コマンドが実行されたのと同じディレクトリ内で "
-"`keycloak.jks` ファイルが生成されます。"
+"テスト目的なので、 `localhost` を使用します。このコマンドを実行すると、 `keytool` コマンドが実行されたのと同じディレクトリー内で"
+" `keycloak.jks` ファイルが生成されます。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:68
@@ -216,7 +216,7 @@ msgid ""
 " a little set up first before doing this though."
 msgstr ""
 "第三者署名証明書が必要だが用意していない場合、 http://www.cacert.org[cacert.org] "
-"で無料で取得することができます。しかしこの方法で取得する前に、少し設定が必要になります。 "
+"から無料で取得することができます。しかしこの方法で取得する前に、少し設定が必要になります。 "
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:70
@@ -324,10 +324,10 @@ msgid ""
 "_domain.xml_ file to use the keystore and enable HTTPS.  (See <<_operating-"
 "mode, operating mode>>)."
 msgstr ""
-"適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}を設定する必要があります。まず、キーストアファイルを"
-" _configuration/_ ディレクトリ構成に移動し、キーストアを使用するように _standalone.xml_ 、 _standalone-"
-"ha.xml_ または _domain.xml_ ファイルを編集し、HTTPSを有効にします（<<_operating-mode, "
-"動作モード>>をご参照ください）。"
+"適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}を設定する必要があります。まず、キーストア・ファイルを"
+" _configuration/_ ディレクトリー構成に移動し、キーストアを使用するように _standalone.xml_ 、 "
+"_standalone-ha.xml_ または _domain.xml_ ファイルを編集し、HTTPSを有効にします（<<_operating-"
+"mode, 動作モード>>をご参照ください）。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:126

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -39,7 +39,7 @@ msgid ""
 "link:{adminguide_link}[{adminguide_name}], but let's give some context and a"
 " brief overview of these modes."
 msgstr ""
-"このデフォルトの動作は、各{project_name}レルムのSSL/HTTPSモードによって定義されています。これについて詳しくはlink:{adminguide_link}[{adminguide_name}]でご説明しますが、これらのモードの関連事項と簡単な概要についてはここで示します。"
+"このデフォルトの動作は、各{project_name}レルムのSSL/HTTPSモードによって定義されています。これについて詳しくはlink:{adminguide_link}[{adminguide_name}]で説明しますが、これらのモードの関連事項と簡単な概要についてはここで示します。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:10

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -327,7 +327,7 @@ msgstr ""
 "適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}を設定する必要があります。まず、キーストア・ファイルを"
 " _configuration/_ ディレクトリー構成に移動し、キーストアを使用するように _standalone.xml_ 、 "
 "_standalone-ha.xml_ または _domain.xml_ ファイルを編集し、HTTPSを有効にします（<<_operating-"
-"mode, 動作モード>>をご参照ください）。"
+"mode, 動作モード>>を参照してください）。"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:126

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -73,7 +73,7 @@ msgstr "none"
 msgid ""
 "{project_name} does not require SSL.  This should really only be used in "
 "development when you are playing around with things."
-msgstr "{project_name}はSSLを要求しません。この設定は、開発段階でいろいろといじっている時にのみ使用すべきです。"
+msgstr "{project_name}はSSLを要求しません。この設定は、開発段階でいろいろと検証している時にのみ使用すべきです。"
 
 #. type: Labeled list
 #: source/server_installation/topics/network/https.adoc:17

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -29,7 +29,7 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くおすすめします。\n"
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバース・プロキシー上のいずれかでSSLを有効にすることを強くおすすめします。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:9

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -29,7 +29,7 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバース・プロキシー上のいずれかでSSLを有効にすることを強くおすすめします。\n"
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバース・プロキシー上のいずれかでSSLを有効にすることを強くお勧めします。\n"
 
 #. type: Plain text
 #: source/server_installation/topics/network/https.adoc:9


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
