### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
@@ -48,18 +48,18 @@ msgid ""
 "Allowed` on. As in a normal login, roles from access token are the "
 "intersection of:"
 msgstr ""
-"サービス・アカウントを使用するには、有効な `コンフィデンシャル` "
+"サービス・アカウントを使用するには、有効な `confidential` "
 "クライアントを登録していなければなりません。また、そのクライアントの{project_name}管理コンソールの `Service Accounts "
 "Enabled` スイッチをオンにする必要があります。 `Service Account Roles` "
 "タブでは、このクライアントに代わって取得されたサービス・アカウントで使用可能なロールを設定できます。 `Full Scope Allowed` "
-"をオンにしない限り、このクライアントのロールスコープ・マッピング（ `Scope` タブ）でロールを利用可能にする必要があることに注意してください。 "
-"通常のログインと同様に、アクセストークンからの役割は次のものです。"
+"をオンにしない限り、このクライアントのロール・スコープ・マッピング（ `Scope` "
+"タブ）でロールを利用可能にする必要があることに注意してください。通常のログインと同様に、アクセストークンのロールは以下の論理積となります。"
 
 #. type: Plain text
 msgid ""
 "Role scope mappings of particular client combined with the role scope "
 "mappings inherited from linked client scopes"
-msgstr "リンクされたクライアント・スコープから継承されたロールスコープ・マッピングと結合された特定のクライアントのロールスコープ・マッピング"
+msgstr "リンクされたクライアント・スコープから継承されたロール・スコープ・マッピングと結合された特定のクライアントのロール・スコープ・マッピング"
 
 #. type: Plain text
 msgid "Service account roles"

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:3
 #, no-wrap
 msgid "Service Accounts"
 msgstr "サービス・アカウント"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:10
 msgid ""
 "Each OIDC client has a built-in _service account_ which allows it to obtain "
 "an access token.  This is covered in the OAuth 2.0 specifiation under "
@@ -40,25 +38,34 @@ msgstr ""
 "クライアント・クレデンシャル>>を設定していることを確認してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:14
 msgid ""
 "To use it you must have registered a valid `confidential` Client and you "
 "need to check the switch `Service Accounts Enabled` in {project_name} admin "
 "console for this client.  In tab `Service Account Roles` you can configure "
 "the roles available to the service account retrieved on behalf of this "
-"client.  Don't forget that you need those roles to be available in Scopes of"
-" this client as well (unless you have `Full Scope Allowed` on). As in normal"
-" login, roles from access token are the intersection of scopes and the "
-"service account roles."
+"client.  Remember that you must have the roles available in Role Scope "
+"Mappings (tab `Scope`) of this client as well, unless you have `Full Scope "
+"Allowed` on. As in a normal login, roles from access token are the "
+"intersection of:"
 msgstr ""
 "サービス・アカウントを使用するには、有効な `コンフィデンシャル` "
 "クライアントを登録していなければなりません。また、そのクライアントの{project_name}管理コンソールの `Service Accounts "
 "Enabled` スイッチをオンにする必要があります。 `Service Account Roles` "
 "タブでは、このクライアントに代わって取得されたサービス・アカウントで使用可能なロールを設定できます。 `Full Scope Allowed` "
-"がオンの場合を除いて、このクライアントのスコープで利用できるロールが必要であることを忘れないでください。通常のログインと同様に、アクセストークンからのロールは、スコープとサービス・アカウントのロールの共通集合です。"
+"をオンにしない限り、このクライアントのロールスコープ・マッピング（ `Scope` タブ）でロールを利用可能にする必要があることに注意してください。 "
+"通常のログインと同様に、アクセストークンからの役割は次のものです。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:19
+msgid ""
+"Role scope mappings of particular client combined with the role scope "
+"mappings inherited from linked client scopes"
+msgstr "リンクされたクライアント・スコープから継承されたロールスコープ・マッピングと結合された特定のクライアントのロールスコープ・マッピング"
+
+#. type: Plain text
+msgid "Service account roles"
+msgstr "サービス・アカウント・ロール"
+
+#. type: Plain text
 msgid ""
 "The REST URL to invoke on is `/auth/realms/{realm-name}/protocol/openid-"
 "connect/token`.  Invoking on this URL is a POST request and requires you to "
@@ -76,14 +83,12 @@ msgstr ""
 " `grant_type=client_credentials` を使う必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:21
 msgid ""
 "For example the POST invocation to retrieve a service account can look like "
 "this:"
 msgstr "たとえば、サービス・アカウントを取得するためのPOST呼び出しは次のようになります。"
 
 #. type: delimited block -
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:28
 #, no-wrap
 msgid ""
 "    POST /auth/realms/demo/protocol/openid-connect/token\n"
@@ -95,13 +100,11 @@ msgstr ""
 " Content-Type: application/x-www-form-urlencoded\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:30
 #, no-wrap
 msgid "    grant_type=client_credentials\n"
 msgstr "grant_type=client_credentials\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:32
 msgid ""
 "The response would be this "
 "https://tools.ietf.org/html/rfc6749#section-4.4.3[standard JSON document] "
@@ -112,7 +115,6 @@ msgstr ""
 "になります。"
 
 #. type: delimited block -
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:40
 #, no-wrap
 msgid ""
 "HTTP/1.1 200 OK\n"
@@ -126,7 +128,6 @@ msgstr ""
 "Pragma: no-cache\n"
 
 #. type: delimited block -
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:51
 #, no-wrap
 msgid ""
 "{\n"
@@ -152,7 +153,6 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/service-accounts.adoc:53
 msgid ""
 "The retrieved access token can be refreshed or logged out by an out-of-bound"
 " request."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__service-accounts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
