### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:3
 #, no-wrap
 msgid "IDP Keys sub element"
 msgstr "IDP Keysサブ要素"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:9
 msgid ""
 "The Keys sub element of IDP is only used to define the certificate or public"
 " key to use to verify documents signed by the IDP.  It is defined in the "
@@ -36,7 +34,6 @@ msgstr ""
 "keys,SPの鍵とKeys要素>>と同じ方法で定義されます。しかし、証明書または公開鍵の参照を1つだけ定義する必要があります。IDPとSPが{project_name}サーバーとアダプターによって実現された場合、それぞれで、署名の検証のために鍵を指定する必要はないことに注意してください（以下を参照してください）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:22
 msgid ""
 "It is possible to configure SP to obtain public keys for IDP signature "
 "validation from published certificates automatically, provided both SP and "
@@ -56,7 +53,6 @@ msgstr ""
 "、<<_sp-idp-httpclient,IDP HttpClientサブ要素>>内に設定できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:28
 msgid ""
 "It is also possible to specify multiple keys for signature verification. "
 "This is done by declaring multiple Key elements within Keys sub element that"
@@ -69,7 +65,6 @@ msgstr ""
 "に設定し、Keysサブ要素内に複数のKey要素を宣言することによって行います。これは、たとえばIDPの署名鍵をローテーションするような状況で役に立ちます。通常、新しいSAMLプロトコルのメッセージとアサーションが新しい鍵で署名されても、以前の鍵で署名されたものを受け入れられる移行期間があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:32
 msgid ""
 "It is not possible to configure {project_name} to both obtain the keys for "
 "signature verification automatically and define additional static signature "
@@ -78,7 +73,6 @@ msgstr ""
 "署名検証用の鍵を自動的に取得することと、追加の静的な署名検証の鍵を定義することの、両方を{project_name}に設定することはできません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config/idp_keys_subelement.adoc:45
 #, no-wrap
 msgid ""
 "       <IDP entityID=\"idp\">\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_keys_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_keys_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
