### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/authentication/flows.adoc:3
 #, no-wrap
 msgid "Authentication Flows"
 msgstr "認証フロー"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:10
 msgid ""
 "An _authentication flow_ is a container for all authentications, screens, "
 "and actions that must happen during login, registration, and other "
@@ -39,27 +37,21 @@ msgstr ""
 " `browser` を選択すると、以下の画面が表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/authentication/flows.adoc:11
-#: source/server_admin/topics/authentication/kerberos.adoc:88
 #, no-wrap
 msgid "Browser Flow"
 msgstr "ブラウザーフロー"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:13
-#: source/server_admin/topics/authentication/kerberos.adoc:90
 msgid "image:{project_images}/browser-flow.png[]"
 msgstr "image:{project_images}/browser-flow.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:16
 msgid ""
 "If you hover over the tooltip (the tiny question mark) to the right of the "
 "flow selection list, this will describe what the flow is and does."
 msgstr "フロー選択リストの右側にあるツールチップ（小さな疑問符）の上にカーソルを合わせると、フローの内容とその説明が表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:21
 msgid ""
 "The `Auth Type` column is the name of authentication or action that will be "
 "executed.  If an authentication is indented this means it is in a sub-flow "
@@ -72,13 +64,11 @@ msgstr ""
 " `Requirement` 列は、アクションが実行されるかどうかを定義するラジオボタンのセットです。各ラジオボタンの意味を説明します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:22
 #, no-wrap
 msgid "Required"
 msgstr "Required"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:27
 msgid ""
 "This authentication execution must execute successfully.  If the user "
 "doesn't have that type of authentication mechanism configured and there is a"
@@ -92,51 +82,43 @@ msgstr ""
 "に切り替えると、OTPジェネレーターが設定されていないユーザーには、OTPジェネレーターの設定が要求されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:27
 #, no-wrap
 msgid "Optional"
 msgstr "Optional"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:29
 msgid ""
 "If the user has the authentication type configured, it will be executed.  "
 "Otherwise, it will be ignored."
 msgstr "ユーザーに認証タイプが設定されている場合は、その認証タイプが実行されます。それ以外の場合は無視されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:29
 #, no-wrap
 msgid "Disabled"
 msgstr "Disabled"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:31
 msgid "If disabled, the authentication type is not executed."
 msgstr "無効にすると、認証タイプは実行されません。"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:31
 #, no-wrap
 msgid "Alternative"
 msgstr "Alternative"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:33
 msgid ""
 "This means that at least one alternative authentication type must execute "
 "successfully at that level of the flow."
 msgstr "少なくとも1つの代替の認証タイプが、そのフローのレベルで正常に実行されなければならないことを意味します。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:35
 msgid ""
 "This is better described in an example.  Let's walk through the `browser` "
 "authentication flow."
 msgstr "以下の `browser` 認証フローの例を見てみましょう。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:39
 msgid ""
 "The first authentication type is `Cookie`.  When a user successfully logs in"
 " for the first time, a session cookie is set.  If this cookie has already "
@@ -150,7 +132,6 @@ msgstr ""
 " _alternative_ であるため、他のエグゼキューションは実行されず、ログインに成功します。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:40
 msgid ""
 "Next the flow looks at the Kerberos execution.  This authenticator is "
 "disabled by default and will be skipped."
@@ -158,7 +139,6 @@ msgstr ""
 "フローの次の認証タイプは、Kerberosエグゼキューションです。このオーセンティケーターはデフォルトで無効になっており、スキップされます。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:43
 msgid ""
 "The next execution is a subflow called Forms.  Since this subflow is marked "
 "as _alternative_ it will not be executed if the `Cookie` authentication type"
@@ -170,7 +150,6 @@ msgstr ""
 "認証タイプが成功すると実行されません。このサブフローには、実行する必要のある追加の認証タイプが含まれています。サブフローのエグゼキューションはロードされ、同じ処理ロジックが発生します。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:45
 msgid ""
 "The first execution in the Forms subflow is the Username Password Form.  "
 "This authentication type renders the username and password page.  It is "
@@ -182,7 +161,6 @@ msgstr ""
 "とされているため、ユーザーは有効なユーザー名とパスワードを入力する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:48
 msgid ""
 "The next execution is the OTP Form.  This is marked as _optional_.  If the "
 "user has OTP set up, then this authentication type must run and be "
@@ -193,24 +171,20 @@ msgstr ""
 "としてマークされています。ユーザーがOTPを設定している場合は、この認証タイプを実行して成功させる必要があります。ユーザーにOTPが設定されていない場合、この認証タイプは無視されます。"
 
 #. type: Title ===
-#: source/server_admin/topics/authentication/flows.adoc:50
 #, no-wrap
 msgid "Executions"
 msgstr "エグゼキューション"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:53
 msgid "Executions can be used"
 msgstr "以下のエグゼキューションが利用可能です。"
 
 #. type: Block title
-#: source/server_admin/topics/authentication/flows.adoc:54
 #, no-wrap
 msgid "Script Authenticator"
 msgstr "スクリプト・オーセンティケーター"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:59
 msgid ""
 "A _script_ authenticator allows to define custom authentication logic via "
 "JavaScript.  Custom authenticators. Authentication scripts must at least "
@@ -225,94 +199,78 @@ msgstr ""
 "から呼び出される `action(..)`。"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:62
 msgid ""
-"Custom `Authenticator`'s should at least provide the `authenticate(..)` "
+"Custom `Authenticator` should at least provide the `authenticate(..)` "
 "function.  The following script `javax.script.Bindings` are available for "
 "convenient use within script code."
 msgstr ""
-"カスタム `オーセンティケーター` は、 `authenticate(..)` 関数を提供するべきです。次のスクリプト "
-"`javax.script.Bindings` は、スクリプトコード内で便利に利用できます。"
+"カスタム `Authenticator` は、少なくとも `authenticate(..)` 関数を提供す必要があります。次のスクリプト "
+"`javax.script.Bindings` は、スクリプトコード内での便利な使用のために利用できます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:63
 #, no-wrap
 msgid "`script`"
 msgstr "`script`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:65
 msgid "the `ScriptModel` to access script metadata"
 msgstr "スクリプトのメタデータにアクセスするための `ScriptModel` "
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:65
 #, no-wrap
 msgid "`realm`"
 msgstr "`realm`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:67
 msgid "the `RealmModel`"
 msgstr "`RealmModel`"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:67
 #, no-wrap
 msgid "`user`"
 msgstr "`user`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:69
 msgid "the current `UserModel`"
 msgstr "現在の `UserModel`"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:69
 #, no-wrap
 msgid "`session`"
 msgstr "`session`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:71
 msgid "the active `KeycloakSession`"
 msgstr "アクティブな `KeycloakSession`"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:71
 #, no-wrap
 msgid "`authenticationSession`"
 msgstr "`authenticationSession`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:73
 msgid "the current `AuthenticationSessionModel`"
 msgstr "現在の `AuthenticationSessionModel`"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:73
 #, no-wrap
 msgid "`httpRequest`"
 msgstr "`httpRequest`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:75
 msgid "the current `org.jboss.resteasy.spi.HttpRequest`"
 msgstr "現在の `org.jboss.resteasy.spi.HttpRequest`"
 
 #. type: Labeled list
-#: source/server_admin/topics/authentication/flows.adoc:75
 #, no-wrap
 msgid "`LOG`"
 msgstr "`LOG`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:77
 msgid "a `org.jboss.logging.Logger` scoped to `ScriptBasedAuthenticator`"
 msgstr "`ScriptBasedAuthenticator` にスコープされた `org.jboss.logging.Logger`"
 
 #. type: Plain text
-#: source/server_admin/topics/authentication/flows.adoc:80
 msgid ""
 "Note that additional context information can be extracted from the `context`"
 " argument passed to the `authenticate(context)` `action(context)` function."
@@ -321,7 +279,6 @@ msgstr ""
 " 引数から抽出できます。"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:84
 #, no-wrap
 msgid ""
 "AuthenticationFlowError = "
@@ -331,19 +288,16 @@ msgstr ""
 "Java.type(\"org.keycloak.authentication.AuthenticationFlowError\");\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:86
 #, no-wrap
 msgid "function authenticate(context) {\n"
 msgstr "function authenticate(context) {\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:88
 #, no-wrap
 msgid "  LOG.info(script.name + \" --> trace auth for: \" + user.username);\n"
 msgstr "  LOG.info(script.name + \" --> trace auth for: \" + user.username);\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:92
 #, no-wrap
 msgid ""
 "  if (   user.username === \"tester\"\n"
@@ -355,7 +309,6 @@ msgstr ""
 "      && user.getAttribute(\"someAttribute\").contains(\"someValue\")) {\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:96
 #, no-wrap
 msgid ""
 "      context.failure(AuthenticationFlowError.INVALID_USER);\n"
@@ -367,7 +320,6 @@ msgstr ""
 "  }\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/authentication/flows.adoc:99
 #, no-wrap
 msgid ""
 "  context.success();\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__flows
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
