### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings/default-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings/default-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings/default-roles.ja_JP.po
@@ -16,14 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/roles/user-role-mappings/default-roles.adoc:2
-#: source/server_admin/topics/roles/user-role-mappings/default-roles.adoc:8
 #, no-wrap
 msgid "Default Roles"
 msgstr "デフォルトロール"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings/default-roles.adoc:7
 msgid ""
 "Default roles allow you to automatically assign user role mappings when any "
 "user is newly created or imported through <<_identity_broker, Identity "
@@ -35,12 +32,10 @@ msgstr ""
 " `Roles` に移動し、 `Default Roles` タブをクリックします。"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings/default-roles.adoc:10
 msgid "image:{project_images}/default-roles.png[]"
 msgstr "image:{project_images}/default-roles.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/roles/user-role-mappings/default-roles.adoc:12
 msgid ""
 "As you can see from the screenshot, there are already a number of _default "
 "roles_ set up by default."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings/default-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__user-role-mappings__default-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
