### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/ssl.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/threat/ssl.adoc:2
 #, no-wrap
 msgid "SSL/HTTPS Requirement"
 msgstr "SSL/HTTPS要件"
 
 #. type: Plain text
-#: source/server_admin/topics/threat/ssl.adoc:8
 msgid ""
 "If you do not use SSL/HTTPS for all communication between the {project_name}"
 " auth server and the clients it secures, you will be very vulnerable to man "
@@ -36,7 +34,6 @@ msgstr ""
 "Connectはセキュリティーのためにアクセストークンを使用します。SSL/HTTPSなしでは、攻撃者はネットワークを盗聴してアクセストークンを取得することができます。アクセストークンを取得すれば、トークンにアクセス許可が与えられたあらゆる操作を実行できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/threat/ssl.adoc:13
 msgid ""
 "{project_name} has <<_ssl_modes,three modes for SSL/HTTPS>>.  SSL can be "
 "hard to set up, so out of the box, {project_name} allows non-HTTPS "
@@ -47,7 +44,6 @@ msgstr ""
 "{project_name}は<<_ssl_modes,SSL/HTTPSの3つのモード>>を持っています。SSLは設定が難しいのですぐにセットアップできるように、{project_name}はデフォルトでlocalhost、192.168.x.x、その他のプライベートIPアドレスを介した非HTTPS通信を許可します。プロダクション環境では、SSLが有効になっており全面的に必要とされることを確認する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/threat/ssl.adoc:19
 msgid ""
 "On the adapter/client side, {project_name} allows you to turn off the SSL "
 "trust manager.  The trust manager ensures identity the client is talking to."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
