### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,17 +16,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/saml/java/idp-registration.adoc:2
 #, no-wrap
 msgid "Registering with an Identity Provider"
 msgstr "アイデンティティ・プロバイダーでの登録"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/idp-registration.adoc:6
 msgid ""
 "For each servlet-based adapter, the endpoint you register for the assert "
-"consumer service URL and and single logout service must be the base URL of "
-"your servlet application with `/saml` appended to it, that is, "
+"consumer service URL and single logout service must be the base URL of your "
+"servlet application with `/saml` appended to it, that is, "
 "`$$https://example.com/contextPath/saml$$`."
 msgstr ""
 "サーブレット・ベース・アダプターごとに、アサート・コンシューマー・サービスURLとシングル・ログアウト・サービスURLに登録するエンドポイントは、 "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__idp-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
