### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication.ja_JP.po
@@ -16,14 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/securing_apps/topics/client-registration.adoc:20
-#: source/server_admin/topics/authentication.adoc:2
 #, no-wrap
 msgid "Authentication"
 msgstr "認証"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication.adoc:7
 msgid ""
 "There are a few features you should be aware of when configuring "
 "authentication for your realm.  Many organizations have strict password and "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
