### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -94,8 +94,8 @@ msgstr "オリジナルの 'Host' HTTPヘッダーを保持するように、リ
 #. type: Plain text
 msgid ""
 "Configure the authentication server to read the client's IP address from `X"
-"-Forwarded-For header`."
-msgstr "`X-Forwarded-For` ヘッダーからのクライアントのIPアドレスを読み取るように、認証サーバーを設定します。"
+"-Forwarded-For` header."
+msgstr "`X-Forwarded-For` ヘッダーからクライアントのIPアドレスを読み取るように認証サーバーを設定します。"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -95,7 +95,7 @@ msgstr "オリジナルの 'Host' HTTPヘッダーを保持するように、リ
 msgid ""
 "Configure the authentication server to read the client's IP address from `X"
 "-Forwarded-For` header."
-msgstr "`X-Forwarded-For` ヘッダーからクライアントのIPアドレスを読み取るように認証サーバーを設定します。"
+msgstr "`X-Forwarded-For` ヘッダーからクライアントのIPアドレスを読み取るように、認証サーバーを設定します。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__load-balancer
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
