### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/bind-address.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/bind-address.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/bind-address.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_installation/topics/network/bind-address.adoc:4
 #, no-wrap
 msgid "Bind Addresses"
 msgstr "バインドアドレス"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:10
 msgid ""
 "By default {project_name} binds to the localhost loopback address "
 "`127.0.0.1`.  That's not a very useful default if you want the "
@@ -37,7 +35,6 @@ msgstr ""
 " `localhost` 以外のものにバインドする必要があります。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:13
 msgid ""
 "Setting the bind address is quite easy and can be done on the command line "
 "with either the _standalone.sh_ or _domain.sh_ boot scripts discussed in the"
@@ -47,18 +44,15 @@ msgstr ""
 "_domain.sh_ 起動スクリプトを使用して、コマンドライン上で設定することができます。"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/bind-address.adoc:17
 #, no-wrap
 msgid "$ standalone.sh -b 192.168.0.5\n"
 msgstr "$ standalone.sh -b 192.168.0.5\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:20
 msgid "The `-b` switch sets the IP bind address for any public interfaces."
 msgstr "`-b` スイッチにより、パブリック・インターフェイス用のIPバインドアドレスは設定されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:24
 msgid ""
 "Alternatively, if you don't want to set the bind address at the command "
 "line, you can edit the profile configuration of your deployment.  Open up "
@@ -71,7 +65,6 @@ msgstr ""
 "になりますが、そのいずれかのプロファイル設定ファイルを開き、XMLブロックの `interfaces` を検索します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/bind-address.adoc:35
 #, no-wrap
 msgid ""
 "    <interfaces>\n"
@@ -93,7 +86,6 @@ msgstr ""
 "    </interfaces>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:41
 msgid ""
 "The `public` interface corresponds to subsystems creating sockets that are "
 "available publicly.  An example of one of these subsystems is the web layer "
@@ -110,25 +102,22 @@ msgstr ""
 "cli.sh` コマンドライン・インターフェイスと{appserver_name}のwebコンソールを使用できるソケットになります。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:44
 msgid ""
 "In looking at the `public` interface you see that it has a special string "
 "`${jboss.bind.address:127.0.0.1}`.  This string denotes a value `127.0.0.1` "
-"that can be overriden on the command line by setting a Java system property,"
-" i.e.:"
+"that can be overridden on the command line by setting a Java system "
+"property, i.e.:"
 msgstr ""
 "`public` インターフェイスを確認すると、特別な文字列 `${jboss.bind.address:127.0.0.1}` "
 "が表示されています。この文字列は、 `127.0.0.1` "
 "という値を示していますが、コマンドラインでJavaシステム・プロパティーを設定して上書きすることができます。"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/bind-address.adoc:48
 #, no-wrap
 msgid "$ domain.sh -Djboss.bind.address=192.168.0.5\n"
 msgstr "$ domain.sh -Djboss.bind.address=192.168.0.5\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:52
 msgid ""
 "The `-b` is just a shorthand notation for this command.  So, you can either "
 "change the bind address value directly in the profile config, or change it "
@@ -138,7 +127,6 @@ msgstr ""
 "は、このコマンドの簡略表記です。したがって、このバインドアドレス値は、プロファイル設定で直接変更、または起動時にコマンドラインで変更することができます。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/bind-address.adoc:53
 msgid ""
 "There are many more options available when setting up `interface` "
 "definitions. For more information, see link:{appserver_network_link}[the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/bind-address.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__bind-address
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
