### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -118,8 +118,8 @@ msgid ""
 "one/configuration/profile.properties` for `server-one` in domain mode). Add "
 "the following to the file:"
 msgstr ""
-"`standalone/configuration/profile.properties` （またはドメインモード内の `server-one` 用の"
-" `domain/servers/server-one/configuration/profile.properties` "
+"`standalone/configuration/profile.properties` （またはドメインモード内の `server-one` 用の "
+"`domain/servers/server-one/configuration/profile.properties` "
 "）ファイルを作成することにより、これを永続的に設定することができます。以下をファイルに追加します。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
