### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgstr "クラスター内での{project_name}の起動は<<_operating-mode, 動
 #. type: Title ===
 #, no-wrap
 msgid "Standalone Mode"
-msgstr "スタンドアロン・モード"
+msgstr "スタンドアローン・モード"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__booting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
