### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/adapter-context.adoc:1
 #, no-wrap
 msgid "Security Context"
 msgstr "セキュリティー・コンテキスト"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/adapter-context.adoc:5
 msgid ""
 "The `KeycloakSecurityContext` interface is available if you need to access "
 "to the tokens directly. This could be useful if you want to retrieve "
@@ -33,7 +31,6 @@ msgstr ""
 "インターフェイスはトークンに直接アクセスする必要がある場合に利用できます。これは、トークンから追加の詳細情報（ユーザー・プロファイル情報など）を取得する場合や、{project_name}によって保護されているRESTfulサービスを呼び出す場合に便利です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/adapter-context.adoc:7
 msgid ""
 "In servlet environments it is available in secured invocations as an "
 "attribute in HttpServletRequest:"
@@ -42,7 +39,6 @@ msgstr ""
 "の属性として以下のようにセキュリティー・コンテキストを利用できます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/adapter-context.adoc:11
 #, no-wrap
 msgid ""
 "httpServletRequest\n"
@@ -52,13 +48,10 @@ msgstr ""
 "    .getAttribute(KeycloakSecurityContext.class.getName());\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/adapter-context.adoc:14
-msgid ""
-"Or, it is available in secure and insecure requests in the HttpSession:"
+msgid "Or, it is available in insecured requests in the HttpSession:"
 msgstr "または、セキュアでないリクエストでは以下のように `HttpSession` からセキュリティー・コンテキストを利用できます。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/adapter-context.adoc:19
 #, no-wrap
 msgid ""
 "httpServletRequest.getSession()\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/adapter-context.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__adapter-context
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
