### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
@@ -16,31 +16,26 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/roles/user-role-mappings.adoc:2
 #, no-wrap
 msgid "User Role Mappings"
 msgstr "ユーザー・ロール・マッピング"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings.adoc:5
 msgid ""
 "User role mappings can be assigned individually to each user through the "
 "`Role Mappings` tab for that single user."
 msgstr "ユーザー・ロール・マッピングは、各ユーザーの `Role Mappings`  タブを介して個別に割り当てることができます。"
 
 #. type: Block title
-#: source/server_admin/topics/roles/user-role-mappings.adoc:6
 #, no-wrap
 msgid "Role Mappings"
 msgstr "ロールマッピング"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings.adoc:8
 msgid "image:{project_images}/user-role-mappings.png[]"
 msgstr "image:{project_images}/user-role-mappings.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings.adoc:11
 msgid ""
 "In the above example, we are about to assign the composite role `developer` "
 "that was created in the <<_composite-roles, Composite Roles>> chapter."
@@ -48,18 +43,15 @@ msgstr ""
 "上の例では、<<_composite-roles, 複合ロール>>の章で作成した複合ロール `developer` を割り当てようとしています。"
 
 #. type: Block title
-#: source/server_admin/topics/roles/user-role-mappings.adoc:12
 #, no-wrap
 msgid "Effective Role Mappings"
 msgstr "有効なロールマッピング"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings.adoc:14
 msgid "image:{project_images}/effective-role-mappings.png[]"
 msgstr "image:{project_images}/effective-role-mappings.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings.adoc:17
 msgid ""
 "Once the `developer` role is assigned, you see that the `employee` role that"
 " is associated with the `developer` composite shows up in the `Effective "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__user-role-mappings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
