### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,27 +15,27 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Plain text
+#, no-wrap
+msgid "*Resource Management*\n"
+msgstr "*リソース管理*\n"
+
 #. type: Title =
-#: source/authorization_services/topics/auth-services-architecture.adoc:94
-#: source/authorization_services/topics/service-protection-protection-api.adoc:2
 #, no-wrap
 msgid "Protection API"
 msgstr "保護API"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-protection-api.adoc:5
+#, no-wrap
+msgid "*Permission Management*\n"
+msgstr "*パーミッション管理*\n"
+
+#. type: Plain text
 msgid ""
 "The Protection API provides a UMA-compliant set of endpoints providing:"
 msgstr "保護APIは、UMA準拠のエンドポイントのセットを提供します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-protection-api.adoc:7
-#, no-wrap
-msgid "*Resource Registration*\n"
-msgstr "*Resource Registration*\n"
-
-#. type: Plain text
-#: source/authorization_services/topics/service-protection-protection-api.adoc:9
 msgid ""
 "With this endpoint, resource servers can manage their resources remotely and"
 " enable <<_enforcer_overview, policy enforcers>> to query the server for the"
@@ -45,20 +45,14 @@ msgstr ""
 "ポリシー・エンフォーサー>>が保護を必要とするリソースをサーバーに問い合わせできるようになります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-protection-api.adoc:11
-#, no-wrap
-msgid "*Permission Registration*\n"
-msgstr "*Permission Registration*\n"
-
-#. type: Plain text
-#: source/authorization_services/topics/service-protection-protection-api.adoc:13
 msgid ""
-"In the UMA protocol, resource servers access this endpoint, which issues "
-"permission tickets."
-msgstr "UMAプロトコルでは、リソースサーバーはこのエンドポイントにアクセスし、パーミッション・チケットを発行します。"
+"In the UMA protocol, resource servers access this endpoint to create "
+"permission tickets. {project_name} also provides endpoints to manage the "
+"state of permissions and query permissions."
+msgstr ""
+"UMAプロトコルでは、リソースサーバーはこのエンドポイントにアクセスしてパーミッション・チケットを作成します。{project_name}には、パーミッションの状態やクエリー・パーミッションを管理するためのエンドポイントも用意されています。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-protection-protection-api.adoc:15
 msgid ""
 "An important requirement for this API is that _only_ resource servers are "
 "allowed to access its endpoints using a special OAuth2 access token called a"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-protection-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
