### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/jaas.adoc:2
 #, no-wrap
 msgid "JAAS plugin"
 msgstr "JAASプラグイン"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:7
 msgid ""
 "It's generally not needed to use JAAS for most of the applications, "
 "especially if they are HTTP based, and you should most likely choose one of "
@@ -34,18 +32,15 @@ msgstr ""
 "しかし、一部のアプリケーションやシステムは、依然として純粋なレガシーJAASソリューションに依存している場合があります。{project_name}は、このような状況に役立つ2つのログイン・モジュールを提供します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:9
 msgid "The provided login modules are:"
 msgstr "提供されるログイン・モジュールは次のとおりです。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/jaas.adoc:10
 #, no-wrap
 msgid "org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule"
 msgstr "org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:15
 msgid ""
 "This login module allows to authenticate with username/password from "
 "{project_name}.  It's using "
@@ -59,13 +54,11 @@ msgstr ""
 "このログイン・モジュールは、{project_name}のユーザー名/パスワードで認証することができます。<<_resource_owner_password_credentials_flow,リソース・オーナー・パスワード・クレデンシャル>>のフローを使用して、提供されたユーザー名/パスワードが有効かどうかを検証します。JAASに依存する必要があり、{project_name}を使用したい非Webベースのシステムにとっては有益ですが、Web以外の性質のため、標準のブラウザー・ベースのフローを使用することはできません。このようなアプリケーションとして挙げられるのは、メッセージングやSSHです。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/jaas.adoc:16
 #, no-wrap
 msgid "org.keycloak.adapters.jaas.BearerTokenLoginModule"
 msgstr "org.keycloak.adapters.jaas.BearerTokenLoginModule"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:20
 msgid ""
 "This login module allows to authenticate with {project_name} access token "
 "passed to it through CallbackHandler as password.  It may be useful for "
@@ -75,21 +68,18 @@ msgid ""
 "system."
 msgstr ""
 "このログイン・モジュールでは、パスワードとして `CallbackHandler` "
-"を介して渡された{project_name}のアクセス・トークンで認証できます。たとえば、標準ベースの認証フローから{project_name}のアクセス・トークンを取得し、WebアプリケーションがJAASに依存する外部の非Webベースのシステムと対話する必要がある場合などに便利です。たとえば、メッセージング・システムです。"
+"を介して渡された{project_name}のアクセストークンで認証できます。たとえば、標準ベースの認証フローから{project_name}のアクセストークンを取得し、WebアプリケーションがJAASに依存する外部の非Webベースのシステムと対話する必要がある場合などに便利です。たとえば、メッセージング・システムです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:22
 msgid "Both modules use the following configuration properties:"
 msgstr "どちらのモジュールも次の設定プロパティーを使用します。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/jaas.adoc:23
 #, no-wrap
 msgid "keycloak-config-file"
 msgstr "keycloak-config-file"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:27
 msgid ""
 "The location of the `keycloak.json` configuration file. The configuration "
 "file can either be located on the filesystem or on the classpath. If it's "
@@ -101,13 +91,11 @@ msgstr ""
 "`classpath:` を付ける必要があります（たとえば `classpath:/path/keycloak.json` ）。これは _必須_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/jaas.adoc:28
 #, no-wrap
 msgid "`role-principal-class`"
 msgstr "`role-principal-class`"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/jaas.adoc:31
 msgid ""
 "Configure alternative class for Role principals attached to JAAS Subject.  "
 "Default value is `org.keycloak.adapters.jaas.RolePrincipal`. Note: The class"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jaas
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
