### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/securing_wars.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/securing_wars.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/securing_wars.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:2
 #, no-wrap
 msgid "Securing WARs via {project_name} SAML Subsystem"
 msgstr "{project_name} SAMLサブシステムを介してWARをセキュリティー保護する"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:9
 msgid ""
 "You do not have to crack open a WAR to secure it with {project_name}.  "
 "Alternatively, you can externally secure it via the {project_name} SAML "
@@ -39,7 +37,6 @@ msgstr ""
 " `standalone.xml` のサブシステム設定セクションのXML内で定義されます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:16
 #, no-wrap
 msgid ""
 "<extensions>\n"
@@ -51,7 +48,6 @@ msgstr ""
 "</extensions>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:26
 #, no-wrap
 msgid ""
 "<profile>\n"
@@ -75,7 +71,6 @@ msgstr ""
 "</profile>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:31
 msgid ""
 "The `secure-deployment` `name` attribute identifies the WAR you want to "
 "secure.  Its value is the `module-name` defined in `web.xml` with `.war` "
@@ -88,12 +83,10 @@ msgstr ""
 "`keycloak-saml.xml` 設定と同じXML構文を使用します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:33
 msgid "An example configuration:"
 msgstr "設定例を次に示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:61
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:keycloak-saml:1.1\">\n"
@@ -147,7 +140,6 @@ msgstr ""
 "            bindingUrl=\"http://localhost:8080/auth/realms/saml-demo/protocol/saml\"/>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/jboss-adapter/securing_wars.adoc:82
 #, no-wrap
 msgid ""
 "        <SingleLogoutService\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/securing_wars.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__securing_wars
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
