### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-logic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-logic.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-logic.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/policy-logic.adoc:2
 #, no-wrap
 msgid "Positive and Negative Logic"
 msgstr "肯定ロジックと否定ロジック"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-logic.adoc:5
 msgid ""
 "Policies can be configured with positive or negative logic. Briefly, you can"
 " use this option to define whether the policy result should be kept as it is"
@@ -30,7 +28,6 @@ msgid ""
 msgstr "ポリシーには肯定または否定のオプションを付与できます。これにより、ポリシー適用の結果を反転させることができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-logic.adoc:8
 msgid ""
 "For example, suppose you want to create a policy where only users *not* "
 "granted with a specific role should be given access. In this case, you can "
@@ -38,5 +35,6 @@ msgid ""
 "*Negative*. If you keep *Positive*, which is the default behavior, the "
 "policy result will be kept as it is."
 msgstr ""
-"たとえば、特定のロールを与えられて *いない* ユーザーのみアクセスを許可したいとします。この場合、まずそのロールを使ったロールベース・ポリシーを作成し、"
-" *Logic* を *Negative* にセットします。*Positive* のままにしておくと、ポリシーはその定義どおりに適用されます。"
+"たとえば、特定のロールを与えられて *いない* "
+"ユーザーのみアクセスを許可したいとします。この場合、まずそのロールを使ったロールベース・ポリシーを作成し、 *Logic* を *Negative* "
+"にセットします。*Positive* のままにしておくと、ポリシーはその定義どおりに適用されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-logic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-logic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
