### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/role-scope-mappings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/role-scope-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/role-scope-mappings.ja_JP.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Role Scope Mappings"
+msgstr "ロール・スコープ・マッピング"
+
+#. type: Plain text
+msgid ""
+"When an OIDC access token or SAML assertion is created, all the user role "
+"mappings of the user are, by default, added as claims within the token or "
+"assertion.  Applications use this information to make access decisions on "
+"the resources controlled by that application.  In {project_name}, access "
+"tokens are digitally signed and can actually be re-used by the application "
+"to invoke on other remotely secured REST services.  This means that if an "
+"application gets compromised or there is a rogue client registered with the "
+"realm, attackers can get access tokens that have a broad range of "
+"permissions and your whole network is compromised.  This is where _role "
+"scope mappings_ becomes important."
+msgstr ""
+"OIDCアクセストークンまたはSAMLアサーションが作成されると、ユーザーのすべてのユーザー・ロール・マッピングは、デフォルトでトークンまたはアサーション内にクレームとして追加されます。アプリケーションは、この情報を使用して、そのアプリケーションによって制御されるリソースのアクセスを決定します。{project_name}では、アクセストークンはデジタル署名されており、実際にアプリケーションによって再利用され、他のリモートで保護されたRESTサービスを呼び出すことができます。これは、アプリケーションが危険にさらされたり、レルムに登録された不正なクライアントが存在する場合、攻撃者が広範囲のパーミッションを持つアクセストークンを取得し、ネットワーク全体が侵害されることを意味します。これは、"
+" _ロール・スコープ・マッピング_ が重要になる場面です。"
+
+#. type: Plain text
+msgid ""
+"_Role Scope Mappings_ is a way to limit the roles that get declared inside "
+"an access token.  When a client requests that a user be authenticated, the "
+"access token they receive back will only contain the role mappings you've "
+"explicitly specified for the client's scope.  This allows you to limit the "
+"permissions each individual access token has rather than giving the client "
+"access to all of the user's permissions.  By default, each client gets all "
+"the role mappings of the user.  You can view this in the `Scope` tab of each"
+" client."
+msgstr ""
+"_ロール・スコープ・マッピング_ "
+"は、アクセストークン内で宣言されるロールを制限する方法です。クライアントがユーザーの認証を要求すると、受け取ったアクセストークンには、クライアントのスコープに対して明示的に指定したロールマッピングのみが含まれます。これにより、ユーザーの全パーミッションへのアクセスをクライアントに与えるのではなく、個々のアクセストークンのパーミッションを制限することができます。デフォルトでは、各クライアントはユーザーのすべてのロールマッピングを取得します。各クライアントの"
+" `Scope` タブでこれを見ることができます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Full Scope"
+msgstr "フルスコープ"
+
+#. type: Plain text
+msgid "image:{project_images}/full-client-scope.png[]"
+msgstr "image:{project_images}/full-client-scope.png[]"
+
+#. type: Plain text
+msgid ""
+"You can see from the picture that the effective roles of the scope are every"
+" declared role in the realm.  To change this default behavior, you must "
+"explicitly turn off the `Full Scope Allowed` switch and declare the specific"
+" roles you want in each individual client.  Alternatively, you can also use "
+"<<_client_scopes, client scopes>> to define the same role scope mappings for"
+" a whole set of clients."
+msgstr ""
+"この図から、スコープの有効なロールは、レルム内のすべての宣言されたロールであることが分かります。このデフォルト動作を変更するには、 `Full "
+"Scope Allowed` "
+"スイッチを明示的にオフにして、個々のクライアントで必要な特定のロールを宣言する必要があります。また、<<_client_scopes, "
+"クライアント・スコープ>>を使用して、クライアント全体で同じロール・スコープ・マッピングを定義することもできます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Partial Scope"
+msgstr "部分的なスコープ"
+
+#. type: Plain text
+msgid "image:{project_images}/client-scope.png[]"
+msgstr "image:{project_images}/client-scope.png[]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/role-scope-mappings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__role-scope-mappings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
