### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/threat/password-db-compromised.adoc:2
 #, no-wrap
 msgid "Password database compromised"
 msgstr "パスワード・データベースの侵害"
 
 #. type: Plain text
-#: source/server_admin/topics/threat/password-db-compromised.adoc:9
 msgid ""
 "{project_name} does not store passwords in raw text.  It stores a hash of "
 "them using the PBKDF2 algorithm.  It actually uses a default of 20,000 "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__password-db-compromised
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
