### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,7 +95,7 @@ msgid ""
 "on a session to authenticate users, that information is usually stored in a "
 "user's session and retrieved from there for each request."
 msgstr ""
-"保護されたリソースへのアクセスを許可するかどうかを判定するために、リソースサーバー（保護されたリソースを処理するアプリケーションまたはサービス）は、通常、何らかの情報に依存しています。RESTfulベースのリソースサーバーの場合、通常、その情報はセキュリティートークンから取得されます。そのトークンは、通常、サーバーへのリクエストごとにベアラートークンとして送信されます。ユーザーを認証するためにセッションに依存するWebアプリケーションの場合、通常、その情報はユーザーのセッションに格納され、リクエストごとにそこから取得されます。"
+"保護されたリソースへのアクセスを許可するかどうかを判定するために、リソースサーバー（保護されたリソースを処理するアプリケーションまたはサービス）は、通常、何らかの情報に依存しています。RESTfulベースのリソースサーバーの場合、通常、その情報はセキュリティー・トークンから取得されます。そのトークンは、通常、サーバーへのリクエストごとにベアラートークンとして送信されます。ユーザーを認証するためにセッションに依存するWebアプリケーションの場合、通常、その情報はユーザーのセッションに格納され、リクエストごとにそこから取得されます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
@@ -58,8 +58,8 @@ msgid ""
 "** Using JavaScript\n"
 "** Using JBoss Drools\n"
 msgstr ""
-"** Using JavaScript\n"
-"** Using JBoss Drools\n"
+"** JavaScriptを使用\n"
+"** JBoss Droolsを使用\n"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,36 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/getting_started/topics/overview.adoc:2
-#: source/securing_apps/topics/overview/overview.adoc:1
-#: source/securing_apps/topics/saml/java/saml_adapter_overview.adoc:1
-#: source/server_admin/topics/overview.adoc:1
-#: source/authorization_services/topics/auth-services-overview.adoc:2
 #, no-wrap
 msgid "Overview"
 msgstr "概要"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:6
-msgid ""
-"Authorization Services is a Technology Preview feature and is not fully "
-"supported. This feature is disabled by default."
-msgstr "認可サービスは、テクノロジー・プレビュー機能であり、完全にはサポートされていません。この機能はデフォルトで無効になっています。"
-
-#. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:9
-msgid ""
-"To enable Authorization Services add the "
-"`standalone/configuration/profile.properties` file with the contents "
-"`profile=preview` or start the server with `-Dkeycloak.profile=preview` to "
-"enable all technology preview features."
-msgstr ""
-"認可サービスを有効にするには、 `profile=preview` という内容で "
-"`standalone/configuration/profile.properties` ファイルを追加するか、または "
-"`-Dkeycloak.profile=preview` でサーバーを起動し、すべてのテクノロジー・プレビュー機能を有効にします。"
-
-#. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:13
 msgid ""
 "{project_name} supports fine-grained authorization policies and is able to "
 "combine different access control mechanisms such as:"
@@ -53,53 +28,45 @@ msgstr ""
 "{project_name}はきめ細かい認可ポリシーをサポートし、以下のような異なるアクセス・コントロール機構を組み合わせることができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:15
 #, no-wrap
 msgid "**Attribute-based access control (ABAC)**\n"
 msgstr "**属性ベースのアクセス・コントロール（ABAC）**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:16
 #, no-wrap
 msgid "**Role-based access control (RBAC)**\n"
 msgstr "**ロールベースのアクセス・コントロール（RBAC）**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:17
 #, no-wrap
 msgid "**User-based access control (UBAC)**\n"
 msgstr "**ユーザーベースのアクセス・コントロール（UBAC）**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:18
 #, no-wrap
 msgid "**Context-based access control (CBAC)**\n"
 msgstr "**コンテキストベースのアクセス・コントロール（CBAC）**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:19
 #, no-wrap
 msgid "**Rule-based access control**\n"
 msgstr "**ルールベースのアクセス・コントロール**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:21
 #, no-wrap
 msgid ""
-"** Using Javascript\n"
+"** Using JavaScript\n"
 "** Using JBoss Drools\n"
 msgstr ""
-"** Javascriptを使用\n"
-"** JBoss Droolsを使用\n"
+"** Using JavaScript\n"
+"** Using JBoss Drools\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:22
 #, no-wrap
 msgid "**Time-based access control**\n"
 msgstr "**時間ベースのアクセス・コントロール**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:23
 #, no-wrap
 msgid ""
 "**Support for custom access control mechanisms (ACMs) through a Policy "
@@ -108,7 +75,6 @@ msgstr ""
 "**ポリシー・プロバイダー・サービス・プロバイダー・インターフェイス（SPI）によるカスタム・アクセス・コントロール機構（ACMs）のサポート**\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:26
 msgid ""
 "{project_name} is based on a set of administrative UIs and a RESTful API, "
 "and provides the necessary means to create permissions for your protected "
@@ -120,7 +86,6 @@ msgstr ""
 "APIのセットに基づいており、保護されるリソースとスコープのアクセス許可を作成し、そのアクセス許可を認可ポリシーに関連づけ、アプリケーションやサービスで認可判断を行うために必要な手段を提供します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:28
 msgid ""
 "Resource servers (applications or services serving protected resources) "
 "usually rely on some kind of information to decide if access should be "
@@ -133,7 +98,6 @@ msgstr ""
 "保護されたリソースへのアクセスを許可するかどうかを判定するために、リソースサーバー（保護されたリソースを処理するアプリケーションまたはサービス）は、通常、何らかの情報に依存しています。RESTfulベースのリソースサーバーの場合、通常、その情報はセキュリティートークンから取得されます。そのトークンは、通常、サーバーへのリクエストごとにベアラートークンとして送信されます。ユーザーを認証するためにセッションに依存するWebアプリケーションの場合、通常、その情報はユーザーのセッションに格納され、リクエストごとにそこから取得されます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:30
 msgid ""
 "Frequently, resource servers only perform authorization decisions based on "
 "role-based access control (RBAC), where the roles granted to the user trying"
@@ -144,7 +108,6 @@ msgstr ""
 "多くの場合、リソースサーバーはロールベースのアクセス・コントロール（RBAC）に基づいて認可判断のみを行います。ロールベースのアクセス・コントロールでは、保護されたリソースにアクセスしようとするユーザーに付与されたロールが、同リソースにマップされたロールに対してチェックされます。ロールは非常に有用でアプリケーションで使用されますが、以下のようないくつかの制限もあります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:32
 msgid ""
 "Resources and roles are tightly coupled and changes to roles (such as "
 "adding, removing, or changing an access context) can impact multiple "
@@ -153,21 +116,18 @@ msgstr ""
 "リソースとロールは密結合されており、ロールへの変更（アクセス・コンテキストの追加、削除、変更など）は複数のリソースに影響を与える可能性があります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:33
 msgid ""
 "Changes to your security requirements can imply deep changes to application "
 "code to reflect these changes"
 msgstr "セキュリティー要件の変更は、反映するにはアプリケーション・コードに大幅な変更が必要となるでしょう。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:34
 msgid ""
 "Depending on your application size, role management might become difficult "
 "and error-prone"
 msgstr "アプリケーションのサイズによっては、ロール管理が困難になり、エラーを起こしやすくなる可能性があります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:35
 msgid ""
 "It is not the most flexible access control mechanism. Roles do not represent"
 " who you are and lack contextual information. If you have been granted a "
@@ -176,7 +136,6 @@ msgstr ""
 "これは最も柔軟なアクセス・コントロール機構ではありません。ロールは、誰であるかを表すものではなく、コンテキスト情報が欠けています。ロールが付与されているということは、少なくともいくらかのアクセス権を持っている、ということを表すだけです。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:38
 msgid ""
 "Considering that today we need to consider heterogeneous environments where "
 "users are distributed across different regions, with different local "
@@ -187,34 +146,28 @@ msgstr ""
 "今日、ユーザーは異なるローカルポリシーの異なる地域におり、異なるデバイスを使用し、情報共有のニーズが高い異種環境を考慮する必要があります。{project_name}認可サービスは以下を提供し、アプリケーションやサービスの認可機能を向上させるのに役立つでしょう。"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:40
 msgid ""
 "Resource protection using fine-grained authorization policies and different "
 "access control mechanisms"
 msgstr "きめ細かい認可ポリシーと異なるアクセス・コントロール機構を使用したリソース保護"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:41
 msgid "Centralized Resource, Permission, and Policy Management"
 msgstr "一元的なリソース、アクセス許可、およびポリシー管理"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:42
 msgid "Centralized Policy Decision Point"
 msgstr "一元的なポリシー決定点"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:43
 msgid "REST security based on a set of REST-based authorization services"
 msgstr "一連のRESTベースの認可サービスに基づくRESTセキュリティー"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:44
 msgid "Authorization workflows and User-Managed Access"
 msgstr "認可ワークフローとUser-Managed Access"
 
 #. type: Plain text
-#: source/authorization_services/topics/auth-services-overview.adoc:44
 msgid ""
 "The infrastructure to help avoid code replication across projects (and "
 "redeploys) and quickly adapt to changes in your security requirements."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
