### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/saml/java/general-config.adoc:3
 #, no-wrap
 msgid "General Adapter Config"
 msgstr "共通アダプター設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config.adoc:7
 msgid ""
 "Each SAML client adapter supported by {project_name} can be configured by a "
 "simple XML text file.  This is what one might look like:"
@@ -30,7 +28,6 @@ msgstr ""
 "{project_name}でサポートされているSAMLクライアント・アダプターは、いずれも簡単なXMLテキストファイルで設定できます。これは以下のようなものです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config.adoc:38
 #, no-wrap
 msgid ""
 "<keycloak-saml-adapter xmlns=\"urn:keycloak:saml:adapter\"\n"
@@ -92,7 +89,6 @@ msgstr ""
 "                    />\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config.adoc:55
 #, no-wrap
 msgid ""
 "            <SingleLogoutService\n"
@@ -130,12 +126,11 @@ msgstr ""
 "</keycloak-saml-adapter>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config.adoc:60
 msgid ""
 "Some of these configuration switches may be adapter specific and some are "
 "common across all adapters.  For Java adapters you can use `${...}` "
 "enclosure as System property replacement.  For example "
 "`${jboss.server.config.dir}`."
 msgstr ""
-"これらの設定の中には、アダプター固有のものもあれば、すべてのアダプターに共通のものもあります。Javaアダプターの場合は、システム・プロパティーの置換に "
-"`${...}`  エンクロージャーを使用できます。 たとえば、 `${jboss.server.config.dir}` です。"
+"これらの設定の中には、アダプター固有のものもあれば、すべてのアダプターに共通のものもあります。Javaアダプターの場合は、システム・プロパティーの置換に"
+" `${...}`  エンクロージャーを使用できます。 たとえば、 `${jboss.server.config.dir}` です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
