### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/serialized.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/serialized.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/serialized.ja_JP.po
@@ -16,15 +16,13 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/clustering/serialized.adoc:3
 #, no-wrap
 msgid "Serialized Cluster Startup"
 msgstr "シリアライズされたクラスターの起動"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/serialized.adoc:8
 msgid ""
-"{project_name} cluster nodes are allowed to boot concurrenty.  When "
+"{project_name} cluster nodes are allowed to boot concurrently.  When "
 "{project_name} server instance boots up it may do some database migration, "
 "importing, or first time initializations.  A DB lock is used to prevent "
 "start actions from conflicting with one another when cluster nodes boot up "
@@ -33,7 +31,6 @@ msgstr ""
 "{project_name}クラスター・ノードは並行して起動することができます。{project_name}サーバー・インスタンスが起動すると、データベースの移行、インポート、初回の初期化を行います。DBロックは、クラスター・ノードが同時に起動した場合、起動アクションが競合するのを防ぐために使用されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/clustering/serialized.adoc:14
 msgid ""
 "By default, the maximum timeout for this lock is 900 seconds.  If a node is "
 "waiting on this lock for more than the timeout it will fail to boot.  "
@@ -47,7 +44,6 @@ msgstr ""
 "ファイルで、念のためこの増減を設定することができます。このファイルの場所は、<<_operating-mode, 動作モード>>に依存します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/clustering/serialized.adoc:24
 #, no-wrap
 msgid ""
 "<spi name=\"dblock\">\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/serialized.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__serialized
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
