### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -146,8 +146,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The initial config file can be obtained from the the admin console. This can"
-" be done by opening the admin console, select `Clients` from the menu and "
+"The initial config file can be obtained from the admin console. This can be "
+"done by opening the admin console, select `Clients` from the menu and "
 "clicking on the corresponding client. Once the page for the client is opened"
 " click on the `Installation` tab and select `Keycloak OIDC JSON`."
 msgstr ""
@@ -402,7 +402,7 @@ msgstr "expose-token"
 
 #. type: Plain text
 msgid ""
-"If `true`, an authenticated browser client (via a Javascript HTTP "
+"If `true`, an authenticated browser client (via a JavaScript HTTP "
 "invocation) can obtain the signed access token via the URL "
 "`root/k_query_bearer_token`.  This is _OPTIONAL_.  The default value is "
 "_false_."

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -408,7 +408,7 @@ msgid ""
 "_false_."
 msgstr ""
 "`true` の場合、（JavaScriptのHTTP呼び出しを介して）認証されたブラウザー・クライアントが、 "
-"`root/k_query_bearer_token` のURLを介して署名付きのアクセス・トークンを取得できます。これは _OPTIONAL_ "
+"`root/k_query_bearer_token` のURLを介して署名付きのアクセストークンを取得できます。これは _OPTIONAL_ "
 "です。デフォルト値は _false_ です。"
 
 #. type: Labeled list
@@ -545,7 +545,7 @@ msgid ""
 "<<_applicationclustering,Application Clustering>> for details"
 msgstr ""
 "_true_ の場合、アダプターは{project_name}に登録リクエストを送信します。これはデフォルトで _false_ "
-"であり、アプリケーションがクラスター化されている場合にのみ有効です。詳細は<<_applicationclustering,アプリケーション・クラスターリング>>を参照してください。"
+"であり、アプリケーションがクラスター化されている場合にのみ有効です。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -558,7 +558,7 @@ msgid ""
 "application is clustered.  See <<_applicationclustering,Application "
 "Clustering>> for details"
 msgstr ""
-"{project_name}へアダプターを再登録する期間です。アプリケーションがクラスター化されている場合に便利です。詳細は<<_applicationclustering,アプリケーション・クラスターリング>>を参照してください。"
+"{project_name}へアダプターを再登録する期間です。アプリケーションがクラスター化されている場合に便利です。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -574,7 +574,7 @@ msgid ""
 msgstr ""
 "設定可能な値は _session_ と _cookie_ です。デフォルトは _session_ "
 "です。つまり、アダプターがアカウント情報をHTTPセッションに保管します。一方、 _cookie_ "
-"は情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,アプリケーション・クラスターリング>>を参照してください。"
+"は情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__java-adapter-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
