### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -15,22 +15,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
-#: source/securing_apps/topics/oidc/oidc-generic.adoc:134
-#: source/securing_apps/topics/client-registration.adoc:126
-#: source/server_development/topics/admin-rest-api.adoc:13
-#, no-wrap
-msgid "Example using CURL"
-msgstr "CURLを使用した例"
-
 #. type: Title ==
-#: source/securing_apps/topics/client-registration.adoc:2
 #, no-wrap
 msgid "Client Registration"
 msgstr "クライアントの登録"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:7
 msgid ""
 "In order for an application or service to utilize {project_name} it has to "
 "register a client in {project_name}.  An admin can do this through the admin"
@@ -40,7 +30,6 @@ msgstr ""
 "{project_name}をアプリケーションまたはサービスで使用するには、{project_name}にクライアントを登録する必要があります。管理者は管理コンソール（または管理RESTエンドポイント）にて登録できますが、クライアント自身でも{project_name}クライアント登録サービスにおいて登録することはできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:10
 msgid ""
 "The Client Registration Service provides built-in support for {project_name}"
 " Client Representations, OpenID Connect Client Meta Data and SAML Entity "
@@ -48,50 +37,40 @@ msgid ""
 ">/clients-registrations/<provider>`."
 msgstr ""
 "クライアント登録サービスには、{project_name} Client Representations、OpenID Connect Client "
-"Meta DataおよびSAML Entity "
-"Descriptorsのビルトインサポートが用意されています。クライアント登録サービスのエンドポイントは `/realms/<realm"
-">/clients-registrations/<provider>` です。"
+"Meta DataおよびSAML Entity Descriptorsのビルトインサポートが用意されています。クライアント登録サービスのエンドポイントは"
+" `/realms/<realm>/clients-registrations/<provider>` です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:12
 msgid "The built-in supported `providers` are:"
 msgstr "サポートされている組み込みの `providers` は以下のとおりです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:14
 msgid "default - {project_name} Client Representation (JSON)"
 msgstr "default - {project_name} Client Representation（JSON）"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:15
 msgid "install - {project_name} Adapter Configuration (JSON)"
 msgstr "install - {project_name}アダプター設定 （JSON）"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:16
 msgid "openid-connect - OpenID Connect Client Metadata Description (JSON)"
 msgstr "openid-connect - OpenID Connectクライアント・メタデータ・ディスクリプション（JSON）"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:17
 msgid "saml2-entity-descriptor - SAML Entity Descriptor (XML)"
 msgstr "saml2-entity-descriptor - SAMLエンティティー記述子（XML）"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:19
 msgid ""
 "The following sections will describe how to use the different providers."
 msgstr "以下のセクションでは、異なるプロバイダーを使用する方法を説明します。"
 
 #. type: Title ==
-#: source/securing_apps/topics/client-registration.adoc:20
-#: source/server_admin/topics/authentication.adoc:2
 #, no-wrap
 msgid "Authentication"
 msgstr "認証"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:24
 msgid ""
 "To invoke the Client Registration Services you usually need a token. The "
 "token can be a bearer token, an initial access token or a registration "
@@ -102,13 +81,11 @@ msgstr ""
 "クライアント登録サービスを呼び出すには、通常トークンが必要です。トークンは、ベアラー・トークン、初期アクセス・トークン、登録アクセス・トークンのいずれかです。いずれのトークンも含まず、同様に新規クライアントを登録する方法がありますが、クライアント登録ポリシー（下記参照）を設定する必要があります。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:25
 #, no-wrap
 msgid "Bearer Token"
 msgstr "ベアラー・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:28
 msgid ""
 "The bearer token can be issued on behalf of a user or a Service Account. The"
 " following permissions are required to invoke the endpoints (see "
@@ -117,22 +94,18 @@ msgstr ""
 "ベアラー・トークンは、ユーザーやサービス・アカウントに代わって発行されます。エンドポイントを呼び出すには、次の権限が必要です（詳細についてはlink:{adminguide_link}[{adminguide_name}]を参照してください）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:30
 msgid "create-client or manage-client - To create clients"
 msgstr "create-client または manage-client - クライアントの作成権限"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:31
 msgid "view-client or manage-client - To view clients"
 msgstr "view-client または manage-client - クライアントの参照権限"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:32
 msgid "manage-client - To update or delete client"
 msgstr "manage-client - クライアントの更新または削除権限"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:34
 msgid ""
 "If you are using a bearer token to create clients it's recommend to use a "
 "token from a Service Account with only the `create-client` role (see "
@@ -142,13 +115,11 @@ msgstr ""
 "ロールのみを持つサービス・アカウントのトークンを使用することをお勧めします（詳細については、link:{adminguide_link}[{adminguide_name}]を参照してください）。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:36
 #, no-wrap
 msgid "Initial Access Token"
 msgstr "初期アクセス・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:40
 msgid ""
 "The recommended approach to registering new clients is by using initial "
 "access tokens.  An initial access token can only be used to create clients "
@@ -158,7 +129,6 @@ msgstr ""
 "新しいクライアントを登録するための推奨される方法は、初期アクセス・トークンを使用することです。初期アクセス・トークンは、クライアントを作成する場合にのみ使用でき、有効期限が設定できるだけでなく、クライアントを作成可能な回数の上限も設定できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:44
 msgid ""
 "An initial access token can be created through the admin console.  To create"
 " a new initial access token first select the realm in the admin console, "
@@ -171,7 +141,6 @@ msgstr ""
 "`Initial Access Tokens` のサブ・タブをクリックします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:48
 msgid ""
 "You will now be able to see any existing initial access tokens. If you have "
 "access you can delete tokens that are no longer required. You can only "
@@ -186,7 +155,6 @@ msgstr ""
 "`Save` をクリックすると、トークンの値が表示されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:50
 msgid ""
 "It is important that you copy/paste this token now as you won't be able to "
 "retrieve it later. If you forget to copy/paste it, then delete the token and"
@@ -195,7 +163,6 @@ msgstr ""
 "後でトークンを取得することはできないので、このトークンをコピー/ペーストすることが重要です。コピー/ペーストすることを忘れた場合は、そのトークンを削除し、別のトークンを作成してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:53
 msgid ""
 "The token value is used as a standard bearer token when invoking the Client "
 "Registration Services, by adding it to the Authorization header in the "
@@ -204,19 +171,16 @@ msgstr ""
 "リクエストにAuthorizationヘッダーを追加することにより、トークンの値はクライアント登録サービスを呼び出す際の標準ベアラー・トークンとして使用されます。以下に例を示します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:57
 #, no-wrap
 msgid "Authorization: bearer eyJhbGciOiJSUz...\n"
 msgstr "Authorization: bearer eyJhbGciOiJSUz...\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:59
 #, no-wrap
 msgid "Registration Access Token"
 msgstr "登録アクセス・トークン"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:65
 msgid ""
 "When you create a client through the Client Registration Service the "
 "response will include a registration access token.  The registration access "
@@ -229,7 +193,6 @@ msgstr ""
 "クライアント登録サービスを介してクライアントを作成する際には、レスポンスには登録アクセス・トークンが含まれます。登録アクセス・トークンは、クライアント設定を取得するだけでなく、クライアントの更新や削除のためのアクセス権を提供します。登録アクセス・トークンは、ベアラー・トークンや初期アクセス・トークンと同じ方法でリクエストに含まれます。登録アクセス・トークンの使用は一度だけ有効であり、新しいトークンがレスポンスに含まれます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:69
 msgid ""
 "If a client was created outside of the Client Registration Service it won't "
 "have a registration access token associated with it.  You can create one "
@@ -242,13 +205,11 @@ msgstr ""
 " `Credentials` をクリックします。そして、 `Generate registration access token` をクリックします。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:70
 #, no-wrap
 msgid "{project_name} Representations"
 msgstr "{project_name} Representations"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:75
 msgid ""
 "The `default` client registration provider can be used to create, retrieve, "
 "update and delete a client.  It uses {project_name} Client Representation "
@@ -261,7 +222,6 @@ msgstr ""
 " Client Representation形式を使用します。また、プロトコル・マッパーの設定例が含まれています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:77
 msgid ""
 "To create a client create a Client Representation (JSON) then perform an "
 "HTTP POST request to `/realms/<realm>/clients-registrations/default`."
@@ -270,7 +230,6 @@ msgstr ""
 "`/realms/<realm>/clients-registrations/default` に送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:80
 msgid ""
 "It will return a Client Representation that also includes the registration "
 "access token.  You should save the registration access token somewhere if "
@@ -280,7 +239,6 @@ msgstr ""
 "Representationが返されます。設定を取得したり、クライアントを後で更新、削除したい場合は、登録アクセス・トークンをどこかに保存する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:82
 msgid ""
 "To retrieve the Client Representation perform an HTTP GET request to "
 "`/realms/<realm>/clients-registrations/default/<client id>`."
@@ -289,13 +247,10 @@ msgstr ""
 "registrations/default/<client id>` に送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:84
-#: source/securing_apps/topics/client-registration.adoc:89
 msgid "It will also return a new registration access token."
 msgstr "新しい登録アクセス・トークンも返します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:87
 msgid ""
 "To update the Client Representation perform an HTTP PUT request with the "
 "updated Client Representation to: `/realms/<realm>/clients-"
@@ -305,7 +260,6 @@ msgstr ""
 "`/realms/<realm>/clients-registrations/default/<client id>` 。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:92
 msgid ""
 "To delete the Client Representation perform an HTTP DELETE request to: "
 "`/realms/<realm>/clients-registrations/default/<client id>`"
@@ -314,13 +268,11 @@ msgstr ""
 "registrations/default/<client id>` に送信します。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:93
 #, no-wrap
 msgid "{project_name} Adapter Configuration"
 msgstr "{project_name}アダプター設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:98
 msgid ""
 "The `installation` client registration provider can be used to retrieve the "
 "adapter configuration for a client.  In addition to token authentication you"
@@ -331,22 +283,19 @@ msgstr ""
 "BASIC認証を使用してクライアント・クレデンシャルで認証することもできます。 これを行うには、リクエストに次のヘッダーを含めます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:102
 #, no-wrap
 msgid "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
 msgstr "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:105
 msgid ""
-"To retrieve the Adapter Configuration then perfrom an HTTP GET request to "
+"To retrieve the Adapter Configuration then perform an HTTP GET request to "
 "`/realms/<realm>/clients-registrations/install/<client id>`."
 msgstr ""
-"アダプター設定を取得するには、HTTP GETリクエストを   `/realms/<realm>/clients-"
+"アダプター設定を取得するには、HTTP GETリクエストを `/realms/<realm>/clients-"
 "registrations/install/<client id>` に送信します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:108
 msgid ""
 "No authentication is required for public clients.  This means that for the "
 "JavaScript adapter you can load the client configuration directly from "
@@ -355,13 +304,11 @@ msgstr ""
 "パブリック・クライアントは認証が要求されません。これは、JavaScriptアダプターは、上記URLを使用して、直接{project_name}からクライアント設定を読み込めることを意味します。"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:109
 #, no-wrap
 msgid "OpenID Connect Dynamic Client Registration"
 msgstr "OpenID Connect動的クライアント登録"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:112
 msgid ""
 "{project_name} implements https://openid.net/specs/openid-connect-"
 "registration-1_0.html[OpenID Connect Dynamic Client Registration], which "
@@ -376,7 +323,6 @@ msgstr ""
 " Dynamic Client Registration] を実装しています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:114
 msgid ""
 "The endpoint to use these specifications to register clients in "
 "{project_name} is `/realms/<realm>/clients-registrations/openid-"
@@ -386,7 +332,6 @@ msgstr ""
 "registrations/openid-connect[/<client id>]` です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:116
 msgid ""
 "This endpoints can also be found in the OpenID Connect Discovery endpoint "
 "for the realm, `/realms/<realm>/.well-known/openid-configuration`."
@@ -395,14 +340,11 @@ msgstr ""
 "known/openid-configuration` ）でも見つかります。"
 
 #. type: Title ====
-#: source/securing_apps/topics/client-registration.adoc:117
-#: source/server_admin/topics/clients/saml/entity-descriptors.adoc:2
 #, no-wrap
 msgid "SAML Entity Descriptors"
 msgstr "SAMLエンティティー記述子"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:123
 msgid ""
 "The SAML Entity Descriptor endpoint only supports using SAML v2 Entity "
 "Descriptors to create clients.  It doesn't support retrieving, updating or "
@@ -418,7 +360,6 @@ msgstr ""
 " Client Representationが返されます（登録アクセス・トークンを含みます）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:125
 msgid ""
 "To create a client perform an HTTP POST request with the SAML Entity "
 "Descriptor to `/realms/<realm>/clients-registrations/saml2-entity-"
@@ -427,8 +368,12 @@ msgstr ""
 "クライアントを作成するには、SAMLエンティティー記述子を使用して `/realms/<realm>/clients-"
 "registrations/saml2-entity-descriptor` にHTTP POSTリクエストを送信します。"
 
+#. type: Title ===
+#, no-wrap
+msgid "Example using CURL"
+msgstr "CURLを使用した例"
+
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:130
 msgid ""
 "The following example creates a client with the clientId `myclient` using "
 "CURL. You need to replace `eyJhbGciOiJSUz...` with a proper initial access "
@@ -439,7 +384,6 @@ msgstr ""
 "を置き換える必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:138
 #, no-wrap
 msgid ""
 "curl -X POST \\\n"
@@ -455,13 +399,11 @@ msgstr ""
 "    http://localhost:8080/auth/realms/master/clients-registrations/default\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:140
 #, no-wrap
 msgid "Example using Java Client Registration API"
 msgstr "Javaクライアント登録APIを使用した例"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:144
 msgid ""
 "The Client Registration Java API makes it easy to use the Client "
 "Registration Service using Java.  To use include the dependency "
@@ -471,7 +413,6 @@ msgstr ""
 ":keycloak-client-registration-api:>VERSION<` の依存関係を含めてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:147
 msgid ""
 "For full instructions on using the Client Registration refer to the "
 "JavaDocs.  Below is an example of creating a client. You need to replace "
@@ -481,13 +422,11 @@ msgstr ""
 "`eyJhbGciOiJSUz...` を適切な初期アクセス・トークンまたはベアラー・トークンに置き換える必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:151
 #, no-wrap
 msgid "String token = \"eyJhbGciOiJSUz...\";\n"
 msgstr "String token = \"eyJhbGciOiJSUz...\";\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:154
 #, no-wrap
 msgid ""
 "ClientRepresentation client = new ClientRepresentation();\n"
@@ -497,7 +436,6 @@ msgstr ""
 "client.setClientId(CLIENT_ID);\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:158
 #, no-wrap
 msgid ""
 "ClientRegistration reg = ClientRegistration.create()\n"
@@ -509,38 +447,32 @@ msgstr ""
 "    .build();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:160
 #, no-wrap
 msgid "reg.auth(Auth.token(token));\n"
 msgstr "reg.auth(Auth.token(token));\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:162
 #, no-wrap
 msgid "client = reg.create(client);\n"
 msgstr "client = reg.create(client);\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/client-registration.adoc:164
 #, no-wrap
 msgid "String registrationAccessToken = client.getRegistrationAccessToken();\n"
 msgstr "String registrationAccessToken = client.getRegistrationAccessToken();\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/client-registration.adoc:166
 #, no-wrap
 msgid "Client Registration Policies"
 msgstr "クライアント登録ポリシー"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:169
 msgid ""
 "{project_name} currently supports 2 ways how can be new clients registered "
 "through Client Registration Service."
 msgstr "{project_name}は現在、クライアント登録サービスを介して新しいクライアントを登録できる2つの方法をサポートしています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:171
 msgid ""
 "Authenticated requests - Request to register new client must contain either "
 "`Initial Access Token` or `Bearer Token` as mentioned above."
@@ -549,14 +481,12 @@ msgstr ""
 "のいずれかを含める必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:173
 msgid ""
 "Anonymous requests - Request to register new client doesn't need to contain "
 "any token at all"
 msgstr "匿名リクエスト - 新しいクライアントを登録するためのリクエストは、すべての任意のトークンを含める必要はありません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:176
 msgid ""
 "Anonymous client registration requests are very interesting and powerful "
 "feature, however you usually don't want that anyone is able to register new "
@@ -568,7 +498,6 @@ msgstr ""
 " `Client Registration Policy SPI` があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:179
 msgid ""
 "In {project_name} admin console, you can click to `Client Registration` tab "
 "and then `Client Registration Policies` sub-tab. Here you will see what "
@@ -580,7 +509,6 @@ msgstr ""
 "サブタブをクリックします。ここでは、匿名リクエストに対してデフォルトでどのようなポリシーが設定されるか、認証リクエストに対してどのようなポリシーを設定されるかが表示されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:185
 msgid ""
 "The anonymous requests (requests without any token) are allowed just for "
 "creating (registration) of new clients. So when you register new client "
@@ -599,12 +527,10 @@ msgstr ""
 "`Consent Required` ポリシーが存在する場合に、 `Consent Required` を無効にするなどはできません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:187
 msgid "Currently we have these policy implementations:"
 msgstr "現在、以下のポリシーの実装があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:191
 msgid ""
 "Trusted Hosts Policy - You can configure list of trusted hosts and trusted "
 "domains. Request to Client Registration Service can be sent just from those "
@@ -612,7 +538,7 @@ msgid ""
 "URLs of newly registered client must also use just those trusted hosts or "
 "domains. For example it won't be allowed to set `Redirect URI` of client "
 "pointing to some untrusted host. By default, there is not any whitelisted "
-"host, so anonymous client registration is de-facto disabled by default."
+"host, so anonymous client registration is de-facto disabled."
 msgstr ""
 "Trusted Hosts Policy - "
 "信頼されたホストと信頼されているドメインの一覧を設定できます。それらのホストやドメインだけからクライアント登録サービスへのリクエストを送信できます。信頼されていないIPから送信されたリクエストは拒否されます。また、新たに登録されたクライアントのURLは、信頼されたホストやドメインだけを使わなければなりません。たとえば、信頼できないホストを指すクライアントの"
@@ -620,19 +546,17 @@ msgstr ""
 "を設定することは許可されません。デフォルトでは、ホワイトリストに登録されているホストが無いため、匿名クライアント登録は事実上無効になっています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:195
 msgid ""
 "Consent Required Policy - Newly registered clients will have `Consent "
 "Allowed` switch enabled. So after successful authentication, user will "
-"always see consent screen when he needs to approve personal info and "
-"permissions (protocol mappers and roles). It means that client won't have "
-"access to any personal info or permission of user unless user approves it."
+"always see consent screen when he needs to approve permissions (client "
+"scopes). It means that client won't have access to any personal info or "
+"permission of user unless user approves it."
 msgstr ""
 "Consent Required Policy - 新たに登録されたクライアントは、 `Consent Allowed` "
-"スイッチが有効になります。したがって、認証成功後、個人情報とアクセス権（プロトコルマッパーとロール）を承認する必要がある場合、常に同意画面が表示されます。つまり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権にアクセスすることができません。"
+"スイッチが有効になります。したがって、認証成功後、アクセス権（クライアントのスコープ）を承認する必要がある場合、常に同意画面が表示されます。つまり、ユーザーが承認しない限り、クライアントはユーザーの個人情報やアクセス権にアクセスすることができません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:199
 msgid ""
 "Protocol Mappers Policy - Allows to configure list of whitelisted protocol "
 "mapper implementations. New client can't be registered or updated if it "
@@ -644,17 +568,17 @@ msgstr ""
 "プロトコル・マッパー実装のホワイトリストを設定できます。ホワイトリストに無いプロトコル・マッパーが含まれている場合は、新たなクライアントを登録または更新できません。このポリシーは認証済みのリクエストにも使用されるため、認証済みのリクエストに対しても、どのプロトコル・マッパーを使用できるかの制限があることに注意してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:202
 msgid ""
-"Client Template Policy - Allow to whitelist `Client Templates`, which can be"
-" used with newly registered or updated clients.  There are no whitelisted "
-"templates by default."
+"Client Scope Policy - Allow to whitelist `Client Scopes`, which can be used "
+"with newly registered or updated clients.  There are no whitelisted scopes "
+"by default; only the client scopes, which are defined as `Realm Default "
+"Client Scopes` are whitelisted by default."
 msgstr ""
-"Client Template Policy - 新たに登録または更新したクライアントで使うことができる `Client Templates` "
-"のホワイトリスト化を許可します。デフォルトでは、ホワイトリスト化されたテンプレートはありません。"
+"Client Scope Policy - 新たに登録または更新したクライアントで使うことができる `Client Scopes` "
+"のホワイトリスト化を許可します。デフォルトでは、ホワイトリスト化されたスコープはありません。 `Realm Default Client Scopes`"
+" として定義されているクライアントスコープのみがデフォルトでホワイトリストに登録されています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:205
 msgid ""
 "Full Scope Policy - Newly registered clients will have `Full Scope Allowed` "
 "switch disabled. This means they won't have any scoped realm roles or client"
@@ -664,7 +588,6 @@ msgstr ""
 "スイッチが無効に切り替わります。これは、スコープが設定されたレルム・ロールや他のクライアントのクライアント・ロールが無いことを意味します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:207
 msgid ""
 "Max Clients Policy - Rejects registration if current number of clients in "
 "the realm is same or bigger than specified limit. It's 200 by default for "
@@ -673,7 +596,6 @@ msgstr ""
 "Max Clients Policy - レルム内の現在のクライアント数が指定された制限以上の場合、登録を拒否します。匿名登録のデフォルトは200です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/client-registration.adoc:210
 msgid ""
 "Client Disabled Policy - Newly registered client will be disabled. This "
 "means that admin needs to manually approve and enable all newly registered "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
