### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/saml-jboss-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/saml-jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/saml-jboss-adapter.ja_JP.po
@@ -16,30 +16,24 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:4
-#: source/securing_apps/topics/saml/java/saml-jboss-adapter.adoc:4
 #, no-wrap
-msgid "JBoss EAP/Wildfly Adapter"
-msgstr "JBoss EAP/Wildflyアダプター"
+msgid "JBoss EAP/WildFly Adapter"
+msgstr "JBoss EAP/WildFlyアダプター "
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/jboss-adapter.adoc:7
-#: source/securing_apps/topics/saml/java/saml-jboss-adapter.adoc:7
 #, no-wrap
 msgid "JBoss EAP Adapter"
 msgstr "JBoss EAPアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/saml-jboss-adapter.adoc:12
 msgid ""
-"To be able to secure WAR apps deployed on JBoss EAP or Wildfly, you must "
+"To be able to secure WAR apps deployed on JBoss EAP or WildFly, you must "
 "install and configure the {project_name} SAML Adapter Subsystem."
 msgstr ""
-"JBoss EAPまたはWildflyにデプロイされたWARアプリケーションを保護するには、{project_name} "
+"JBoss EAPまたはWildFlyにデプロイされたWARアプリケーションを保護するには、{project_name} "
 "SAMLアダプター・サブシステムをインストールして設定する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/saml-jboss-adapter.adoc:15
 msgid ""
 "To be able to secure WAR apps deployed on JBoss EAP, you must install and "
 "configure the {project_name} SAML Adapter Subsystem."
@@ -48,7 +42,6 @@ msgstr ""
 "SAMLアダプター・サブシステムをインストールして設定する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/saml-jboss-adapter.adoc:18
 msgid ""
 "You then provide a keycloak config, `/WEB-INF/keycloak-saml.xml` file in "
 "your WAR and change the auth-method to KEYCLOAK-SAML within web.xml.  Both "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/saml-jboss-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__saml-jboss-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
