### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po
@@ -16,23 +16,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/clustering/multicast.adoc:2
 #, no-wrap
 msgid "Multicast Network Setup"
 msgstr "マルチキャスト・ネットワークの設定"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/multicast.adoc:5
 msgid ""
 "Out of the box clustering support needs IP Multicast. Multicast is a network"
 " broadcast protocol. This protocol is used at boot time to discover and join"
 " the cluster. It is also used to broadcast messages for the replication and "
 "invalidation of distributed caches used by {project_name}."
 msgstr ""
-"ほとんど設定せずにクラスターリングを利用するには、IPマルチキャストが必要となります。マルチキャストとはネットワーク・ブロードキャスト・プロトコルのことです。このプロトコルは、起動時にクラスターを検出して参加させるために使用されます。また、{project_name}が使用する分散キャッシュのレプリケーションおよび無効化のためのメッセージをブロードキャストするためにも使用されます。"
+"ほとんど設定せずにクラスタリングを利用するには、IPマルチキャストが必要となります。マルチキャストとはネットワーク・ブロードキャスト・プロトコルのことです。このプロトコルは、起動時にクラスターを検出して参加させるために使用されます。また、{project_name}が使用する分散キャッシュのレプリケーションおよび無効化のためのメッセージをブロードキャストするためにも使用されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/multicast.adoc:8
 msgid ""
 "The clustering subsystem for {project_name} runs on the JGroups stack. Out "
 "of the box, the bind addresses for clustering are bound to a private network"
@@ -40,18 +37,16 @@ msgid ""
 "_standalone-ha.xml_ or _domain.xml_ sections discussed in the <<_bind-"
 "address,Bind Address>> chapter."
 msgstr ""
-"{project_name}のクラスターリング・サブシステムは、JGroupsスタック上で実行されます。クラスターリングのためのバインドアドレスは、デフォルトのIPアドレスとして127.0.0.1で、プライベート・ネットワーク・インターフェイスにバインドされています"
+"{project_name}のクラスタリング・サブシステムは、JGroupsスタック上で実行されます。クラスタリングのためのバインドアドレスは、デフォルトのIPアドレスとして127.0.0.1で、プライベート・ネットワーク・インターフェイスにバインドされています"
 "。<<_bind-address,バインドアドレス>>の章で説明した _standalone-ha.xml_ または _domain.xml_ "
 "セクションを編集する必要があります。"
 
 #. type: Block title
-#: source/server_installation/topics/clustering/multicast.adoc:9
 #, no-wrap
 msgid "private network config"
 msgstr "プライベート・ネットワーク設定"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/multicast.adoc:28
 #, no-wrap
 msgid ""
 "    <interfaces>\n"
@@ -89,21 +84,20 @@ msgstr ""
 "    </socket-binding-group>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/multicast.adoc:31
 msgid ""
 "Things you'll want to configure are the `jboss.bind.address.private` and "
 "`jboss.default.multicast.address` as well as the ports of the services on "
 "the clustering stack."
 msgstr ""
 "設定したい項目は `jboss.bind.address.private` 、 `jboss.default.multicast.address` "
-"そしてクラスターリング・スタック上のサービスのポートになるでしょう。"
+"そしてクラスタリング・スタック上のサービスのポートになるでしょう。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/multicast.adoc:33
 msgid ""
 "It is possible to cluster {project_name} without IP Multicast, but this "
 "topic is beyond the scope of this guide. For more information, see "
 "link:{appserver_jgroups_link}[JGroups] in the _{appserver_jgroups_name}_."
 msgstr ""
-"IPマルチキャストなしで{project_name}をクラスターリングすることは可能ですが、このトピックはこのガイドの説明範囲を超えています。詳しくは、 "
-"_{appserver_jgroups_name}_ 内のlink:{appserver_jgroups_link}[JGroups]を参照してください。"
+"IPマルチキャストなしで{project_name}をクラスタリングすることは可能ですが、このトピックはこのガイドの説明範囲を超えています。詳しくは、 "
+"_{appserver_jgroups_name}_ "
+"内のlink:{appserver_jgroups_link}[JGroups]を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__multicast
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
