### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,94 +16,55 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:11
-#: source/getting_started/topics/secure-jboss-app/before.adoc:14
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:52
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:11
-#: source/server_installation/topics/operating-mode/domain.adoc:187
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:37
-#: source/server_installation/topics/operating-mode/standalone.adoc:20
-#: source/server_installation/topics/manage.adoc:15
-#: source/server_admin/topics/initialization.adoc:27
-#: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:17
-#: source/getting_started/topics/secure-jboss-app/before.adoc:20
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:58
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:17
-#: source/server_installation/topics/operating-mode/domain.adoc:193
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:43
-#: source/server_installation/topics/operating-mode/standalone.adoc:26
-#: source/server_installation/topics/manage.adoc:21
-#: source/server_admin/topics/initialization.adoc:33
-#: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
 
 #. type: Title ===
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:3
-#: source/server_installation/topics/manage.adoc:11
 #, no-wrap
 msgid "Start the {appserver_name} CLI"
 msgstr "{appserver_name}CLIの起動"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:15
-#: source/server_installation/topics/manage.adoc:19
 #, no-wrap
 msgid "$ .../bin/jboss-cli.sh\n"
 msgstr "$ .../bin/jboss-cli.sh\n"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:21
-#: source/server_installation/topics/manage.adoc:25
 #, no-wrap
 msgid "> ...\\bin\\jboss-cli.bat\n"
 msgstr "> ...\\bin\\jboss-cli.bat\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:24
-#: source/server_installation/topics/manage.adoc:28
 msgid "This will bring you to a prompt like this:"
 msgstr "これを実行すると、以下のようにプロンプトが表示されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:25
-#: source/server_installation/topics/manage.adoc:29
-#: source/server_admin/topics/identity-broker/oidc.adoc:50
 #, no-wrap
 msgid "Prompt"
 msgstr "プロンプト"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:29
-#: source/server_installation/topics/manage.adoc:33
 #, no-wrap
 msgid "[disconnected /]\n"
 msgstr "[disconnected /]\n"
 
 #. type: Block title
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:34
-#: source/server_installation/topics/manage.adoc:39
 #, no-wrap
 msgid "connect"
 msgstr "接続"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:46
-#: source/server_installation/topics/manage.adoc:49
 msgid ""
 "You may be thinking to yourself, \"I didn't enter in any username or "
 "password!\".  If you run `jboss-cli` on the same machine as your running "
 "standalone server or domain controller and your account has appropriate file"
-" permissions, you do not have to setup or enter in a admin username and "
+" permissions, you do not have to setup or enter in an admin username and "
 "password.  See the "
 "link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more details"
 " on how to make things more secure if you are uncomfortable with that setup."
@@ -112,13 +73,11 @@ msgstr ""
 "を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。"
 
 #. type: Title ==
-#: source/server_installation/topics/manage.adoc:3
 #, no-wrap
 msgid "Manage Configuration at Runtime"
 msgstr "実行時の構成管理"
 
 #. type: Plain text
-#: source/server_installation/topics/manage.adoc:9
 msgid ""
 "In the upcoming chapters, you'll often be provided two options for applying "
 "application server configuration changes to your deployment.  You'll be "
@@ -134,13 +93,11 @@ msgstr ""
 " CLI）を使用して、稼働中のサーバーに対して構成変更を適用する方法も示します。この章では、この方法について説明します。"
 
 #. type: Plain text
-#: source/server_installation/topics/manage.adoc:14
 msgid ""
 "To start the {appserver_name} CLI, you need to run the `jboss-cli` script."
 msgstr "{appserver_name} CLIを開始するには、 ``jboss-cli` スクリプトを実行する必要があります。"
 
 #. type: Plain text
-#: source/server_installation/topics/manage.adoc:38
 msgid ""
 "There's a few commands you can execute without a running standalone server "
 "or domain controller, but usually you will have to have those services "
@@ -151,7 +108,6 @@ msgstr ""
 " `connect` を実行するだけです。"
 
 #. type: delimited block -
-#: source/server_installation/topics/manage.adoc:45
 #, no-wrap
 msgid ""
 "[disconnected /] connect\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__manage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
