### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgid ""
 "Realm Settings->Cache Config page.  On this page you can clear the realm "
 "cache, the user cache or cache of external public keys."
 msgstr ""
-"レルムまたはユーザー・キャッシュをクリアするには、{project_name}の管理コンソールのRealm "
+"レルム・キャッシュまたはユーザー・キャッシュをクリアするには、{project_name}の管理コンソールのRealm "
 "Settings->Cache設定ページへ移動します。このページでは、レルム・キャッシュ、ユーザー・キャッシュ、外部の公開鍵キャッシュをクリアすることができます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__clear
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
