### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po
@@ -16,15 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/overview/supported-protocols.adoc:42
-#: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:2
 #, no-wrap
 msgid "OpenID Connect vs. SAML"
 msgstr "OpenID Connect vs SAML"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-protocols.adoc:45
-#: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:5
 msgid ""
 "Choosing between OpenID Connect and SAML is not just a matter of using a "
 "newer protocol (OIDC) instead of the older more mature protocol (SAML)."
@@ -33,20 +29,14 @@ msgstr ""
 "ConnectとSAMLの選択は、古いより成熟したプロトコル（SAML）の代わりに新しいプロトコル（OIDC）を使用するだけの問題ではありません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-protocols.adoc:47
-#: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:7
 msgid "In most cases {project_name} recommends using OIDC."
 msgstr "ほとんどの場合において、{project_name}ではOIDCを使用することをお勧めします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-protocols.adoc:49
-#: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:9
 msgid "SAML tends to be a bit more verbose than OIDC."
 msgstr "SAMLは、OIDCよりも少し冗長になる傾向があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-protocols.adoc:54
-#: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:14
 msgid ""
 "Beyond verbosity of exchanged data, if you compare the specifications you'll"
 " find that OIDC was designed to work with the web while SAML was retrofitted"
@@ -64,8 +54,6 @@ msgstr ""
 "1_0.html#ChangeNotification[iframeトリック]の仕様をチェックしてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/supported-protocols.adoc:56
-#: source/server_admin/topics/sso-protocols/saml-vs-oidc.adoc:15
 msgid ""
 "SAML has its uses though. As you see the OIDC specifications evolve you see "
 "they implement more and more features that SAML has had for years. What we "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml-vs-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml-vs-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
