### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/general-config/roleidentifiers_element.adoc:2
 #, no-wrap
 msgid "RoleIdentifiers Element"
 msgstr "RoleIdentifiers要素"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/roleidentifiers_element.adoc:6
 msgid ""
 "The `RoleIdentifiers` element defines what SAML attributes within the "
 "assertion received from the user should be used as role identifiers within "
@@ -32,7 +30,6 @@ msgstr ""
 "EEのセキュリティー・コンテキスト内のロール識別子として使用されるか定義します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config/roleidentifiers_element.adoc:15
 #, no-wrap
 msgid ""
 "<RoleIdentifiers>\n"
@@ -48,7 +45,6 @@ msgstr ""
 "</RoleIdentifiers>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/roleidentifiers_element.adoc:20
 msgid ""
 "By default `Role` attribute values are converted to Java EE roles.  Some "
 "IdPs send roles using a `member` or `memberOf` attribute assertion.  You can"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__roleidentifiers_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
