### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -16,8 +16,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/https.adoc:6
-#: source/server_admin/topics/realms/ssl.adoc:11
 #, no-wrap
 msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
@@ -26,57 +24,39 @@ msgstr ""
 "{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くお勧めします。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/https.adoc:10
-#: source/server_admin/topics/realms/ssl.adoc:19
 #, no-wrap
 msgid "external requests"
 msgstr "external requests"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/https.adoc:14
-#: source/server_admin/topics/realms/ssl.adoc:23
 #, no-wrap
 msgid "none"
 msgstr "none"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/https.adoc:17
-#: source/server_admin/topics/realms/ssl.adoc:27
 #, no-wrap
 msgid "all requests"
 msgstr "all requests"
 
 #. type: Plain text
-#: source/server_installation/topics/network/https.adoc:19
-#: source/server_admin/topics/realms/ssl.adoc:28
 msgid "{project_name} requires SSL for all IP addresses."
 msgstr "{project_name}はすべてのIPアドレスに対してSSLを要求します。"
 
 #. type: Block title
-#: source/server_admin/topics/login-settings/forgot-password.adoc:7
-#: source/server_admin/topics/login-settings/remember-me.adoc:10
-#: source/server_admin/topics/users/user-registration.adoc:10
-#: source/server_admin/topics/realms/ssl.adoc:14
 #, no-wrap
 msgid "Login Tab"
 msgstr "Loginタブ"
 
 #. type: Plain text
-#: source/server_admin/topics/login-settings/forgot-password.adoc:9
-#: source/server_admin/topics/login-settings/remember-me.adoc:12
-#: source/server_admin/topics/users/user-registration.adoc:12
-#: source/server_admin/topics/realms/ssl.adoc:16
 msgid "image:{project_images}/login-tab.png[]"
 msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Title ===
-#: source/server_admin/topics/realms/ssl.adoc:3
 #, no-wrap
 msgid "SSL Mode"
 msgstr "SSLモード"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/ssl.adoc:8
 msgid ""
 "Each realm has an SSL Mode associated with it.  The SSL Mode defines the "
 "SSL/HTTPS requirements for interacting with the realm.  Browsers and "
@@ -87,7 +67,6 @@ msgstr ""
 "各レルムには、SSLモードが関連付けられています。SSLモードは、レルムと対話するためのSSL/HTTPS要件を定義します。レルムと対話するブラウザーとアプリケーションは、SSLモードで定義されたSSL/HTTPS要件を満たしている必要があり、そうでなければサーバーと対話できません。"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/ssl.adoc:13
 msgid ""
 "To configure the SSL Mode of your realm, you need to click on the `Realm "
 "Settings` left menu item and go to the `Login` tab."
@@ -95,25 +74,22 @@ msgstr ""
 "レルムのSSLモードを設定するには、左のメニュー項目の `Realm Settings` をクリックし、 `Login` タブに移動する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/ssl.adoc:18
 msgid ""
 "The `Require SSL` option allows you to pick the SSL Mode you want.  Here is "
 "an explanation of each mode:"
 msgstr "`Require SSL` オプションにより、SSLモードが選択できます。各モードの説明は次のとおりです。"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/ssl.adoc:22
 msgid ""
 "Users can interact with {project_name} so long as they stick to private IP "
 "addresses like `localhost`, `127.0.0.1`, `10.0.x.x`, `192.168.x.x`, and "
-"`172..16.x.x`.  If you try to access {project_name} from a non-private IP "
+"`172.16.x.x`.  If you try to access {project_name} from a non-private IP "
 "address you will get an error."
 msgstr ""
 "`localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 `172.16.x.x` "
 "のようなプライベートIPアドレスに固定する限り、ユーザーは{project_name}と対話できます。非プライベートIPアドレスから{project_name}にアクセスしようとすると、エラーが発生します。"
 
 #. type: Plain text
-#: source/server_admin/topics/realms/ssl.adoc:26
 msgid ""
 "{project_name} does not require SSL.  This should really only be used in "
 "development when you are playing around with things and don't want to bother"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
