### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po
@@ -42,8 +42,7 @@ msgid ""
 "autoconfiguration so all you need to do is add the Keycloak Spring Boot "
 "starter to your project.  They Keycloak Spring Boot Starter is also directly"
 " available from the http://start.spring.io/[Spring Start Page].  To add it "
-"manually and if you are using Maven, add the following to your dependencies "
-":"
+"manually using Maven, add the following to your dependencies:"
 msgstr ""
 "Keycloak Spring Bootアダプターは、Spring Bootの自動設定を利用するので、Keycloak Spring Boot "
 "Starterをプロジェクトに追加するだけです。Keycloak Spring Boot Starterも "
@@ -64,8 +63,8 @@ msgstr ""
 "</dependency>\n"
 
 #. type: Plain text
-msgid "Make also sure to add the Adapter POM dependency :"
-msgstr "アダプターのBOM依存関係も追加してください。"
+msgid "Add the Adapter BOM dependency:"
+msgstr "アダプターのBOM依存関係も追加して下さい。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__spring-boot-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
