### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -81,10 +81,10 @@ msgid ""
 "the link:https://docs.docker.com/registry/configuration/[registry config "
 "file specification] for more information on how the file should be set up, "
 "or start with "
-"href:https://github.com/docker/distribution/blob/master/cmd/registry/config-"
+"link:https://github.com/docker/distribution/blob/master/cmd/registry/config-"
 "example.yml[a basic example]."
 msgstr ""
-"この出力は、既存のレジストリー設定ファイルにコピーできます。ファイルの設定方法の詳細については、link:https://docs.docker.com/registry/configuration/[レジストリー設定ファイルの仕様]を参照してください。または、href:https://github.com/docker/distribution/blob/master/cmd/registry"
+"この出力は、既存のレジストリー設定ファイルにコピーできます。ファイルの設定方法の詳細については、link:https://docs.docker.com/registry/configuration/[レジストリー設定ファイルの仕様]を参照してください。または、link:https://github.com/docker/distribution/blob/master/cmd/registry"
 "/config-example.yml[基本的な例]から始めてください。"
 
 #. type: Plain text
@@ -160,8 +160,7 @@ msgstr ""
 msgid ""
 "From the desired realm, create a client configuration.  At this point you "
 "won't have a docker registry - the quickstart will take care of that part."
-msgstr ""
-"目的のレルムから、クライアント設定を作成します。この時点で、Dockerレジストリーはありません。クイックスタートがその部分を担当します。"
+msgstr "目的のレルムから、クライアント設定を作成します。この時点で、Dockerレジストリーはありません。クイックスタートがその部分を担当します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
