### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po
@@ -16,23 +16,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/clustering/recommended.adoc:2
 #, no-wrap
 msgid "Recommended Network Architecture"
 msgstr "推奨ネットワーク・アーキテクチャー"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/recommended.adoc:7
 msgid ""
 "The recommended network architecture for deploying {project_name} is to set "
 "up an HTTP/HTTPS load balancer on a public IP address that routes requests "
 "to {project_name} servers sitting on a private network.  This isolates all "
 "clustering connections and provides a nice means of protecting the servers."
 msgstr ""
-"{project_name}をデプロイするための推奨ネットワーク・アーキテクチャーは、パブリックIPアドレスを持つHTTP/HTTPSロードバランサーを配置し、プライベート・ネットワーク上の{project_name}サーバーへのリクエストをルーティングさせます。これにより、クラスターリング接続はすべて分離され、サーバーを保護する優れた手段が提供されます。"
+"{project_name}をデプロイするための推奨ネットワーク・アーキテクチャーは、パブリックIPアドレスを持つHTTP/HTTPSロードバランサーを配置し、プライベート・ネットワーク上の{project_name}サーバーへのリクエストをルーティングさせます。これにより、クラスタリング接続はすべて分離され、サーバーを保護する優れた手段が提供されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/recommended.adoc:10
 #, no-wrap
 msgid ""
 "By default, there is nothing to prevent unauthorized nodes from joining the cluster and broadcasting multicast messages.\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/recommended.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__recommended
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
