### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_installation/topics/config-subsystem.adoc:3
 #, no-wrap
 msgid "Manage Subsystem Configuration"
 msgstr "サブシステム設定の管理"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem.adoc:9
 #, no-wrap
 msgid ""
 "Low-level configuration of {project_name} is done by editing the\n"
@@ -35,7 +33,6 @@ msgstr ""
 "動作モード>>によって異なります。\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem.adoc:13
 msgid ""
 "While there are endless settings you can configure here, this section will "
 "focus on configuration of the _keycloak-server_ subsystem.  No matter which "
@@ -46,14 +43,12 @@ msgstr ""
 "サブシステムの設定について説明します。どの設定ファイルを使用していても、 _keycloak-server_ サブシステムの設定は同じです。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem.adoc:15
 msgid ""
 "The keycloak-server subsystem is typically declared toward the end of the "
 "file like this:"
 msgstr "keycloak-serverサブシステムは通常、以下のようにファイルの末尾で宣言されています。"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem.adoc:21
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:keycloak-server:1.1\">\n"
@@ -67,7 +62,6 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem.adoc:23
 msgid ""
 "Note that anything changed in this subsystem will not take effect until the "
 "server is rebooted."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
