### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_development/topics/user-storage/model-interfaces.adoc:2
 #, no-wrap
 msgid "Model Interfaces"
 msgstr "モデル・インターフェイス"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:5
 msgid ""
 "Most of the methods defined in the _capability_ _interfaces_ either return "
 "or are passed in representations of a user. These representations are "
@@ -35,13 +33,11 @@ msgstr ""
 "インターフェイスによって定義されます。アプリ開発者はこのインターフェイスを実装する必要があります。これは、外部ユーザーストアと{project_name}が使用するユーザー・メタモデルとの間のマッピングを提供します。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:9
 #, no-wrap
 msgid "package org.keycloak.models;\n"
 msgstr "package org.keycloak.models;\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:12
 #, no-wrap
 msgid ""
 "public interface UserModel extends RoleMapperModel {\n"
@@ -51,7 +47,6 @@ msgstr ""
 "    String getId();\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:15
 #, no-wrap
 msgid ""
 "    String getUsername();\n"
@@ -61,7 +56,6 @@ msgstr ""
 "    void setUsername(String username);\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:18
 #, no-wrap
 msgid ""
 "    String getFirstName();\n"
@@ -71,7 +65,6 @@ msgstr ""
 "    void setFirstName(String firstName);\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:21
 #, no-wrap
 msgid ""
 "    String getLastName();\n"
@@ -81,7 +74,6 @@ msgstr ""
 "    void setLastName(String lastName);\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:26
 #, no-wrap
 msgid ""
 "    String getEmail();\n"
@@ -95,7 +87,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:29
 msgid ""
 "`UserModel` implementations provide access to read and update metadata about"
 " the user including things like username, name, email, role and group "
@@ -105,7 +96,6 @@ msgstr ""
 "の実装は、ユーザー名、名前、電子メール、ロール、グループ・マッピング、その他の任意の属性などのユーザーに関するメタデータの読み取りと更新のためのアクセスを提供します。"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:31
 msgid ""
 "There are other model classes within the `org.keycloak.models` package that "
 "represent other parts of the {project_name} metamodel: `RealmModel`, "
@@ -115,13 +105,11 @@ msgstr ""
 "`RealmModel` 、 `RoleModel` 、 ` GroupModel` 、および `ClientModel` があります。"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/model-interfaces.adoc:32
 #, no-wrap
 msgid "Storage Ids"
 msgstr "ストレージID"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:35
 msgid ""
 "One important method of `UserModel` is the `getId()` method. When "
 "implementing `UserModel` developers must be aware of the user id format. The"
@@ -131,13 +119,11 @@ msgstr ""
 "を実装する場合、開発者はユーザーIDの形式を意識している必要があります。フォーマットは以下のとおりでなければなりません。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:38
 #, no-wrap
 msgid "\"f:\" + component id + \":\" + external id\n"
 msgstr "\"f:\" + component id + \":\" + external id\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:41
 msgid ""
 "The {project_name} runtime often has to look up users by their user id. The "
 "user id contains enough information so that the runtime does not have to "
@@ -147,7 +133,6 @@ msgstr ""
 " `UserStorageProvider` にクエリーを発行する必要がありません。"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:43
 msgid ""
 "The component id is the id returned from `ComponentModel.getId()`. The "
 "`ComponentModel` is passed in as a parameter when creating the provider "
@@ -159,19 +144,17 @@ msgstr ""
 "は、プロバイダー・クラスを作成するときにパラメーターとして渡されるので、そこから取得できます。外部IDは、プロバイダー・クラスが外部ストアでユーザーを見つけるために必要な情報です。これは多くの場合、ユーザー名かUIDです。たとえば、次のようになります。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/model-interfaces.adoc:46
 #, no-wrap
 msgid "f:332a234e31234:wburke\n"
 msgstr "f:332a234e31234:wburke\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/model-interfaces.adoc:49
 msgid ""
 "When the runtime does a lookup by id, the id is parsed to obtain the "
 "component id. The component id is used to locate the `UserStorageProvider` "
 "that was originally used to load the user. That provider is then passed the "
-"id. The provider again parses the id to obtain the external id it will use "
-"to locate the user in external user storage."
+"id. The provider again parses the id to obtain the external id and it will "
+"use to locate the user in external user storage."
 msgstr ""
 "ランタイムがIDによるルックアップを実行すると、コンポーネントIDを取得するためにIDが解析されます。コンポーネントIDは、もともとユーザーをロードするために使用された"
 " `UserStorageProvider` "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__model-interfaces
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
