### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po
@@ -16,14 +16,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:146
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:118
-#: source/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc:18
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:63
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:36
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:24
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:28
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:20
 #, no-wrap
 msgid ""
 "<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
@@ -37,31 +29,20 @@ msgstr ""
 "      version=\"3.0\">\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/jetty9-adapter.adoc:120
-#: source/securing_apps/topics/oidc/java/tomcat-adapter.adoc:65
-#: source/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.adoc:38
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:26
-#: source/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.adoc:30
-#: source/securing_apps/topics/saml/java/jboss-adapter/required_per_war_configuration.adoc:22
 #, no-wrap
 msgid "\t<module-name>customer-portal</module-name>\n"
 msgstr "\t<module-name>customer-portal</module-name>\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc:2
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:2
 #, no-wrap
 msgid "Java Servlet Filter Adapter"
 msgstr "Javaサーブレット・フィルター・アダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/servlet-filter-adapter.adoc:58
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:49
 msgid "To use this filter, include this maven artifact in your WAR poms:"
 msgstr "このフィルタを使用するには、WARのpomに次のmavenアーティファクトを含めます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:11
 msgid ""
 "If you want to use SAML with a Java servlet application that doesn't have an"
 " adapter for that servlet platform, you can opt to use the servlet filter "
@@ -78,7 +59,6 @@ msgstr ""
 "にセキュリティー制約を定義しません。代わりに{project_name}サーブレット・フィルター・アダプターを使用してフィルター・マッピングを定義して、URLパターンでセキュリティー保護します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:15
 #, no-wrap
 msgid ""
 "Backchannel logout works a bit differently than the standard adapters.\n"
@@ -90,14 +70,12 @@ msgstr ""
 "セッションIDに基づいてHTTPセッションを任意に無効にする方法はありません。\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:17
 msgid ""
 "Backchannel logout does not currently work when you have a clustered "
 "application that uses the SAML filter."
 msgstr "現時点では、SAMLフィルターを使用するクラスター化されたアプリケーションでは、バックチャネル・ログアウトは機能しません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:36
 #, no-wrap
 msgid ""
 "    <filter>\n"
@@ -121,7 +99,6 @@ msgstr ""
 "</web-app>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:40
 msgid ""
 "The {project_name} filter has the same configuration parameters available as"
 " the other adapters except you must define them as filter init params "
@@ -130,14 +107,12 @@ msgstr ""
 "{project_name}フィルターは、コンテキスト・パラメータの代わりにフィルター初期化パラメータとして定義する必要がある以外は、他のアダプターと同じ設定パラメータを使用できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:42
 msgid ""
 "You can define multiple filter mappings if you have various different secure"
 " and unsecure url patterns."
 msgstr "さまざまな異なる安全なURLパターンと安全でないURLパターンが存在する場合は、複数のフィルター・マッピングを定義できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:45
 #, no-wrap
 msgid ""
 "You must have a filter mapping that covers `/saml`.\n"
@@ -147,7 +122,6 @@ msgstr ""
 "このマッピングは、すべてのサーバー・コールバックを対象としています。\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:47
 msgid ""
 "When registering SPs with an IdP, you must register `http[s]://hostname"
 "/{context-root}/saml` as your Assert Consumer Service URL and Single Logout "
@@ -157,7 +131,6 @@ msgstr ""
 "`http[s]://hostname/{context-root}/saml` を登録する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/servlet-filter-adapter.adoc:57
 #, no-wrap
 msgid ""
 "<dependency>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__servlet-filter-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
