### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po
@@ -16,16 +16,14 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/network/ports.adoc:4
 #, no-wrap
 msgid "Socket Port Bindings"
 msgstr "ソケットポート・バインディング"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:9
 msgid ""
 "The ports opened for each socket have a pre-defined default that can be "
-"overriden at the command line or within configuration.  To illustrate this "
+"overridden at the command line or within configuration.  To illustrate this "
 "configuration, let's pretend you are running in <<_standalone-"
 "mode,standalone mode>> and open up the "
 "_.../standalone/configuration/standalone.xml_.  Search for `socket-binding-"
@@ -37,7 +35,6 @@ msgstr ""
 "group` を検索します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/ports.adoc:24
 #, no-wrap
 msgid ""
 "    <socket-binding-group name=\"standard-sockets\" default-interface=\"public\" port-offset=\"${jboss.socket.binding.port-offset:0}\">\n"
@@ -67,7 +64,6 @@ msgstr ""
 "    </socket-binding-group>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:28
 #, no-wrap
 msgid ""
 "`socket-bindings` define socket connections that will be opened by the server.  These bindings specify the\n"
@@ -77,35 +73,29 @@ msgstr ""
 "のバインドアドレスとポート番号を指定します。最も重要な項目は、以下のとおりです。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/ports.adoc:29
 #, no-wrap
 msgid "http"
 msgstr "http"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:31
 msgid "Defines the port used for {project_name} HTTP connections"
 msgstr "{project_name}のHTTP接続に使用されるポートの定義"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/ports.adoc:31
 #, no-wrap
 msgid "https"
 msgstr "https"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:33
 msgid "Defines the port used for {project_name} HTTPS connections"
 msgstr "{project_name}のHTTPS接続に使用されるポートの定義"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/ports.adoc:33
 #, no-wrap
 msgid "ajp"
 msgstr "ajp"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:36
 msgid ""
 "This socket binding defines the port used for the AJP protocol.  This "
 "protocol is used by Apache HTTPD server in conjunction `mod-cluster` when "
@@ -115,19 +105,16 @@ msgstr ""
 "HTTPDサーバーをロードバランサーとして使用している場合、ApacheHTTPDサーバーによって `mod-cluster` と共に使用されます。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/ports.adoc:36
 #, no-wrap
 msgid "management-http"
 msgstr "management-http"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:38
 msgid ""
 "Defines the HTTP connection used by {appserver_name} CLI and web console."
 msgstr "{appserver_name} CLIとwebコンソールで使用されるHTTP接続を定義します。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:42
 msgid ""
 "When running in <<_domain-mode,domain mode>> setting the socket "
 "configurations is a bit trickier as the example _domain.xml_ file has "
@@ -140,13 +127,11 @@ msgstr ""
 " `server-group` にどの `socket-binding-group` が使用されているのか確認することができます。"
 
 #. type: Block title
-#: source/server_installation/topics/network/ports.adoc:43
 #, no-wrap
 msgid "domain socket bindings"
 msgstr "ドメイン・ソケット・バインディング"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/ports.adoc:56
 #, no-wrap
 msgid ""
 "    <server-groups>\n"
@@ -172,7 +157,6 @@ msgstr ""
 "    </server-groups>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/ports.adoc:58
 msgid ""
 "There are many more options available when setting up `socket-binding-group`"
 " definitions.  For more information, see link:{appserver_socket_link}[the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__ports
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
