### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,63 +16,39 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/create-client.adoc:12
-#: source/server_admin/topics/clients/client-oidc.adoc:9
-#: source/server_admin/topics/clients/client-saml.adoc:10
-#: source/authorization_services/topics/resource-server-create-client.adoc:10
 #, no-wrap
 msgid "Clients"
 msgstr "Clients"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/create-client.adoc:14
-#: source/server_admin/topics/clients/client-oidc.adoc:11
-#: source/server_admin/topics/clients/client-saml.adoc:12
 msgid "image:{project_images}/clients.png[]"
 msgstr "image:{project_images}/clients.png[]"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/create-client.adoc:19
-#: source/server_admin/topics/clients/client-oidc.adoc:15
-#: source/server_admin/topics/clients/client-saml.adoc:16
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:7
 #, no-wrap
 msgid "Add Client"
 msgstr "Add Client"
 
 #. type: Labeled list
-#: source/server_installation/topics/profiles.adoc:14
-#: source/server_installation/topics/profiles.adoc:61
-#: source/server_admin/topics/clients/client-saml.adoc:38
 #, no-wrap
 msgid "Name"
 msgstr "Name"
 
 #. type: Labeled list
-#: source/server_installation/topics/profiles.adoc:15
-#: source/server_installation/topics/profiles.adoc:62
-#: source/server_admin/topics/clients/client-saml.adoc:43
 #, no-wrap
 msgid "Description"
 msgstr "Description"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:13
-#: source/server_admin/topics/clients/client-saml.adoc:14
 msgid "This will bring you to the `Add Client` page."
 msgstr "これにより、 `Add Client` ページが表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/client-oidc.adoc:27
-#: source/server_admin/topics/clients/client-saml.adoc:29
-#: source/authorization_services/topics/resource-server-create-client.adoc:27
 #, no-wrap
 msgid "Client Settings"
 msgstr "クライアントの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:41
-#: source/server_admin/topics/clients/client-saml.adoc:42
 msgid ""
 "This is the display name for the client whenever it is displayed in a "
 "{project_name} UI screen.  You can localize the value of this field by "
@@ -82,23 +58,17 @@ msgstr ""
 "これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:45
-#: source/server_admin/topics/clients/client-saml.adoc:45
 msgid ""
 "This specifies the description of the client.  This can also be localized."
 msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:49
-#: source/server_admin/topics/clients/client-saml.adoc:48
 msgid ""
 "If this is turned off, the client will not be allowed to request "
 "authentication."
 msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:55
-#: source/server_admin/topics/clients/client-saml.adoc:53
 msgid ""
 "If this is on, then users will get a consent page which asks the user if "
 "they grant access to that application.  It will also display the metadata "
@@ -110,21 +80,17 @@ msgstr ""
 "これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:75
-#: source/server_admin/topics/clients/client-saml.adoc:118
 msgid ""
 "If {project_name} uses any configured relative URLs, this value is prepended"
 " to them."
 msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
 
 #. type: Title ===
-#: source/server_admin/topics/clients/client-saml.adoc:2
 #, no-wrap
 msgid "SAML Clients"
 msgstr "SAMLクライアント"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:7
 msgid ""
 "{project_name} supports <<_saml,SAML 2.0>> for registered applications.  "
 "Both POST and Redirect bindings are supported.  You can choose to require "
@@ -135,7 +101,6 @@ msgstr ""
 "2.0>>をサポートしています。POSTバインディングとREDIRECTバインディングの両方がサポートされています。クライアントの署名検証を要求することもできますし、サーバーに署名したり、レスポンスを暗号化したりすることもできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:9
 msgid ""
 "To create a SAML client go to the `Clients` left menu item.  On this page "
 "you'll see a `Create` button on the right."
@@ -143,46 +108,38 @@ msgstr ""
 "SAMLクライアントを作成するには、左側メニューの項目 `Clients` に移動します。このページには右側に `Create` ボタンがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:18
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:9
 msgid "image:{project_images}/add-client-saml.png[]"
 msgstr "image:{project_images}/add-client-saml.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:28
 msgid ""
 "Enter in the `Client ID` of the client.  This is often a URL and will be the"
 " expected `issuer` value in SAML requests sent by the application.  Next "
-"select `saml` in the `Client Protocol` drop down box.  Ignore the `Client "
-"Template` listbox for now, we'll go over that later in this chapter.  "
-"Finally enter in the `Client SAML Endpoint` URL.  Enter the URL you want the"
-" {project_name} server to send SAML requests and responses to.  Usually "
-"applications have only one URL for processing SAML requests.  If your "
-"application has different URLs for its bindings, don't worry, you can fix "
-"this in the `Settings` tab of the client.  Click `Save`.  This will create "
-"the client and bring you to the client `Settings` tab."
+"select `saml` in the `Client Protocol` drop down box.  Finally enter in the "
+"`Client SAML Endpoint` URL.  Enter the URL you want the {project_name} "
+"server to send SAML requests and responses to.  Usually applications have "
+"only one URL for processing SAML requests.  If your application has "
+"different URLs for its bindings, don't worry, you can fix this in the "
+"`Settings` tab of the client.  Click `Save`.  This will create the client "
+"and bring you to the client `Settings` tab."
 msgstr ""
-"クライアントの `Client ID` を入力します。これは、よく見かけるURLであり、アプリケーションが送信するSAMLリクエストの期待される "
-"`issuer` 値になります。次に、 `Client Protocol` ドロップダウン・ボックスで `saml` を選択します。今は `Client"
-" Template` リストボックスを無視して、この章の後半で説明します。最後に、 `Client SAML Endpoint` "
-"URLを入力します。{project_name}サーバーがSAMLリクエストとレスポンスを送信するURLを入力します。通常、アプリケーションにはSAMLリクエストを処理するURLが1つしかありません。アプリケーションのバインディングに異なるURLがある場合でも、クライアントの"
-" `Settings` タブでこれを修正できます。 `Save` をクリックすることでクライアントが作成され、クライアントの `Settings` "
+"クライアントの `Client ID` に入力します。これはしばしばURLであり、アプリケーションが送信するSAMLリクエスト内の期待される "
+"`issuer` 値になります。次に、 `Client Protocol` ドロップダウンボックスで `saml` を選択します。最後に、 "
+"`Client SAML Endpoint` "
+"URLを入力します。{project_name}サーバーがSAMLリクエストとレスポンスを送信するURLを入力します。通常、アプリケーションにはSAMLリクエストを処理するURLが1つしかありません。アプリケーションがそのバインディングのために異なるURLを持っていれば、心配する問題はありません。クライアントの"
+" `Settings` タブでこれを修正できます。 `Save` をクリックすると、クライアントが作成され、クライアントの `Settings` "
 "タブに移動します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:31
 msgid "image:{project_images}/client-settings-saml.png[]"
 msgstr "image:{project_images}/client-settings-saml.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:34
-#: source/server_admin/topics/identity-broker/oidc.adoc:37
 #, no-wrap
 msgid "Client ID"
 msgstr "Client ID"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:37
 msgid ""
 "This value must match the issuer value sent with AuthNRequests.  "
 "{project_name} will pull the issuer from the Authn SAML request and match it"
@@ -192,27 +149,21 @@ msgstr ""
 "SAMLリクエストから引き出し、この値でクライアントに照合します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:46
-#: source/server_admin/topics/identity-broker/configuration.adoc:53
 #, no-wrap
 msgid "Enabled"
 msgstr "Enabled"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:49
-#: source/server_admin/topics/clients/protocol-mappers.adoc:32
 #, no-wrap
 msgid "Consent Required"
 msgstr "Consent Required"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:54
 #, no-wrap
 msgid "Include AuthnStatement"
 msgstr "Include AuthnStatement"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:57
 msgid ""
 "SAML login responses may specify the authentication method used (password, "
 "etc.) as well as a timestamp of the login.  Setting this to on will include "
@@ -221,26 +172,22 @@ msgstr ""
 "SAMLログイン・レスポンスは、使用された認証方法（パスワードなど）とログインのタイムスタンプを含めることができます。これをONに設定すると、そのステートメントがレスポンス・ドキュメントに含まれます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:58
 #, no-wrap
 msgid "Sign Documents"
 msgstr "Sign Documents"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:60
 msgid ""
 "When turned on, {project_name} will sign the document using the realm's "
 "private key."
 msgstr "onにすると、{project_name}はレルムの秘密鍵を使用してドキュメントに署名します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:61
 #, no-wrap
 msgid "Optimize REDIRECT signing key lookup"
 msgstr "Optimize REDIRECT signing key lookup"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:72
 msgid ""
 "When turned on, the SAML protocol messages will include {project_name} "
 "native extension that contains a hint with signing key ID. When the SP "
@@ -258,13 +205,11 @@ msgstr ""
 " `Sign Documents` がonになっている場合にのみ関係します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:73
 #, no-wrap
 msgid "Sign Assertions"
 msgstr "Sign Assertions"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:76
 msgid ""
 "The `Sign Documents` switch signs the whole document.  With this setting the"
 " assertion is also signed and embedded within the SAML XML Auth response."
@@ -273,26 +218,20 @@ msgstr ""
 "Authレスポンスに埋め込まれます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:77
-#: source/server_admin/topics/identity-broker/saml.adoc:43
 #, no-wrap
 msgid "Signature Algorithm"
 msgstr "Signature Algorithm"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:79
 msgid "Choose between a variety of algorithms for signing SAML documents."
 msgstr "SAMLドキュメントに署名するためのアルゴリズムを選択します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:80
-#: source/server_admin/topics/identity-broker/saml.adoc:46
 #, no-wrap
 msgid "SAML Signature Key Name"
 msgstr "SAML Signature Key Name"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:87
 msgid ""
 "Signed SAML documents sent via POST binding contain identification of "
 "signing key in `KeyName` element. This by default contains {project_name} "
@@ -311,37 +250,31 @@ msgstr ""
 " `NONE` ）を制御します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:88
 #, no-wrap
 msgid "Canonicalization Method"
 msgstr "Canonicalization Method"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:90
 msgid "Canonicalization method for XML signatures."
 msgstr "XML署名の正規化方法を選択します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:91
 #, no-wrap
 msgid "Encrypt Assertions"
 msgstr "Encrypt Assertions"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:94
 msgid ""
 "Encrypt assertions in SAML documents with the realm's private key.  The AES "
 "algorithm is used with a key size of 128 bits."
 msgstr "レルムの秘密鍵を使用してSAMLドキュメントのアサーションを暗号化します。AESアルゴリズムは128ビットの鍵サイズで使用されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:95
 #, no-wrap
 msgid "Client Signature Required"
 msgstr "Client Signature Required"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:98
 msgid ""
 "Expect that documents coming from a client are signed.  {project_name} will "
 "validate this signature using the client public key or cert set up in the "
@@ -351,13 +284,11 @@ msgstr ""
 "タブに設定されたクライアント公開鍵または証明書を使用して、この署名を検証します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:99
 #, no-wrap
 msgid "Force POST Binding"
 msgstr "Force POST Binding"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:102
 msgid ""
 "By default, {project_name} will respond using the initial SAML binding of "
 "the original request.  By turning on this switch, you will force "
@@ -368,13 +299,11 @@ msgstr ""
 " POSTバインディングを使用して応答するようになります。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:103
 #, no-wrap
 msgid "Front Channel Logout"
 msgstr "Front Channel Logout"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:107
 msgid ""
 "If true, this application requires a browser redirect to be able to perform "
 "a logout.  For example, the application may require a cookie to be reset "
@@ -385,13 +314,11 @@ msgstr ""
 "trueの場合、このアプリケーションは、ログアウトを実行するのにブラウザーのリダイレクトを必要とします。たとえば、アプリケーションは、リダイレクトを介してのみリセットすることができるCookieを必要とするかもしれません。このスイッチがfalseの場合、{project_name}はバックグラウンドのSAMLリクエストを呼び出してアプリケーションをログアウトします。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:108
 #, no-wrap
 msgid "Force Name ID Format"
 msgstr "Force Name ID Format"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:110
 msgid ""
 "If the request has a name ID policy, ignore it and used the value configured"
 " in the admin console under Name ID Format"
@@ -399,13 +326,11 @@ msgstr ""
 "リクエストにName IDポリシーがある場合、それを無視し、管理コンソールの `Name ID Format` で設定された値を使用します。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:111
 #, no-wrap
 msgid "Name ID Format"
 msgstr "Name ID Format"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:115
 msgid ""
 "Name ID Format for the subject.  If no name ID policy is specified in the "
 "request or if the Force Name ID Format attribute is true, this value is "
@@ -415,19 +340,16 @@ msgstr ""
 "Format` 属性がtrueの場合、この値が使用されます。フォーマットとして使用されるプロパティーが定義されています。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:116
 #, no-wrap
 msgid "Root URL"
 msgstr "Root URL"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:119
 #, no-wrap
 msgid "Valid Redirect URIs"
 msgstr "Valid Redirect URIs"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:124
 msgid ""
 "This is an optional field.  Enter in a URL pattern and click the + sign to "
 "add.  Click the - sign next to URLs you want to remove.  Remember that you "
@@ -442,24 +364,20 @@ msgstr ""
 "のように、URIの最後にのみ使用できます。このフィールドは、正確なSAMLエンドポイントが登録されておらず、{project_name}がリクエストからアサーション・コンシューマURLを取得している場合に使用されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:125
 #, no-wrap
 msgid "Base URL"
 msgstr "Base URL"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:127
 msgid "If {project_name} needs to link to the client, this URL would be used."
 msgstr "{project_name}がクライアントにリンクする必要がある場合、このURLが使用されます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:128
 #, no-wrap
 msgid "Master SAML Processing URL"
 msgstr "Master SAML Processing URL"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:132
 msgid ""
 "This URL will be used for all SAML requests and the response will be "
 "directed to the SP.  It will be used as the Assertion Consumer Service URL "
@@ -471,46 +389,38 @@ msgstr ""
 " Redirect URIパターンで妥当性を確認する必要があります。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:133
 #, no-wrap
 msgid "Assertion Consumer Service POST Binding URL"
 msgstr "Assertion Consumer Service POST Binding URL"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:135
 msgid "POST Binding URL for the Assertion Consumer Service."
 msgstr "アサーション・コンシューマー・サービスのPOSTバインディングURL。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:136
 #, no-wrap
 msgid "Assertion Consumer Service Redirect Binding URL"
 msgstr "Assertion Consumer Service Redirect Binding URL"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:138
 msgid "Redirect Binding URL for the Assertion Consumer Service."
 msgstr "アサーション・コンシューマー・サービスのREDIRECTバインディングURL。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:139
 #, no-wrap
 msgid "Logout Service POST Binding URL"
 msgstr "Logout Service POST Binding URL"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:141
 msgid "POST Binding URL for the Logout Service."
 msgstr "ログアウト・サービスのPOSTバインディングURL。"
 
 #. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:142
 #, no-wrap
 msgid "Logout Service Redirect Binding URL"
 msgstr "Logout Service Redirect Binding URL"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:144
 #, no-wrap
 msgid "Redirect Binding URL for the Logout Service.     \n"
 msgstr "ログアウト・サービスのREDIRECTバインディングURL。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
