### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -582,11 +582,11 @@ msgstr "Mapper Typeのドロップダウン・リストから *Group list* を�
 
 #. type: Plain text
 msgid "Set Name to \"group list\"."
-msgstr "*group list* に名前を設定します。"
+msgstr "\"group list\"に名前を設定します。"
 
 #. type: Plain text
 msgid "Set the SAML attribute name to \"groups\"."
-msgstr "*groups* にSAML属性名を設定します。"
+msgstr "\"groups\"にSAML属性名を設定します。"
 
 #. type: Plain text
 msgid "The remaining steps are performed on $sp_host."

--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -30,7 +30,7 @@ msgid ""
 msgstr ""
 "https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] "
 "モジュールは、SAML用のApache HTTPDプラグインです。使用している言語/環境がApache "
-"HTTPDをプロキシとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティ保護できます。このモジュールの詳細については、"
+"HTTPDをプロキシとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティー保護できます。このモジュールの詳細については、"
 " _mod_auth_mellon_ のGitHubリポジトリを参照してください。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -26,12 +26,12 @@ msgid ""
 " Apache HTTPD plugin for SAML. If your language/environment supports using "
 "Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your web"
 " application with SAML. For more details on this module see the "
-"_mod_auth_mellon_ Github repo."
+"_mod_auth_mellon_ GitHub repo."
 msgstr ""
 "https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] "
 "モジュールは、SAML用のApache HTTPDプラグインです。使用している言語/環境がApache "
-"HTTPDをプロキシとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティー保護できます。このモジュールの詳細については、"
-" _mod_auth_mellon_ のGithubリポジトリーを参照してください。"
+"HTTPDをプロキシとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティ保護できます。このモジュールの詳細については、"
+" _mod_auth_mellon_ のGitHubリポジトリを参照してください。"
 
 #. type: Plain text
 msgid "To configure mod_auth_mellon you'll need:"
@@ -581,11 +581,11 @@ msgid "From the Mapper Type drop-down list select *Group list*."
 msgstr "Mapper Typeのドロップダウン・リストから *Group list* を選択します。"
 
 #. type: Plain text
-msgid "Set Name to \"group list.\""
+msgid "Set Name to \"group list\"."
 msgstr "*group list* に名前を設定します。"
 
 #. type: Plain text
-msgid "Set the SAML attribute name to \"groups.\""
+msgid "Set the SAML attribute name to \"groups\"."
 msgstr "*groups* にSAML属性名を設定します。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -31,7 +31,7 @@ msgstr ""
 "https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] "
 "モジュールは、SAML用のApache HTTPDプラグインです。使用している言語/環境がApache "
 "HTTPDをプロキシとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティー保護できます。このモジュールの詳細については、"
-" _mod_auth_mellon_ のGitHubリポジトリを参照してください。"
+" _mod_auth_mellon_ のGitHubリポジトリーを参照してください。"
 
 #. type: Plain text
 msgid "To configure mod_auth_mellon you'll need:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__mod-auth-mellon
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
