### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,21 +16,20 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/threat/scope.adoc:2
 #, no-wrap
 msgid "Limiting Scope"
 msgstr "スコープの制限"
 
 #. type: Plain text
-#: source/server_admin/topics/threat/scope.adoc:8
 msgid ""
-"By default, each new client application has an unlimited scope.  This means "
-"that every access token that is created for that client will contain all the"
-" permissions the user has.  If the client gets compromised and the access "
-"token is leaked, then each system that the user has permission to access is "
-"now also compromised.  It is highly suggested that you limit the roles an "
-"access token is assigned by using the <<_client_scope, Scope menu>> for each"
-" client."
+"By default, each new client application has an unlimited `role scope "
+"mappings`.  This means that every access token that is created for that "
+"client will contain all the permissions the user has.  If the client gets "
+"compromised and the access token is leaked, then each system that the user "
+"has permission to access is now also compromised.  It is highly suggested "
+"that you limit the roles an access token is assigned by using the "
+"<<_role_scope_mappings, Scope menu>> for each client."
 msgstr ""
-"デフォルトでは、新しいクライアント・アプリケーションごとに無制限のスコープがあります。つまり、そのクライアント用に作成されたすべてのアクセストークンには、ユーザーが持つすべての権限が含まれます。クライアントが侵害されてアクセストークンが漏洩した場合、ユーザーがアクセス許可を持つ各システムも侵害されます。クライアントごとに<<_client_scope,"
+"デフォルトでは、新しいクライアント・アプリケーションごとに無制限の `role scope mappings` "
+"があります。つまり、そのクライアント用に作成されたすべてのアクセストークンには、ユーザーが持つすべての権限が含まれます。クライアントが侵害されてアクセストークンが漏洩した場合、ユーザーがアクセス許可を持つ各システムも侵害されます。クライアントごとに<<_role_scope_mappings,"
 " スコープ・メニュー>>を使用してアクセストークンが割り当てられるロールを制限することを強くお勧めします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__scope
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
