### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:3
 #, no-wrap
 msgid "Configure SPI Providers"
 msgstr "SPIプロバイダーの設定"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:8
 msgid ""
 "The specifics of each configuration setting is discussed elsewhere in "
 "context with that setting.  However, it is useful to understand the format "
@@ -31,7 +29,6 @@ msgstr ""
 "各設定の詳細については、その設定と関連する別の箇所で説明します。ただし、SPIプロバイダー設定の宣言に使用される形式について学ぶことをお勧めします。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:13
 msgid ""
 "{project_name} is a highly modular system that allows great flexibility.  "
 "There are more than 50 service provider interfaces (SPIs), and you are "
@@ -42,7 +39,6 @@ msgstr ""
 " _provider_ によって行われます。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:16
 #, no-wrap
 msgid ""
 "All elements in an SPI declaration are optional, but a full SPI declaration\n"
@@ -50,7 +46,6 @@ msgid ""
 msgstr "SPI宣言のすべての要素は任意で選択できるものですが、完全なSPI宣言は以下のようになります。\n"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:31
 #, no-wrap
 msgid ""
 "<spi name=\"myspi\">\n"
@@ -82,7 +77,6 @@ msgstr ""
 "</spi>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:36
 msgid ""
 "Here we have two providers defined for the SPI `myspi`.  The `default-"
 "provider` is listed as `myprovider`.  However it is up to the SPI to decide "
@@ -94,7 +88,6 @@ msgstr ""
 " `default-provider` はSPIの選択の手助けになります。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:40
 msgid ""
 "Also notice that each provider defines its own set of configuration "
 "properties.  The fact that both providers above have a property called `foo`"
@@ -104,17 +97,15 @@ msgstr ""
 "というプロパティーを持っている点は単なる偶然です。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:43
 msgid ""
 "The type of each property value is interpreted by the provider.  However, "
-"there is one exception.  Consider the `jpa` provider for the `eventStore` "
-"API:"
+"there is one exception.  Consider the `jpa` provider for the `eventsStore` "
+"SPI:"
 msgstr ""
 "プロパティー値のタイプはそれぞれプロバイダーによって解釈されます。ただし、1つ例外があります。 `eventsStore` のSPIの `jpa` "
 "プロバイダーについて確認してみましょう。"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:53
 #, no-wrap
 msgid ""
 "<spi name=\"eventsStore\">\n"
@@ -136,7 +127,6 @@ msgstr ""
 "</spi>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/configure-spi-providers.adoc:58
 msgid ""
 "We see that the value begins and ends with square brackets.  That means that"
 " the value will be passed to the provider as a list.  In this example, the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__configure-spi-providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
