### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po
@@ -16,15 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:3
-#: source/securing_apps/topics/saml/java/error_handling.adoc:2
 #, no-wrap
 msgid "Error Handling"
 msgstr "エラー処理"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/adapter_error_handling.adoc:16
-#: source/securing_apps/topics/saml/java/error_handling.adoc:16
 #, no-wrap
 msgid ""
 "<error-page>\n"
@@ -38,7 +34,6 @@ msgstr ""
 "</error-page>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/error_handling.adoc:8
 msgid ""
 "{project_name} has some error handling facilities for servlet based client "
 "adapters.  When an error is encountered in authentication, the client "
@@ -51,7 +46,6 @@ msgstr ""
 "pageを設定してエラーを処理することができます。クライアント・アダプターは、400、401、403、500のエラーをスローできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/error_handling.adoc:23
 msgid ""
 "The client adapter also sets an `HttpServletRequest` attribute that you can "
 "retrieve.  The attribute name is "
@@ -66,7 +60,6 @@ msgstr ""
 "にキャストします。このクラスは、正確に何が起こったかを伝えることができます。この属性が設定されない場合、アダプターはエラーコードに対して何もしません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/error_handling.adoc:33
 #, no-wrap
 msgid ""
 "public class SamlAuthenticationError implements AuthenticationError {\n"
@@ -84,7 +77,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/error_handling.adoc:41
 #, no-wrap
 msgid ""
 "    public Reason getReason() {\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/error_handling.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__error_handling
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
