### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_installation/topics/openshift.adoc:4
 #, no-wrap
 msgid "Running {project_name} Server on OpenShift"
 msgstr "OpenShift上の{project_name}サーバーの実行"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:9
 #, no-wrap
 msgid ""
 "{project_name} provides a OpenShift cartridge to make it easy to get it running on OpenShift.\n"
@@ -34,7 +32,6 @@ msgstr ""
 "を参照してください。Webツールまたはコマンドライン・ツールを使用して{project_name}インスタンスを作成することができます。両方のアプローチについては後述します。\n"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:12
 #, no-wrap
 msgid ""
 "It's important that immediately after creating a {project_name} instance you open the `Administration Console`            and login to reset the password.\n"
@@ -44,13 +41,11 @@ msgstr ""
 "を開き、ログインしてパスワードをリセットすることが重要です。これが行われていない場合、{project_name}インスタンスに対する管理者権限を簡単に得ることができます。\n"
 
 #. type: Title ===
-#: source/server_installation/topics/openshift.adoc:13
 #, no-wrap
 msgid "Create {project_name} instance with the web tool"
 msgstr "Webツールを使用して{project_name}インスタンスを作成する"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:16
 msgid ""
 "Open https://openshift.redhat.com/app/console/applications and click on `Add"
 " Application`."
@@ -59,13 +54,11 @@ msgstr ""
 " をクリックしてください。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:17
 msgid ""
 "Scroll down to the bottom of the page to find the `Code Anything` section."
 msgstr "ページの一番下までスクロールして、 `Code Anything` セクションを探します。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:18
 msgid ""
 "Insert `http://cartreflect-claytondev.rhcloud.com/github/keycloak/openshift-"
 "keycloak-cartridge` into the `URL to a cartridge definition` field and click"
@@ -76,40 +69,33 @@ msgstr ""
 "`Next` をクリックします。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:19
 msgid "Fill in the following form and click on `Create Application`."
 msgstr "次のフォームに記入し、 `Create Application` をクリックします。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:20
 msgid "Click on `Continue to the application overview page`."
 msgstr "`Continue to the application overview page` をクリックします。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:21
 msgid ""
 "Under the list of applications you should find your {project_name} instance "
 "and the status should be `Started`."
 msgstr "アプリケーションのリストの下に{project_name}インスタンスがあり、ステータスは `Started` になっているはずです。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:22
 msgid "Click on it to open the {project_name} servers homepage."
 msgstr "これをクリックすると、{project_name}サーバーのホームページが開きます。"
 
 #. type: Title ===
-#: source/server_installation/topics/openshift.adoc:23
 #, no-wrap
 msgid "Create {project_name} instance with the command-line tool"
 msgstr "コマンドラインツールを使用して{project_name}インスタンスを作成する"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:26
 msgid "Run the following command from a terminal:"
 msgstr "ターミナルから次のコマンドを実行します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/openshift.adoc:30
 #, no-wrap
 msgid ""
 "rhc app create <APPLICATION NAME> http://cartreflect-"
@@ -119,14 +105,12 @@ msgstr ""
 "claytondev.rhcloud.com/github/keycloak/openshift-keycloak-cartridge\n"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:33
 msgid ""
 "Replace `<APPLICATION NAME>` with the name you want (for example "
 "{project_name})."
 msgstr "`<APPLICATION NAME>` を任意の名前（たとえば{project_name}）に置き換えてください。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:36
 msgid ""
 "Once the instance is created the rhc tool outputs details about it.  Open "
 "the returned `URL` in a browser to open the {project_name} servers homepage."
@@ -135,13 +119,11 @@ msgstr ""
 "を開き、{project_name}サーバーのホームページを開きます。"
 
 #. type: Title ===
-#: source/server_installation/topics/openshift.adoc:37
 #, no-wrap
 msgid "Next steps"
 msgstr "次のステップ"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:43
 msgid ""
 "The {project_name} servers homepage shows the {project_name} logo and "
 "`Welcome to {project_name}`.  There is also a link to the `Administration "
@@ -153,7 +135,6 @@ msgstr ""
 "`admin` を使ってログインしてください。最初のログイン時にパスワードを変更する必要があります。"
 
 #. type: Plain text
-#: source/server_installation/topics/openshift.adoc:45
 msgid ""
 "On OpenShift {project_name} has been configured to only accept requests over"
 " https.  If you try to use http you will be redirected to https."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/openshift.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__openshift
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
