### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
@@ -16,30 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ====
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:2
 #, no-wrap
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:6
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "LinkedIn.  First, go to the `Identity Providers` left menu item and select "
@@ -51,12 +37,10 @@ msgstr ""
 "provider` ページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:9
 msgid "image:{project_images}/linked-in-add-identity-provider.png[]"
 msgstr "image:{project_images}/linked-in-add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:13
 msgid ""
 "You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
 " Secret` from LinkedIn.  One piece of data you'll need from this page is the"
@@ -68,7 +52,6 @@ msgstr ""
 "です。クライアントとして{project_name}を登録するときに、LinkedInにそれを提供する必要がありますので、このURIをクリップボードにコピーしておいてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:15
 msgid ""
 "To enable login with LinkedIn you first have to create an application in "
 "https://www.linkedin.com/developer/apps[LinkedIn Developer Network]."
@@ -77,25 +60,21 @@ msgstr ""
 "Developer Network] でアプリケーションを作成する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:17
 msgid ""
 "LinkedIn may change the look and feel of application registration, so these "
 "directions may not always be up to date."
 msgstr "LinkedInはアプリケーション登録のデザインを変更する可能性があるため、これらの指示は常に最新のものではない場合があります。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:18
 #, no-wrap
 msgid "Developer Network"
 msgstr "Developer Network"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:20
 msgid "image:images/linked-in-developer-network.png[]"
 msgstr "image:images/linked-in-developer-network.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:22
 msgid ""
 "Click on the `Create Application` button.  This will bring you to the "
 "`Create a New Application` Page."
@@ -104,36 +83,30 @@ msgstr ""
 "ページが表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:23
 #, no-wrap
 msgid "Create App"
 msgstr "アプリケーションの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:25
 msgid "image:images/linked-in-create-app.png[]"
 msgstr "image:images/linked-in-create-app.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:27
 msgid ""
-"Fill in the form with the approriate values, then click the `Submit` button."
-"  This will bring you to the new application's settings page."
+"Fill in the form with the appropriate values, then click the `Submit` "
+"button.  This will bring you to the new application's settings page."
 msgstr "フォームに適切な値を入力し、 `Submit` ボタンをクリックします。 これにより、新しいアプリケーションの設定ページが表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:28
 #, no-wrap
 msgid "App Settings"
 msgstr "アプリケーションの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:30
 msgid "image:images/linked-in-app-settings.png[]"
 msgstr "image:images/linked-in-app-settings.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:35
 msgid ""
 "Select `r_basicprofile` and `r_emailaddress` in the `Default Application "
 "Permissions` section.  You'll have to copy the `Redirect URI` from the "
@@ -147,7 +120,6 @@ msgstr ""
 "フィールドに入力する必要があります。入力後、 `Update` ボタンをクリックすることを忘れないでください！"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:37
 msgid ""
 "You will then need to obtain the client ID and secret from this page so you "
 "can enter them into the {project_name} `Add identity provider` page.  Go "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__linked-in
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
