### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po
@@ -16,41 +16,31 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:19
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:20
 #, no-wrap
 msgid "signRequest"
 msgstr "signRequest"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:30
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:24
 #, no-wrap
 msgid "validateResponseSignature"
 msgstr "validateResponseSignature"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:33
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:28
 #, no-wrap
 msgid "requestBinding"
 msgstr "requestBinding"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:37
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:32
 #, no-wrap
 msgid "responseBinding"
 msgstr "responseBinding"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:3
 #, no-wrap
 msgid "IDP SingleSignOnService sub element"
 msgstr "IDP SingleSignOnServiceサブ要素"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:8
 msgid ""
 "The `SingleSignOnService` sub element defines the login SAML endpoint of the"
 " IDP.  The client adapter will send requests to the IDP formatted via the "
@@ -60,7 +50,6 @@ msgstr ""
 "サブ要素は、IDPのログインSAMLエンドポイントを定義します。クライアント・アダプターは、ログインしたいときに、この要素内の設定によって書式設定されたIDPにリクエストを送信します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:16
 #, no-wrap
 msgid ""
 "<SingleSignOnService signRequest=\"true\"\n"
@@ -74,12 +63,10 @@ msgstr ""
 "                     bindingUrl=\"url\"/>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:19
 msgid "Here are the config attributes you can define on this element:"
 msgstr "この要素に定義できる設定属性は次のとおりです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:23
 msgid ""
 "Should the client sign authn requests? This setting is _OPTIONAL_.  Defaults"
 " to whatever the IDP `signaturesRequired` element value is."
@@ -88,7 +75,6 @@ msgstr ""
 "`signaturesRequired` 要素の値です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:27
 msgid ""
 "Should the client expect the IDP to sign the assertion response document "
 "sent back from an auhtn request? This setting _OPTIONAL_. Defaults to "
@@ -98,7 +84,6 @@ msgstr ""
 "_OPTIONAL_ です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:31
 msgid ""
 "This is the SAML binding type used for communicating with the IDP.  This "
 "setting is _OPTIONAL_.  The default value is `POST`, but you can set it to "
@@ -108,7 +93,6 @@ msgstr ""
 "`REDIRECT` に設定することもできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:36
 msgid ""
 "SAML allows the client to request what binding type it wants authn responses"
 " to use.  The values of this can be `POST` or `REDIRECT`.  This setting is "
@@ -120,13 +104,11 @@ msgstr ""
 "です。デフォルトでは、クライアントはレスポンスに対して特定のバインディング・タイプを要求しません。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:37
 #, no-wrap
 msgid "assertionConsumerServiceUrl"
 msgstr "assertionConsumerServiceUrl"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:43
 msgid ""
 "URL of the assertion consumer service (ACS) where the IDP login service "
 "should send responses to.  This setting is _OPTIONAL_. By default it is "
@@ -144,13 +126,11 @@ msgstr ""
 "属性を伴います。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:44
 #, no-wrap
 msgid "bindingUrl"
 msgstr "bindingUrl"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:46
 msgid ""
 "This is the URL for the IDP login service that the client will send requests"
 " to. This setting is _REQUIRED_."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_singlesignonservice_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
