### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po
@@ -16,19 +16,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/getting_started/topics/first-realm/before.adoc:2
-#: source/getting_started/topics/secure-jboss-app/before.adoc:2
-#: source/authorization_services/topics/hello-world-before-start.adoc:1
 #, no-wrap
 msgid "Before You Start"
 msgstr "始める前に"
 
 #. type: Plain text
-#: source/getting_started/topics/first-realm/before.adoc:6
 msgid ""
-"Before you can participate in this tutorial, you need to complete the "
-"installation of {project_name} and create the initial admin user as shown in"
-" the <<_install-boot, Installing and Booting>> tutorial."
+"Before you can create your first realm, complete the installation of "
+"{project_name} and create the initial admin user as shown in <<_install-"
+"boot, Installing and Booting>>."
 msgstr ""
-"このチュートリアルの操作を始める前に、{project_name}のインストールを完了し、<<_install-boot, "
-"インストールと起動>>のチュートリアルに沿って初期管理者ユーザーを作成する必要があります。"
+"最初のレルムを作成する前に、{project_name}のインストールを完了し、<<_install-boot, "
+"インストールと起動>>に沿って初期管理者ユーザーを作成する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-realm/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-realm__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
