### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: KojiNose <knose.dev@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,108 +16,62 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:37
-#: source/authorization_services/topics/permission-create-resource.adoc:14
-#: source/authorization_services/topics/permission-create-scope.adoc:14
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:22
-#: source/authorization_services/topics/policy-client-policy.adoc:14
-#: source/authorization_services/topics/policy-drools-policy.adoc:16
-#: source/authorization_services/topics/policy-group-policy.adoc:14
-#: source/authorization_services/topics/policy-js-policy.adoc:15
-#: source/authorization_services/topics/policy-role-policy.adoc:18
-#: source/authorization_services/topics/policy-time-policy.adoc:14
-#: source/authorization_services/topics/policy-user-policy.adoc:14
-#: source/authorization_services/topics/resource-create.adoc:15
 #, no-wrap
 msgid "*Name*\n"
 msgstr "*Name*\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/client-oidc.adoc:43
-#: source/authorization_services/topics/permission-create-resource.adoc:19
-#: source/authorization_services/topics/permission-create-scope.adoc:19
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:27
-#: source/authorization_services/topics/policy-client-policy.adoc:19
-#: source/authorization_services/topics/policy-drools-policy.adoc:21
-#: source/authorization_services/topics/policy-group-policy.adoc:19
-#: source/authorization_services/topics/policy-js-policy.adoc:20
-#: source/authorization_services/topics/policy-role-policy.adoc:23
-#: source/authorization_services/topics/policy-time-policy.adoc:19
-#: source/authorization_services/topics/policy-user-policy.adoc:19
 #, no-wrap
 msgid "*Description*\n"
 msgstr "*Description*\n"
 
 #. type: Title ==
-#: source/authorization_services/topics/permission-create-resource.adoc:11
-#: source/authorization_services/topics/permission-create-scope.adoc:11
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:19
-#: source/authorization_services/topics/policy-client-policy.adoc:11
-#: source/authorization_services/topics/policy-drools-policy.adoc:13
-#: source/authorization_services/topics/policy-group-policy.adoc:11
-#: source/authorization_services/topics/policy-js-policy.adoc:12
-#: source/authorization_services/topics/policy-role-policy.adoc:15
-#: source/authorization_services/topics/policy-time-policy.adoc:11
-#: source/authorization_services/topics/policy-user-policy.adoc:11
-#: source/authorization_services/topics/service-client-api.adoc:21
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:17
-#: source/authorization_services/topics/permission-create-scope.adoc:17
 msgid ""
 "A human-readable and unique string describing the permission. A best "
 "practice is to use names that are closely related to your business and "
 "security requirements, so you can identify them more easily."
 msgstr ""
-"権限を説明する、人が判別可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することすることです。そうすることで簡単に識別することができます。"
+"パーミッションを説明する、人が判別可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:21
-#: source/authorization_services/topics/permission-create-scope.adoc:21
 msgid "A string containing details about this permission."
 msgstr "パーミッションに関する詳細を含む文字列。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:36
-#: source/authorization_services/topics/permission-create-scope.adoc:31
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:31
 #, no-wrap
 msgid "*Apply Policy*\n"
 msgstr "*Apply Policy*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:38
-#: source/authorization_services/topics/permission-create-scope.adoc:33
-msgid "Defines a set of one or more policies to associate with a permission."
-msgstr "パーミッションに関連付ける1つ以上のポリシーのセットを定義します。"
+msgid ""
+"Defines a set of one or more policies to associate with a permission. To "
+"associate a policy you can either select an existing policy or create a new "
+"one by selecting the type of the policy you want to create."
+msgstr ""
+"パーミッションに関連付ける1つ以上のポリシーのセットを定義します。ポリシーを関連付けるには、既存のポリシーを選択するか、作成するポリシーのタイプを選択して新しいポリシーを作成します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:40
-#: source/authorization_services/topics/permission-create-scope.adoc:35
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:35
 #, no-wrap
 msgid "*Decision Strategy*\n"
 msgstr "*Decision Strategy*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-resource.adoc:41
-#: source/authorization_services/topics/permission-create-scope.adoc:36
 msgid ""
 "The <<_permission_decision_strategies, Decision Strategy>> for this "
 "permission."
 msgstr "パーミッションのための<<_permission_decision_strategies, 決定戦略>>"
 
 #. type: Title =
-#: source/authorization_services/topics/permission-create-scope.adoc:2
 #, no-wrap
 msgid "Creating Scope-Based Permissions"
 msgstr "スコープベースのパーミッションの作成"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:5
 msgid ""
 "A scope-based permission defines a set of one or more scopes to protect "
 "using a set of one or more authorization policies. Unlike resource-based "
@@ -129,7 +83,6 @@ msgstr ""
 "スコープベースのパーミッションは、1つ以上の認可ポリシーのセットを使用して保護する1つ以上のスコープのセットを定義します。リソースベースのパーミッションとは異なり、このパーミッションのタイプを使用して、リソースだけでなく、それに関連付けられたスコープのパーミッションを作成し、リソースを管理するパーミッションとそれらに対して実行可能なアクションを定義する際に、より詳細な情報を提供します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:7
 msgid ""
 "To create a new scope-based permission, select *Scope-based* in the dropdown"
 " list in the upper right corner of the permission listing."
@@ -138,13 +91,11 @@ msgstr ""
 "を選択します。"
 
 #. type: Block title
-#: source/authorization_services/topics/permission-create-scope.adoc:8
 #, no-wrap
 msgid "Add Scope-Based Permission"
 msgstr "スコープベースのパーミッションの追加"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:10
 msgid ""
 "image:{project_images}/permission/create-scope.png[alt=\"Add Scope-Based "
 "Permission\"]"
@@ -153,28 +104,21 @@ msgstr ""
 "scope.png[alt=\"スコープベースのパーミッションの追加\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:23
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:21
 #, no-wrap
 msgid "*Resource*\n"
 msgstr "*Resource*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:25
 msgid ""
 "Restricts the scopes to those associated with the selected resource. If none"
 " is selected, all scopes are available."
 msgstr "選択したリソースに関連付けられているものにスコープを制限します。選択されていない場合は、すべてのスコープを使用できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:27
-#: source/authorization_services/topics/permission-overview.adoc:16
-#: source/authorization_services/topics/resource-create.adoc:31
 #, no-wrap
 msgid "*Scopes*\n"
 msgstr "*Scopes*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:29
 msgid "Defines a set of one or more scopes to protect."
 msgstr "保護する1つ以上のスコープのセットを定義します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/permission-create-scope.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__permission-create-scope
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
