### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/clustering/securing-cluster-comm.adoc:2
 #, no-wrap
 msgid "Securing Cluster Communication"
 msgstr "クラスター通信のセキュリティー保護"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/securing-cluster-comm.adoc:5
 msgid ""
 "When cluster nodes are isolated on a private network it requires access to "
 "the private network to be able to join a cluster or to view communication in"
@@ -34,14 +32,13 @@ msgstr ""
 "クラスター・ノードがプライベート・ネットワークで隔離されている場合は、クラスターに参加したり、クラスター内の通信を表示したりするために、プライベート・ネットワークへのアクセスが必要です。また、クラスター通信の認証と暗号化を有効にすることもできます。プライベート・ネットワークが安全である限り、認証と暗号化を有効にする必要はありません。どちらの場合も、{project_name}はクラスター上で機密情報を送信しません。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/securing-cluster-comm.adoc:6
 msgid ""
 "If you want to enable authentication and encryption for clustering "
 "communication see link:https://access.redhat.com/documentation/en-"
 "us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/configuring_high_availability#securing_cluster[Securing"
 " a Cluster] in the _JBoss EAP Configuration Guide_."
 msgstr ""
-"クラスターリング通信の認証と暗号化を有効にする場合は、 _JBoss EAP Configuration Guide_  "
+"クラスタリング通信の認証と暗号化を有効にする場合は、 _JBoss EAP Configuration Guide_  "
 "のlink:https://access.redhat.com/documentation/en-"
 "us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/configuring_high_availability#securing_cluster[Securing"
 " a Cluster]を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__securing-cluster-comm
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
