### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po
@@ -18,34 +18,34 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 msgstr ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 msgstr ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 
 #. type: Plain text
 msgid ""
@@ -112,6 +112,11 @@ msgstr ""
 "        </auth-constraint>\n"
 "    </security-constraint>\n"
 
+#. type: Title =====
+#, no-wrap
+msgid "Per WAR Configuration"
+msgstr "WARごとの設定"
+
 #. type: Plain text
 msgid ""
 "Next you must create a `keycloak-saml.xml` adapter config file within the "
@@ -121,11 +126,6 @@ msgstr ""
 "次に、WARの `WEB-INF` ディレクトリーに `keycloak-saml.xml` "
 "アダプター設定ファイルを作成する必要があります。この設定ファイルの形式は、<<_saml-general-"
 "config,共通アダプター設定>>のセクションで説明しています。"
-
-#. type: Title =====
-#, no-wrap
-msgid "Per WAR Configuration"
-msgstr "WARごとの設定"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
