### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -16,27 +16,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/server_installation/topics/installation.adoc:2
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:15
 #, no-wrap
 msgid "Installation"
 msgstr "インストール"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/installed-adapter.adoc:60
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:45
 #, no-wrap
 msgid "Usage"
 msgstr "使い方"
 
 #. type: Title ===
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:2
 #, no-wrap
 msgid "Node.js Adapter"
 msgstr "Node.jsアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:5
 msgid ""
 "{project_name} provides a Node.js adapter built on top of "
 "https://github.com/senchalabs/connect[Connect] to protect server-side "
@@ -49,7 +43,6 @@ msgstr ""
 "などのフレームワークと統合するのに十分な柔軟性を得ることです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:9
 msgid ""
 "The library can be downloaded directly from https://www.npmjs.com/package"
 "/keycloak-connect[ {project_name} organization] and the source is available "
@@ -60,7 +53,6 @@ msgstr ""
 "nodejs-connect[GitHub] で利用可能です。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:12
 msgid ""
 "To use the Node.js adapter, first you must create a client for your "
 "application in the {project_name} Administration Console. The adapter "
@@ -71,7 +63,6 @@ msgstr ""
 "、bearer-onlyのアクセス・タイプをサポートします。どれを選択するかは、ユースケースのシナリオに依存します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:14
 msgid ""
 "Once the client is created click the `Installation` tab, select "
 "`{project_name} OIDC JSON` for `Format Option`, and then click `Download`. "
@@ -83,7 +74,6 @@ msgstr ""
 "ファイルはプロジェクトのルート・フォルダーに配置します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:18
 msgid ""
 "Assuming you've already installed https://nodejs.org[Node.js], create a "
 "folder for your application:"
@@ -91,13 +81,11 @@ msgstr ""
 "すでに https://nodejs.org[Node.js] がインストールされていると仮定して、アプリケーション用のフォルダーを作成します。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:20
 #, no-wrap
 msgid "    mkdir myapp && cd myapp\n"
 msgstr "    mkdir myapp && cd myapp\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:22
 msgid ""
 "Use `npm init` command to create a `package.json` for your application. Now "
 "add the {project_name} connect adapter in the dependencies list:"
@@ -106,7 +94,6 @@ msgstr ""
 "を作成してください。依存関係リストに{project_name}接続アダプターを追加します。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:30
 #, no-wrap
 msgid ""
 "    \"dependencies\": {\n"
@@ -118,7 +105,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:41
 #, no-wrap
 msgid ""
 "    \"dependencies\": {\n"
@@ -130,13 +116,11 @@ msgstr ""
 "    }\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:46
 #, no-wrap
 msgid "Instantiate a Keycloak class"
 msgstr "Keycloakクラスのインスタンスの作成"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:51
 msgid ""
 "The `Keycloak` class provides a central point for configuration and "
 "integration with your application.  The simplest creation involves no "
@@ -144,7 +128,6 @@ msgid ""
 msgstr "`Keycloak` クラスは、アプリケーションの設定と統合のための中心的なポイントを提供します。最も簡単な作成では引数はありません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:56
 #, no-wrap
 msgid ""
 "    var session = require('express-session');\n"
@@ -154,7 +137,6 @@ msgstr ""
 "    var Keycloak = require('keycloak-connect');\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:59
 #, no-wrap
 msgid ""
 "    var memoryStore = new session.MemoryStore();\n"
@@ -164,7 +146,6 @@ msgstr ""
 "    var keycloak = new Keycloak({ store: memoryStore });\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:65
 msgid ""
 "By default, this will locate a file named `keycloak.json` alongside the main"
 " executable of your application to initialize keycloak-specific settings "
@@ -176,7 +157,6 @@ msgstr ""
 "ファイルは、{project_name}管理者コンソールから取得できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:69
 msgid ""
 "Instantiation with this method results in all of the reasonable defaults "
 "being used. As alternative, it's also possible to provide a configuration "
@@ -186,16 +166,15 @@ msgstr ""
 "ファイルではなく、次のように設定オブジェクトを提供することも可能です。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:79
 #, no-wrap
 msgid ""
 "    let kcConfig = {\n"
-"    clientId: 'myclient',\n"
-"    bearerOnly: true,\n"
-"    serverUrl: 'http://localhost:8080/auth',\n"
-"    realm: 'myrealm',\n"
-"    realmPublicKey: 'MIIBIjANB...'\n"
-"};\n"
+"        clientId: 'myclient',\n"
+"        bearerOnly: true,\n"
+"        serverUrl: 'http://localhost:8080/auth',\n"
+"        realm: 'myrealm',\n"
+"        realmPublicKey: 'MIIBIjANB...'\n"
+"    };\n"
 msgstr ""
 "    let kcConfig = {\n"
 "        clientId: 'myclient',\n"
@@ -206,19 +185,16 @@ msgstr ""
 "    };\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:81
 #, no-wrap
-msgid "let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
+msgid "    let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
 msgstr "    let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:84
 #, no-wrap
 msgid "Configuring a web session store"
 msgstr "Webセッションストアの設定"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:90
 msgid ""
 "If you want to use web sessions to manage server-side state for "
 "authentication, you need to initialize the `Keycloak(...)` with at least a "
@@ -229,7 +205,6 @@ msgstr ""
 "を初期化し、実際のセッションストアで `express-session` 使用する必要があります。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:94
 #, no-wrap
 msgid ""
 "    var session = require('express-session');\n"
@@ -239,19 +214,16 @@ msgstr ""
 "    var memoryStore = new session.MemoryStore();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:96
 #, no-wrap
 msgid "    var keycloak = new Keycloak({ store: memoryStore });\n"
 msgstr "    var keycloak = new Keycloak({ store: memoryStore });\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:97
 #, no-wrap
 msgid "Passing a custom scope value"
 msgstr "カスタムスコープ値を渡す"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:100
 msgid ""
 "By default, the scope value `openid` is passed as a query parameter to "
 "{project_name}'s login URL, but you can add an additional custom value:"
@@ -260,73 +232,61 @@ msgstr ""
 "はクエリー・パラメーターとして{project_name}のログインURLに渡されますが、次のようにカスタム値を新たに追加することもできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:102
 #, no-wrap
 msgid "    var keycloak = new Keycloak({ scope: 'offline_access' });\n"
 msgstr "    var keycloak = new Keycloak({ scope: 'offline_access' });\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:103
 #, no-wrap
 msgid "Installing Middleware"
 msgstr "Middlewareのインストール"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:106
 msgid ""
 "Once instantiated, install the middleware into your connect-capable app:"
 msgstr "インスタンス化が完了したら、Middlewareをconnectに対応したアプリケーションにインストールします。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:110
 #, no-wrap
 msgid "    var app = express();\n"
 msgstr "    var app = express();\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:112
 #, no-wrap
 msgid "    app.use( keycloak.middleware() );\n"
 msgstr "    app.use( keycloak.middleware() );\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:114
 #, no-wrap
 msgid "Protecting Resources"
 msgstr "リソースの保護"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:116
 #, no-wrap
 msgid "Simple authentication"
 msgstr "単純な認証"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:120
 msgid ""
-"To enforce that an user must be authenticated before accessing a resource, "
+"To enforce that a user must be authenticated before accessing a resource, "
 "simply use a no-argument version of `keycloak.protect()`:"
 msgstr "リソースにアクセスする前にユーザーの認証を強制するには、引数のないバージョンの `keycloak.protect()` を使うだけです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:124
 #, no-wrap
 msgid "    app.get( '/complain', keycloak.protect(), complaintHandler );\n"
 msgstr "    app.get( '/complain', keycloak.protect(), complaintHandler );\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:126
 #, no-wrap
 msgid "Role-based authorization"
 msgstr "ロールベースの認可"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:129
 msgid "To secure a resource with an application role for the current app:"
 msgstr "現在のアプリケーションのアプリケーション・ロールでリソースを保護するには次のようにします。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:133
 #, no-wrap
 msgid ""
 "    app.get( '/special', keycloak.protect('special'), specialHandler );\n"
@@ -334,12 +294,10 @@ msgstr ""
 "    app.get( '/special', keycloak.protect('special'), specialHandler );\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:136
 msgid "To secure a resource with an application role for a *different* app:"
 msgstr "*別の* アプリケーションのアプリケーション・ロールでリソースを保護するには次のようにします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:139
 #, no-wrap
 msgid ""
 "    app.get( '/extra-special', keycloak.protect('other-app:special', "
@@ -349,12 +307,10 @@ msgstr ""
 "extraSpecialHandler );\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:141
 msgid "To secure a resource with a realm role:"
 msgstr "レルムロールを使用してリソースを保護するには次のようにします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:144
 #, no-wrap
 msgid ""
 "    app.get( '/admin', keycloak.protect( 'realm:admin' ), adminHandler );\n"
@@ -362,20 +318,17 @@ msgstr ""
 "    app.get( '/admin', keycloak.protect( 'realm:admin' ), adminHandler );\n"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:145
 #, no-wrap
 msgid "Advanced authorization"
 msgstr "高度な認可"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:149
 msgid ""
 "To secure resources based on parts of the URL itself, assuming a role exists"
 " for each section:"
 msgstr "URLの一部に基づいてリソースを保護するには次のようにします（各セクションにロールが存在すると仮定します）。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:155
 #, no-wrap
 msgid ""
 "    function protectBySection(token, request) {\n"
@@ -387,7 +340,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:157
 #, no-wrap
 msgid ""
 "    app.get( '/:section/:page', keycloak.protect( protectBySection ), "
@@ -397,19 +349,16 @@ msgstr ""
 "sectionHandler );\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:159
 #, no-wrap
 msgid "Additional URLs"
 msgstr "追加のURL"
 
 #. type: Labeled list
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:161
 #, no-wrap
 msgid "Explicit user-triggered logout"
 msgstr "明示的なユーザー・トリガー・ログアウト"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:166
 msgid ""
 "By default, the middleware catches calls to `/logout` to send the user "
 "through a {project_name}-centric logout workflow. This can be changed by "
@@ -420,18 +369,15 @@ msgstr ""
 "設定パラメーターを `middleware()` の呼び出しに指定することで変更できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:168
 #, no-wrap
 msgid "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
 msgstr "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:170
 msgid "{project_name} Admin Callbacks::"
 msgstr "{project_name} Adminコールバック"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:175
 msgid ""
 "Also, the middleware supports callbacks from the {project_name} console to "
 "log out a single session or all sessions.  By default, these type of admin "
@@ -442,7 +388,6 @@ msgstr ""
 " `/` のルートURLを基準に発生しますが、 `admin` パラメーターを `middleware()` の呼び出しに与えることで変更できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/nodejs-adapter.adoc:176
 #, no-wrap
 msgid "    app.use( keycloak.middleware( { admin: '/callbacks' } );\n"
 msgstr "    app.use( keycloak.middleware( { admin: '/callbacks' } );\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
