### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po
@@ -15,7 +15,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title ===
 #, no-wrap
 msgid "OpenID Connect"
 msgstr "OpenID Connect"
@@ -27,8 +27,8 @@ msgstr "サポートされているプロトコル"
 
 #. type: Plain text
 msgid ""
-"link:http://openid.net/connect/[Open ID Connect] (OIDC) is an authentication"
-" protocol that is an extension of "
+"link:http://openid.net/connect/[OpenID Connect] (OIDC) is an authentication "
+"protocol that is an extension of "
 "link:https://tools.ietf.org/html/rfc6749[OAuth 2.0].  While OAuth 2.0 is "
 "only a framework for building authorization protocols and is mainly "
 "incomplete, OIDC is a full-fledged authentication and authorization "
@@ -37,7 +37,7 @@ msgid ""
 "JSON format and ways to digitally sign and encrypt that data in a compact "
 "and web-friendly way."
 msgstr ""
-"link:http://openid.net/connect/[Open ID "
+"link:http://openid.net/connect/[OpenID "
 "Connect]（OIDC）はlink:https://tools.ietf.org/html/rfc6749[OAuth "
 "2.0]を拡張した認証プロトコルです。OAuth "
 "2.0が認可プロトコルのみを構築するためのフレームワークで、不完全であるのに対し、OIDCは完成された認証および認可のプロトコルです。OIDCはまた、link:https://jwt.io[Json"
@@ -46,7 +46,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"There is really two types of use cases when using OIDC.  The first is an "
+"There are really two types of use cases when using OIDC.  The first is an "
 "application that asks the {project_name} server to authenticate a user for "
 "them.  After a successful login, the application will receive an _identity "
 "token_ and an _access token_.  The _identity token_ contains information "
@@ -56,9 +56,9 @@ msgid ""
 "determine what resources the user is allowed to access on the application."
 msgstr ""
 "OIDCを使用するユースケースは、実際には2つの種類があります。1つ目は、{project_name}サーバーにユーザーの認証を要求するアプリケーションのユースケースです。ログインが成功すると、アプリケーションは"
-" _IDトークン_ と _アクセストークン_ を受け取ります。 _IDトークン_ "
-"には、ユーザー名、電子メール、その他のプロファイル情報など、ユーザーに関する情報が含まれています。 _アクセストークン_ "
-"はレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報（ユーザー・ロール・マッピングなど）が含まれています。"
+" _identity token_ と _access token_ を受け取ります。 _Identity token_ "
+"には、ユーザー名、電子メール、その他のプロファイル情報など、ユーザーに関する情報が含まれています。 _Access token_ "
+"はレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報（ユーザー・ロール・マッピングのような）が含まれています。"
 
 #. type: Plain text
 msgid ""
@@ -108,7 +108,7 @@ msgstr "{project_name}では、SAMLはブラウザー・アプリケーション
 
 #. type: Plain text
 msgid ""
-"There is really two types of use cases when using SAML.  The first is an "
+"There are really two types of use cases when using SAML.  The first is an "
 "application that asks the {project_name} server to authenticate a user for "
 "them.  After a successful login, the application will receive an XML "
 "document that contains something called a SAML assertion that specifies "
@@ -119,7 +119,7 @@ msgid ""
 msgstr ""
 "SAMLを使用するユースケースは、実際には2つの種類があります。1つ目は、{project_name}サーバーにユーザーの認証を要求するアプリケーションのユースケースです。ログインが成功すると、アプリケーションは"
 " "
-"ユーザーに関するさまざまな属性を指定するSAMLアサーションと呼ばれるものが含まれるXMLドキュメントを受け取ります。このXMLドキュメントはレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報(ユーザー・ロール・マッピングなど)が含まれています。"
+"ユーザーに関する様々な属性を指定するSAMLアサーションと呼ばれるものが含まれるXMLドキュメントを受け取ります。このXMLドキュメントはレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報(ユーザー・ロール・マッピングなど)が含まれています。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__supported-protocols
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
