### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/permission-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/permission-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,35 +16,27 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:32
-#: source/authorization_services/topics/permission-overview.adoc:15
 #, no-wrap
 msgid "*Resources*\n"
 msgstr "*Resources*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:27
-#: source/authorization_services/topics/permission-overview.adoc:16
-#: source/authorization_services/topics/resource-create.adoc:31
 #, no-wrap
 msgid "*Scopes*\n"
 msgstr "*Scopes*\n"
 
 #. type: Title =
-#: source/authorization_services/topics/permission-overview.adoc:2
 #, no-wrap
 msgid "Managing Permissions"
 msgstr "パーミッションの管理"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:5
 msgid ""
 "A permission associates the object being protected and the policies that "
 "must be evaluated to decide whether access should be granted."
 msgstr "パーミッションは、保護されているオブジェクトとアクセスを許可するかどうかを決定するために評価されなければならないポリシーを関連付けます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:8
 msgid ""
 "After creating the resources you want to protect and the policies you want "
 "to use to protect these resources, you can start managing permissions. To "
@@ -55,24 +47,19 @@ msgstr ""
 " *Permissions* タブをクリックします。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:9
-#: source/authorization_services/topics/resource-server-import-config.adoc:9
 #, no-wrap
 msgid "Permissions"
 msgstr "パーミッション"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:11
 msgid "image:{project_images}/permission/view.png[alt=\"Permissions\"]"
 msgstr "image:{project_images}/permission/view.png[alt=\"権限\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:13
 msgid "Permissions can be created to protect two main types of objects:"
 msgstr "主な2つのタイプのオブジェクトを保護するパーミッションを作成できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:17
 msgid ""
 "To create a permission, select the permission type you want to create from "
 "the dropdown list in the upper right corner of the permission listing. The "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/permission-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__permission-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
