### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po
@@ -15,100 +15,82 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:2
-msgid "The changes that have been made for RH-SSO 7.1 include:"
-msgstr "RH-SSO 7.1用の変更は、以下を含みます。"
+#. type: Title =====
+#, no-wrap
+msgid "Theme changes RH-SSO 7.1"
+msgstr "テーマの変更 RH-SSO 7.1"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:4
 #, no-wrap
 msgid "**Templates**\n"
 msgstr "**テンプレート**\n"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:6
 msgid "Account: account.ftl"
 msgstr "アカウント：account.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:7
 msgid "Account: federatedIdentity.ftl"
 msgstr "アカウント：federatedIdentity.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:8
 msgid "Account: totp.ftl"
 msgstr "アカウント：totp.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:9
 msgid "Login: info.ftl"
 msgstr "ログイン：info.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:10
 msgid "Login: login-config-totp.ftl"
 msgstr "ログイン：login-config-totp.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:11
 msgid "Login: login-reset-password.ftl"
 msgstr "ログイン：login-reset-password.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:12
 msgid "Login: login.ftl"
 msgstr "ログイン：login.ftl"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:14
 #, no-wrap
 msgid "**Messages**\n"
 msgstr "**メッセージ**\n"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:16
 msgid "Account: editAccountHtmlTtile renamed to editAccountHtmlTitle"
 msgstr "アカウント：editAccountHtmlTtileはeditAccountHtmlTitleに名前が書き換えられました"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:17
 msgid "Account: role_uma_authorization added"
 msgstr "アカウント：role_uma_authorizationが追加されました"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:18
 msgid "Login: loginTotpStep1 value changed"
 msgstr "ログイン：loginTotpStep1の値が変更されました"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:19
 msgid "Login: invalidPasswordGenericMessage added"
 msgstr "ログイン：invalidPasswordGenericMessageが追加されました"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:20
 msgid "Login: invlidRequesterMessage renamed to invalidRequesterMessage"
 msgstr "ログイン：invlidRequesterMessageはinvalidRequesterMessageに名前が書き換えられました"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:21
 msgid "Login: clientDisabledMessage added"
 msgstr "ログイン：clientDisabledMessageが追加されました"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:23
 #, no-wrap
 msgid "**Styles**\n"
 msgstr "**スタイル**\n"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:25
 msgid "Account: account.css"
 msgstr "アカウント：account.css"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/migrate_themes-changes-71.adoc:25
 msgid "Login: login.css"
 msgstr "ログイン：login.css"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-71.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__rhsso__migrate_themes-changes-71
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
