### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po
@@ -16,17 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/getting_started/topics/overview.adoc:2
-#: source/securing_apps/topics/overview/overview.adoc:1
-#: source/securing_apps/topics/saml/java/saml_adapter_overview.adoc:1
-#: source/server_admin/topics/overview.adoc:1
-#: source/authorization_services/topics/auth-services-overview.adoc:2
 #, no-wrap
 msgid "Overview"
 msgstr "概要"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/saml_adapter_overview.adoc:6
 msgid ""
 "This document describes the Keycloak SAML client adapter and how it can be "
 "configured for a variety of platforms.  The Keycloak SAML client adapter is "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/saml_adapter_overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__saml_adapter_overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
