### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -7,28 +7,13 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: n.watanabe <nwatanabe.ase@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "}\n"
-msgstr "}\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "    ...\n"
-msgstr "    ...\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "    }\n"
-msgstr "    }\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -42,12 +27,12 @@ msgstr "サービス・プロバイダー・インターフェイス（SPI）"
 
 #. type: Plain text
 msgid ""
-"Keycloak is designed to cover most use-cases without requiring custom code, "
-"but we also want it to be customizable.  To achieve this Keycloak has a "
-"number of Service Provider Interfaces (SPI) for which you can implement your"
-" own providers."
+"{project_name} is designed to cover most use-cases without requiring custom "
+"code, but we also want it to be customizable.  To achieve this "
+"{project_name} has a number of Service Provider Interfaces (SPI) for which "
+"you can implement your own providers."
 msgstr ""
-"Keycloakは、必要なカスタム・コードが無くても、ほとんどのユースケースをカバーできるように作られていますが、カスタマイズもできるようにする必要があります。これを実現するために、Keycloakには独自のプロバイダーを実装できる多数のサービス・プロバイダー・インタフェース（SPI）があります。"
+"{project_name}は、必要なカスタム・コードが無くても、ほとんどのユースケースをカバーできるように作られていますが、カスタマイズもできるようにする必要があります。これを実現するために、{project_name}には独自のプロバイダーを実装できる多数のサービス・プロバイダー・インタフェース（SPI）があります。"
 
 #. type: Title ===
 #, no-wrap
@@ -63,18 +48,18 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For example, to implement the Event Listener SPI you need to implement "
-"EventListenerProviderFactory and EventListenerProvider and also provide the "
-"file `META-INF/services/org.keycloak.events.EventListenerProviderFactory`."
+"For example, to implement the Theme Selector Spi you need to implement "
+"ThemeSelectorProviderFactory and ThemeSelectorProvider and also provide the "
+"file `META-INF/services/org.keycloak.theme.ThemeSelectorProviderFactory`."
 msgstr ""
-"たとえば、Event Listener "
-"SPIを実装するには、EventListenerProviderFactoryとEventListenerProviderを実装して、 `META-"
-"INF/services/org.keycloak.events.EventListenerProviderFactory` "
+"たとえば、Theme Selector "
+"SPIを実装するには、ThemeSelectorProviderFactoryとThemeSelectorProviderを実装して、 `META-"
+"INF/services/org.keycloak.theme.ThemeSelectorProviderFactory` "
 "のファイルを提供する必要があります。"
 
 #. type: Plain text
-msgid "Example EventListenerProviderFactory:"
-msgstr "EventListenerProviderFactoryのサンプルを次に示します。"
+msgid "Example ThemeSelectorProviderFactory:"
+msgstr "ThemeSelectorProviderFactoryのサンプルを次に示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -84,152 +69,140 @@ msgstr "package org.acme.provider;\n"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"public class MyEventListenerProviderFactory implements "
-"EventListenerProviderFactory {\n"
+"public class MyThemeSelectorProviderFactory implements "
+"ThemeSelectorProviderFactory {\n"
 msgstr ""
-"public class MyEventListenerProviderFactory implements "
-"EventListenerProviderFactory {\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "    private List<Event> events;\n"
-msgstr "    private List<Event> events;\n"
+"public class MyThemeSelectorProviderFactory implements "
+"ThemeSelectorProviderFactory {\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public String getId() {\n"
-"        return \"my-event-listener\";\n"
-"    }\n"
+"      @Override\n"
+"        public ThemeSelectorProvider create(KeycloakSession session) {\n"
+"            return new MyThemeSelectorProvider(session);\n"
+"        }\n"
 msgstr ""
-"    public String getId() {\n"
-"        return \"my-event-listener\";\n"
-"    }\n"
+"      @Override\n"
+"        public ThemeSelectorProvider create(KeycloakSession session) {\n"
+"            return new MyThemeSelectorProvider(session);\n"
+"        }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public void init(Config.Scope config) {\n"
-"        events = new LinkedList();\n"
-"    }\n"
+"        @Override\n"
+"        public void init(Config.Scope config) {\n"
+"        }\n"
 msgstr ""
-"    public void init(Config.Scope config) {\n"
-"        events = new LinkedList();\n"
-"    }\n"
+"        @Override\n"
+"        public void init(Config.Scope config) {\n"
+"        }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public void postInit(KeycloakSessionFactory factory) {\n"
-"    }\n"
+"        @Override\n"
+"        public void postInit(KeycloakSessionFactory factory) {\n"
+"        }\n"
 msgstr ""
-"    public void postInit(KeycloakSessionFactory factory) {\n"
-"    }\n"
+"        @Override\n"
+"        public void postInit(KeycloakSessionFactory factory) {\n"
+"        }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public EventListenerProvider create(KeycloakSession session) {\n"
-"        return new MyEventListenerProvider(events);\n"
-"    }\n"
+"        @Override\n"
+"        public void close() {\n"
+"        }\n"
 msgstr ""
-"    public EventListenerProvider create(KeycloakSession session) {\n"
-"        return new MyEventListenerProvider(events);\n"
-"    }\n"
+"        @Override\n"
+"        public void close() {\n"
+"        }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public void close() {\n"
-"    }\n"
+"        @Override\n"
+"        public String getId() {\n"
+"            return \"myThemeSelector\";\n"
+"        }\n"
 "}\n"
 msgstr ""
-"    public void close() {\n"
-"    }\n"
+"        @Override\n"
+"        public String getId() {\n"
+"            return \"myThemeSelector\";\n"
+"        }\n"
 "}\n"
 
 #. type: Plain text
 msgid ""
-"Keycloak creates a single instance of `EventListenerProviderFactory` which "
-"makes it possible to store state for multiple requests.  "
-"`EventListenerProvider` instances are created by calling create on the "
-"factory for each requests so these should be light-weight object."
+"Keycloak creates a single instance of provider factories which makes it "
+"possible to store state for multiple requests.  Provider instances are "
+"created by calling create on the factory for each requests so these should "
+"be light-weight object."
 msgstr ""
-"Keycloakは、複数のリクエストの状態を格納することを可能にする `EventListenerProviderFactory` "
-"の単一のインスタンスを作成します。 "
-"`EventListenerProvider`インスタンスは、それぞれのリクエストに対してファクトリーでcreateを呼び出すことによって作成されるため、軽量オブジェクトである必要があります。"
+"Keycloakは、複数のリクエストの状態を格納することを可能にするプロバイダー・ファクトリーの単一のインスタンスを作成します。プロバイダー・インスタンスは、それぞれのリクエストに対してファクトリーでcreateを呼び出すことによって作成されるため、軽量オブジェクトである必要があります。"
 
 #. type: Plain text
-msgid "Example EventListenerProvider:"
-msgstr "EventListenerProviderのサンプル:"
+msgid "Example ThemeSelectorProvider:"
+msgstr "ThemeSelectorProviderのサンプルを次に示します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"public class MyEventListenerProvider implements EventListenerProvider {\n"
+"public class MyThemeSelectorProvider implements ThemeSelectorProvider {\n"
 msgstr ""
-"public class MyEventListenerProvider implements EventListenerProvider {\n"
+"public class MyThemeSelectorProvider implements ThemeSelectorProvider {\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public MyEventListenerProvider(List<Event> events) {\n"
-"        this.events = events;\n"
+"    public MyThemeSelectorProvider(KeycloakSession session) {\n"
 "    }\n"
 msgstr ""
-"    public MyEventListenerProvider(List<Event> events) {\n"
-"        this.events = events;\n"
+"    public MyThemeSelectorProvider(KeycloakSession session) {\n"
 "    }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
 "    @Override\n"
-"    public void onEvent(Event event) {\n"
-"        events.add(event);\n"
+"    public String getThemeName(Theme.Type type) {\n"
+"        return \"my-theme\";\n"
 "    }\n"
 msgstr ""
 "    @Override\n"
-"    public void onEvent(Event event) {\n"
-"        events.add(event);\n"
+"    public String getThemeName(Theme.Type type) {\n"
+"        return \"my-theme\";\n"
 "    }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    @Override\n"
-"    public void close() {\n"
-msgstr ""
-"    @Override\n"
-"    public void close() {\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"    @Override\n"
-"    public void onEvent(AdminEvent event, boolean includeRepresentation) {\n"
-"        // Assume this implementation just ignores admin events\n"
-"    }\n"
+"\t@Override\n"
+"\tpublic void close() {\n"
+"\t}\n"
 "}\n"
 msgstr ""
-"    @Override\n"
-"    public void onEvent(AdminEvent event, boolean includeRepresentation) {\n"
-"        // Assume this implementation just ignores admin events\n"
-"    }\n"
+"\t@Override\n"
+"\tpublic void close() {\n"
+"\t}\n"
 "}\n"
 
 #. type: Plain text
 msgid ""
 "Example service configuration file (`META-"
-"INF/services/org.keycloak.events.EventListenerProviderFactory`):"
+"INF/services/org.keycloak.theme.ThemeSelectorProviderFactory`):"
 msgstr ""
 "サンプル サービス設定ファイル（ `META-"
-"INF/services/org.keycloak.events.EventListenerProviderFactory` ）:"
+"INF/services/org.keycloak.theme.ThemeSelectorProviderFactory` ）:"
 
 #. type: delimited block -
 #, no-wrap
-msgid "org.acme.provider.MyEventListenerProviderFactory\n"
-msgstr "org.acme.provider.MyEventListenerProviderFactory\n"
+msgid "org.acme.provider.MyThemeSelectorProviderFactory\n"
+msgstr "org.acme.provider.MyThemeSelectorProviderFactory\n"
 
 #. type: Plain text
 msgid ""
@@ -250,20 +223,18 @@ msgstr "たとえば、下記を `standalone.xml` に追加します。"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"<spi name=\"eventsListener\">\n"
-"    <provider name=\"my-event-listener\" enabled=\"true\">\n"
+"<spi name=\"themeSelector\">\n"
+"    <provider name=\"myThemeSelector\" enabled=\"true\">\n"
 "        <properties>\n"
-"            <property name=\"aNumber\" value=\"10\"/>\n"
-"            <property name=\"aString\" value=\"Foo\"/>\n"
+"            <property name=\"theme\" value=\"my-theme\"/>\n"
 "        </properties>\n"
 "    </provider>\n"
 "</spi>\n"
 msgstr ""
-"<spi name=\"eventsListener\">\n"
-"    <provider name=\"my-event-listener\" enabled=\"true\">\n"
+"<spi name=\"themeSelector\">\n"
+"    <provider name=\"myThemeSelector\" enabled=\"true\">\n"
 "        <properties>\n"
-"            <property name=\"aNumber\" value=\"10\"/>\n"
-"            <property name=\"aString\" value=\"Foo\"/>\n"
+"            <property name=\"theme\" value=\"my-theme\"/>\n"
 "        </properties>\n"
 "    </provider>\n"
 "</spi>\n"
@@ -276,13 +247,11 @@ msgstr "そうすると、 `ProviderFactory` のinitメソッドで設定を取�
 #, no-wrap
 msgid ""
 "public void init(Config.Scope config) {\n"
-"    Integer aNumber = config.getInt(\"aNumber\");\n"
-"    String aString = config.get(\"aString\");\n"
+"    String themeName = config.get(\"theme\");\n"
 "}\n"
 msgstr ""
 "public void init(Config.Scope config) {\n"
-"    Integer aNumber = config.getInt(\"aNumber\");\n"
-"    String aString = config.get(\"aString\");\n"
+"    String themeName = config.get(\"theme\");\n"
 "}\n"
 
 #. type: Plain text
@@ -292,64 +261,58 @@ msgstr "また、プロバイダーも必要に応じて他のプロバイダー
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    private KeycloakSession session;\n"
-"    private List<Event> events;\n"
+"public class MyThemeSelectorProvider implements EventListenerProvider {\n"
 msgstr ""
-"    private KeycloakSession session;\n"
-"    private List<Event> events;\n"
+"public class MyThemeSelectorProvider implements EventListenerProvider {\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    private KeycloakSession session;\n"
+msgstr "    private KeycloakSession session;\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public MyEventListenerProvider(KeycloakSession session, List<Event> events) {\n"
+"    public MyThemeSelectorProvider(KeycloakSession session) {\n"
 "        this.session = session;\n"
-"        this.events = events;\n"
 "    }\n"
 msgstr ""
-"    public MyEventListenerProvider(KeycloakSession session, List<Event> events) {\n"
+"    public MyThemeSelectorProvider(KeycloakSession session) {\n"
 "        this.session = session;\n"
-"        this.events = events;\n"
 "    }\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    public void onEvent(Event event) {\n"
-"        RealmModel realm = session.realms().getRealm(event.getRealmId());\n"
-"        UserModel user = session.users().getUserById(event.getUserId(), realm);\n"
-msgstr ""
-"    public void onEvent(Event event) {\n"
-"        RealmModel realm = session.realms().getRealm(event.getRealmId());\n"
-"        UserModel user = session.users().getUserById(event.getUserId(), realm);\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"        EmailSenderProvider emailSender = session.getProvider(EmailSenderProvider.class);\n"
-"        emailSender.send(realm, user, \"Hello\", \"Hello plain text\", \"<h1>Hello html</h1>\" );\n"
+"    @Override\n"
+"    public String getThemeName(Theme.Type type) {\n"
+"        return session.getContext().getRealm().getLoginTheme();\n"
 "    }\n"
+"}\n"
 msgstr ""
-"        EmailSenderProvider emailSender = session.getProvider(EmailSenderProvider.class);\n"
-"        emailSender.send(realm, user, \"Hello\", \"Hello plain text\", \"<h1>Hello html</h1>\" );\n"
+"    @Override\n"
+"    public String getThemeName(Theme.Type type) {\n"
+"        return session.getContext().getRealm().getLoginTheme();\n"
 "    }\n"
+"}\n"
 
 #. type: Title ====
 #, no-wrap
-msgid "Show info from you SPI implementation in Keycloak admin console"
-msgstr "Keycloakの管理コンソールでのSPI実装の情報表示"
+msgid "Show info from your SPI implementation in admin console"
+msgstr "管理コンソールでのSPI実装の情報表示"
 
 #. type: Plain text
 msgid ""
 "Sometimes it is useful to show additional info about your Provider to a "
-"Keycloak administrator. You can show provider build time informations (eg. "
-"version of custom provider currently installed), current configuration of "
-"the provider (eg. url of remote system your provider talks to) or some "
+"{project_name} administrator. You can show provider build time informations "
+"(eg. version of custom provider currently installed), current configuration "
+"of the provider (eg. url of remote system your provider talks to) or some "
 "operational info (average time of response from remote system your provider "
-"talks to). Keycloak admin console provides Server Info page to show this "
-"kind of information."
+"talks to). {project_name} admin console provides Server Info page to show "
+"this kind of information."
 msgstr ""
-"Keycloak管理者にプロバイダーに関する追加情報を表示すると、便利なことがあります。 "
-"プロバイダー・ビルド・タイム情報（たとえば、現在インストール済みのカスタム・プロバイダーのバージョン）、プロバイダーの現在の設定（たとえば、プロバイダーが通信するリモートシステムのURL）、または動作情報（たとえば、プロバイダーが通信するリモートシステムからの平均レスポンス・タイム）を表示することができます。Keycloak管理コンソールでは、サーバーの情報ページが提供され、この種の情報が表示されます。"
+"{project_name}管理者にプロバイダーに関する追加情報を表示すると、便利なことがあります。 "
+"プロバイダー・ビルド・タイム情報（たとえば、現在インストール済みのカスタム・プロバイダーのバージョン）、プロバイダーの現在の設定（たとえば、プロバイダーが通信するリモートシステムのURL）、または動作情報（たとえば、プロバイダーが通信するリモートシステムからの平均レスポンス・タイム）を表示することができます。{project_name}管理コンソールでは、サーバーの情報ページが提供され、この種の情報が表示されます。"
 
 #. type: Plain text
 msgid ""
@@ -362,17 +325,17 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Example implementation for `MyEventListenerProviderFactory` from previous "
+"Example implementation for `MyThemeSelectorProviderFactory` from previous "
 "example:"
-msgstr "前のサンプルの `MyEventListenerProviderFactory` のサンプル実装を次に示します。"
+msgstr "前のサンプルの `MyThemeSelectorProviderFactory` のサンプル実装を次に示します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"public class MyEventListenerProviderFactory implements EventListenerProviderFactory, ServerInfoAwareProviderFactory {\n"
+"public class MyThemeSelectorProvider implements ThemeSelectorProvider, ServerInfoAwareProviderFactory {\n"
 "    ...\n"
 msgstr ""
-"public class MyEventListenerProviderFactory implements EventListenerProviderFactory, ServerInfoAwareProviderFactory {\n"
+"public class MyThemeSelectorProvider implements ThemeSelectorProvider, ServerInfoAwareProviderFactory {\n"
 "    ...\n"
 
 #. type: delimited block -
@@ -381,9 +344,7 @@ msgid ""
 "    @Override\n"
 "    public Map<String, String> getOperationalInfo() {\n"
 "        Map<String, String> ret = new LinkedHashMap<>();\n"
-"        ret.put(\"version\", \"1.0\");\n"
-"        ret.put(\"listSizeMax\", max + \"\");\n"
-"        ret.put(\"listSizeCurrent\", events.size() + \"\");\n"
+"        ret.put(\"theme-name\", \"my-theme\");\n"
 "        return ret;\n"
 "    }\n"
 "}\n"
@@ -391,9 +352,7 @@ msgstr ""
 "    @Override\n"
 "    public Map<String, String> getOperationalInfo() {\n"
 "        Map<String, String> ret = new LinkedHashMap<>();\n"
-"        ret.put(\"version\", \"1.0\");\n"
-"        ret.put(\"listSizeMax\", max + \"\");\n"
-"        ret.put(\"listSizeCurrent\", events.size() + \"\");\n"
+"        ret.put(\"theme-name\", \"my-theme\");\n"
 "        return ret;\n"
 "    }\n"
 "}\n"
@@ -406,12 +365,12 @@ msgstr "プロバイダー実装の登録"
 #. type: Plain text
 msgid ""
 "There are two ways to register provider implementations. In most cases the "
-"simplest way is to use the Keyclopak Deployer approach as this handles a "
-"number of dependencies automatically for you. It also supports hot "
+"simplest way is to use the {project_name} deployer approach as this handles "
+"a number of dependencies automatically for you. It also supports hot "
 "deployment as well as re-deployment."
 msgstr ""
-"プロバイダーの実装を登録するには2とおりの方法があります。ほとんどの場合、最も簡単な方法は、Keyclopak "
-"Deployerのアプローチを使用することです。なぜなら、この方法だと自動的にたくさんの依存関係が処理されるからです。また、リデプロイだけでなくホットデプロイもサポートされます。"
+"プロバイダーの実装を登録するには2通りの方法があります。ほとんどの場合、最も簡単な方法は、{project_name} "
+"deployerのアプローチを使用することです。なぜなら、この方法だと自動的にたくさんの依存関係が処理されるからです。また、リデプロイだけでなくホットデプロイもサポートされます。"
 
 #. type: Plain text
 msgid "The alternative approach is to deploy as a module."
@@ -420,29 +379,29 @@ msgstr "代替のアプローチとしては、モジュールとしてデプロ
 #. type: Plain text
 msgid ""
 "If you are creating a custom SPI you will need to deploy it as a module, "
-"otherwise we recommend using the Keycloak Deployer approach."
+"otherwise we recommend using the {project_name} deployer approach."
 msgstr ""
-"カスタムSPIを作成する場合は、モジュールとして展開する必要があります。それ以外の場合は、Keycloak Deployer "
-"のアプローチを使用することをお勧めします。"
+"カスタムSPIを作成する場合は、モジュールとして展開する必要があります。それ以外の場合は、{project_name} "
+"deployerのアプローチを使用することをお勧めします。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Using the Keycloak Deployer"
-msgstr "Keycloak Deployer の使用"
+msgid "Using the {project_name} Deployer"
+msgstr "{project_name} Deployer の使用"
 
 #. type: Plain text
 msgid ""
-"If you copy your provider jar to the Keycloak `deploy/` directory, your "
-"provider will automatically be deployed.  Hot deployment works too.  "
-"Additionally, your provider jar works similarly to other components deployed"
-" in a JBoss/Wildfly environment in that they can use facilities like the "
-"`jboss-deployment-structure.xml` file.  This file allows you to set up "
-"dependencies on other components and load third-party jars and modules."
+"If you copy your provider jar to the {project_name} "
+"`standalone/deployments/` directory, your provider will automatically be "
+"deployed.  Hot deployment works too.  Additionally, your provider jar works "
+"similarly to other components deployed in a {appserver_name} environment in "
+"that they can use facilities like the `jboss-deployment-structure.xml` file."
+"  This file allows you to set up dependencies on other components and load "
+"third-party jars and modules."
 msgstr ""
-"プロバイダーjarをKeycloakの `deploy/` "
-"ディレクトリーにコピーすると、プロバイダーが自動的にデプロイされます。ホットデプロイも機能します。さらにプロバイダーjarは、 "
-"JBoss/Wildfly環境でデプロイされた他のコンポーネントと同じように機能し、その環境下では `jboss-deployment-"
-"structure.xml` "
+"プロバイダーjarを{project_name}の `standalone/deployments/` "
+"ディレクトリーにコピーすると、プロバイダーが自動的にデプロイされます。ホットデプロイも機能します。さらにプロバイダーjarは、{appserver_name}環境でデプロイされた他のコンポーネントと同じように機能し、その環境下では"
+" `jboss-deployment-structure.xml` "
 "ファイルと同じようにファシリティを使用することができます。このファイルによって、他のコンポーネントへの依存関係を設定してサードパーティのjarとモジュールを読み込むことができます。"
 
 #. type: Plain text
@@ -476,33 +435,32 @@ msgstr ""
 #, no-wrap
 msgid ""
 "KEYCLOAK_HOME/bin/jboss-cli.sh --command=\"module add "
-"--name=org.keycloak.examples.event-sysout --resources=target/event-listener-"
-"sysout-example.jar --dependencies=org.keycloak.keycloak-core,org.keycloak"
-".keycloak-server-spi,org.keycloak.keycloak-events-api\"\n"
+"--name=org.acme.provider --resources=target/provider.jar "
+"--dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-server-"
+"spi\"\n"
 msgstr ""
 "KEYCLOAK_HOME/bin/jboss-cli.sh --command=\"module add "
-"--name=org.keycloak.examples.event-sysout --resources=target/event-listener-"
-"sysout-example.jar --dependencies=org.keycloak.keycloak-core,org.keycloak"
-".keycloak-server-spi,org.keycloak.keycloak-events-api\"\n"
+"--name=org.acme.provider --resources=target/provider.jar "
+"--dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-server-"
+"spi\"\n"
 
 #. type: Plain text
 msgid ""
 "Or to manually create it start by creating the folder "
-"`KEYCLOAK_HOME/modules/org/keycloak/examples/event-sysout/main`.  Then copy "
-"`event-listener-sysout-example.jar` to this folder and create `module.xml` "
-"with the following content:"
+"`KEYCLOAK_HOME/modules/org/acme/provider/main`.  Then copy `provider.jar` to"
+" this folder and create `module.xml` with the following content:"
 msgstr ""
-"または、それを手動で作成するには、 `KEYCLOAK_HOME/modules/org/keycloak/examples/event-"
-"sysout/main` フォルダーを作成して起動します。次に `event-listener-sysout-example.jar` "
-"をこのフォルダーにコピーし、以下のコンテンツで `module.xml` を作成します。"
+"または、それを手動で作成するには、 `KEYCLOAK_HOME/modules/org/acme/provider/main` "
+"フォルダーを作成して起動します。次に `provider.jar` をこのフォルダーにコピーし、以下のコンテンツで `module.xml` "
+"を作成します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-"<module xmlns=\"urn:jboss:module:1.3\" name=\"org.keycloak.examples.event-sysout\">\n"
+"<module xmlns=\"urn:jboss:module:1.3\" name=\"org.acme.provider\">\n"
 "    <resources>\n"
-"        <resource-root path=\"event-listener-sysout-example.jar\"/>\n"
+"        <resource-root path=\"provider.jar\"/>\n"
 "    </resources>\n"
 "    <dependencies>\n"
 "        <module name=\"org.keycloak.keycloak-core\"/>\n"
@@ -511,9 +469,9 @@ msgid ""
 "</module>\n"
 msgstr ""
 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-"<module xmlns=\"urn:jboss:module:1.3\" name=\"org.keycloak.examples.event-sysout\">\n"
+"<module xmlns=\"urn:jboss:module:1.3\" name=\"org.acme.provider\">\n"
 "    <resources>\n"
-"        <resource-root path=\"event-listener-sysout-example.jar\"/>\n"
+"        <resource-root path=\"provider.jar\"/>\n"
 "    </resources>\n"
 "    <dependencies>\n"
 "        <module name=\"org.keycloak.keycloak-core\"/>\n"
@@ -524,11 +482,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Once you've created the module you need to register this module with "
-"Keycloak.  This is done by editing the keycloak-server subsystem section of "
-"`standalone.xml`, `standalone-ha.xml`, or `domain.xml`, and adding it to the"
-" providers:"
+"{project_name}.  This is done by editing the keycloak-server subsystem "
+"section of `standalone.xml`, `standalone-ha.xml`, or `domain.xml`, and "
+"adding it to the providers:"
 msgstr ""
-"モジュールを作成すると、Keycloakでこのモジュールを登録する必要があります。 これは `standalone.xml` 、 "
+"モジュールを作成すると、{project_name}でこのモジュールを登録する必要があります。 これは `standalone.xml` 、 "
 "`standalone-ha.xml` 、または `domain.xml` のkeycloak-"
 "serverサブシステムセクションを編集し、それをプロバイダーに追加することにより行われます。"
 
@@ -548,40 +506,6 @@ msgstr ""
 "        <provider>module:org.keycloak.examples.event-sysout</provider>\n"
 "    </providers>\n"
 "    ...\n"
-
-#. type: Title ====
-#, no-wrap
-msgid "Configuring a provider"
-msgstr "プロバイダーの設定"
-
-#. type: Plain text
-msgid ""
-"You can pass configuration options to your provider by setting them in "
-"`standalone.xml`, `standalone-ha.xml`, or `domain.xml`.  For example to set "
-"the max value for `my-event-listener` add:"
-msgstr ""
-"`standalone.xml` 、 `standalone-ha.xml` 、または `domain.xml` "
-"内で設定することにより、設定オプションをプロバイダーに渡すことができます。たとえば、 `my-event-listener` "
-"に最大値を設定するには、以下を追加します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<spi name=\"eventsListener\">\n"
-"    <provider name=\"my-event-listener\" enabled=\"true\">\n"
-"        <properties>\n"
-"            <property name=\"max\" value=\"100\"/>\n"
-"        </properties>\n"
-"    </provider>\n"
-"</spi>\n"
-msgstr ""
-"<spi name=\"eventsListener\">\n"
-"    <provider name=\"my-event-listener\" enabled=\"true\">\n"
-"        <properties>\n"
-"            <property name=\"max\" value=\"100\"/>\n"
-"        </properties>\n"
-"    </provider>\n"
-"</spi>\n"
 
 #. type: Title ====
 #, no-wrap
@@ -615,27 +539,27 @@ msgstr "Java EEの活用"
 
 #. type: Plain text
 msgid ""
-"The can be packaged within any Java EE component so long as you set up the "
-"`META-INF/services` file correctly to point to your providers.  For example,"
-" if your provider needs to use third party libraries, you can package up "
-"your provider within an ear and store these third pary libraries in the "
-"ear's `lib/` directory.  Also note that provider jars can make use of the "
-"`jboss-deployment-structure.xml` file that EJBs, WARS, and EARs can use in a"
-" JBoss/Wildfly environment.  See the JBoss/Wildfly documentation for more "
-"details on this file.  It allows you to pull in external dependencies among "
-"other fine grain actions."
+"The service providers can be packaged within any Java EE component so long "
+"as you set up the `META-INF/services` file correctly to point to your "
+"providers.  For example, if your provider needs to use third party "
+"libraries, you can package up your provider within an ear and store these "
+"third pary libraries in the ear's `lib/` directory.  Also note that provider"
+" jars can make use of the `jboss-deployment-structure.xml` file that EJBs, "
+"WARS, and EARs can use in a {appserver_name} environment.  See the "
+"{appserver_name} documentation for more details on this file.  It allows you"
+" to pull in external dependencies among other fine grain actions."
 msgstr ""
-"プロバイダーを指し示すように `META-INF/services` ファイルを正しく設定している限りは、 いかなるJava "
+"サービス・プロバイダーは、プロバイダーを指し示すように `META-INF/services` ファイルを正しく設定している限りは、いかなるJava "
 "EEコンポーネント内でもこれをパッケージ化することができます。たとえば、プロバイダーがサードパーティーのライブラリーを使用する必要がある場合、プロバイダーをEAR内にパッケージ化し、これらのサードパーティーのライブラリーをEARの"
-" `lib/` ディレクトリーに格納します。また、プロバイダーjarは、JBossまたはWildfly環境でEJB、WAR、およびEARが使用可能な "
+" `lib/` ディレクトリーに格納します。また、プロバイダーjarは、{appserver_name}環境でEJB、WAR、およびEARが使用可能な "
 "`jboss-deployment-structure.xml` "
-"ファイルを使用することができる点に注意してください。このファイルについて、詳しくは、JBossまたはWildflyのドキュメントを参照してください。これにより、他の細かい動作間で外部との依存関係を引き出すことができます。"
+"ファイルを使用することができる点に注意してください。このファイルについて、詳しくは、{appserver_name}のドキュメントを参照ください。これにより、他の細かい動作間で外部との依存関係を引き出すことができます。"
 
 #. type: Plain text
 msgid ""
 "`ProviderFactory` implementations are required to be plain java objects.  "
 "But, we also currently support implementing provider classes as Stateful "
-"EJBs.  TThis is how you would do it:"
+"EJBs.  This is how you would do it:"
 msgstr ""
 "`ProviderFactory` "
 "の実装はプレーンなJavaオブジェクトである必要があります。ただし、現在は、ステートフルEJBとしてプロバイダー・クラスとして実装することもサポートもしています。"
@@ -792,113 +716,9 @@ msgstr "利用可能なSPI"
 
 #. type: Plain text
 msgid ""
-"Here's a list of the most important available SPIs and a brief description. "
-"For more details on each SPI refer to individual sections.  If you want to "
-"see list of all available SPIs at runtime, you can check `Server Info` page "
-"in admin console as described in <<_providers_admin_console,Admin Console>> "
-"section."
+"If you want to see list of all available SPIs at runtime, you can check "
+"`Server Info` page in admin console as described in "
+"<<_providers_admin_console,Admin Console>> section."
 msgstr ""
-"最も重要で利用可能なSPIのリストと簡単な説明については、こちらになります。各SPIについて、詳しくは、個別のセクションを参照してください。利用可能なすべてのSPIのリストを実行時に確認する必要がある場合は、<<_providers_admin_console,"
-" 管理コンソール>>セクションでの説明どおりに、管理コンソール内の `Server Info` ページを確認します。"
-
-#. type: Plain text
-msgid "SPI|Description"
-msgstr "SPI|の説明"
-
-#. type: Plain text
-msgid ""
-"Connections Infinispan|Loads and configures Infinispan connections. The "
-"default implementation can load connections from the Infinispan subsystem, "
-"or alternatively can be manually configured in standalone.xml"
-msgstr ""
-"Infinispanコネクション|Infinispanコネクションをロードして設定します。デフォルトの実装では、Infinispanサブシステムからコネクションをロードすることができますが、その代わりの方法としてstandalone.xmlで手動で設定することもできます"
-
-#. type: Plain text
-msgid ""
-"Connections Jpa|Loads and configures Jpa connections. The default "
-"implementation can load datasources from WildFly/EAP, or alternatively can "
-"be manually configured in standalone.xml"
-msgstr ""
-"Jpaコネクション|Jpaコネクションをロードして設定します。デフォルトの実装では、WildFlyまたはEAPからデータソースを読み込むことができますが、その代わりの方法としてstandalone.xmlで手動で設定することもできます"
-
-#. type: Plain text
-msgid ""
-"Connections Mongo|Loads and configures MongoDB connections. The default "
-"implementation is configured in standalone.xml"
-msgstr "Mongoコネクション|MongoDBコネクションをロードして設定します。デフォルトの実装は、standalone.xmlで設定します"
-
-#. type: Plain text
-msgid "Email Sender|Sends email. The default implementation uses JavaMail"
-msgstr "電子メールの送信者|デフォルトの実装では、JavaMailを使用します"
-
-#. type: Plain text
-msgid ""
-"Email Template|Format email and uses Email Sender to send the email. The "
-"default implementation uses FreeMarker templates"
-msgstr ""
-"電子メールのテンプレート|電子メールをフォーマットし、電子メール送信者を使用して電子メールを送信します。デフォルトの実装では、FreeMarkerテンプレートを使用します"
-
-#. type: Plain text
-msgid ""
-"Events Listener|Listen to user related events for example user login success"
-" and failures. Keycloak provides two implementations out of box. One that "
-"logs events to the server log and another that can send email notifications "
-"to users on certain events"
-msgstr ""
-"イベントリスナー|ユーザーログインの成功や失敗など、ユーザー関連のイベントについてリッスンします。Keycloakでは、そのまますぐに使用できる2つの実装が提供されます。1つは、サーバーログにイベントの記録を残すもので、2つ目は特定のイベントでユーザーに電子メールで通知するものです"
-
-#. type: Plain text
-msgid ""
-"Login Protocol|Provides protocols. Keycloak provides implementations of "
-"OpenID Connect and SAML 2.0"
-msgstr "ログイン・プロトコル|プロトコルを提供します。Keycloakでは、OpenID ConnectとSAML2.0の実装が提供されます"
-
-#. type: Plain text
-msgid ""
-"Realm|Provides realm and application meta-data. Keycloak provides "
-"implementations for Relational Databases and MongoDB"
-msgstr ""
-"レルム|レルムとアプリケーション・メタデータを提供します。Keycloakでは、リレーショナル・データベースとMongoDBのための実装が提供されます"
-
-#. type: Plain text
-msgid ""
-"Realm Cache|Caches realm and application meta-data to improve performance. "
-"Default implementation uses Infinispan"
-msgstr ""
-"レルムキャッシュ|レルムとアプリケーション・メタデータをキャッシュして、パフォーマンスを向上させます。デフォルトの実装には、Infinispanが使用されます"
-
-#. type: Plain text
-msgid ""
-"Timer|Executes scheduled tasks. Keycloak provides a basic implementation "
-"based on java.util.Timer"
-msgstr ""
-"タイマー|スケジューリングされているタスクを実行します。Keycloakでは、java.util.Timerに基づく基本的な実装が提供されます"
-
-#. type: Plain text
-msgid ""
-"User|Provides users and role-mappings. Keycloak provides implementations for"
-" Relational Databases and MongoDB"
-msgstr ""
-"ユーザー|ユーザーとロール・マッピングを提供します。Keycloakでは、リレーショナル・データベースとMongoDBのための実装が提供されます"
-
-#. type: Plain text
-msgid ""
-"User Cache|Caches users to improve performance. Default implementation uses "
-"Infinispan"
-msgstr "ユーザー・キャッシュ|ユーザーをキャッシュしてパフォーマンスを向上させます。デフォルトの実装には、Infinispanが使用されます"
-
-#. type: Plain text
-msgid ""
-"User Federation|Support syncing users from an external source. Keycloak "
-"provides implementations for LDAP and Active Directory"
-msgstr ""
-"ユーザー・フェデレーション|外部ソースからのユーザーの同期をサポートします。Keycloakでは、LDAPとActive "
-"Directoryのための実装が提供されます"
-
-#. type: Plain text
-msgid ""
-"User Sessions|Provides users session information. Keycloak provides "
-"implementations for basic in-memory, Infinispan, Relational Databases and "
-"MongoDB"
-msgstr ""
-"ユーザー・セッション|ユーザー・セッション情報を提供します。Keycloakでは、基本的なインメモリー、Infinispan、リレーショナル・データベースおよびMongoDBのための実装が提供されます"
+"利用可能なすべてのSPIのリストを実行時に確認する必要がある場合は、<<_providers_admin_console, "
+"管理コンソール>>セクションでの説明通りに、管理コンソール内の `Server Info` ページを確認します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
