### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po
@@ -16,14 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/oidc/java/logout.adoc:1
-#: source/securing_apps/topics/saml/java/logout.adoc:1
 #, no-wrap
 msgid "Logout"
 msgstr "ログアウト"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:7
 msgid ""
 "There are multiple ways you can logout from a web application.  For Java EE "
 "servlet containers, you can call `HttpServletRequest.logout()`. For any "
@@ -39,17 +36,15 @@ msgstr ""
 "を渡すことができます。これにより、ブラウザーとのSSOセッションがある場合は、ログアウトされます。"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/logout.adoc:9
 #, no-wrap
 msgid "Logout in Clustered Environment"
 msgstr "クラスター環境でのログアウト"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:15
 msgid ""
 "Internally, the SAML adapter stores a mapping between the SAML session "
 "index, principal name (when known), and HTTP session ID.  This mapping can "
-"be maintained in JBoss application server family (Wildfly 10/11, EAP 6/7) "
+"be maintained in JBoss application server family (WildFly 10/11, EAP 6/7) "
 "across cluster for distributable applications. As a precondition, the HTTP "
 "sessions need to be distributed across cluster (i.e. application is marked "
 "with `<distributable/>` tag in application's `web.xml`)."
@@ -60,19 +55,16 @@ msgstr ""
 "`web.xml` に `<distributable/>` タグが設定されています）。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:17
 msgid ""
 "To enable the functionality, add the following section to your "
 "`/WEB_INF/web.xml` file:"
 msgstr "この機能を有効にするには、 `/WEB_INF/web.xml` ファイルに次のセクションを追加してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:19
-msgid "For EAP 7, Wildfly 10/11:"
-msgstr "EAP 7、Wildfly 10/11の場合："
+msgid "For EAP 7, WildFly 10/11:"
+msgstr "EAP 7、WildFly 10/11の場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/logout.adoc:26
 #, no-wrap
 msgid ""
 "<context-param>\n"
@@ -86,12 +78,10 @@ msgstr ""
 "</context-param>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:29
 msgid "For EAP 6:"
 msgstr "EAP 6の場合："
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/logout.adoc:36
 #, no-wrap
 msgid ""
 "<context-param>\n"
@@ -105,7 +95,6 @@ msgstr ""
 "</context-param>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:43
 msgid ""
 "If the session cache of the deployment is named `_deployment-cache_`, the "
 "cache used for SAML mapping will be named as `_deployment-cache_.ssoCache`. "
@@ -122,7 +111,6 @@ msgstr ""
 " `keycloak.sessionIdMapperUpdater.infinispan.containerName` によってオーバーライドできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:46
 msgid ""
 "By default, the configuration of the SAML mapping cache will be derived from"
 " session cache. The configuration can be manually overridden in cache "
@@ -131,7 +119,6 @@ msgstr ""
 "デフォルトでは、SAMLマッピング・キャッシュの設定はセッション・キャッシュから取得されます。この設定は、他のキャッシュとまったく同じサーバーのキャッシュ設定セクションで手動でオーバーライドできます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:50
 msgid ""
 "Currently, to provide reliable service, it is recommended to use replicated "
 "cache for the SAML session cache.  Using distributed cache may lead to "
@@ -142,39 +129,33 @@ msgstr ""
 "現在、信頼性の高いサービスを提供するために、SAMLセッション・キャッシュにレプリケート・キャッシュを使用することをお勧めします。分散キャッシュを使用すると、SAMLログアウト・リクエストがSAMLセッション・インデックスからHTTPセッション・マッピングへのアクセスがないノードに到達し、ログアウトに失敗する結果につながる可能性があります。"
 
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/logout.adoc:52
 #, no-wrap
 msgid "Logout in Cross DC Scenario"
 msgstr "クロスDCシナリオでのログアウト"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:55
 msgid ""
-"The cross DC scenario only applies to Wildfly 10 and higher, and EAP 7 and "
+"The cross DC scenario only applies to WildFly 10 and higher, and EAP 7 and "
 "higher."
-msgstr "クロスDCシナリオは、Wildfly 10以上、EAP 7以上にのみ適用されます。"
+msgstr "クロスDCシナリオは、WildFly 10以上、EAP 7以上にのみ適用されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:57
 msgid ""
 "Special handling is needed for handling sessions that span multiple data "
 "centers. Imagine the following scenario:"
 msgstr "複数のデータセンターにまたがるセッションを処理するには、特別な処理が必要です。以下のシナリオを想像してみてください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:59
 msgid "Login requests are handled within cluster in data center 1."
 msgstr "ログイン・リクエストは、データセンター1のクラスター内で処理されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:61
 msgid ""
 "Admin issues logout request for a particular SAML session, the request lands"
 " in data center 2."
 msgstr "管理者が特定のSAMLセッションのログアウト・リクエストを発行すると、そのリクエストはデータセンター2に送信されます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:64
 msgid ""
 "The data center 2 has to log out all sessions that are present in data "
 "center 1 (and all other data centers that share HTTP sessions)."
@@ -182,7 +163,6 @@ msgstr ""
 "データセンター2は、データセンター1（およびHTTPセッションを共有する他のすべてのデータセンター）に存在するすべてのセッションをログアウトする必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:68
 msgid ""
 "To cover this case, the SAML session cache described "
 "<<_saml_logout_in_cluster,above>> needs to be replicated not only within "
@@ -200,19 +180,16 @@ msgstr ""
 "externalize_sessions#Externalize_HTTP_Session_from_JBoss_EAP_6.x_to_JBoss_Data_Grid[スタンド・アロンInfinispan/JDGサーバー経由]："
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:70
 msgid "A cache has to be added to the standalone Infinispan/JDG server."
 msgstr "スタンドアローンのInfinispan/JDGサーバーにキャッシュを追加する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:72
 msgid ""
 "The cache from previous item has to be added as a remote store for the "
 "respective SAML session cache."
 msgstr "前の項目のキャッシュは、それぞれのSAMLセッション・キャッシュ用にリモートストアとして追加する必要があります。"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/logout.adoc:74
 msgid ""
 "Once remote store is found to be present on SAML session cache during "
 "deployment, it is watched for changes and the local SAML session cache is "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__logout
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
