### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -16,25 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:37
-#: source/server_admin/topics/identity-broker/social/google.adoc:78
 msgid ""
 "You will need to obtain the client ID and secret from this page so you can "
 "enter them into the {project_name} `Add identity provider` page.  Go back to"
@@ -44,13 +30,11 @@ msgstr ""
 "ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
 
 #. type: Title ====
-#: source/server_admin/topics/identity-broker/social/google.adoc:1
 #, no-wrap
 msgid "Google"
 msgstr "Google"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:5
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "Google.  First, go to the `Identity Providers` left menu item and select "
@@ -62,12 +46,10 @@ msgstr ""
 "provider` ページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:8
 msgid "image:{project_images}/google-add-identity-provider.png[]"
 msgstr "image:{project_images}/google-add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:12
 msgid ""
 "You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
 " Secret` from Google.  One piece of data you'll need from this page is the "
@@ -79,7 +61,6 @@ msgstr ""
 "です。Googleに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:15
 msgid ""
 "To enable login with Google you first have to create a project and a client "
 "in the https://console.cloud.google.com/project[Google Developer Console].  "
@@ -91,7 +72,6 @@ msgstr ""
 "でプロジェクトとクライアントを作成する必要があります。次に、クライアントIDとシークレットを{project_name}の管理コンソールにコピーする必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:18
 #, no-wrap
 msgid ""
 "Google often changes the look and feel of the Google Developer Console, so these directions might not always be up to date and the\n"
@@ -101,12 +81,10 @@ msgstr ""
 "Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:20
 msgid "Let's see first how to create a project with Google."
 msgstr "最初にGoogleでプロジェクトを作成する方法を説明します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:22
 msgid ""
 "Log in to the link:https://console.cloud.google.com/project[Google Developer"
 " Console]."
@@ -115,18 +93,15 @@ msgstr ""
 "Console]にログインします。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:23
 #, no-wrap
 msgid "Google Developer Console"
 msgstr "Google Developer Console"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:25
 msgid "image:images/google-developer-console.png[]"
 msgstr "image:images/google-developer-console.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:30
 msgid ""
 "Click the `Create Project` button.  Use any value for `Project name` and "
 "`Project ID` you want, then click the `Create` button.  Wait for the project"
@@ -138,18 +113,15 @@ msgstr ""
 "ボタンをクリックします。プロジェクトが作成されるのを待ちます（これには時間がかかることがあります）。作成されると、プロジェクトのダッシュボードに遷移します。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:31
 #, no-wrap
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:33
 msgid "image:images/google-dashboard.png[]"
 msgstr "image:images/google-dashboard.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:36
 msgid ""
 "To be able to retrieve the profiles of Google users, you need to turn on the"
 " Google+ APIs.  Select the `Enable and manage APIs` and click the `Google+ "
@@ -159,18 +131,15 @@ msgstr ""
 " を選択し、 `Google+ API` リンクをクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:37
 #, no-wrap
 msgid "APIs"
 msgstr "API"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:39
 msgid "image:images/google-api-list.png[]"
 msgstr "image:images/google-api-list.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:42
 msgid ""
 "Click the `Enable` button on this page.  You will get a message that you "
 "must create the credentials of your project.  So click the `Go to "
@@ -180,23 +149,19 @@ msgstr ""
 " to Credentials` ボタンをクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:43
 #, no-wrap
 msgid "Go To Credentials"
 msgstr "クレデンシャルへ移動"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:45
 msgid "image:images/google-go-to-credentials.png[]"
 msgstr "image:images/google-go-to-credentials.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:47
 msgid "You will then be brought to the credentials page."
 msgstr "これで、クレデンシャルのページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:50
 #, no-wrap
 msgid ""
 "If you logout in the middle of this, there is a menu in the top left hand corner.  Select `API Manager` and it\n"
@@ -204,25 +169,21 @@ msgid ""
 msgstr "この間にログアウトすると、左上隅にメニューが表示されます。 `API Manager` を選択すると、目的の画面が表示されます。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:52
 msgid ""
 "You will then be asked to specify what credentials you need and what type of"
 " data you will be accessing."
 msgstr "次に、必要なクレデンシャルとアクセスするデータの種類を指定するよう求められます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:53
 #, no-wrap
 msgid "Add Credentials"
 msgstr "クレデンシャルの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:55
 msgid "image:images/google-add-credentials.png[]"
 msgstr "image:images/google-add-credentials.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:57
 msgid ""
 "Select `Web server` and `User data` and click the `What credentials do I "
 "need?` button."
@@ -230,18 +191,15 @@ msgstr ""
 "`Web server` と `User data` を選択し、 `What credentials do I need?` ボタンをクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:58
 #, no-wrap
 msgid "Create OAuth ID"
 msgstr "OAuth IDの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:60
 msgid "image:images/google-create-oauth-id.png[]"
 msgstr "image:images/google-create-oauth-id.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:64
 msgid ""
 "Next you'll need to create an OAuth 2.0 client ID.  Specify the name you "
 "want for your client.  You'll also need to copy and paste the `Redirect URI`"
@@ -254,7 +212,6 @@ msgstr ""
 "フィールドに貼り付ける必要があります。これを済ませたら、 `Create client ID` ボタンをクリックします。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:68
 msgid ""
 "When users log into Google from {project_name} they will see a consent "
 "screen from Google which will ask the user if {project_name} is allowed to "
@@ -264,7 +221,6 @@ msgstr ""
 "ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。次のGoogleの設定画面に、この画面に関する情報が表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:71
 msgid ""
 "Once you click `Done` you will be brought to the `Credentials` page.  Click "
 "on your new OAuth 2.0 Client ID to view the settings of your new Google "
@@ -274,18 +230,15 @@ msgstr ""
 "2.0クライアントのIDをクリックすると、新しいGoogleクライアントの設定が表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/google.adoc:72
 #, no-wrap
 msgid "Google Client Credentials"
 msgstr "Googleクライアント・クレデンシャル"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:74
 msgid "image:images/google-client-credentials.png[]"
 msgstr "image:images/google-client-credentials.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/google.adoc:82
 msgid ""
 "One config option to note on the `Add identity provider` page for Google is "
 "the `Default Scopes` field.  This field allows you to manually specify the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
