### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -16,46 +16,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:11
-#: source/getting_started/topics/secure-jboss-app/before.adoc:14
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:52
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:11
-#: source/server_installation/topics/operating-mode/domain.adoc:187
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:37
-#: source/server_installation/topics/operating-mode/standalone.adoc:20
-#: source/server_installation/topics/manage.adoc:15
-#: source/server_admin/topics/initialization.adoc:27
-#: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:17
-#: source/getting_started/topics/secure-jboss-app/before.adoc:20
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:58
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:17
-#: source/server_installation/topics/operating-mode/domain.adoc:193
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:43
-#: source/server_installation/topics/operating-mode/standalone.adoc:26
-#: source/server_installation/topics/manage.adoc:21
-#: source/server_admin/topics/initialization.adoc:33
-#: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
 
 #. type: Title ===
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:3
-#: source/server_installation/topics/manage.adoc:11
 #, no-wrap
 msgid "Start the {appserver_name} CLI"
 msgstr "{appserver_name}CLIの起動"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:8
 msgid ""
 "Besides editing the configuration by hand, you also have the option of "
 "changing the configuration by issuing commands via the _jboss-cli_ tool.  "
@@ -66,61 +41,45 @@ msgstr ""
 "ツールでコマンドを発行して行うこともできます。CLIを使用すると、サーバーをローカルでもリモートでも設定することができます。スクリプティングと組み合わせると特に便利です。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:10
 msgid "To start the {appserver_name} CLI, you need to run `jboss-cli`."
 msgstr "{appserver_name}CLIを起動するには、 `jboss-cli` を実行する必要があります。"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:15
-#: source/server_installation/topics/manage.adoc:19
 #, no-wrap
 msgid "$ .../bin/jboss-cli.sh\n"
 msgstr "$ .../bin/jboss-cli.sh\n"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:21
-#: source/server_installation/topics/manage.adoc:25
 #, no-wrap
 msgid "> ...\\bin\\jboss-cli.bat\n"
 msgstr "> ...\\bin\\jboss-cli.bat\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:24
-#: source/server_installation/topics/manage.adoc:28
 msgid "This will bring you to a prompt like this:"
 msgstr "これを実行すると、以下のようにプロンプトが表示されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:25
-#: source/server_installation/topics/manage.adoc:29
-#: source/server_admin/topics/identity-broker/oidc.adoc:50
 #, no-wrap
 msgid "Prompt"
 msgstr "プロンプト"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:29
-#: source/server_installation/topics/manage.adoc:33
 #, no-wrap
 msgid "[disconnected /]\n"
 msgstr "[disconnected /]\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:33
 msgid ""
 "If you wish to execute commands on a running server, you will first execute "
 "the `connect` command."
 msgstr "実行中のサーバーでコマンドを実行する場合、まず `connect` コマンドを実行します。"
 
 #. type: Block title
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:34
-#: source/server_installation/topics/manage.adoc:39
 #, no-wrap
 msgid "connect"
 msgstr "接続"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:40
 #, no-wrap
 msgid ""
 "[disconnected /] connect\n"
@@ -132,13 +91,11 @@ msgstr ""
 "[standalone@localhost:9990 /]\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:46
-#: source/server_installation/topics/manage.adoc:49
 msgid ""
 "You may be thinking to yourself, \"I didn't enter in any username or "
 "password!\".  If you run `jboss-cli` on the same machine as your running "
 "standalone server or domain controller and your account has appropriate file"
-" permissions, you do not have to setup or enter in a admin username and "
+" permissions, you do not have to setup or enter in an admin username and "
 "password.  See the "
 "link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more details"
 " on how to make things more secure if you are uncomfortable with that setup."
@@ -147,31 +104,27 @@ msgstr ""
 "を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。"
 
 #. type: Title ===
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:47
 #, no-wrap
 msgid "CLI Embedded Mode"
 msgstr "CLI組み込みモード"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:53
 msgid ""
 "If you do happen to be on the same machine as your standalone server and you"
 " want to issue commands while the server is not active, you can embed the "
 "server into CLI and make changes in a special mode that disallows incoming "
-"requests.  To do this, first execute the `embed` command with the config "
-"file you wish to change."
+"requests.  To do this, first execute the `embed-server` command with the "
+"config file you wish to change."
 msgstr ""
 "サーバーがアクティブではない間にスタンドアローン・サーバーと同じマシン上にコマンドが発行された場合は、サーバーをCLIに組み込み、受信要求を許可しない特殊モードに変更することができます。これを行うには、まず、変更したい設定ファイルで"
 " `embed-server` コマンドを実行します。"
 
 #. type: Block title
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:54
 #, no-wrap
-msgid "embed"
+msgid "embed-server"
 msgstr "embed-server"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:59
 #, no-wrap
 msgid ""
 "[disconnected /] embed-server --server-config=standalone.xml\n"
@@ -181,13 +134,11 @@ msgstr ""
 "[standalone@embedded /]\n"
 
 #. type: Title ===
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:61
 #, no-wrap
 msgid "CLI GUI Mode"
 msgstr "CLI GUIモード "
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:68
 msgid ""
 "The CLI can also run in GUI mode.  GUI mode launches a Swing application "
 "that allows you to graphically view and edit the entire management model of "
@@ -198,19 +149,16 @@ msgstr ""
 "CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションが起動します。GUIモードは、CLIコマンドの書式を設定したり、オプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
 
 #. type: Block title
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:69
 #, no-wrap
 msgid "Start in GUI mode"
 msgstr "GUIモードの起動"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:73
 #, no-wrap
 msgid "$ .../bin/jboss-cli.sh --gui\n"
 msgstr "$ .../bin/jboss-cli.sh --gui\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:76
 msgid ""
 "_Note: to connect to a remote server, you pass the `--connect` option as "
 "well.  Use the --help option for more details._"
@@ -218,7 +166,6 @@ msgstr ""
 "_Note: リモートサーバーに接続するには、 `--connect` オプションも渡します。詳しくは、 --helpオプションを参照してください。_"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:81
 msgid ""
 "After launching GUI mode, you will probably want to scroll down to find the "
 "node, `subsystem=keycloak-server`.  If you right-click on the node and click"
@@ -230,18 +177,15 @@ msgstr ""
 "serverサブシステムのみを表示する新しいタブが表示されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:83
 msgid "image:images/cli-gui.png[]"
 msgstr "image:images/cli-gui.png[]"
 
 #. type: Title ===
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:84
 #, no-wrap
 msgid "CLI Scripting"
 msgstr "CLIスクリプト"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:89
 msgid ""
 "The CLI has extensive scripting capabilities.  A script is just a text file "
 "with CLI commands in it.  Consider a simple script that turns off theme and "
@@ -250,13 +194,11 @@ msgstr ""
 "CLIには、さまざまなスクリプト機能があります。スクリプトはCLIコマンドを含む単なるテキストファイルです。テーマとテンプレートのキャッシュをオフにする簡単なスクリプトを見ていきましょう。"
 
 #. type: Block title
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:90
 #, no-wrap
 msgid "turn-off-caching.cli"
 msgstr "turn-off-caching.cli"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:95
 #, no-wrap
 msgid ""
 "/subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheThemes,value=false)\n"
@@ -266,7 +208,6 @@ msgstr ""
 "/subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheTemplates,value=false)\n"
 
 #. type: Plain text
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:98
 msgid ""
 "To execute the script, I can follow the `Scripts` menu in CLI GUI, or "
 "execute the script from the command line as follows:"
@@ -274,7 +215,6 @@ msgstr ""
 "スクリプトを実行するには、CLI GUI の `Scripts` メニューに従う、または以下のようにコマンドラインからスクリプトを実行します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:101
 #, no-wrap
 msgid "$ .../bin/jboss-cli.sh --file=turn-off-caching.cli\n"
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
