### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -22,13 +22,13 @@ msgstr "アダプターのインストール"
 
 #. type: Block title
 #, no-wrap
-msgid "Wildfly 11"
-msgstr "Wildfly 11"
+msgid "WildFly 11"
+msgstr "WildFly 11"
 
 #. type: Block title
 #, no-wrap
-msgid "Any other server but Wildfly 11"
-msgstr "Wildfly 11以外の他のサーバー"
+msgid "JBoss EAP 7.1"
+msgstr "JBoss EAP 7.1"
 
 #. type: Title =====
 #, no-wrap
@@ -49,8 +49,8 @@ msgid ""
 msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードできます。"
 
 #. type: Plain text
-msgid "Install on Wildfly 9 or 10, 11 or JBoss EAP 7:"
-msgstr "Wildfly 9、10、11、またはJBoss EAP 7へのインストールは次のとおりです。"
+msgid "Install on WildFly 9 or 10, 11 or JBoss EAP 7:"
+msgstr "WildFly 9、10、11、またはJBoss EAP 7へのインストールは次のとおりです。"
 
 #. type: delimited block -
 #, no-wrap
@@ -74,15 +74,6 @@ msgstr ""
 "$ cd $JBOSS_HOME\n"
 "$ unzip keycloak-saml-eap6-adapter-dist.zip\n"
 
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ cd $JBOSS_HOME\n"
-"$ unzip rh-sso-saml-eap6-adapter.zip\n"
-msgstr ""
-"$ cd $JBOSS_HOME\n"
-"$ unzip rh-sso-saml-eap6-adapter.zip\n"
-
 #. type: Plain text
 msgid "Install on JBoss EAP 7.x:"
 msgstr "JBoss EAP 7.xへのインストールは次のとおりです。"
@@ -90,18 +81,27 @@ msgstr "JBoss EAP 7.xへのインストールは次のとおりです。"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"$ cd $JBOSS_HOME\n"
+"$ cd $EAP_HOME\n"
 "$ unzip rh-sso-saml-eap7-adapter.zip\n"
 msgstr ""
-"$ cd $JBOSS_HOME\n"
+"$ cd $EAP_HOME\n"
 "$ unzip rh-sso-saml-eap7-adapter.zip\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd $EAP_HOME\n"
+"$ unzip rh-sso-saml-eap6-adapter.zip\n"
+msgstr ""
+"$ cd $EAP_HOME\n"
+"$ unzip rh-sso-saml-eap6-adapter.zip\n"
 
 #. type: Plain text
 msgid ""
-"These zip files create new JBoss Modules specific to the Wildfly/JBoss EAP "
-"SAML Adapter within your Wildfly or JBoss EAP distro."
+"These zip files create new JBoss Modules specific to the WildFly/JBoss EAP "
+"SAML Adapter within your WildFly or JBoss EAP distro."
 msgstr ""
-"これらのzipファイルは、WildflyまたはJBoss EAP用の配布物内のWildfly/JBoss EAP "
+"これらのzipファイルは、WildFlyまたはJBoss EAP用の配布物内のWildFly/JBoss EAP "
 "SAMLアダプターに固有の新しいJBossモジュールを作成します。"
 
 #. type: Plain text
@@ -126,6 +126,11 @@ msgstr ""
 "$ cd bin\n"
 "$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
 
+#. type: Block title
+#, no-wrap
+msgid "WildFly 10 and older"
+msgstr "WildFly 10以上"
+
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -134,6 +139,11 @@ msgid ""
 msgstr ""
 "$ cd $JBOSS_HOME/bin\n"
 "$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "JBoss EAP 7.0 and EAP 6"
+msgstr "JBoss EAP 7.0とEAP 6"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
