### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_development/topics/user-storage/cache.adoc:2
 #, no-wrap
 msgid "User Caches"
 msgstr "ユーザー・キャッシュ"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:8
 msgid ""
 "When a user is loaded by ID, username, or email queries it is cached. When a"
 " user is cached, it iterates through the entire `UserModel` interface and "
@@ -36,19 +34,16 @@ msgstr ""
 "クラスターでは、このキャッシュはまだローカルですが、無効化キャッシュになります。ユーザーが変更されると、キャッシュは削除されます。このエビクション・イベントはクラスター全体に伝播され、他のノードのユーザー・キャッシュも無効になります。"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/cache.adoc:9
 #, no-wrap
 msgid "Managing the user cache"
 msgstr "ユーザー・キャッシュの管理"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:12
 msgid ""
 "You can access the user cache by calling `KeycloakSession.userCache()`."
 msgstr "`KeycloakSession.userCache()` を呼び出すことで、ユーザー・キャッシュにアクセスできます。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:28
 #, no-wrap
 msgid ""
 "/**\n"
@@ -80,7 +75,6 @@ msgstr ""
 "    void evict(RealmModel realm, UserModel user);\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:35
 #, no-wrap
 msgid ""
 "    /**\n"
@@ -98,7 +92,6 @@ msgstr ""
 "    void evict(RealmModel realm);\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:42
 #, no-wrap
 msgid ""
 "    /**\n"
@@ -116,20 +109,17 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:45
 msgid ""
 "There are methods for evicting specific users, users contained in a specific"
 " realm, or the entire cache."
 msgstr "特定のユーザー、レルムに含まれるユーザー、またはキャッシュ全体を削除するメソッドがあります。"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/cache.adoc:46
 #, no-wrap
 msgid "OnUserCache Callback Interface"
 msgstr "OnUserCacheコールバック・インターフェイス"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:50
 msgid ""
 "You might want to cache additional information that is specific to your "
 "provider implementation. The User Storage SPI has a callback whenever a user"
@@ -140,7 +130,6 @@ msgstr ""
 "）。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:56
 #, no-wrap
 msgid ""
 "public interface OnUserCache {\n"
@@ -152,7 +141,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:61
 msgid ""
 "Your provider class should implement this interface if it wants this "
 "callback. The `UserModel` delegate parameter is the `UserModel` instance "
@@ -164,13 +152,11 @@ msgstr ""
 "`UserModel` インターフェイスです。これは、ローカル・ストレージにローカルでキャッシュされるインスタンスです。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:65
 #, no-wrap
 msgid "public interface CachedUserModel extends UserModel {\n"
 msgstr "public interface CachedUserModel extends UserModel {\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:72
 #, no-wrap
 msgid ""
 "    /**\n"
@@ -188,13 +174,11 @@ msgstr ""
 "    UserModel getDelegateForUpdate();\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:74
 #, no-wrap
 msgid "    boolean isMarkedForEviction();\n"
 msgstr "    boolean isMarkedForEviction();\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:80
 #, no-wrap
 msgid ""
 "    /**\n"
@@ -210,7 +194,6 @@ msgstr ""
 "    void invalidate();\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:87
 #, no-wrap
 msgid ""
 "    /**\n"
@@ -228,7 +211,6 @@ msgstr ""
 "    long getCacheTimestamp();\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/cache.adoc:95
 #, no-wrap
 msgid ""
 "    /**\n"
@@ -248,7 +230,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:99
 msgid ""
 "This `CachedUserModel` interface allows you to evict the user from the cache"
 " and get the provider `UserModel` instance.  The `getCachedWith()` method "
@@ -265,13 +246,11 @@ msgstr ""
 "`getCachedWith()` メソッドを使ってユーザーのクレデンシャルをキャッシュします。"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/cache.adoc:100
 #, no-wrap
 msgid "Cache Policies"
 msgstr "キャッシュ・ポリシー"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/cache.adoc:103
 msgid ""
 "On the administration console management page for your user storage "
 "provider, you can specify a unique cache policy."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
