### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,20 +16,17 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:2
 #, no-wrap
 msgid "Evaluating and Testing Policies"
 msgstr "ポリシーの評価とテスト"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:5
 msgid ""
 "When designing your policies, you can simulate authorization requests to "
 "test how your policies are being evaluated."
 msgstr "ポリシーを設計する際に、認可リクエストをシミュレートして、ポリシーの評価方法をテストすることができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:7
 msgid ""
 "You can access the Policy Evaluation Tool by clicking the `Evaluate` tab "
 "when editing a resource server. There you can specify different inputs to "
@@ -39,7 +36,6 @@ msgstr ""
 "タブをクリックすると、ポリシー評価ツールにアクセスできます。そこで、さまざまな入力を指定して、実際の認可リクエストをシミュレートし、ポリシーの効果をテストすることができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:9
 msgid ""
 "image:{project_images}/policy-evaluation-tool/policy-evaluation-"
 "tool.png[alt=\"Policy Evaluation Tool\"]"
@@ -48,33 +44,22 @@ msgstr ""
 "tool.png[alt=\"ポリシー評価ツール\"]"
 
 #. type: Title ==
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:10
 #, no-wrap
 msgid "Providing Identity Information"
 msgstr "アイデンティティー情報の提供"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:13
 msgid ""
 "The *Identity Information* filters can be used to specify the user "
 "requesting permissions."
 msgstr "*Identity Information* フィルターを使用して、パーミッションを要求するユーザーを指定できます。"
 
-#. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:15
-msgid ""
-"You can also click *Entitlement* to obtain all permissions for the user you "
-"selected."
-msgstr "*Entitlement* をクリックして、選択したユーザーのすべてのパーミッションを取得することもできます。"
-
 #. type: Title ==
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:16
 #, no-wrap
 msgid "Providing Contextual Information"
 msgstr "コンテキスト情報の提供"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:19
 msgid ""
 "The *Contextual Information* filters can be used to define additional "
 "attributes to the evaluation context, so that policies can obtain these same"
@@ -84,13 +69,11 @@ msgstr ""
 "フィルターを使用して、評価コンテキストに追加の属性を定義し、ポリシーがこれらの同じ属性を取得できるようにすることができます。"
 
 #. type: Title ==
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:20
 #, no-wrap
 msgid "Providing the Permissions"
 msgstr "パーミッションの提供"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:24
 msgid ""
 "The *Permissions* filters can be used to build an authorization request. You"
 " can request permissions for a set of one or more resources and scopes. If "
@@ -102,6 +85,5 @@ msgstr ""
 " `Resources` または `Scopes` を指定せずに *Add* をクリックします。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-evaluation-tool-overview.adoc:25
 msgid "When you've specified your desired values, click *Evaluate*."
 msgstr "目的の値を指定したら、 *Evaluate* をクリックします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-evaluation-tool-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-evaluation-tool-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
