### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -16,25 +16,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:3
 #, no-wrap
 msgid "Securing the Hawtio Administration Console"
 msgstr "Hawtio管理コンソールのセキュリティー保護"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:6
 msgid ""
 "To secure the Hawtio Administration Console with {project_name}, complete "
 "the following steps:"
 msgstr "{project_name}を使用して、Hawtio管理コンソールをセキュリティー保護するには、以下の手順を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:8
 msgid "Add these properties to the `$FUSE_HOME/etc/system.properties` file:"
 msgstr "これらのプロパティーを `$FUSE_HOME/etc/system.properties` ファイルに追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:15
 #, no-wrap
 msgid ""
 "hawtio.keycloakEnabled=true\n"
@@ -48,7 +44,6 @@ msgstr ""
 "hawtio.rolePrincipalClasses=org.keycloak.adapters.jaas.RolePrincipal,org.apache.karaf.jaas.boot.principal.RolePrincipal\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:18
 msgid ""
 "Create a client in the {project_name} administration console in your realm. "
 "For example, in the {project_name} `demo` realm, create a client `hawtio-"
@@ -62,14 +57,13 @@ msgstr ""
 "Origin（この場合は、\\http://localhost:8181）も設定する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:20
 msgid ""
 "Create the `keycloak-hawtio-client.json` file in the `$FUSE_HOME/etc` "
 "directory using content similar to that shown in the example below. Change "
 "the `realm`, `resource`, and `auth-server-url` properties according to your "
 "{project_name} environment. The `resource` property must point to the client"
 " created in the previous step. This file is used by the client (Hawtio "
-"Javascript application) side."
+"JavaScript application) side."
 msgstr ""
 "`$FUSE_HOME/etc` ディレクトリーに `keycloak-hawtio-client.json` "
 "ファイルを作成します。このファイルは、以下の例のような内容で作成します。{project_name}環境に応じて、 `realm` 、 "
@@ -78,7 +72,6 @@ msgstr ""
 "JavaScriptアプリケーション）側で使用されます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:30
 #, no-wrap
 msgid ""
 "{\n"
@@ -98,7 +91,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:33
 msgid ""
 "Create the `keycloak-hawtio.json` file in the `$FUSE_HOME/etc` dicrectory "
 "using content similar to that shown in the example below. Change the `realm`"
@@ -111,7 +103,6 @@ msgstr ""
 "server-url` プロパティーを変更してください。このファイルは、サーバー（JAASログイン・モジュール）側のアダプターによって使用されます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:45
 #, no-wrap
 msgid ""
 "{\n"
@@ -135,7 +126,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:48
 msgid ""
 "Start {fuseVersion} and install the keycloak feature if you have not already"
 " done so. The commands in Karaf terminal are similar to this example:"
@@ -143,9 +133,6 @@ msgstr ""
 "Keycloakフィーチャーをまだインストールしていない場合は、{fuseVersion}を起動し、インストールしてください。Karafターミナルのコマンドはこの例に似ています。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:53
-#: source/securing_apps/topics/oidc/java/fuse/install-feature.adoc:37
-#: source/securing_apps/topics/oidc/java/fuse/install-feature.adoc:82
 #, no-wrap
 msgid ""
 "features:addurl mvn:org.keycloak/keycloak-osgi-features/{project_versionMvn}/xml/features\n"
@@ -155,14 +142,12 @@ msgstr ""
 "features:install keycloak\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:56
 msgid ""
 "Go to http://localhost:8181/hawtio and log in as a user from your "
 "{project_name} realm."
 msgstr "http://localhost:8181/hawtio に移動し、{project_name}のレルムからユーザーとしてログインします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:58
 msgid ""
 "Note that the user needs to have the proper realm role to successfully "
 "authenticate to Hawtio. The available roles are configured in the "
@@ -172,20 +157,17 @@ msgstr ""
 "`hawtio.roles` の `$FUSE_HOME/etc/system.properties` ファイルで設定されます。"
 
 #. type: Title ======
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:59
 #, no-wrap
 msgid "Securing Hawtio on {fuseHawtioEAPVersion}"
 msgstr "{fuseHawtioEAPVersion}上のHawtioのセキュリティー保護"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:62
 msgid ""
 "To run Hawtio on the {fuseHawtioEAPVersion} server, complete the following "
 "steps:"
 msgstr "{fuseHawtioEAPVersion}サーバーでHawtioを実行するには、以下の手順を実行します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:64
 msgid ""
 "Set up {project_name} as described in the previous section, Securing the "
 "Hawtio Administration Console. It is assumed that:"
@@ -193,17 +175,14 @@ msgstr ""
 "前のセクション（Hawtio管理コンソールをセキュリティー保護する）で説明したように、{project_name}を設定します。次のように仮定します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:65
 msgid "you have a {project_name} realm `demo` and client `hawtio-client`"
 msgstr "{project_name}のレルムのデモとクライアント `hawtio-client` を持っている"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:66
 msgid "your {project_name} is running on `localhost:8080`"
 msgstr "{project_name}が `localhost:8080` で動作している"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:67
 msgid ""
 "the {fuseHawtioEAPVersion} server with deployed Hawtio will be running on "
 "`localhost:8181`. The directory with this server is referred in next steps "
@@ -213,7 +192,6 @@ msgstr ""
 "で動作します。このサーバーのディレクトリーは、次のステップでは、 `$EAP_HOME` と呼ばれます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:69
 msgid ""
 "Copy the `{fuseHawtioWARVersion}` archive to the "
 "`$EAP_HOME/standalone/configuration` directory. For more details about "
@@ -227,7 +205,6 @@ msgstr ""
 "Hawtio documentation]を参照してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:71
 msgid ""
 "Copy the `keycloak-hawtio.json` and `keycloak-hawtio-client.json` files with"
 " the above content to the `$EAP_HOME/standalone/configuration` directory."
@@ -236,7 +213,6 @@ msgstr ""
 "`$EAP_HOME/standalone/configuration` ディレクトリーにコピーします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:73
 msgid ""
 "Install the {project_name} adapter subsystem to your {fuseHawtioEAPVersion} "
 "server as described in the <<_jboss_adapter,JBoss adapter documentation>>."
@@ -244,7 +220,6 @@ msgstr ""
 "<<_jboss_adapter,JBossアダプターのドキュメント>>の説明に従って、{project_name}アダプター・サブシステムを{fuseHawtioEAPVersion}サーバーにインストールします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:75
 msgid ""
 "In the `$EAP_HOME/standalone/configuration/standalone.xml` file configure "
 "the system properties as in this example:"
@@ -253,7 +228,6 @@ msgstr ""
 "ファイルで、次の例のようにシステムのプロパティーを設定します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:81
 #, no-wrap
 msgid ""
 "<extensions>\n"
@@ -265,7 +239,6 @@ msgstr ""
 "</extensions>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:91
 #, no-wrap
 msgid ""
 "<system-properties>\n"
@@ -289,13 +262,11 @@ msgstr ""
 "</system-properties>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:94
 msgid ""
 "Add the Hawtio realm to the same file in the `security-domains` section:"
 msgstr "Hawtioレルムを同じファイルの `security-domains` セクションに追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:104
 #, no-wrap
 msgid ""
 "<security-domain name=\"hawtio\" cache-type=\"default\">\n"
@@ -315,7 +286,6 @@ msgstr ""
 "</security-domain>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:107
 msgid ""
 "Add the `secure-deployment` section `hawtio` to the adapter subsystem. This "
 "ensures that the Hawtio WAR is able to find the JAAS login module classes."
@@ -324,7 +294,6 @@ msgstr ""
 "WARがJAASログイン・モジュール・クラスを見つけることができます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:114
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\">\n"
@@ -336,12 +305,10 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:117
 msgid "Restart the {fuseHawtioEAPVersion} server with Hawtio:"
 msgstr "Hawtioと{fuseHawtioEAPVersion}サーバーを再起動します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:122
 #, no-wrap
 msgid ""
 "cd $EAP_HOME/bin\n"
@@ -351,7 +318,6 @@ msgstr ""
 "./standalone.sh -Djboss.socket.binding.port-offset=101\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/hawtio.adoc:125
 msgid ""
 "Access Hawtio at http://localhost:8181/hawtio. It is secured by "
 "{project_name}."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__hawtio
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
