### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_installation/topics/database.adoc:3
 #, no-wrap
 msgid "Relational Database Setup"
 msgstr "リレーショナル・データベースの設定"
 
 #. type: Plain text
-#: source/server_installation/topics/database.adoc:9
 msgid ""
 "{project_name} comes with its own embedded Java-based relational database "
 "called H2.  This is the default database that {project_name} will use to "
@@ -36,7 +34,6 @@ msgstr ""
 "{project_name}には、H2というJavaベースのリレーショナル・データベースが組み込まれています。これは、{project_name}がデータを保存するために使用するデフォルトのデータベースで、単に認証サーバーをそのまま実行できるように組み込まれただけのものです。そのため、プロダクション用の外部データベースに置き換えることを強くお勧めします。H2データベースは並行性の高いシチュエーションではあまり実用的ではないので、クラスター内でも使用しないでください。この章では、{project_name}をより成熟度の高いデータベースに接続する方法を説明します。"
 
 #. type: Plain text
-#: source/server_installation/topics/database.adoc:13
 msgid ""
 "{project_name} uses two layered technologies to persist its relational data."
 "  The bottom layered technology is JDBC.  JDBC is a Java API that is used to"
@@ -47,7 +44,6 @@ msgstr ""
 "{project_name}では、リレーショナル・データを保存するために2つの階層化技術が使用されます。最下層の技術はJDBCです。JDBCは、RDBMSへの接続に使用されるJavaAPIです。データベース・ベンダーによって提供されるデータベース・タイプ毎に、さまざまなJDBCドライバーがあります。この章では、これらのベンダー固有のドライバーのいずれかを使用するように{project_name}を設定する方法について説明します。"
 
 #. type: Plain text
-#: source/server_installation/topics/database.adoc:17
 msgid ""
 "The top layered technology for persistence is Hibernate JPA.  This is a "
 "object to relational mapping API that maps Java Objects to relational data."
@@ -59,7 +55,6 @@ msgstr ""
 "JPAです。これは、Javaオブジェクトをリレーショナル・データにマップするORマッピングAPIの1つです。{project_name}のデプロイメントで、Hibernateの設定に触れる必要はほとんどありませんが、そのまれなケースに遭遇した場合どうなるかを説明します。"
 
 #. type: Plain text
-#: source/server_installation/topics/database.adoc:19
 #, no-wrap
 msgid ""
 "Datasource configuration is covered much more thoroughly in link:{appserver_datasource_link}[the datasource configuration chapter]\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
