### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,18 +15,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ###
-#: source/server_installation/topics/clustering/troubleshooting.adoc:2
-#: source/securing_apps/topics/client-registration/client-registration-cli.adoc:391
-#: source/securing_apps/topics/saml/java/debugging.adoc:2
-#: source/server_admin/topics/authentication/kerberos.adoc:191
-#: source/server_admin/topics/authentication/x509.adoc:201
+#. type: Attribute :installguide_troubleshooting_name:
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/debugging.adoc:4
 msgid ""
 "The best way to troubleshoot problems is to turn on debugging for SAML in "
 "both the client adapter and {project_name} Server. Using your logging "
@@ -36,4 +30,4 @@ msgid ""
 msgstr ""
 "問題を解決する最善の方法は、SAMLクライアント・アダプターと{project_name}サーバーの両方でデバッギングを有効にすることです。ロギング・フレームワークを使用して、"
 " `org.keycloak.saml` パッケージのログ・レベルを `DEBUG` "
-"に設定します。これを有効にすることで、サーバー間で送信されるSAMLのリクエスト/レスポンスドキュメントを見ることができます。"
+"に設定します。これを有効にすることで、サーバー間で送信されるSAMLのリクエスト/レスポンスのドキュメントを見ることができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/debugging.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__debugging
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
