### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,30 +16,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/create-client.adoc:12
-#: source/server_admin/topics/clients/client-oidc.adoc:9
-#: source/server_admin/topics/clients/client-saml.adoc:10
-#: source/authorization_services/topics/resource-server-create-client.adoc:10
 #, no-wrap
 msgid "Clients"
 msgstr "クライアント"
 
 #. type: Block title
-#: source/server_admin/topics/clients/client-oidc.adoc:27
-#: source/server_admin/topics/clients/client-saml.adoc:29
-#: source/authorization_services/topics/resource-server-create-client.adoc:27
 #, no-wrap
 msgid "Client Settings"
 msgstr "クライアントの設定"
 
 #. type: Title =
-#: source/authorization_services/topics/resource-server-create-client.adoc:2
 #, no-wrap
 msgid "Creating a Client Application"
 msgstr "クライアント・アプリケーションの作成"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:5
 msgid ""
 "The first step to enable {project_name} Authorization Services is to create "
 "the client application that you want to turn into a resource server."
@@ -47,33 +38,27 @@ msgstr ""
 "{project_name}認可サービスを有効にするための最初の手順は、リソースサーバーにするクライアント・アプリケーションを作成することです。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:7
 msgid "To create a client application, complete the following steps:"
 msgstr "クライアント・アプリケーションを作成するには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:9
 msgid "Click *Clients*."
 msgstr "*Clients* をクリックします。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:12
 msgid "image:{project_images}/resource-server/client-list.png[alt=\"Clients\"]"
 msgstr "image:{project_images}/resource-server/client-list.png[alt=\"クライアント\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:14
 msgid "On this page, click *Create*."
 msgstr "このページで、 *Create* をクリックします。"
 
 #. type: Block title
-#: source/authorization_services/topics/resource-server-create-client.adoc:15
 #, no-wrap
 msgid "Create Client"
 msgstr "クライアントの作成"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:17
 msgid ""
 "image:{project_images}/resource-server/client-create.png[alt=\"Create "
 "Client\"]"
@@ -81,29 +66,24 @@ msgstr ""
 "image:{project_images}/resource-server/client-create.png[alt=\"クライアントの作成\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:19
 msgid "Type the `Client ID` of the client. For example, _my-resource-server_."
 msgstr "クライアントの `Client ID` を入力します。たとえば、 _my-resource-server_ 。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:20
 msgid "Type the `Root URL` for your application. For example:"
 msgstr "アプリケーションの `Root URL` を入力します。たとえば"
 
 #. type: Code block
-#: source/authorization_services/topics/resource-server-create-client.adoc:23
 msgid "http://${host}:${port}/my-resource-server"
 msgstr "http://${host}:${port}/my-resource-server"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:26
 msgid ""
 "Click *Save*. The client is created and the client Settings page opens. A "
 "page similar to the following is displayed:"
 msgstr "*Save* をクリックします。クライアントが作成され、クライアントの設定ページが開きます。次のようなページが表示されます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-create-client.adoc:28
 msgid ""
 "image:{project_images}/resource-server/client-enable-authz.png[alt=\"Client "
 "Settings\"]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-create-client.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-create-client
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
