### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -1,0 +1,164 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid ""
+"With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
+" repository. In these instructions only the term repository is used."
+msgstr ""
+"Red Hat Enterprise Linux "
+"7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Plain text
+msgid ""
+"Ensure that your Red Hat Enterprise Linux system is registered to your "
+"account using Red Hat Subscription Manager. For more information see the "
+"link:https://access.redhat.com/documentation/en-"
+"us/red_hat_subscription_management/1/html-"
+"single/quick_registration_for_rhel/index[Red Hat Subscription Management "
+"documentation]."
+msgstr ""
+"Red Hat Subscription Managerを使用して、Red Hat Enterprise "
+"Linuxシステムがアカウントに登録されていることを確認してください。詳細は、link:https://access.redhat.com/documentation"
+"/en-us/red_hat_subscription_management/1/html-"
+"single/quick_registration_for_rhel/index[Red Hat Subscription Management "
+"documentation]のリンクを参照してください。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Installing JBoss EAP Adapter from an RPM"
+msgstr "RPMからJBoss EAPアダプターをインストールします。"
+
+#. type: Plain text
+msgid "Install the EAP 7 Adapters from an RPM:"
+msgstr "次のように、RPMからEAP 7アダプターをインストールします。"
+
+#. type: Plain text
+msgid ""
+"You must subscribe to the JBoss EAP 7.0 repository before you can install "
+"the EAP 7 adapters from an RPM."
+msgstr "RPMからEAP 7アダプターをインストールする前に、JBoss EAP 7.0リポジトリーにサブスクライブする必要があります。"
+
+#. type: Plain text
+msgid ""
+"If you are already subscribed to another JBoss EAP repository, you must "
+"unsubscribe from that repository first."
+msgstr "すでに別のJBoss EAPリポジトリーに登録している場合は、まずそのリポジトリーから登録を解除する必要があります。"
+
+#. type: Plain text
+msgid ""
+"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 7.0 "
+"repository using the following command. Replace <RHEL_VERSION> with either 6"
+" or 7 depending on your Red Hat Enterprise Linux version."
+msgstr ""
+"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
+"7.0リポジトリーをサブスクライブします。Red Hat Enterprise "
+"Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ sudo subscription-manager repos --enable=jb-eap-7-for-rhel-<RHEL_VERSION"
+">-server-rpms\n"
+msgstr ""
+"$ sudo subscription-manager repos --enable=jb-eap-7-for-rhel-<RHEL_VERSION"
+">-server-rpms\n"
+
+#. type: Plain text
+msgid ""
+"The default EAP_HOME path for the RPM installation is "
+"/opt/rh/eap7/root/usr/share/wildfly."
+msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap7/root/usr/share/wildflyです。"
+
+#. type: Plain text
+msgid "Run the appropriate module installation script."
+msgstr "適切なモジュール・インストール・スクリプトを実行します。"
+
+#. type: Plain text
+msgid "Your installation is complete."
+msgstr "インストールは完了です。"
+
+#. type: Plain text
+msgid "Install the EAP 6 Adapters from an RPM:"
+msgstr "次のように、RPMからEAP 6アダプターをインストールします。"
+
+#. type: Plain text
+msgid ""
+"You must subscribe to the JBoss EAP 6.0 repository before you can install "
+"the EAP 6 adapters from an RPM."
+msgstr "RPMからEAP 6アダプターをインストールする前に、JBoss EAP 6.0リポジトリーにサブスクライブする必要があります。"
+
+#. type: Plain text
+msgid ""
+"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 6.0 "
+"repository using the following command. Replace <RHEL_VERSION> with either 6"
+" or 7 depending on your Red Hat Enterprise Linux version."
+msgstr ""
+"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
+"6.0リポジトリーにサブスクライブします。Red Hat Enterprise "
+"Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ sudo subscription-manager repos --enable=jb-eap-6-for-rhel-<RHEL_VERSION"
+">-server-rpms\n"
+msgstr ""
+"$ sudo subscription-manager repos --enable=jb-eap-6-for-rhel-<RHEL_VERSION"
+">-server-rpms\n"
+
+#. type: Plain text
+msgid ""
+"The default EAP_HOME path for the RPM installation is "
+"/opt/rh/eap6/root/usr/share/wildfly."
+msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"
+
+#. type: Plain text
+msgid "Install the EAP 7 adapters for SAML using the following command:"
+msgstr "次のコマンドを使用して、SAML用のEAP 7アダプターをインストールします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
+msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
+
+#. type: Plain text
+msgid "For the SAML module, enter the following command:"
+msgstr "SAMLモジュールの場合は、次のコマンドを実行します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {EAP_HOME}/bin/jboss-cli.sh -c --file=${EAP_HOME}/bin/adapter-install-"
+"saml.cli\n"
+msgstr ""
+"$ {EAP_HOME}/bin/jboss-cli.sh -c --file=${EAP_HOME}/bin/adapter-install-"
+"saml.cli\n"
+
+#. type: Plain text
+msgid "Install the EAP 6 adapters for SAML using the following command:"
+msgstr "次のコマンドを使用して、SAML用のEAP 6アダプターをインストールします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo yum install keycloak-saml-adapter-sso7_2-eap6\n"
+msgstr "$ sudo yum install keycloak-saml-adapter-sso7_2-eap6\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
