### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/getting_started/topics/first-boot/initial-user.adoc:2
 #, no-wrap
 msgid "Creating the Admin Account"
 msgstr "管理者アカウントの作成"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/initial-user.adoc:5
 msgid ""
 "After the server boots, open your browser and go to the "
 "http://localhost:8080/auth URL. The page should look like this:"
@@ -30,20 +28,15 @@ msgstr ""
 "サーバーが起動した後、ブラウザーを開きURL http://localhost:8080/auth へ移動します。ページは以下のようになります。"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/initial-user.adoc:6
-#: source/server_admin/topics/initialization.adoc:13
 #, no-wrap
 msgid "Welcome Page"
 msgstr "ウェルカムページ"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/initial-user.adoc:8
-#: source/server_admin/topics/initialization.adoc:15
 msgid "image:{project_images}/initial-welcome-page.png[]"
 msgstr "image:{project_images}/initial-welcome-page.png[]"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/initial-user.adoc:12
 msgid ""
 "{project_name} does not have a configured admin account by default. You must"
 " create one on the Welcome page.  This account will allow you to create an "
@@ -56,7 +49,6 @@ msgstr ""
 "レルムの管理コンソールへのログインが可能となる管理者を作成できます。それにより、レルムとユーザーの作成および{project_name}に保護されるアプリケーションの登録を始めることができます。"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/initial-user.adoc:16
 #, no-wrap
 msgid ""
 "You can only create an initial admin user on the Welcome Page if you connect using `localhost`. This is a security\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__initial-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
