### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: source/server_installation/topics/proxy.adoc:3
 #, no-wrap
 msgid "{project_name} Security Proxy"
-msgstr "{project_name}セキュリティ・プロキシ"
+msgstr "{project_name}セキュリティー・プロキシー"
 
 #. type: Plain text
 #: source/server_installation/topics/proxy.adoc:8


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__proxy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
