### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -16,103 +16,41 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:37
-#: source/authorization_services/topics/permission-create-resource.adoc:14
-#: source/authorization_services/topics/permission-create-scope.adoc:14
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:22
-#: source/authorization_services/topics/policy-client-policy.adoc:14
-#: source/authorization_services/topics/policy-drools-policy.adoc:16
-#: source/authorization_services/topics/policy-group-policy.adoc:14
-#: source/authorization_services/topics/policy-js-policy.adoc:15
-#: source/authorization_services/topics/policy-role-policy.adoc:18
-#: source/authorization_services/topics/policy-time-policy.adoc:14
-#: source/authorization_services/topics/policy-user-policy.adoc:14
-#: source/authorization_services/topics/resource-create.adoc:15
 #, no-wrap
 msgid "*Name*\n"
 msgstr "*Name*\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:43
-#: source/authorization_services/topics/permission-create-resource.adoc:19
-#: source/authorization_services/topics/permission-create-scope.adoc:19
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:27
-#: source/authorization_services/topics/policy-client-policy.adoc:19
-#: source/authorization_services/topics/policy-drools-policy.adoc:21
-#: source/authorization_services/topics/policy-group-policy.adoc:19
-#: source/authorization_services/topics/policy-js-policy.adoc:20
-#: source/authorization_services/topics/policy-role-policy.adoc:23
-#: source/authorization_services/topics/policy-time-policy.adoc:19
-#: source/authorization_services/topics/policy-user-policy.adoc:19
 #, no-wrap
 msgid "*Description*\n"
 msgstr "*Description*\n"
 
 #. type: Title ==
-#: source/authorization_services/topics/example-overview.adoc:2
-#: source/authorization_services/topics/policy-drools-policy.adoc:56
-#: source/authorization_services/topics/policy-js-policy.adoc:31
-#, no-wrap
-msgid "Examples"
-msgstr "サンプル"
-
-#. type: Title ==
-#: source/authorization_services/topics/permission-create-resource.adoc:11
-#: source/authorization_services/topics/permission-create-scope.adoc:11
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:19
-#: source/authorization_services/topics/policy-client-policy.adoc:11
-#: source/authorization_services/topics/policy-drools-policy.adoc:13
-#: source/authorization_services/topics/policy-group-policy.adoc:11
-#: source/authorization_services/topics/policy-js-policy.adoc:12
-#: source/authorization_services/topics/policy-role-policy.adoc:15
-#: source/authorization_services/topics/policy-time-policy.adoc:11
-#: source/authorization_services/topics/policy-user-policy.adoc:11
-#: source/authorization_services/topics/service-client-api.adoc:21
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:29
-#: source/authorization_services/topics/policy-drools-policy.adoc:23
 msgid "A string with more details about this policy."
 msgstr "このポリシーの詳細を示す文字列。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:39
-#: source/authorization_services/topics/policy-client-policy.adoc:27
-#: source/authorization_services/topics/policy-drools-policy.adoc:53
-#: source/authorization_services/topics/policy-group-policy.adoc:34
-#: source/authorization_services/topics/policy-js-policy.adoc:28
-#: source/authorization_services/topics/policy-role-policy.adoc:35
-#: source/authorization_services/topics/policy-time-policy.adoc:52
-#: source/authorization_services/topics/policy-user-policy.adoc:27
 #, no-wrap
 msgid "*Logic*\n"
 msgstr "*Logic*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:41
-#: source/authorization_services/topics/policy-client-policy.adoc:28
-#: source/authorization_services/topics/policy-drools-policy.adoc:55
-#: source/authorization_services/topics/policy-group-policy.adoc:35
-#: source/authorization_services/topics/policy-js-policy.adoc:30
-#: source/authorization_services/topics/policy-role-policy.adoc:36
-#: source/authorization_services/topics/policy-time-policy.adoc:54
-#: source/authorization_services/topics/policy-user-policy.adoc:28
 msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
 msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
 
 #. type: Title =
-#: source/authorization_services/topics/policy-drools-policy.adoc:2
 #, no-wrap
 msgid "Rule-Based Policy"
 msgstr "ルールベースのポリシー"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:6
 msgid ""
 "With this type of policy you can define conditions for your permissions "
 "using http://www.drools.org[Drools], which is a rule evaluation environment."
@@ -125,7 +63,6 @@ msgstr ""
 "のポリシー・タイプの1つであり、<<_policy_evaluation_api, 評価API>>に基づいたポリシーを柔軟に作成できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:9
 #, no-wrap
 msgid ""
 "To create a new Rule-based policy, in the dropdown list in the right upper corner of the policy listing,\n"
@@ -133,18 +70,15 @@ msgid ""
 msgstr "新しいルールベースのポリシーを作成するには、ポリシーリストの右上隅にあるドロップダウン・リストで、 *Rule* を選択します。\n"
 
 #. type: Block title
-#: source/authorization_services/topics/policy-drools-policy.adoc:10
 #, no-wrap
 msgid "Add Rule Policy"
 msgstr "ルールポリシーの追加"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:12
 msgid "image:{project_images}/policy/create-drools.png[alt=\"Add Rule Policy\"]"
 msgstr "image:{project_images}/policy/create-drools.png[alt=\"ルールポリシーを追加\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:19
 msgid ""
 "A human-readable and unique string describing the policy. We strongly "
 "suggest that you use names that are closely related with your business and "
@@ -154,13 +88,11 @@ msgstr ""
 "ポリシーを説明する、人が判読可能な一意の文字列。ビジネス要件とセキュリティー要件に密接に関連する名前を使用することを強くお勧めします。そうすることで簡単に識別することができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:25
 #, no-wrap
 msgid "*Policy Maven Artifact*\n"
 msgstr "*Policy Maven Artifact*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:27
 msgid ""
 "A Maven groupId-artifactId-version (GAV) pointing to an artifact where the "
 "rules are defined. Once you have provided the GAV, you can click *Resolve* "
@@ -170,77 +102,69 @@ msgstr ""
 "*Resolve* をクリックして、 *Module* と *Session* フィールドの両方を読み込むことができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:29
 #, no-wrap
 msgid "** Group Id\n"
 msgstr "** Group Id\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:31
 msgid "The groupId of the artifact."
 msgstr "アーティファクトのgroupId。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:33
 #, no-wrap
 msgid "** Artifact Id\n"
 msgstr "** Artifact Id\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:35
 msgid "The artifactId of the artifact."
 msgstr "アーティファクトのartifactId。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:37
 #, no-wrap
 msgid "** Version\n"
 msgstr "** Version\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:39
 msgid "The version of the artifact."
 msgstr "アーティファクトのversion。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:41
 #, no-wrap
 msgid "*Module*\n"
 msgstr "*Module*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:43
 msgid ""
 "The module used by this policy. You must provide a module to select a "
 "specific session from which rules will be loaded."
 msgstr "このポリシーで使用されるモジュール。ルールがロードされる特定のセッションを選択するためのモジュールを提供する必要があります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:45
 #, no-wrap
 msgid "*Session*\n"
 msgstr "*Session*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:47
 msgid ""
 "The session used by this policy. The session provides all the rules to "
 "evaluate when processing the policy."
 msgstr "このポリシーで使用されるセッション。セッションは、ポリシーの処理時に評価するすべてのルールを提供します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:49
 #, no-wrap
 msgid "*Update Period*\n"
 msgstr "*Update Period*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:51
 msgid "Specifies an interval for scanning for artifact updates."
 msgstr "アーティファクトの更新をスキャンする間隔を指定します。"
 
+#. type: Title ==
+#, no-wrap
+msgid "Examples"
+msgstr "サンプル"
+
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:60
 msgid ""
 "Here is a simple example of a Drools-based policy that uses attribute-based "
 "access control (ABAC) to define a condition that evaluates to a GRANT only "
@@ -249,7 +173,6 @@ msgstr ""
 "認証されたユーザーがリクエストされたリソースのオーナーである場合にのみ、GRANTに評価される条件を定義するために属性ベースのアクセス・コントロール（ABAC）を使用するDroolsベースのポリシーの簡単な例を次に示します。"
 
 #. type: Code block
-#: source/authorization_services/topics/policy-drools-policy.adoc:74
 #, no-wrap
 msgid ""
 "import org.keycloak.authorization.policy.evaluation.Evaluation;\n"
@@ -279,7 +202,6 @@ msgstr ""
 "end\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:77
 msgid ""
 "You can even use another variant of ABAC to obtain attributes from the "
 "identity and define a condition accordingly:"
@@ -287,7 +209,6 @@ msgstr ""
 "アイデンティティから属性を取得し、それに応じて条件を定義するために、ABAC（属性ベースのアクセス・コントロール）の別のバリアントを使用することもできます。"
 
 #. type: Code block
-#: source/authorization_services/topics/policy-drools-policy.adoc:90
 #, no-wrap
 msgid ""
 "import org.keycloak.authorization.policy.evaluation.Evaluation;\n"
@@ -315,7 +236,6 @@ msgstr ""
 "end\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-drools-policy.adoc:92
 msgid ""
 "For more information about what you can access from the "
 "`org.keycloak.authorization.policy.evaluation.Evaluation` interface, see "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-drools-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
