### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -16,55 +16,46 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/installation/directory-structure.adoc:2
 #, no-wrap
 msgid "Distribution Directory Structure"
 msgstr "配布物のディレクトリー構造"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:5
 msgid ""
 "This chapter walks you through the directory structure of the server "
 "distribution."
 msgstr "この章では、サーバー配布物のディレクトリー構造について説明します。"
 
 #. type: Block title
-#: source/server_installation/topics/installation/directory-structure.adoc:6
 #, no-wrap
 msgid "distribution directory structure"
 msgstr "配布物のディレクトリー構造"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:8
 msgid "image:{project_images}/files.png[alt=\"distribution\"]"
 msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:10
 msgid "Let's examine the purpose of some of the directories:"
 msgstr "いくつかのディレクトリーの目的について学んでいきましょう。"
 
 #. type: Labeled list
-#: source/server_installation/topics/installation/directory-structure.adoc:11
 #, no-wrap
 msgid "_bin/_"
 msgstr "_bin/_"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:13
 msgid ""
 "This contains various scripts to either boot the server or perform some "
 "other management action on the server."
 msgstr "サーバーの起動またはサーバー上でその他管理操作を行う、さまざまなスクリプトが含まれています。"
 
 #. type: Labeled list
-#: source/server_installation/topics/installation/directory-structure.adoc:14
 #, no-wrap
 msgid "_domain/_"
 msgstr "_domain/_"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:16
 msgid ""
 "This contains configuration files and working directory when running "
 "{project_name} in <<_domain-mode,domain mode>>."
@@ -73,24 +64,20 @@ msgstr ""
 "mode,ドメインモード>>で実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
 
 #. type: Labeled list
-#: source/server_installation/topics/installation/directory-structure.adoc:17
 #, no-wrap
 msgid "_modules/_"
 msgstr "_modules/_"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:19
 msgid "These are all the Java libraries used by the server."
 msgstr "サーバー上で使用されるすべてのJavaライブラリーです。"
 
 #. type: Labeled list
-#: source/server_installation/topics/installation/directory-structure.adoc:21
 #, no-wrap
 msgid "_providers/_"
 msgstr "_providers/_"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:23
 msgid ""
 "If you are writing extensions to keycloak, you can put your extensions here."
 "  See the link:{developerguide_link}[{developerguide_name}] for more "
@@ -99,13 +86,11 @@ msgstr ""
 "Keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Labeled list
-#: source/server_installation/topics/installation/directory-structure.adoc:25
 #, no-wrap
 msgid "_standalone/_"
 msgstr "_standalone/_"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:27
 msgid ""
 "This contains configuration files and working directory when running "
 "{project_name} in <<_standalone-mode,standalone mode>>."
@@ -114,20 +99,17 @@ msgstr ""
 "mode>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリーは含まれません。"
 
 #. type: Labeled list
-#: source/server_installation/topics/installation/directory-structure.adoc:28
 #, no-wrap
 msgid "_themes/_"
 msgstr "_themes/_"
 
 #. type: Plain text
-#: source/server_installation/topics/installation/directory-structure.adoc:30
 msgid ""
-"This directory contains all the html, style sheets, javascript files, and "
+"This directory contains all the html, style sheets, JavaScript files, and "
 "images used to display any UI screen displayed by the server.  Here you can "
 "modify an existing theme or create your own.  See the "
 "link:{developerguide_link}[{developerguide_name}] for more information on "
 "this."
 msgstr ""
-"このディレクトリーは、サーバーにより指定されたUI画面を表示するために使用されるhtml、スタイルシート、 "
-"javascriptファイルおよびイメージ画像が含まれています。ここでは、既存のテーマを修正したり、独自のテーマを作成したりすることができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照してください。"
-" "
+"このディレクトリーには、サーバーによって表示されるUI画面を表示するために使用されるすべてのHTML、スタイルシート、JavaScriptファイル、および画像が含まれます。ここでは、既存のテーマを変更したり、独自のテーマを作成したりすることができます。詳細については、"
+" link:{developerguide_link}[{developerguide_name}] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__installation__directory-structure
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
