### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/MigrationFromOlderVersions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/MigrationFromOlderVersions.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/MigrationFromOlderVersions.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,28 +18,21 @@ msgstr ""
 #.  MOVED TO SEPARATE UPGRADE GUIDE!
 #.  Add Keycloak migration changes to upgrading/topics/keycloak/changes.adoc
 #. type: Title ==
-#: source/securing_apps/topics/saml/java/MigrationFromOlderVersions.adoc:1
-#: source/server_admin/topics/MigrationFromOlderVersions.adoc:6
 #, no-wrap
 msgid "Migration from older versions"
 msgstr "以前のバージョンからの移行"
 
 #. type: Title ===
-#: source/securing_apps/topics/saml/java/MigrationFromOlderVersions.adoc:3
-#: source/upgrading/topics/keycloak/changes.adoc:176
 #, no-wrap
 msgid "Migrating to 1.9.0"
 msgstr "1.9.0への移行"
 
 #. type: Title ====
-#: source/securing_apps/topics/saml/java/MigrationFromOlderVersions.adoc:5
-#: source/upgrading/topics/keycloak/changes.adoc:218
 #, no-wrap
 msgid "SAML SP Client Adapter Changes"
 msgstr "SAML SPクライアント・アダプターの変更"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/MigrationFromOlderVersions.adoc:10
 msgid ""
 "Keycloak SAML SP Client Adapter now requires a specific endpoint, `/saml` to"
 " be registered with your IdP.  The SamlFilter must also be bound to /saml in"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/MigrationFromOlderVersions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__MigrationFromOlderVersions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
