### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/login-settings/forgot-password.adoc:2
 #, no-wrap
 msgid "Forgot Password"
 msgstr "パスワード忘れ"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:6
 msgid ""
 "If you enable it, users are able to reset their credentials if they forget "
 "their password or lose their OTP generator.  Go to the `Realm Settings` left"
@@ -33,40 +31,28 @@ msgstr ""
 "`Realm Settings` に移動し、 ` Login` タブをクリックします。 `Forgot Password` スイッチをオンにします。"
 
 #. type: Block title
-#: source/server_admin/topics/login-settings/forgot-password.adoc:7
-#: source/server_admin/topics/login-settings/remember-me.adoc:10
-#: source/server_admin/topics/users/user-registration.adoc:10
-#: source/server_admin/topics/realms/ssl.adoc:14
 #, no-wrap
 msgid "Login Tab"
 msgstr "Loginタブ"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:9
-#: source/server_admin/topics/login-settings/remember-me.adoc:12
-#: source/server_admin/topics/users/user-registration.adoc:12
-#: source/server_admin/topics/realms/ssl.adoc:16
 msgid "image:{project_images}/login-tab.png[]"
 msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:11
 msgid "A `forgot password` link will now show up on your login pages."
 msgstr "ログインページに `forgot password` リンクが表示されるようになります。"
 
 #. type: Block title
-#: source/server_admin/topics/login-settings/forgot-password.adoc:12
 #, no-wrap
 msgid "Forgot Password Link"
 msgstr "パスワード忘れリンク"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:14
 msgid "image:{project_images}/forgot-password-link.png[]"
 msgstr "image:{project_images}/forgot-password-link.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:17
 msgid ""
 "Clicking on this link will bring the user to a page where they can enter in "
 "their username or email and receive an email with a link to reset their "
@@ -75,18 +61,15 @@ msgstr ""
 "このリンクをクリックすると、ユーザー名またはメールアドレスを入力できるページに移動し、クレデンシャルをリセットするためのリンクが記載されたメールが送信されます。"
 
 #. type: Block title
-#: source/server_admin/topics/login-settings/forgot-password.adoc:18
 #, no-wrap
 msgid "Forgot Password Page"
 msgstr "パスワード忘れページ"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:20
 msgid "image:{project_images}/forgot-password-page.png[]"
 msgstr "image:{project_images}/forgot-password-page.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:23
 msgid ""
 "The text sent in the email is completely configurable. You just need to "
 "extend or edit the theme associated with it.  See the "
@@ -95,7 +78,6 @@ msgstr ""
 "電子メールで送信されるテキストは完全に設定可能です。それに関連するテーマを拡張または編集するだけです。詳細については、link:{developerguide_link}[{developerguide_name}]のリンクを参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:28
 msgid ""
 "When the user clicks on the email link, they will be asked to update their "
 "password, and, if they have an OTP generator set up, they will also be asked"
@@ -109,18 +91,15 @@ msgstr ""
 " `Authentication` で `Flows` タブをクリックし、 `Reset Credentials` フローを選択します。"
 
 #. type: Block title
-#: source/server_admin/topics/login-settings/forgot-password.adoc:29
 #, no-wrap
 msgid "Reset Credentials Flow"
 msgstr "Reset Credentialsフロー"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:31
 msgid "image:{project_images}/reset-credentials-flow.png[]"
 msgstr "image:{project_images}/reset-credentials-flow.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:32
 msgid ""
 "If you do not want OTP reset, then just chose the `disabled` radio button to"
 " the right of `Reset OTP`."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__login-settings__forgot-password
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
