### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -16,8 +16,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:153
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:33
 msgid ""
 "If the {project_name} server requires HTTPS and this config option is set to"
 " `true` you do not have to specify a truststore.  This setting should only "
@@ -30,15 +28,11 @@ msgstr ""
 " *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:164
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:43
 #, no-wrap
 msgid "truststore"
 msgstr "truststore"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:177
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:56
 msgid ""
 "Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
 " set and the truststore requires a password."
@@ -47,8 +41,6 @@ msgstr ""
 "を設定すると、トラストストアはパスワードを必要とします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:182
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:61
 msgid ""
 "This is the file path to a keystore file.  This keystore contains client "
 "certificate for two-way SSL when the adapter makes HTTPS requests to the "
@@ -58,13 +50,11 @@ msgstr ""
 " _OPTIONAL_ です。"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:3
 #, no-wrap
 msgid "IDP HttpClient sub element"
 msgstr "IDP HttpClient サブ要素"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:9
 msgid ""
 "The `HttpClient` optional sub element defines the properties of HTTP client "
 "used for automatic obtaining of certificates containing public keys for IDP "
@@ -75,7 +65,6 @@ msgstr ""
 "automatic,enabled>>の場合、IDPのSAML記述子による、IDP署名検証用の公開鍵を含む証明書の自動取得に使用されるます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:20
 #, no-wrap
 msgid ""
 "<HttpClient connectionPoolSize=\"10\"\n"
@@ -97,13 +86,11 @@ msgstr ""
 "            proxyUrl=\"http://proxy/\" />\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:22
 #, no-wrap
 msgid "connectionPoolSize"
 msgstr "connectionPoolSize"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:27
 msgid ""
 "Adapters will make separate HTTP invocations to the {project_name} server to"
 " turn an access code into an access token.  This config option defines how "
@@ -114,19 +101,16 @@ msgstr ""
 " これは _OPTIONAL_ です。デフォルトは `10` です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:28
 #, no-wrap
 msgid "disableTrustManager"
 msgstr "disableTrustManager"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:34
 #, no-wrap
 msgid "allowAnyHostname"
 msgstr "allowAnyHostname"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:42
 msgid ""
 "If the {project_name} server requires HTTPS and this config option is set to"
 " `true` the {project_name} server's certificate is validated via the "
@@ -141,7 +125,6 @@ msgstr ""
 "_OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:52
 msgid ""
 "The value is the file path to a keystore file.  If you prefix the path with "
 "`classpath:`, then the truststore will be obtained from the deployment's "
@@ -158,25 +141,21 @@ msgstr ""
 " `disableTrustManager` が `true` でない限り、 _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:53
 #, no-wrap
 msgid "truststorePassword"
 msgstr "truststorePassword"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:57
 #, no-wrap
 msgid "clientKeystore"
 msgstr "clientKeystore"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:62
 #, no-wrap
 msgid "clientKeystorePassword"
 msgstr "clientKeystorePassword"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:65
 msgid ""
 "Password for the client keystore and for the client's key.  This is "
 "_REQUIRED_ if `clientKeystore` is set."
@@ -184,12 +163,10 @@ msgstr ""
 "クライアントのキーとクライアントのキーストアのパスワードです。 `clientKeystore` が設定されている場合は、 _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:66
 #, no-wrap
 msgid "proxyUrl"
 msgstr "proxyUrl"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.adoc:68
 msgid "URL to HTTP proxy to use for HTTP connections.  This is _OPTIONAL_."
 msgstr "HTTP接続に使用するHTTPプロキシのURLです。これは _OPTIONAL_ です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_httpclient_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
