### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/overview.adoc:3
 #, no-wrap
 msgid "Brokering Overview"
 msgstr "ブローカリングの概要"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:7
 msgid ""
 "When using {project_name} as an identity broker, users are not forced to "
 "provide their credentials in order to authenticate in a specific realm.  "
@@ -32,46 +30,39 @@ msgstr ""
 "{project_name}をアイデンティティー・ブローカーとして使用する場合、ユーザーは特定のレルムで認証するためにクレデンシャルを提供する必要はありません。代わりに、認証可能なアイデンティティー・プロバイダーのリストが提示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:9
 msgid ""
 "You can also configure a default broker. In this case the user will not be "
 "given a choice, but instead be redirected directly to the parent broker."
 msgstr "また、デフォルトのブローカーを設定することもできます。この場合、ユーザーには選択肢が与えられず、親のブローカーに直接リダイレクトされます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:11
 msgid ""
 "The following diagram demonstrates the steps involved when using "
 "{project_name} to broker an external identity provider:"
 msgstr "次の図は、{project_name}を使用して外部アイデンティティー・プロバイダーを仲介するときに、必要な手順を示しています。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/overview.adoc:12
 #, no-wrap
 msgid "Identity Broker Flow"
 msgstr "アイデンティティー・ブローカーのフロー"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:14
 msgid "image:images/identity_broker_flow.png[]"
 msgstr "image:images/identity_broker_flow.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:16
 msgid ""
 "User is not authenticated and requests a protected resource in a client "
 "application."
 msgstr "ユーザーは認証しておらず、クライアント・アプリケーションの保護されたリソースを要求します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:17
 msgid ""
 "The client applications redirects the user to {project_name} to "
 "authenticate."
 msgstr "クライアント・アプリケーションは、ユーザーを認証するために{project_name}にリダイレクトさせます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:18
 msgid ""
 "At this point the user is presented with the login page where there is a "
 "list of identity providers supported by a realm."
@@ -79,14 +70,12 @@ msgstr ""
 "この時点で、ユーザーにはログイン・ページが表示されます。ログイン・ページには、レルムがサポートするアイデンティティー・プロバイダーのリストがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:19
 msgid ""
 "User selects one of the identity providers by clicking on its respective "
 "button or link."
 msgstr "ユーザーは、各ボタンまたはリンクをクリックしてアイデンティティー・プロバイダーの1つを選択します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:22
 msgid ""
 "{project_name} issues an authentication request to the target identity "
 "provider asking for authentication and the user is redirected to the login "
@@ -97,14 +86,12 @@ msgstr ""
 "{project_name}は、ターゲットのアイデンティティー・プロバイダーに認証を要求する認証リクエストを発行し、ユーザーはアイデンティティー・プロバイダーのログイン・ページにリダイレクトされます。アイデンティティー・プロバイダーの接続プロパティーとその他の設定オプションは、管理者が管理コンソールで前もって設定したものになります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:23
 msgid ""
 "User provides his credentials or consent in order to authenticate in the "
 "identity provider."
 msgstr "ユーザーは、アイデンティティー・プロバイダーで認証するためにクレデンシャルまたは同意を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:26
 msgid ""
 "Upon a successful authentication by the identity provider, the user is "
 "redirected back to {project_name} with an authentication response.  Usually "
@@ -115,7 +102,6 @@ msgstr ""
 "アイデンティティー・プロバイダーによる認証が成功すると、ユーザーは認証レスポンスとともに{project_name}にリダイレクトされます。通常、このレスポンスには、{project_name}によって使用されるセキュリティー・トークンが含まれています。セキュリティー・トークンは、アイデンティティー・プロバイダーによって実行された認証を信頼し、そのユーザーに関する情報を取得するために使用されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:33
 msgid ""
 "Now {project_name} is going to check if the response from the identity "
 "provider is valid.  If valid, it will import and create a new user or just "
@@ -141,7 +127,6 @@ msgstr ""
 "Flow>>の設定で指定できます。このステップの最後で、{project_name}がユーザーを認証し、サービス・プロバイダーの要求されたリソースにアクセスするために独自のトークンを発行します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:34
 msgid ""
 "Once the user is locally authenticated, {project_name} redirects the user to"
 " the service provider by sending the token previously issued during the "
@@ -150,14 +135,12 @@ msgstr ""
 "ユーザーがローカルで認証されると、{project_name}は、ローカル認証時に先に発行されたトークンを送信してユーザーをサービス・プロバイダーにリダイレクトします。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:35
 msgid ""
 "The service provider receives the token from {project_name} and allows "
 "access to the protected resource."
 msgstr "サービス・プロバイダーは{project_name}からトークンを受け取り、保護されたリソースへのアクセスを許可します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:39
 msgid ""
 "There are some variations of this flow that we will talk about later.  For "
 "instance, instead of presenting a list of identity providers, the client "
@@ -168,7 +151,6 @@ msgstr ""
 "このフローにはいくつかのバリエーションがありますので、後ほど説明します。たとえば、アイデンティティー・プロバイダーのリストを提示する代わりに、クライアント・アプリケーションは特定のプロバイダーを要求することができます。または、ユーザーが自分のアイデンティティーを統合する前に、ユーザーに追加の情報提供を強制させるように{project_name}に指示できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:43
 #, no-wrap
 msgid ""
 "Different protocols may require different authentication flows.\n"
@@ -178,7 +160,6 @@ msgstr ""
 "異なるプロトコルは、異なる認証フローを必要とすることがあります。現在のところ、{project_name}でサポートされているすべてのアイデンティティー・プロバイダーは、前述のようなフローを使用します。しかし、使用するプロトコルにかかわらず、ユーザー・エクスペリエンスはほぼ同じでなければなりません。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/overview.adoc:47
 msgid ""
 "As you may notice, at the end of the authentication process {project_name} "
 "will always issue its own token to client applications.  What this means is "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
