### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:2
 #, no-wrap
 msgid "Managing Permission Requests"
 msgstr "パーミッション・リクエストの管理"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:5
 msgid ""
 "Resource servers using the UMA protocol can use a specific endpoint to "
 "manage permission requests. This endpoint provides a UMA-compliant flow for "
@@ -31,14 +29,12 @@ msgstr ""
 "UMAプロトコルを使用するリソースサーバーは、特定のエンドポイントを使用してパーミッション・リクエストを管理できます。このエンドポイントは、パーミッション・リクエストを登録し、パーミッション・チケットを取得するためのUMA準拠のフローを提供します。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:8
 msgid ""
 "http://${host}:${port}/auth/realms/${realm_name}/authz/protection/permission"
 msgstr ""
 "http://${host}:${port}/auth/realms/${realm_name}/authz/protection/permission"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:11
 msgid ""
 "A <<_overview_terminology_permission_ticket, permission ticket>> is a "
 "special security token type representing a permission request. Per the UMA "
@@ -49,7 +45,6 @@ msgstr ""
 "UMA仕様では、パーミッション・チケットは次のとおりです。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:13
 msgid ""
 "`A correlation handle that is conveyed from an authorization server to a "
 "resource server, from a resource server to a client, and ultimately from a "
@@ -60,24 +55,6 @@ msgstr ""
 "`認可サーバーからリソースサーバー、リソースサーバーからクライアント、最終的にはクライアントから認可サーバーに伝達され、認可サーバーが認可データの要求に適用する正しいポリシーを評価できるようにする相関ハンドル。`"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:17
-msgid ""
-"_Permission ticket support is limited_.  In the full UMA protocol, resource "
-"servers can register permission requests in the server to support "
-"authorization flows where a resource owner (the user that owns a resource "
-"being requested) can approve access to his resources by third parties, among"
-" other ways. This represents one of the main features of the UMA "
-"specification: resource owners can control their own resources and the "
-"policies that govern them. Currently {project_name} UMA implementation "
-"support is very limited in this regard. For example, the system does not "
-"store permission tickets on the server and we are essentially using UMA to "
-"provide API security and base our authorization offerings. In the future, "
-"full support of UMA and other use cases is planned."
-msgstr ""
-"_パーミッション・チケットのサポートは制限されています_。完全なUMAプロトコルでは、リソースサーバーは、リソースオーナー（要求されているリソースを所有するユーザー）が第三者によるリソースへのアクセスを他の方法で承認することができる認可フローをサポートするためにサーバーにパーミッション・リクエストを登録することができます。これは、UMA仕様の主な機能の1つを表します。リソースオーナーは、独自のリソースとそれらを管理するポリシーを制御できます。現在のところ、{project_name}のUMA実装のサポートは、この点で非常に制限されています。たとえば、システムはサーバー上にパーミッション・チケットを保存せず、基本的にはUMAを使用してAPIセキュリティーを提供し、認可サービスをベースにしています。将来、UMAやその他のユースケースの完全なサポートが計画されています。"
-
-#. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:20
 msgid ""
 "In most cases, you won't need to deal with this endpoint directly. "
 "{project_name} provides a <<_enforcer_overview, policy enforcer>> that "
@@ -91,7 +68,6 @@ msgstr ""
 "ポリシー・エンフォーサー>>を提供し、認可サーバーからパーミッション・チケットを取得し、このチケットをクライアント・アプリケーションに戻し、最後にリクエスティング・パーティ・トークン（RPT）に基づいて認可決定を実施することができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:24
 msgid ""
 "The process of obtaining permission tickets from {project_name} is performed"
 " by resource servers and not regular client applications, where permission "
@@ -103,14 +79,12 @@ msgstr ""
 "{project_name}からパーミッション・チケットを取得するプロセスは、クライアントがリソースにアクセスするために必要な許可なく保護されたリソースにアクセスしようとしたときに、パーミッション・チケットが取得される通常のクライアント・アプリケーションではなくリソースサーバーによって実行されます。パーミッション・チケットの発行は、UMAを使用する際の重要な側面です。これにより、リソースサーバーは次のことが可能になります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:26
 msgid ""
 "Abstract from clients the data associated with the resources protected by "
 "the resource server"
 msgstr "リソースサーバーによって保護されているリソースに関連付けられたデータをクライアントから抽出します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:27
 msgid ""
 "Register in the {project_name} authorization requests which in turn can be "
 "used later in workflows to grant access based on the resource's owner "
@@ -119,21 +93,18 @@ msgstr ""
 "{project_name}の認可リクエストに登録します。これは、後からワークフローを使用して、リソースの所有者の承認に基づいてアクセスを許可します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:28
 msgid ""
 "Decouple resource servers from authorization servers and allow them to "
 "protect and manage their resources using different authorization servers"
 msgstr "リソースサーバーを認可サーバーから切り離し、異なる認証サーバーを使用してリソースを保護および管理できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:30
 msgid ""
 "Client wise, a permission ticket has also important aspects that its worthy "
 "to highlight:"
 msgstr "クライアントの賢明な点として、パーミッション・チケットには重要な側面もあります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:32
 msgid ""
 "Clients don't need to know about how authorization data is associated with "
 "protected resources. A permission ticket is completely opaque to clients."
@@ -141,14 +112,12 @@ msgstr ""
 "クライアントは、認可データが保護されたリソースにどのように関連付けられているかを知る必要はありません。パーミッション・チケットは、クライアントにとって完全に不透明です。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:33
 msgid ""
 "Clients can have access to resources on different resource servers and "
 "protected by different authorization servers"
 msgstr "クライアントは、異なるリソースサーバー上のさまざまな認可サーバーによって保護されたリソースにアクセスできます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-permission-api-papi.adoc:35
 msgid ""
 "These are just some of the benefits brought by UMA where other aspects of "
 "UMA are strongly based on permission tickets, specially regarding privacy "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-permission-api-papi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
