### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po
@@ -15,28 +15,23 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "keycloak.json"
+msgstr "keycloak.json"
+
 #. type: Title =
-#: source/authorization_services/topics/enforcer-https.adoc:2
 #, no-wrap
 msgid "Setting Up TLS/HTTPS"
 msgstr "TLS/HTTPSの設定"
 
 #. type: Plain text
-#: source/authorization_services/topics/enforcer-https.adoc:5
 msgid ""
 "When the server is using HTTPS, ensure your adapter is configured as "
 "follows:"
 msgstr "サーバーでHTTPSを使用する場合は、アダプターが次のように設定されていることを確認してください。"
 
-#. type: Block title
-#: source/authorization_services/topics/enforcer-https.adoc:6
-#: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:17
-#, no-wrap
-msgid "keycloak.json"
-msgstr "keycloak.json"
-
 #. type: Code block
-#: source/authorization_services/topics/enforcer-https.adoc:12
 #, no-wrap
 msgid ""
 "{\n"
@@ -50,7 +45,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/enforcer-https.adoc:16
 msgid ""
 "The configuration above enables TLS/HTTPS to the Authorization Client, "
 "making possible to access a {project_name} Server remotely using the HTTPS "
@@ -59,7 +53,6 @@ msgstr ""
 "上記の設定により、認可クライアントでTLS/HTTPSが有効になり、HTTPSスキームを使用してリモートから{project_name}サーバーにアクセスできるようになります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/enforcer-https.adoc:18
 msgid ""
 "It is strongly recommended that you enable TLS/HTTPS when accessing the "
 "{project_name} Server endpoints."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
