### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -28,7 +28,7 @@ msgid ""
 "switch."
 msgstr ""
 "これを有効にすると、ユーザーはパスワードを忘れたり、OTPジェネレーターを無くした場合でも、クレデンシャルをリセットできます。左のメニュー項目の "
-"`Realm Settings` に移動し、 ` Login` タブをクリックします。 `Forgot Password` スイッチをオンにします。"
+"`Realm Settings` に移動し、 `Login` タブをクリックします。 `Forgot Password` スイッチをオンにします。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__login-settings__forgot-password
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
