### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
@@ -57,7 +57,7 @@ msgstr "スタンドアローン・モード"
 #, no-wrap
 msgid ""
 "Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
-"      by the server.  Instead use the the command line scripting or the web console of {appserver_name}.  See\n"
+"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
 "      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
 msgstr ""
 "サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
