### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
@@ -16,60 +16,29 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/boot.adoc:8
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:34
-#: source/server_installation/topics/operating-mode/standalone.adoc:17
 msgid "image:{project_images}/standalone-boot-files.png[]"
 msgstr "image:{project_images}/standalone-boot-files.png[]"
 
 #. type: Plain text
-#: source/getting_started/topics/first-boot/boot.adoc:10
-#: source/server_installation/topics/operating-mode/domain.adoc:186
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:36
-#: source/server_installation/topics/operating-mode/standalone.adoc:19
 msgid "To boot the server:"
 msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:11
-#: source/getting_started/topics/secure-jboss-app/before.adoc:14
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:52
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:11
-#: source/server_installation/topics/operating-mode/domain.adoc:187
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:37
-#: source/server_installation/topics/operating-mode/standalone.adoc:20
-#: source/server_installation/topics/manage.adoc:15
-#: source/server_admin/topics/initialization.adoc:27
-#: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:17
-#: source/getting_started/topics/secure-jboss-app/before.adoc:20
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:58
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:17
-#: source/server_installation/topics/operating-mode/domain.adoc:193
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:43
-#: source/server_installation/topics/operating-mode/standalone.adoc:26
-#: source/server_installation/topics/manage.adoc:21
-#: source/server_admin/topics/initialization.adoc:33
-#: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
 
 #. type: Title ===
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:4
 #, no-wrap
 msgid "Standalone Clustered Mode"
 msgstr "スタンドアローン・クラスター・モード"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:10
 msgid ""
 "Standalone clustered operation mode is for when you want to run "
 "{project_name} within a cluster.  This mode requires that you have a copy of"
@@ -82,13 +51,11 @@ msgstr ""
 "スタンドアローン・クラスター動作モードは、クラスター内で{project_name}を実行するためのものです。このモードでは、サーバー・インスタンスを実行する各マシンに{project_name}の配布物のコピーが保存されている必要があります。このモードは、最初は非常に簡単にデプロイできますが、後でかなり煩雑になる可能性があります。設定を変更するには、各マシンの配布物を修正する必要があります。大規模なクラスターの場合、時間がかかり、エラーも発生しやすくなります。"
 
 #. type: Title ====
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:11
 #, no-wrap
 msgid "Standalone Clustered Configuration"
 msgstr "スタンドアローン・クラスター設定"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:19
 msgid ""
 "The distribution has a mostly pre-configured app server configuration file "
 "for running within a cluster.  It has all the specific infrastructure "
@@ -102,38 +69,32 @@ msgid ""
 msgstr ""
 "この配布物には、クラスター内で実行するためのアプリケーション・サーバーの設定ファイルが含まれており、その大半は設定が済んでいます。ネットワーク、データベース、キャッシュ、およびディスカバリーのための基盤設定がすべて含まれています。このファイルは"
 " _.../standalone/configuration/standalone-ha.xml_ "
-"にあります。しかし、この設定だけでは足りません。共有データベース接続を設定せずに、クラスター内で{project_name}を実行することはできません。また、クラスターのフロントにいくつかの種類のロードバランサーをデプロイする必要があります。このガイドの<<_clustering,クラスターリング>>と<<_database,データベース>>のセクションでは、これらのことを説明します。"
+"にあります。しかし、この設定だけでは足りません。共有データベース接続を設定せずに、クラスター内で{project_name}を実行することはできません。また、クラスターのフロントにいくつかの種類のロードバランサーをデプロイする必要があります。このガイドの<<_clustering,クラスタリング>>と<<_database,データベース>>のセクションでは、これらのことを説明します。"
 
 #. type: Block title
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:20
 #, no-wrap
 msgid "Standalone HA Config"
 msgstr "スタンドアローンHA設定"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:22
 msgid "image:{project_images}/standalone-ha-config-file.png[]"
 msgstr "image:{project_images}/standalone-ha-config-file.png[]"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:26
-#: source/server_installation/topics/operating-mode/standalone.adoc:44
 #, no-wrap
 msgid ""
 "Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
-"      by the server.  Instead use the the command line scripting or the web console of {appserver_name}.  See\n"
+"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
 "      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
 msgstr ""
 "サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"
 
 #. type: Title ====
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:27
 #, no-wrap
 msgid "Standalone Clustered Boot Script"
 msgstr "スタンドアローン・クラスター起動スクリプト"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:31
 msgid ""
 "You use the same boot scripts to start {project_name} as you do in "
 "standalone mode.  The difference is that you pass in an additional flag to "
@@ -142,19 +103,16 @@ msgstr ""
 "{project_name}を起動するには、スタンドアローン・モードで実行したのと同じ起動スクリプトを使用します。スタンドアローン・モードとの違いは、HA設定ファイルを指し示す追加フラグを渡すという点になります。"
 
 #. type: Block title
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:32
 #, no-wrap
 msgid "Standalone Clustered Boot Scripts"
 msgstr "スタンドアローン・クラスター起動スクリプト"
 
 #. type: delimited block -
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:41
 #, no-wrap
 msgid "$ .../bin/standalone.sh --server-config=standalone-ha.xml\n"
 msgstr "$ .../bin/standalone.sh --server-config=standalone-ha.xml\n"
 
 #. type: delimited block -
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:47
 #, no-wrap
 msgid "> ...\\bin\\standalone.bat --server-config=standalone-ha.xml\n"
 msgstr "> ...\\bin\\standalone.bat --server-config=standalone-ha.xml\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone-ha
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
