### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/resource-server-overview.adoc:2
 #, no-wrap
 msgid "Managing Resource Servers"
 msgstr "リソースサーバーの管理"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-overview.adoc:5
 msgid ""
 "According to the OAuth2 specification, a resource server is a server hosting"
 " the protected resources and capable of accepting and responding to "
@@ -31,7 +29,6 @@ msgstr ""
 "OAuth2の仕様によれば、リソースサーバーは保護されたリソースをホストし、保護されたリソースへのリクエストを受け入れて応答することができるサーバーです。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-overview.adoc:7
 msgid ""
 "In {project_name}, resource servers are provided with a rich platform for "
 "enabling fine-grained authorization for their protected resources, where "
@@ -41,7 +38,6 @@ msgstr ""
 "{project_name}では、リソースサーバーに保護されたリソースに対してきめ細かい認可を与えるための豊富なプラットフォームが用意されており、異なるアクセス制御の仕組みに基いた認可決定を行うことができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-overview.adoc:8
 msgid ""
 "Any client application can be configured to support fine-grained "
 "permissions. In doing so, you are conceptually turning the client "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
