### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.adoc:2
 #, no-wrap
 msgid "Jetty 8 Per WAR Configuration"
 msgstr "Jetty 8 WARごとの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.adoc:5
 msgid ""
 "Enabling Keycloak for your WARs is the same as the Jetty 9.x adapter.  See "
 "<<_saml-jetty9-per-war, Jetty 9 Per War Configuration>>"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty8-per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
