### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/paypal.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/paypal.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/paypal.ja_JP.po
@@ -16,45 +16,26 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:22
-#: source/server_admin/topics/identity-broker/social/github.adoc:21
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:17
 #, no-wrap
 msgid "Add a New App"
 msgstr "新しいアプリの追加"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/github.adoc:26
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:22
 #, no-wrap
 msgid "Register App"
 msgstr "アプリケーションの登録"
 
 #. type: Title ====
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:2
 #, no-wrap
 msgid "PayPal"
 msgstr "PayPal"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:6
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "PayPal.  First, go to the `Identity Providers` left menu item and select "
@@ -66,12 +47,10 @@ msgstr ""
 "provider` ページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:9
 msgid "image:{project_images}/paypal-add-identity-provider.png[]"
 msgstr "image:{project_images}/paypal-add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:13
 msgid ""
 "You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
 " Secret` from PayPal.  One piece of data you'll need from this page is the "
@@ -83,7 +62,6 @@ msgstr ""
 "です。PayPalに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:16
 msgid ""
 "To enable login with PayPal you first have to register an application "
 "project in https://developer.paypal.com/developer/applications[PayPal "
@@ -94,33 +72,27 @@ msgstr ""
 "applications] でアプリケーションを登録する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:19
 msgid "image:images/paypal-developer-applications.png[]"
 msgstr "image:images/paypal-developer-applications.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:21
 msgid "Click the `Create App` button."
 msgstr "`Create App` ボタンをクリックします。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:24
 msgid "image:images/paypal-register-app.png[]"
 msgstr "image:images/paypal-register-app.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:26
 msgid "You will now be brought to the app settings page."
 msgstr "これで、アプリケーションの設定ページが表示されます。"
 
-#. type: Title ====
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:27
+#. type: Block title
 #, no-wrap
-msgid "Do the following changes:"
+msgid "Do the following changes"
 msgstr "次の変更を行います。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:30
 msgid ""
 "Choose to configure either Sandbox or Live (choose Live if you haven't "
 "enabled the `Target Sandbox` switch on the `Add identity provider` page)"
@@ -129,7 +101,6 @@ msgstr ""
 "スイッチを有効にしていない場合は、Liveを選択します）。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:31
 msgid ""
 "Copy Client ID and Secret so you can paste them into the {project_name} `Add"
 " identity provider` page."
@@ -138,12 +109,10 @@ msgstr ""
 "ページに貼り付けることができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:32
 msgid "Scroll down to `App Settings`"
 msgstr "`App Settings` へスクロールダウンしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:33
 msgid ""
 "Copy the `Redirect URI` from the {project_name} `Add Identity Provider` page"
 " and enter it into the `Return URL` field."
@@ -152,23 +121,19 @@ msgstr ""
 "`Return URL` フィールドに入力してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:34
 msgid "Check the `Log In with PayPal` checkbox."
 msgstr "`Log In with PayPal` のチェックボックスをチェックしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:35
 msgid "Check the `Full name` checkbox under the personal information section."
 msgstr "personal informationセクションの `Full name` チェックボックスをチェックしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:36
 msgid ""
 "Check the `Email address` checkbox under the address information section."
 msgstr "address informationセクションの `Email address` チェックボックスをチェックしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:36
 msgid ""
 "Add both a privacy and a user agreement URL pointing to the respective pages"
 " on your domain."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/paypal.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__paypal
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
