### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
@@ -17,13 +17,13 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Supported Platforms"
-msgstr "サポートされているプラットフォーム"
-
-#. type: Title ==
-#, no-wrap
 msgid "OpenID Connect"
 msgstr "OpenID Connect"
+
+#. type: Title ===
+#, no-wrap
+msgid "Supported Platforms"
+msgstr "サポートされているプラットフォーム"
 
 #. type: Title =====
 #, no-wrap
@@ -55,12 +55,12 @@ msgid "<<_servlet_filter_adapter,Servlet Filter>>"
 msgstr "<<_servlet_filter_adapter,Servlet Filter>>"
 
 #. type: Plain text
-msgid "<<_spring_security_adapter,Spring Security>> (community)"
-msgstr "<<_spring_security_adapter,Spring Security>> (community)"
+msgid "<<_spring_boot_adapter,Spring Boot>>"
+msgstr "<<_spring_boot_adapter,Spring Boot>>"
 
 #. type: Plain text
-msgid "<<_spring_boot_adapter,Spring Boot>> (community)"
-msgstr "<<_spring_boot_adapter,Spring Boot>> (community)"
+msgid "<<_spring_security_adapter,Spring Security>>"
+msgstr "<<_spring_security_adapter,Spring Security>>"
 
 #. type: Title =====
 #, no-wrap
@@ -80,24 +80,6 @@ msgstr "Node.js（サーバーサイド）"
 msgid "<<_nodejs_adapter,Node.js>>"
 msgstr "<<_nodejs_adapter,Node.js>>"
 
-#. type: Title =====
-#, no-wrap
-msgid "JavaScript"
-msgstr "JavaScript"
-
-#. type: Title =====
-#, no-wrap
-msgid "Node.js"
-msgstr "Node.js"
-
-#. type: Plain text
-msgid ""
-"https://github.com/keycloak/keycloak-nodejs-connect[{project_name} Connect] "
-"(community)"
-msgstr ""
-"https://github.com/keycloak/keycloak-nodejs-connect[{project_name} Connect] "
-"(community)"
-
 #. type: Title ====
 #, no-wrap
 msgid "C#"
@@ -115,8 +97,8 @@ msgid "Python"
 msgstr "Python"
 
 #. type: Plain text
-msgid "https://pypi.python.org/pypi/oic/[oidc] (generic)"
-msgstr "https://pypi.python.org/pypi/oic/[oidc] (generic)"
+msgid "https://pypi.org/project/oic/[oidc] (generic)"
+msgstr "https://pypi.org/project/oic/[oidc] (generic)"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__supported-platforms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
