### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/saml/entity-descriptors.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/entity-descriptors.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/entity-descriptors.ja_JP.po
@@ -16,29 +16,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/create-client.adoc:19
-#: source/server_admin/topics/clients/client-oidc.adoc:15
-#: source/server_admin/topics/clients/client-saml.adoc:16
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:7
 #, no-wrap
 msgid "Add Client"
 msgstr "クライアントの追加"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:117
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:2
 #, no-wrap
 msgid "SAML Entity Descriptors"
 msgstr "SAMLエンティティー記述子"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:18
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:9
 msgid "image:{project_images}/add-client-saml.png[]"
 msgstr "image:{project_images}/add-client-saml.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:6
 msgid ""
 "Instead of manually registering a SAML 2.0 client, you can import it via a "
 "standard SAML Entity Descriptor XML file.  There is an `Import` option on "
@@ -48,7 +39,6 @@ msgstr ""
 "Clientページには `Import` オプションがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:11
 msgid ""
 "Click the `Select File` button and load your entity descriptor file.  You "
 "should review all the information there to make sure everything is set up "
@@ -58,7 +48,6 @@ msgstr ""
 "ボタンをクリックし、エンティティー記述子ファイルを読み込みます。そこにあるすべての情報を見直して、すべてが正しく設定されていることを確認してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:13
 msgid ""
 "Some SAML client adapters like _mod-auth-mellon_ need the XML Entity "
 "Descriptor for the IDP.  You can obtain this by going to this public URL: "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/saml/entity-descriptors.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__saml__entity-descriptors
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
