### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/saml-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/saml-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/saml-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,18 +16,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/overview/supported-platforms.adoc:66
-#: source/securing_apps/topics/saml/saml-overview.adoc:1
-#: source/server_admin/topics/sso-protocols/saml.adoc:3
 #, no-wrap
 msgid "SAML"
 msgstr "SAML"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/saml-overview.adoc:4
 msgid ""
 "This section describes how you can secure applications and services with "
 "SAML using either {project_name} client adapters or generic SAML provider "
 "libraries."
 msgstr ""
-"このセクションでは、{project_name}クライアント・アダプターまたは汎用SAMLプロバイダー・ライブラリのいずれかを使用して、アプリケーションとサービスをSAMLでセキュリティー保護する方法について説明します。"
+"このセクションでは、{project_name}クライアント・アダプターまたは汎用SAMLプロバイダー・ライブラリーのいずれかを使用して、アプリケーションとサービスをSAMLでセキュリティー保護する方法について説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/saml-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__saml-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
