### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,81 +16,54 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:2
-#: source/authorization_services/topics/service-protection-resources-api.adoc:2
 #, no-wrap
 msgid "Managing Resources"
 msgstr "リソースの管理"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:5
-#: source/authorization_services/topics/service-protection-resources-api.adoc:5
 msgid ""
 "Resource servers can manage their resources remotely using a UMA-compliant "
 "endpoint."
 msgstr "リソースサーバーは、UMA準拠のエンドポイントを使用して、リモートでリソースを管理できます。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:8
-#: source/authorization_services/topics/service-protection-resources-api.adoc:8
 msgid ""
 "http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set"
 msgstr ""
 "http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:11
-#: source/authorization_services/topics/service-protection-resources-api.adoc:11
 msgid ""
-"This endpoint provides registration operations outlined as follows (entire "
-"path omitted for clarity):"
-msgstr "このエンドポイントは、以下に概要を説明した登録操作を提供します（明確にするため、パス全体が省略されています）。"
+"This endpoint provides operations outlined as follows (entire path omitted "
+"for clarity):"
+msgstr "このエンドポイントは、以下の概要を説明した操作を提供します（明確にするため、パス全体が省略されています）。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:13
-#: source/authorization_services/topics/service-protection-resources-api.adoc:13
 msgid "Create resource set description: POST /resource_set"
 msgstr "リソースセットの説明を作成する: POST /resource_set"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:14
-#: source/authorization_services/topics/service-protection-resources-api.adoc:14
 msgid "Read resource set description: GET /resource_set/{_id}"
 msgstr "リソースセットの説明を読み込む: GET /resource_set/{_id}"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:15
-#: source/authorization_services/topics/service-protection-resources-api.adoc:15
 msgid "Update resource set description: PUT /resource_set/{_id}"
 msgstr "リソースセットの説明を更新する: PUT /resource_set/{_id}"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:16
-#: source/authorization_services/topics/service-protection-resources-api.adoc:16
 msgid "Delete resource set description: DELETE /resource_set/{_id}"
 msgstr "リソースセットの説明を削除する: DELETE /resource_set/{_id}"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:17
-#: source/authorization_services/topics/service-protection-resources-api.adoc:17
 msgid "List resource set descriptions: GET /resource_set"
 msgstr "リソースセットの説明を表示する: GET /resource_set"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:18
-#: source/authorization_services/topics/service-protection-resources-api.adoc:18
-msgid ""
-"List resource set descriptions using a filter: GET "
-"/resource_set?filter=${filter}"
-msgstr "フィルターを使用して、リソースセットの説明を表示する: GET /resource_set?filter=${filter}"
-
-#. type: Plain text
-#: source/authorization_services/topics/service-protection-resources-api-papi.adoc:19
-#: source/authorization_services/topics/service-protection-resources-api.adoc:19
 msgid ""
 "For more information about the contract for each of these operations, see "
-"https://docs.kantarainitiative.org/uma/rec-oauth-resource-reg-"
-"v1_0_1.html[UMA Resource Set Registration]."
+"https://docs.kantarainitiative.org/uma/wg/oauth-uma-federated-"
+"authz-2.0-09.html#reg-api[UMA Resource Registration API]."
 msgstr ""
-"各操作の規約の詳細については、 https://docs.kantarainitiative.org/uma/rec-oauth-resource-"
-"reg-v1_0_1.html[UMAリソースセットの登録] を参照してください。"
+"各操作の規約の詳細については、 https://docs.kantarainitiative.org/uma/wg/oauth-uma-"
+"federated-authz-2.0-09.html#reg-api[UMA Resource Registration API] "
+"を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-resources-api-papi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
