### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,28 +16,22 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/upgrading/topics/keycloak/upgrading.adoc:3
-#: source/upgrading/topics/rhsso/upgrading.adoc:3
 #, no-wrap
 msgid "Upgrading {project_name} Server"
 msgstr "{project_name}サーバーのアップグレード"
 
 #. type: Title ==
-#: source/upgrading/topics/keycloak/upgrading.adoc:14
-#: source/upgrading/topics/rhsso/upgrading.adoc:29
 #, no-wrap
 msgid "Upgrading {project_name} Adapters"
 msgstr "{project_name}アダプターのアップグレード"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/upgrading.adoc:7
 msgid ""
 "The upgrade process for the {project_name} server is different if you are "
 "upgrading to a different minor release or not."
 msgstr "{project_name}サーバーのアップグレードプロセスは、異なるマイナーリリースをアップグレードするか否かによって変わります。"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/upgrading.adoc:9
 msgid ""
 "If you are upgrading to a new minor release, for example from 7.0.0 to "
 "7.1.0, follow the steps in xref:_upgrading_minor[Minor Upgrades]."
@@ -46,7 +40,6 @@ msgstr ""
 "Upgrades]の手順に沿い行ってください。"
 
 #. type: Plain text
-#: source/upgrading/topics/rhsso/upgrading.adoc:11
 msgid ""
 "If you are upgrading to a new micro release, for example from 7.1.0 to "
 "7.1.1, follow the steps in xref:_upgrading_micro[Micro Upgrades]."
@@ -55,13 +48,11 @@ msgstr ""
 " Upgrades]の手順に沿い行ってください。"
 
 #. type: Title ===
-#: source/upgrading/topics/rhsso/upgrading.adoc:13
 #, no-wrap
 msgid "Minor Upgrades"
 msgstr "マイナーアップグレード"
 
 #. type: Title ===
-#: source/upgrading/topics/rhsso/upgrading.adoc:24
 #, no-wrap
 msgid "Micro Upgrades"
 msgstr "マイクロアップグレード"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/rhsso/upgrading.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__rhsso__upgrading
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
