### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
@@ -16,58 +16,49 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/resource-server-default-config.adoc:2
 #, no-wrap
 msgid "Default Configuration"
 msgstr "デフォルト設定"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:5
 msgid ""
 "When you create a resource server, {project_name} creates a default "
 "configuration for your newly created resource server."
 msgstr "リソースサーバーを作成すると、{project_name}は新しく作成したリソースサーバーのデフォルト設定を作成します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:7
 msgid "The default configuration consists of:"
 msgstr "デフォルト設定は次のとおりです。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:9
 msgid ""
 "A default protected resource representing all resources in your application."
 msgstr "アプリケーションのすべてのリソースを表すデフォルトの保護されたリソース。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:10
 msgid ""
 "A policy that always grants access to the resources protected by this "
 "policy."
 msgstr "このポリシーで保護されているリソースへのアクセスを常に許可するポリシー。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:11
 msgid ""
 "A permission that governs access to all resources based on the default "
 "policy."
 msgstr " デフォルトのポリシーに基づいてすべてのリソースへのアクセスを管理するパーミッション。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:13
 msgid ""
 "The default protected resource is referred to as the *default resource* and "
 "you can view it if you navigate to the *Resources* tab."
 msgstr "デフォルトの保護されたリソースは *default resource* と呼ばれ、 *Resources* タブに移動すると表示できます。"
 
 #. type: Block title
-#: source/authorization_services/topics/resource-server-default-config.adoc:14
 #, no-wrap
 msgid "Default Resource"
 msgstr "デフォルト・リソース"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:16
 msgid ""
 "image:{project_images}/resource-server/default-resource.png[alt=\"Default "
 "Resource\"]"
@@ -76,7 +67,6 @@ msgstr ""
 "resource.png[alt=\"デフォルト・リソース\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:21
 msgid ""
 "This resource defines a `Type`, namely `urn:my-resource-"
 "server:resources:default` and a `URI` `/*`. Here, the `URI` field defines a "
@@ -92,7 +82,6 @@ msgstr ""
 " ポリシー適用>>を有効にすると、アクセス権を付与する前に、リソースに関連付けられているすべてのパーミッションが検査されます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:24
 msgid ""
 "The `Type` mentioned previously defines a value that can be used to create "
 "<<_permission_typed_resource, typed resource permissions>> that must be "
@@ -104,7 +93,6 @@ msgstr ""
 "タイプ付きリソース・パーミッション>>を作成するために使用できる値を定義します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:26
 msgid ""
 "The default policy is referred to as the *only from realm policy* and you "
 "can view it if you navigate to the *Policies* tab."
@@ -112,13 +100,11 @@ msgstr ""
 "デフォルトのポリシーは、 *only from realm policy* と呼ばれ、 *Policies* タブに移動すると表示できます。"
 
 #. type: Block title
-#: source/authorization_services/topics/resource-server-default-config.adoc:27
 #, no-wrap
 msgid "Default Policy"
 msgstr "デフォルト・ポリシー"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:29
 msgid ""
 "image:{project_images}/resource-server/default-policy.png[alt=\"Default "
 "Policy\"]"
@@ -127,7 +113,6 @@ msgstr ""
 "policy.png[alt=\"デフォルト・ポリシー\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:31
 msgid ""
 "This policy is a <<_policy_js, JavaScript-based policy>> defining a "
 "condition that always grants access to the resources protected by this "
@@ -138,7 +123,6 @@ msgstr ""
 "JavaScriptベースのポリシー>>です。このポリシーをクリックすると、次のようにルールが定義されていることが分かります。"
 
 #. type: Code block
-#: source/authorization_services/topics/resource-server-default-config.adoc:35
 #, no-wrap
 msgid ""
 "// by default, grants any permission associated with this policy\n"
@@ -148,7 +132,6 @@ msgstr ""
 "$evaluation.grant();\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:38
 msgid ""
 "Lastly, the default permission is referred to as the *default permission* "
 "and you can view it if you navigate to the *Permissions* tab."
@@ -156,13 +139,11 @@ msgstr ""
 "最後に、デフォルトのパーミッションは、 *default permission* と呼ばれ、 *Permissions* タブに移動すると表示できます。"
 
 #. type: Block title
-#: source/authorization_services/topics/resource-server-default-config.adoc:39
 #, no-wrap
 msgid "Default Permission"
 msgstr "デフォルト・パーミッション"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:41
 msgid ""
 "image:{project_images}/resource-server/default-permission.png[alt=\"Default "
 "Permission\"]"
@@ -171,7 +152,6 @@ msgstr ""
 "permission.png[alt=\"デフォルト・パーミッション\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:43
 msgid ""
 "This permission is a <<_permission_create_resource, resource-based "
 "permission>>, defining a set of one or more policies that are applied to all"
@@ -181,20 +161,17 @@ msgstr ""
 "リソースベースのパーミッション>>で、特定のタイプのすべてのリソースに適用される1つ以上のポリシーのセットを定義します。"
 
 #. type: Title ==
-#: source/authorization_services/topics/resource-server-default-config.adoc:44
 #, no-wrap
 msgid "Changing the Default Configuration"
 msgstr "デフォルト設定の変更"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:47
 msgid ""
 "You can change the default configuration by removing the default resource, "
 "policy, or permission definitions and creating your own."
 msgstr "デフォルトの設定を変更するには、デフォルトのリソース、ポリシー、またはパーミッションの定義を削除し、独自の定義を作成します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:50
 msgid ""
 "The default resource is created with an **URI** that maps to any resource or"
 " path in your application using a **/*** pattern. Before creating your own "
@@ -205,7 +182,6 @@ msgstr ""
 "で作成されます。独自のリソース、権限、ポリシーを作成する前に、デフォルト設定が自分の設定と矛盾しないことを確認してください。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-default-config.adoc:52
 msgid ""
 "The default configuration defines a resource that maps to all paths in your "
 "application. If you are about to write permissions to your own resources, be"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-default-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
