### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/clients/client-link.adoc:2
 #, no-wrap
 msgid "Client Links"
 msgstr "クライアントのリンク"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-link.adoc:5
 msgid ""
 "For scenarios where one wants to link from one client to another, "
 "{project_name} provides a special redirect endpoint: "
@@ -32,7 +30,6 @@ msgstr ""
 "`/realms/realm_name/clients/\\{client-id}/redirect` を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-link.adoc:7
 msgid ""
 "If a client accesses this endpoint via an `HTTP GET` request, {project_name}"
 " returns the configured base URL for the provided Client and Realm in the "
@@ -44,7 +41,6 @@ msgstr ""
 "（テンポラリー・リダイレクト）形式で、指定されたクライアントとレルムの設定済みのベースURLを返します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-link.adoc:10
 msgid ""
 "Thus, a client only needs to know the Realm name and the Client ID in order "
 "to link to them.  This indirection helps avoid hard-coding client base URLs."
@@ -52,18 +48,15 @@ msgstr ""
 "したがって、クライアントは、それらにリンクするために、レルム名とクライアントIDだけを知る必要があります。この間接参照は、クライアントのベースURLのハード・コーディングを避けるのに役立ちます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-link.adoc:12
 msgid "As an example, given the realm `master` and the client-id `account`:"
 msgstr "一例として、レルムの `master` とクライアントIDの `account` が指定されているとします。"
 
 #. type: delimited block -
-#: source/server_admin/topics/clients/client-link.adoc:16
 #, no-wrap
 msgid "http://host:port/auth/realms/master/clients/account/redirect\n"
 msgstr "http://host:port/auth/realms/master/clients/account/redirect\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-link.adoc:18
 msgid ""
 "Would temporarily redirect to: http://host:port/auth/realms/master/account"
 msgstr "一時的に http://host:port/auth/realms/master/account にリダイレクトします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-link
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
