### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapters.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapters.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapters.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,15 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/oidc/java/java-adapters.adoc:1
-#: source/securing_apps/topics/saml/java/java-adapters.adoc:2
 #, no-wrap
 msgid "Java Adapters"
 msgstr "Javaアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapters.adoc:4
-#: source/securing_apps/topics/saml/java/java-adapters.adoc:4
 msgid ""
 "{project_name} comes with a range of different adapters for Java "
 "application. Selecting the correct adapter depends on the target platform."
@@ -32,7 +28,6 @@ msgstr ""
 "{project_name}には、Javaアプリケーション用のさまざまなアダプターが付属しています。正しいアダプターの選択は、対象のプラットフォームによって異なります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapters.adoc:5
 msgid ""
 "All Java adapters share a set of common configuration options described in "
 "the <<_java_adapter_config,Java Adapters Config>> chapter."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapters.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__java-adapters
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
