### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po
@@ -16,42 +16,30 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:22
-#: source/server_admin/topics/identity-broker/social/github.adoc:21
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:17
 #, no-wrap
 msgid "Add a New App"
 msgstr "新しいアプリの追加"
 
-#. type: Title ====
-#: source/server_admin/topics/identity-broker/social/github.adoc:2
+#. type: Block title
 #, no-wrap
-msgid "Github"
-msgstr "Github"
+msgid "Register App"
+msgstr "アプリケーションの登録"
+
+#. type: Title ====
+#, no-wrap
+msgid "GitHub"
+msgstr "GitHub"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:6
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
-"Github.  First, go to the `Identity Providers` left menu item and select "
-"`Github` from the `Add provider` drop down list.  This will bring you to the"
+"GitHub.  First, go to the `Identity Providers` left menu item and select "
+"`GitHub` from the `Add provider` drop down list.  This will bring you to the"
 " `Add identity provider` page."
 msgstr ""
 "GitHubにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
@@ -59,16 +47,14 @@ msgstr ""
 "provider` ページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:9
 msgid "image:{project_images}/github-add-identity-provider.png[]"
 msgstr "image:{project_images}/github-add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:13
 msgid ""
 "You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from Github.  One piece of data you'll need from this page is the "
-"`Redirect URI`.  You'll have to provide that to Github when you register "
+" Secret` from GitHub.  One piece of data you'll need from this page is the "
+"`Redirect URI`.  You'll have to provide that to GitHub when you register "
 "{project_name} as a client there, so copy this URI to your clipboard."
 msgstr ""
 "GitHubから `Client ID` と `Client Secret` "
@@ -76,9 +62,8 @@ msgstr ""
 "です。GitHubに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:16
 msgid ""
-"To enable login with Github you first have to register an application "
+"To enable login with GitHub you first have to register an application "
 "project in https://github.com/settings/developers[GitHub Developer "
 "applications]."
 msgstr ""
@@ -86,62 +71,46 @@ msgstr ""
 "Developer applications] でアプリケーションを登録する必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:19
 #, no-wrap
 msgid ""
-"Github often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
+"GitHub often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
 "      configuration steps might be slightly different.\n"
 msgstr ""
-"Githubはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
+"GitHubはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:23
 msgid "image:images/github-developer-applications.png[]"
 msgstr "image:images/github-developer-applications.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:25
 msgid "Click the `Register a new application` button."
 msgstr "`Register a new application` ボタンをクリックします。"
 
-#. type: Block title
-#: source/server_admin/topics/identity-broker/social/github.adoc:26
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:22
-#, no-wrap
-msgid "Register App"
-msgstr "アプリケーションの登録"
-
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:28
 msgid "image:images/github-register-app.png[]"
 msgstr "image:images/github-register-app.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:32
 msgid ""
 "You'll have to copy the `Redirect URI` from the {project_name} `Add Identity"
 " Provider` page and enter it into the `Authorization callback URL` field on "
-"the Github `Register a new OAuth application` page.  Once you've completed "
+"the GitHub `Register a new OAuth application` page.  Once you've completed "
 "this page you will be brought to the application's management page."
 msgstr ""
-"{project_name}の `Add Identity Provider` ページから `Redirect URI` をコピーし、Githubの "
+"{project_name}の `Add Identity Provider` ページから `Redirect URI` をコピーし、GitHubの "
 "`Register a new OAuth application` ページの `Authorization callback URL` "
 "フィールドにそれを入力する必要があります。このページを完了すると、アプリケーションの管理ページに移動します。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/github.adoc:33
 #, no-wrap
-msgid "Github App Page"
-msgstr "Githubアプリケーション・ページ"
+msgid "GitHub App Page"
+msgstr "GitHubアプリケーション・ページ"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:35
 msgid "image:images/github-app-page.png[]"
 msgstr "image:images/github-app-page.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/github.adoc:37
-#: source/server_admin/topics/identity-broker/social/google.adoc:78
 msgid ""
 "You will need to obtain the client ID and secret from this page so you can "
 "enter them into the {project_name} `Add identity provider` page.  Go back to"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__github
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
