### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/cache/replication.adoc:2
 #, no-wrap
 msgid "Replication and Failover"
 msgstr "レプリケーションとフェイルオーバー"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/replication.adoc:9
 msgid ""
 "The `sessions`, `authenticationSessions`, `offlineSessions` and "
 "`loginFailures` caches are the only caches that may perform replication.  "
@@ -39,7 +37,6 @@ msgstr ""
 "キャッシュは、レプリケーションを実行するだけのキャッシュです。エントリーはすべてのノードにひとつひとつレプリケーションされるわけではありませんが、1つ以上のノードがそのデータの所有者として選ばれます。ノードが特定のキャッシュ・エントリーの所有者ではない場合は、そのキャッシュ・エントリーを取得するためにクラスターに問い合わせをします。これがフェイルオーバーに対して何を意味するかというと、データを保持しているノードがすべてダウンした場合は、そのデータは永遠に失われてしまうということです。デフォルトでは、{project_name}が指定するデータの所有者は1つだけです。そのため、その1つのノードがダウンした場合は、そのデータは失われることになります。このことは通常、ユーザーはログアウトされ、再度ログインし直さなければならないということを意味します。"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/replication.adoc:11
 msgid ""
 "You can change the number of nodes that replicate a piece of data by change "
 "the `owners` attribute in the `distributed-cache` declaration."
@@ -47,13 +44,11 @@ msgstr ""
 "`distributed-cache` の宣言で `owners` 属性を変更すると、データをレプリケートするノードの数を変更することができます。"
 
 #. type: Block title
-#: source/server_installation/topics/cache/replication.adoc:12
 #, no-wrap
 msgid "owners"
 msgstr "owners"
 
 #. type: delimited block -
-#: source/server_installation/topics/cache/replication.adoc:19
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:infinispan:4.0\">\n"
@@ -67,14 +62,12 @@ msgstr ""
 "...\n"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/replication.adoc:22
 msgid ""
 "Here we've changed it so at least two nodes will replicate one specific user"
 " login session."
 msgstr "ここで上記のとおりに変更すると、少なくとも2つのノードが1つの特定のユーザー・ログイン・セッションをレプリケーションします。"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/replication.adoc:25
 #, no-wrap
 msgid ""
 "The number of owners recommended is really dependent on your deployment.  If you do not care if users are logged\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__replication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
