### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-role-policy-required-role.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-role-policy-required-role.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-role-policy-required-role.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/policy-role-policy-required-role.adoc:2
 #, no-wrap
 msgid "Defining a Role as Required"
 msgstr "ロールを必須として定義する"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-role-policy-required-role.adoc:6
 msgid ""
 "When creating a role-based policy, you can specify a specific role as "
 "`Required`. When you do that, the policy will grant access only if the user "
@@ -33,13 +31,11 @@ msgstr ""
 "ロールを付与されたユーザーにのみアクセス権を与えることができます。レルムロールとクライアントロールの両方にこの設定を適用することができます。"
 
 #. type: Block title
-#: source/authorization_services/topics/policy-role-policy-required-role.adoc:7
 #, no-wrap
 msgid "Example of Required Role"
 msgstr "必須ロールの例"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-role-policy-required-role.adoc:9
 msgid ""
 "image:{project_images}/policy/create-role.png[alt=\"Example of Required "
 "Role\"]"
@@ -48,14 +44,12 @@ msgstr ""
 "Role\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-role-policy-required-role.adoc:11
 msgid ""
 "To specify a role as required, select the `Required` checkbox for the role "
 "you want to configure as required."
 msgstr "ロールを必須と指定するには、そのロールの `Required` チェックボックスをチェックします。"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-role-policy-required-role.adoc:13
 msgid ""
 "Required roles can be useful when your policy defines multiple roles but "
 "only a subset of them are mandatory. In this case, you can combine realm and"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-role-policy-required-role.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-role-policy-required-role
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
