### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -16,61 +16,53 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:3
 #, no-wrap
-msgid "JBoss Fuse Adapter"
-msgstr "JBoss Fuseアダプター"
+msgid "JBoss Fuse 6 Adapter"
+msgstr "JBoss Fuse 6アダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:6
 msgid ""
-"Currently {project_name} supports securing your web applications running "
-"inside https://developers.redhat.com/products/fuse/overview/[JBoss Fuse]."
+"{project_name} supports securing your web applications running inside "
+"https://developers.redhat.com/products/fuse/overview/[JBoss Fuse 6]."
 msgstr ""
-"現在、{project_name}は "
-"https://developers.redhat.com/products/fuse/overview/[JBoss Fuse] "
-"内で実行されているWebアプリケーションのセキュリティー保護をサポートしています。"
+"{project_name}は https://developers.redhat.com/products/fuse/overview/[JBoss "
+"Fuse 6] 内で実行されているWebアプリケーションのセキュリティー保護をサポートしています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:10
 msgid ""
-"It leverages <<_jetty9_adapter,Jetty 9 adapter>> as {fuseVersion} is bundled"
-" with http://www.eclipse.org/jetty/[Jetty 9.2 server] under the covers and "
-"Jetty is used for running various kinds of web applications."
+"JBoss Fuse 6 leverages <<_jetty9_adapter,Jetty 9 adapter>> as {fuseVersion} "
+"is bundled with http://www.eclipse.org/jetty/[Jetty 9.2 server] under the "
+"covers and Jetty is used for running various kinds of web applications."
 msgstr ""
 "{fuseVersion}は http://www.eclipse.org/jetty/[Jetty 9.2 server] "
-"にバンドルされており、Jettyはさまざまな種類のWebアプリケーションの実行に使用されているため、<<_jetty9_adapter,Jetty "
-"9アダプター>>を活用しています。"
+"にバンドルされており、Jettyはさまざまな種類のWebアプリケーションの実行に使用されているため、JBoss Fuse "
+"6は<<_jetty9_adapter,Jetty 9アダプター>>を活用しています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:13
 msgid ""
-"The only supported version of Fuse is {fuseVersion}. If you use earlier "
-"versions of Fuse, it is possible that some functions will not work "
+"The only supported version of Fuse 6 is {fuseVersion}. If you use earlier "
+"versions of Fuse 6, it is possible that some functions will not work "
 "correctly. In particular, the http://hawt.io[Hawtio] integration will not "
-"work with earlier versions of Fuse."
+"work with earlier versions of Fuse 6."
 msgstr ""
-"サポートされているFuseのバージョンは{fuseVersion}のみです。以前のバージョンのFuseを使用している場合、一部の機能が正しく動作しない可能性があります。特に、"
-" http://hawt.io[Hawtio] との統合は、Fuseの以前のバージョンでは機能しません。"
+"サポートされているFuse 6のバージョンは{fuseVersion}のみです。以前のバージョンのFuse "
+"6を使用している場合、一部の機能が正しく動作しない可能性があります。特に、 http://hawt.io[Hawtio] との統合は、Fuse "
+"6の以前のバージョンでは機能しません。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:15
 msgid "Security for the following items is supported for Fuse:"
 msgstr "Fuseに対して、以下の項目のセキュリティーがサポートされています。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:17
 msgid "Classic WAR applications deployed on Fuse with Pax Web War Extender"
 msgstr "Pax Web War Extenderを使用して、FuseにデプロイされたクラシックWARアプリケーション"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:18
 msgid ""
 "Servlets deployed on Fuse as OSGI services with Pax Web Whiteboard Extender"
 msgstr "Pax Web Whiteboard Extenderを使用して、FuseにOSGIサービスとしてデプロイされたサーブレット"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:19
 msgid ""
 "http://camel.apache.org/[Apache Camel] Jetty endpoints running with the "
 "http://camel.apache.org/jetty.html[Camel Jetty] component"
@@ -79,7 +71,6 @@ msgstr ""
 "http://camel.apache.org/[Apache Camel] Jettyエンドポイント"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:20
 msgid ""
 "http://cxf.apache.org/[Apache CXF] endpoints running on their own separate "
 "http://cxf.apache.org/docs/jetty-configuration.html[Jetty engine]"
@@ -88,7 +79,6 @@ msgstr ""
 "で動作する http://cxf.apache.org/[Apache CXF] エンドポイント"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:21
 msgid ""
 "http://cxf.apache.org/[Apache CXF] endpoints running on the default engine "
 "provided by the CXF servlet"
@@ -97,23 +87,19 @@ msgstr ""
 "エンドポイント"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:22
 msgid "SSH and JMX admin access"
 msgstr "SSHおよびJMXの管理者アクセス"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:23
 msgid "http://hawt.io[Hawtio administration console]"
 msgstr "http://hawt.io[Hawtio administration console]"
 
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:24
 #, no-wrap
-msgid "Securing Your Web Applications Inside Fuse"
-msgstr "Fuse内でWebアプリケーションを保護する"
+msgid "Securing Your Web Applications Inside Fuse 6"
+msgstr "Fuse 6内でWebアプリケーションを保護する"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:28
 msgid ""
 "You must first install the {project_name} Karaf feature. Next you will need "
 "to perform the steps according to the type of application you want to "
@@ -128,7 +114,6 @@ msgstr ""
 "Jettyオーセンティケーターを、基盤となるJettyサーバーに注入する必要があります。これを達成するための手順は、アプリケーションの種類によって異なります。詳細は以下のとおりです。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse-adapter.adoc:32
 msgid ""
 "The best place to start is look at Fuse demo bundled as part of "
 "{project_name} examples in directory `fuse` . Most of the steps should be "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
