### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po
@@ -16,20 +16,17 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:2
 #, no-wrap
 msgid "IDP Element"
 msgstr "IDP要素"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:5
 msgid ""
 "Everything in the IDP element describes the settings for the identity "
 "provider (authentication server) the SP is communicating with."
 msgstr "IDP要素内には、SPと通信しているアイデンティティー・プロバイダー（認証サーバー）の設定を記述します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:14
 #, no-wrap
 msgid ""
 "<IDP entityID=\"idp\"\n"
@@ -47,32 +44,26 @@ msgstr ""
 "</IDP>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:17
 msgid ""
 "Here are the attribute config options you can specify within the `IDP` "
 "element declaration."
 msgstr "`IDP` 要素宣言内で指定できる属性設定オプションを示します。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:18
-#: source/securing_apps/topics/saml/java/general-config/sp_element.adoc:18
 #, no-wrap
 msgid "entityID"
 msgstr "entityID"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:20
 msgid "This is the issuer ID of the IDP. This setting is _REQUIRED_."
 msgstr "IDPの発行者IDです。この設定は _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:21
 #, no-wrap
 msgid "signaturesRequired"
 msgstr "signaturesRequired"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:26
 msgid ""
 "If set to `true`, the client adapter will sign every document it sends to "
 "the IDP.  Also, the client will expect that the IDP will be signing any "
@@ -85,13 +76,11 @@ msgstr ""
 " _OPTIONAL_ で、 `false` がデフォルトとなります。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:26
 #, no-wrap
 msgid "signatureAlgorithm"
 msgstr "signatureAlgorithm"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:31
 msgid ""
 "This is the signature algorithm that the IDP expects signed documents to "
 "use.  Allowed values are: `RSA_SHA1`, `RSA_SHA256`, `RSA_SHA512`, and "
@@ -101,13 +90,11 @@ msgstr ""
 "`RSA_SHA512` 、 `DSA_SHA1` です。 この設定は _OPTIONAL_ で、デフォルトは `RSA_SHA256` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:31
 #, no-wrap
 msgid "signatureCanonicalizationMethod"
 msgstr "signatureCanonicalizationMethod"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_element.adoc:34
 msgid ""
 "This is the signature canonicalization method that the IDP expects signed "
 "documents to use.  This setting is _OPTIONAL_.  The default value is "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
