### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,14 +15,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
-#: source/server_installation/topics/clustering/load-balancer.adoc:2
+#. type: Attribute :installguide_loadbalancer_name:
 #, no-wrap
 msgid "Setting Up a Load Balancer or Proxy"
-msgstr "ロードバランサーまたはプロキシの設定"
+msgstr "ロードバランサーまたはプロキシーの設定"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:7
 msgid ""
 "This section discusses a number of things you need to configure before you "
 "can put a reverse proxy or load balancer in front of your clustered "
@@ -33,13 +31,11 @@ msgstr ""
 "<<_clustered-domain-example, クラスター構成ドメインのサンプル>>でもご確認いただけます。"
 
 #. type: Title ====
-#: source/server_installation/topics/clustering/load-balancer.adoc:9
 #, no-wrap
 msgid "Identifying Client IP Addresses"
 msgstr "クライアントIPアドレスの特定"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:13
 msgid ""
 "A few features in {project_name} rely on the fact that the remote address of"
 " the HTTP client connecting to the authentication server is the real IP "
@@ -48,33 +44,28 @@ msgstr ""
 "{project_name}のいくつかの機能は、認証サーバーに接続するHTTPクライアントのリモート・アドレスがクライアント・マシンの実際のIPアドレスであることを前提としています。サンプルとしては、以下の通りです。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:15
 msgid ""
 "Event logs - a failed login attempt would be logged with the wrong source IP"
 " address"
 msgstr "イベントログ - 間違ったソースIPアドレスでログインエラーが記録されます"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:16
 msgid ""
 "SSL required - if the SSL required is set to external (the default) it "
 "should require SSL for all external requests"
 msgstr "SSLの要求 - SSLの要求がexternal（デフォルト）に設定されている場合、すべての外部リクエストに対してSSLを要求します"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:17
 msgid ""
 "Authentication flows - a custom authentication flow that uses the IP address"
 " to for example show OTP only for external requests"
 msgstr "認証フロー - IPアドレスを使用して、例えば外部リクエストに対してのみOTPを表示するようなカスタム認証フロー"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:18
 msgid "Dynamic Client Registration"
 msgstr "動的クライアント登録"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:23
 msgid ""
 "This can be problematic when you have a reverse proxy or loadbalancer in "
 "front of your {project_name} authentication server.  The usual setup is that"
@@ -87,7 +78,6 @@ msgstr ""
 "{project_name}認証サーバーの前にリバースプロキシまたはロードバランサーが置いてある場合、問題になる可能性があります。通常の設定では、パブリック・ネットワーク上にフロントエンドのプロキシを置いています。このプロキシはプライベート・ネットワーク内のバックエンドの{project_name}サーバー・インスタンスに負荷を分散して要求を転送するものです。実際のクライアントIPアドレスが転送され、{project_name}サーバー・インスタンスによって処理されるように、追加設定する必要があります。具体的には以下の通りです。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:25
 msgid ""
 "Configure your reverse proxy or loadbalancer to properly set `X-Forwarded-"
 "For` and `X-Forwarded-Proto` HTTP headers."
@@ -96,21 +86,18 @@ msgstr ""
 "HTTPヘッダーを適切にセットするように、リバースプロキシまたはロードバランサーを設定します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:26
 msgid ""
 "Configure your reverse proxy or loadbalancer to preserve the original 'Host'"
 " HTTP header."
 msgstr "オリジナルの 'Host' HTTPヘッダーを保持するように、リバースプロキシまたはロードバランサーを設定します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:27
 msgid ""
 "Configure the authentication server to read the client's IP address from `X"
 "-Forwarded-For header`."
 msgstr "`X-Forwarded-For header` からのクライアントのIPアドレスを読み取るように、認証サーバーを設定します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:33
 #, no-wrap
 msgid ""
 "Configuring your proxy to generate the `X-Forwarded-For` and `X-Forwarded-Proto` HTTP headers and preserving the\n"
@@ -125,7 +112,6 @@ msgstr ""
 "クライアントがこのヘッダーを自身で設定して、クライアントが実際とは異なるIPアドレスから接続していると{project_name}に認識させることができてしまいます。IPアドレスのブラックまたはホワイトリストを作成している場合、この設定は非常に重要です。\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:39
 msgid ""
 "Beyond the proxy itself, there are a few things you need to configure on the"
 " {project_name} side of things.  If your proxy is forwarding requests via "
@@ -143,13 +129,11 @@ msgstr ""
 "）を開き、 `{subsystem_undertow_xml_urn}` XMLブロックを検索します。"
 
 #. type: Block title
-#: source/server_installation/topics/clustering/load-balancer.adoc:40
 #, no-wrap
 msgid "`X-Forwarded-For` HTTP Config"
 msgstr "`X-Forwarded-For` HTTP設定"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:53
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
@@ -175,7 +159,6 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:56
 msgid ""
 "Add the `proxy-address-forwarding` attribute to the `http-listener` element."
 "  Set the value to `true`."
@@ -183,7 +166,6 @@ msgstr ""
 "`http-listener` 要素に `proxy-address-forwarding` 属性を追加します。値を `true` に設定します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:60
 msgid ""
 "If your proxy is using the AJP protocol instead of HTTP to forward requests "
 "(i.e. Apache HTTPD + mod-cluster), then you have to configure things a "
@@ -195,13 +177,11 @@ msgstr ""
 "を変更する代わりに、AJPパケットからこの情報を取得するフィルタを追加する必要があります。"
 
 #. type: Block title
-#: source/server_installation/topics/clustering/load-balancer.adoc:62
 #, no-wrap
 msgid "`X-Forwarded-For` AJP Config"
 msgstr "`X-Forwarded-For` AJP設定"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:83
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
@@ -243,20 +223,17 @@ msgstr ""
 " </subsystem>\n"
 
 #. type: Title ====
-#: source/server_installation/topics/clustering/load-balancer.adoc:85
 #, no-wrap
 msgid "Enable HTTPS/SSL with a Reverse Proxy"
 msgstr "リバースプロキシでのHTTPS/SSLの有効化"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:88
 msgid ""
 "Assuming that your reverse proxy doesn't use port 8443 for SSL you also need"
 " to configure what port HTTPS traffic is redirected to."
 msgstr "リバースプロキシがSSL用にポート8443を使用しない場合、HTTPSトラフィックのどのポートをリダイレクトするか設定する必要があります。"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:96
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
@@ -274,7 +251,6 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:100
 msgid ""
 "Add the `redirect-socket` attribute to the `http-listener` element.  The "
 "value should be `proxy-https` which points to a socket binding you also need"
@@ -284,7 +260,6 @@ msgstr ""
 "を設定しますが、これは定義が必要なソケット・バインディングを指しています。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:102
 msgid ""
 "Then add a new `socket-binding` element to the `socket-binding-group` "
 "element:"
@@ -292,7 +267,6 @@ msgstr ""
 "次に、新しい `socket-binding` 要素を `socket-binding-group` 要素に追加します。以下のようになります。"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:112
 #, no-wrap
 msgid ""
 "<socket-binding-group name=\"standard-sockets\" default-interface=\"public\"\n"
@@ -310,13 +284,11 @@ msgstr ""
 "</socket-binding-group>\n"
 
 #. type: Title ====
-#: source/server_installation/topics/clustering/load-balancer.adoc:114
 #, no-wrap
 msgid "Verify Configuration"
 msgstr "設定の確認"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:121
 msgid ""
 "You can verify the reverse proxy or load balancer configuration by opening "
 "the path `/auth/realms/master/.well-known/openid-configuration` through the "
@@ -335,7 +307,6 @@ msgstr ""
 "URLを開きます。そうすると、{project_name}用のエンドポイントの数を示すJSONドキュメントが表示されます。エンドポイントが、リバースプロキシまたはロードバランサーのアドレス（スキーム、ドメイン、ポート）で始まることを確認します。このようにして、{project_name}が正しいエンドポイントを使用しているか確認します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:125
 msgid ""
 "You should also verify that {project_name} sees the correct source IP "
 "address for requests. Do check this you can try to login to the admin "
@@ -345,7 +316,6 @@ msgstr ""
 "また、{project_name}がリクエストのソースIPアドレスを正しく認識しているか確認する必要があります。無効なユーザー名とパスワードの両方またはいずれかで管理コンソールにログインしてみて、ご確認ください。これを行うと、サーバーログに以下のような警告が表示されます。"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:129
 #, no-wrap
 msgid ""
 "08:14:21,287 WARN  XNIO-1 task-45 [org.keycloak.events] type=LOGIN_ERROR, "
@@ -365,7 +335,6 @@ msgstr ""
 "username=admin\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:133
 #, no-wrap
 msgid ""
 "Check that the value of `ipAddress` is the IP address of the machine you tried to login with and not the IP address\n"
@@ -375,13 +344,11 @@ msgstr ""
 "の値はログインしようとしているマシンのIPアドレスで、リバースプロキシまたはロードバランサーのIPアドレスではないということをご確認ください。\n"
 
 #. type: Title ====
-#: source/server_installation/topics/clustering/load-balancer.adoc:134
 #, no-wrap
 msgid "Using the Built-In Load Balancer"
 msgstr "組み込みロードバランサーの使用"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:138
 msgid ""
 "This section covers configuring the built in load balancer that is discussed"
 " in the <<_clustered-domain-example, Clustered Domain Example>>."
@@ -390,7 +357,6 @@ msgstr ""
 "クラスター構成ドメインのサンプル>>でご説明する組み込みロードバランサーの設定方法についてご説明します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:141
 msgid ""
 "The <<_clustered-domain-example, Clustered Domain Example>> is only designed"
 " to run on one machine.  To bring up a slave on another host, you'll need to"
@@ -399,12 +365,10 @@ msgstr ""
 "クラスター構成ドメインのサンプル>>は1台のマシンで実行するためにのみ作られています。他のホストでスレーブを起動するには、次の操作が必要です。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:143
 msgid "Edit the _domain.xml_ file to point to your new host slave"
 msgstr "新しいホスト・スレーブを指し示すように、 _domain.xml_ ファイルを編集します。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:145
 msgid ""
 "Copy the server distribution.  You don't need the _domain.xml_, _host.xml_, "
 "or _host-master.xml_ files.  Nor do you need the _standalone/_ directory."
@@ -413,7 +377,6 @@ msgstr ""
 "_standalone/_ ディレクトリも必要ありません。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:146
 msgid ""
 "Edit the _host-slave.xml_ file to change the bind addresses used or override"
 " them on the command line"
@@ -421,13 +384,11 @@ msgstr ""
 "使用しているバインド・アドレスを変更、またはコマンドラインでそのアドレスを上書きするように、 _host-slave.xml_ ファイルを編集します。"
 
 #. type: Title =====
-#: source/server_installation/topics/clustering/load-balancer.adoc:149
 #, no-wrap
 msgid "Register a New Host With Load Balancer"
 msgstr "ロードバランサーでの新しいホスト登録"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:154
 msgid ""
 "Let's look first at registering the new host slave with the load balancer "
 "configuration in _domain.xml_.  Open this file and go to the undertow "
@@ -439,13 +400,11 @@ msgstr ""
 "`remote-host3` と呼ばれる `host` の新しい定義を追加します。"
 
 #. type: Block title
-#: source/server_installation/topics/clustering/load-balancer.adoc:155
 #, no-wrap
 msgid "domain.xml reverse-proxy config"
 msgstr "domain.xmlのreverse-proxy設定 "
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:169
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
@@ -473,7 +432,6 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:174
 msgid ""
 "The `output-socket-binding` is a logical name pointing to a `socket-binding`"
 " configured later in the _domain.xml_ file.  the `instance-id` attribute "
@@ -485,7 +443,6 @@ msgstr ""
 "新しいホスト固有のものでなければなりません。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:177
 msgid ""
 "Next go down to the `load-balancer-sockets` `socket-binding-group` and add "
 "the `outbound-socket-binding` for `remote-host3`.  This new binding needs to"
@@ -496,13 +453,11 @@ msgstr ""
 "を追加します。この新しいバインディングは、新しいホストのホスト名とポートを指し示す必要があります。"
 
 #. type: Block title
-#: source/server_installation/topics/clustering/load-balancer.adoc:178
 #, no-wrap
 msgid "domain.xml outbound-socket-binding"
 msgstr "domain.xmlのoutbound-socket-binding"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:193
 #, no-wrap
 msgid ""
 "<socket-binding-group name=\"load-balancer-sockets\" default-interface=\"public\">\n"
@@ -532,13 +487,11 @@ msgstr ""
 "</socket-binding-group>\n"
 
 #. type: Title =====
-#: source/server_installation/topics/clustering/load-balancer.adoc:195
 #, no-wrap
 msgid "Master Bind Addresses"
 msgstr "マスター・バインド・アドレス"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:200
 msgid ""
 "Next thing you'll have to do is to change the `public` and `management` bind"
 " addresses for the master host.  Either edit the _domain.xml_ file as "
@@ -550,7 +503,6 @@ msgstr ""
 "ファイルを編集するか、以下のとおりコマンドライン上でこれらのバインド・アドレスを指定します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:204
 #, no-wrap
 msgid ""
 "$ domain.sh --host-config=host-master.xml -Djboss.bind.address=192.168.0.2 "
@@ -560,13 +512,11 @@ msgstr ""
 "-Djboss.bind.address.management=192.168.0.2\n"
 
 #. type: Title =====
-#: source/server_installation/topics/clustering/load-balancer.adoc:206
 #, no-wrap
 msgid "Host Slave Bind Addresses"
 msgstr "ホスト・スレーブ・バインド・アドレス"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:210
 msgid ""
 "Next you'll have to change the `public`, `management`, and domain controller"
 " bind addresses (`jboss.domain.master-address`).  Either edit the _host-"
@@ -577,7 +527,6 @@ msgstr ""
 "ファイルを編集するか、以下のとおりコマンドラインでこれらを指定します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/load-balancer.adoc:217
 #, no-wrap
 msgid ""
 "$ domain.sh --host-config=host-slave.xml\n"
@@ -591,7 +540,6 @@ msgstr ""
 "       -Djboss.domain.master.address=192.168.0.2\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:222
 msgid ""
 "The values of `jboss.bind.address` and `jboss.bind.addres.management` "
 "pertain to the host slave's IP address.  The value of "
@@ -603,13 +551,11 @@ msgstr ""
 "の値は、マスター・ホストの管理アドレスであるドメイン・コントローラーのIPアドレスとする必要があります。"
 
 #. type: Title ====
-#: source/server_installation/topics/clustering/load-balancer.adoc:223
 #, no-wrap
 msgid "Configuring Other Load Balancers"
 msgstr "その他のロードバランサー設定"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/load-balancer.adoc:225
 msgid ""
 "See link:{appserver_loadbalancer_link}[the load balancing] section in the "
 "_{appserver_loadbalancer_name}_ for information how to use other software-"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__load-balancer
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
