### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po
@@ -16,26 +16,22 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/packaging.adoc:2
-#: source/server_development/topics/user-storage/simple-example.adoc:252
 #, no-wrap
 msgid "Packaging and Deployment"
 msgstr "パッケージ化とデプロイ"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/packaging.adoc:5
 msgid ""
 "User Storage providers are packaged in a JAR and deployed or undeployed to "
 "the {project_name} runtime in the same way you would deploy something in the"
-" JBoss/Wildfly application server. You can either copy the JAR directly to "
-"the `deploy/` directory of the server, or use the JBoss CLI to execute the "
-"deployment."
+" {appserver_name} application server. You can either copy the JAR directly "
+"to the `deploy/` directory of the server, or use the JBoss CLI to execute "
+"the deployment."
 msgstr ""
-"ユーザー・ストレージ・プロバイダーは、JBoss/Wildflyアプリケーション・サーバーに何かをデプロイするのと同じ方法で、JARにパッケージ化され、{project_name}ランタイムにデプロイまたはアンデプロイされます。JARをサーバーの"
+"ユーザー・ストレージ・プロバイダーは、{appserver_name}アプリケーション・サーバーに何かをデプロイするのと同じ方法で、JARにパッケージ化され、{project_name}ランタイムにデプロイまたはアンデプロイされます。JARをサーバーの"
 " `deploy/` ディレクトリーに直接コピーするか、またはJBoss CLIを使用してデプロイを実行することができます。"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/packaging.adoc:7
 msgid ""
 "In order for {project_name} to recognize the provider, you need to add a "
 "file to the JAR: `META-"
@@ -49,7 +45,6 @@ msgstr ""
 "の実装の完全修飾クラス名の行区切りリストが含まれていなければなりません。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/packaging.adoc:11
 #, no-wrap
 msgid ""
 "org.keycloak.examples.federation.properties.ClasspathPropertiesStorageFactory\n"
@@ -59,7 +54,6 @@ msgstr ""
 "org.keycloak.examples.federation.properties.FilePropertiesStorageFactory\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/packaging.adoc:14
 msgid ""
 "{project_name} supports hot deployment of these provider JARs. You'll also "
 "see later in this chapter that you can package it within and as Java EE "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__packaging
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
