### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
@@ -16,20 +16,17 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/getting_started/topics/first-boot/admin-console.adoc:2
 #, no-wrap
 msgid "Logging in to the Admin Console"
 msgstr "管理コンソールへのログイン"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/admin-console.adoc:5
 msgid ""
 "After you create the initial admin account, you can log in to the Admin "
 "Console by completing the following steps:"
 msgstr "初期管理者アカウントを作成した後、以下の手順に沿って、管理コンソールにログインすることができます。"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/admin-console.adoc:8
 msgid ""
 "At the bottom of the Welcome page click the _Administration Console_ link.  "
 "Alternatively you can go to the console URL directly at "
@@ -39,42 +36,30 @@ msgstr ""
 "http://localhost:8080/auth/admin/ にてコンソールのURLに直接アクセスすることも可能です。"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/admin-console.adoc:9
-#: source/server_admin/topics/admin-console.adoc:7
-#: source/authorization_services/topics/hello-world-deploy.adoc:77
 #, no-wrap
 msgid "Login Page"
 msgstr "ログインページ"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/admin-console.adoc:11
-#: source/server_admin/topics/admin-console.adoc:9
 msgid "image:{project_images}/login-page.png[]"
 msgstr "image:{project_images}/login-page.png[]"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/admin-console.adoc:13
 msgid ""
 "Type the username and password you created on the Welcome page. The "
 "{project_name} Admin Console page opens."
 msgstr "ウェルカムページにて作成したユーザー名とパスワードを入力します。{project_name}管理コンソールページが開きます。"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/admin-console.adoc:14
-#: source/server_admin/topics/admin-console.adoc:2
-#: source/server_admin/topics/admin-console.adoc:13
 #, no-wrap
 msgid "Admin Console"
 msgstr "管理コンソール"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/admin-console.adoc:16
-#: source/server_admin/topics/admin-console.adoc:15
 msgid "image:{project_images}/admin-console.png[]"
 msgstr "image:{project_images}/admin-console.png[]"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/admin-console.adoc:20
 #, no-wrap
 msgid ""
 "If you are curious about a certain feature, button, or field within the Admin Console, hover your mouse\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__admin-console
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
