### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po
@@ -15,10 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-msgid "SPI|Description"
-msgstr "SPI|説明"
-
 #. type: Title ===
 #, no-wrap
 msgid "Provider Capability Interfaces"
@@ -39,7 +35,11 @@ msgstr ""
 "インターフェイスを注意深く見てみると、ユーザーを検索したり管理したりするメソッドが定義されていないことに気がつくでしょう。これらのメソッドは "
 "_ケイパビリティー・インターフェイス_ "
 "として定義されており、外部ユーザーストアが持つ機能に依存しています。たとえば、あるユーザーストアがリードオンリーで単純なクエリーとクレデンシャル検証機能のみ持つ場合、必要な作業はそれらの機能のみを"
-" _ケイパビリティー・インタフェース_ として実装することだけです。"
+" _ケイパビリティー・インターフェイス_ として実装することだけです。"
+
+#. type: Plain text
+msgid "SPI|Description"
+msgstr "SPI|説明"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__provider-capability-interfaces
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
