### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/preface.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/preface.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/preface.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_development/topics/preface.adoc:1
 #, no-wrap
 msgid "Preface"
 msgstr "はじめに"
 
 #. type: Plain text
-#: source/server_development/topics/preface.adoc:5
 msgid ""
 "In some of the example listings, what is meant to be displayed on one line "
 "does not fit inside the available page width. These lines have been broken "
@@ -33,7 +31,6 @@ msgstr ""
 "は、次の行がインデントされたページに収まるように改行が導入されたことを意味します。したがって、"
 
 #. type: delimited block -
-#: source/server_development/topics/preface.adoc:12
 #, no-wrap
 msgid ""
 "Let's pretend to have an extremely \\\n"
@@ -47,12 +44,10 @@ msgstr ""
 "This one is short\n"
 
 #. type: Plain text
-#: source/server_development/topics/preface.adoc:14
 msgid "Is really:"
 msgstr "上記は、実際には下記のとおりになります。"
 
 #. type: delimited block -
-#: source/server_development/topics/preface.adoc:19
 #, no-wrap
 msgid ""
 "Let's pretend to have an extremely long line that does not fit\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/preface.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__preface
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
