### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-builtin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-builtin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-builtin.ja_JP.po
@@ -1,0 +1,230 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "</blueprint>\n"
+msgstr "</blueprint>\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "Securing an Apache CXF Endpoint on the Default Jetty Engine"
+msgstr "デフォルトのJettyエンジンでのApache CXFエンドポイントの保護"
+
+#. type: Plain text
+msgid ""
+"The configuration file `OSGI-INF/blueprint/blueprint.xml` inside your "
+"application might resemble the one below. Note that it adds the JAX-RS "
+"`customerservice` endpoint, which is endpoint-specific to your application, "
+"but more importantly, secures the entire `/cxf` context."
+msgstr ""
+"アプリケーション内の設定ファイル `OSGI-INF/blueprint/blueprint.xml` は、以下のようになります。JAX-RSの "
+"`customerservice` エンドポイント（アプリケーション固有のエンドポイント）を追加しますが、もっと重要なのは、 `/cxf` "
+"コンテキスト全体をセキュリティー保護することです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
+"           xsi:schemaLocation=\"\n"
+"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
+"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
+msgstr ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
+"           xsi:schemaLocation=\"\n"
+"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
+"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    <!-- JAXRS Application -->\n"
+msgstr "    <!-- JAXRS Application -->\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"customerBean\" "
+"class=\"org.keycloak.example.rs.CxfCustomerService\" />\n"
+msgstr ""
+"    <bean id=\"customerBean\" "
+"class=\"org.keycloak.example.rs.CxfCustomerService\" />\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <jaxrs:server id=\"cxfJaxrsServer\" address=\"/customerservice\">\n"
+"        <jaxrs:providers>\n"
+"            <bean class=\"com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider\" />\n"
+"        </jaxrs:providers>\n"
+"        <jaxrs:serviceBeans>\n"
+"            <ref component-id=\"customerBean\" />\n"
+"        </jaxrs:serviceBeans>\n"
+"    </jaxrs:server>\n"
+msgstr ""
+"    <jaxrs:server id=\"cxfJaxrsServer\" address=\"/customerservice\">\n"
+"        <jaxrs:providers>\n"
+"            <bean class=\"com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider\" />\n"
+"        </jaxrs:providers>\n"
+"        <jaxrs:serviceBeans>\n"
+"            <ref component-id=\"customerBean\" />\n"
+"        </jaxrs:serviceBeans>\n"
+"    </jaxrs:server>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"defaultCxfReregistration\" class=\"org.keycloak.adapters.osgi.ServletReregistrationService\" depends-on=\"cxfKeycloakPaxWebIntegration\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"managedServiceReference\">\n"
+"            <reference interface=\"org.osgi.service.cm.ManagedService\" filter=\"(service.pid=org.apache.cxf.osgi)\" timeout=\"5000\"  />\n"
+"        </property>\n"
+"    </bean>\n"
+msgstr ""
+"    <bean id=\"defaultCxfReregistration\" class=\"org.keycloak.adapters.osgi.ServletReregistrationService\" depends-on=\"cxfKeycloakPaxWebIntegration\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"managedServiceReference\">\n"
+"            <reference interface=\"org.osgi.service.cm.ManagedService\" filter=\"(service.pid=org.apache.cxf.osgi)\" timeout=\"5000\"  />\n"
+"        </property>\n"
+"    </bean>\n"
+
+#. type: Plain text
+msgid ""
+"The `Import-Package` in `META-INF/MANIFEST.MF` must contain at least these "
+"imports:"
+msgstr ""
+"`META-INF/MANIFEST.MF` の `Import-Package` は、少なくとも以下のインポートを含んでいなければなりません。"
+
+#. type: Plain text
+msgid ""
+"Some services automatically come with deployed servlets on startup. One such"
+" service is the CXF servlet running in the $$http://localhost:8181/cxf$$ "
+"context. Securing such endpoints can be complicated. One approach, which "
+"{project_name} is currently using, is `ServletReregistrationService` which "
+"undeploys a built-in servlet at startup, enabling you to redeploy it on a "
+"context secured by {project_name}."
+msgstr ""
+"いくつかのサービスは、起動時にデプロイされたサーブレットを自動的に提供します。そのようなサービスの1つは、$$http://localhost:8181/cxf$$"
+" "
+"コンテキストで実行されているCXFサーブレットです。そのようなエンドポイントを保護することは複雑になる可能性があります。{project_name}が現在使用しているアプローチの1つは"
+" `ServletReregistrationService` "
+"で、これは組み込みのサーブレットを起動時にアンデプロイし、{project_name}によってセキュリティー保護されたコンテキストに再デプロイできるようにします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <!-- Securing of whole /cxf context by unregister default cxf servlet from paxweb and re-register with applied security constraints -->\n"
+"    <bean id=\"cxfConstraintMapping\" class=\"org.keycloak.adapters.osgi.PaxWebSecurityConstraintMapping\">\n"
+"        <!-- user accessing the servise has to have at least one of the following roles -->\n"
+"        <property name=\"roles\">\n"
+"            <list>\n"
+"                <value>user</value>\n"
+"            </list>\n"
+"        </property>\n"
+"        <property name=\"url\" value=\"/cxf/*\" />\n"
+"        <property name=\"authentication\" value=\"true\"/>\n"
+"    </bean>\n"
+msgstr ""
+"    <!-- Securing of whole /cxf context by unregister default cxf servlet from paxweb and re-register with applied security constraints -->\n"
+"    <bean id=\"cxfConstraintMapping\" class=\"org.keycloak.adapters.osgi.PaxWebSecurityConstraintMapping\">\n"
+"        <!-- user accessing the servise has to have at least one of the following roles -->\n"
+"        <property name=\"roles\">\n"
+"            <list>\n"
+"                <value>user</value>\n"
+"            </list>\n"
+"        </property>\n"
+"        <property name=\"url\" value=\"/cxf/*\" />\n"
+"        <property name=\"authentication\" value=\"true\"/>\n"
+"    </bean>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"cxfKeycloakPaxWebIntegration\" class=\"org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"constraintMappings\">\n"
+"            <list>\n"
+"                <ref component-id=\"cxfConstraintMapping\" />\n"
+"            </list>\n"
+"        </property>\n"
+"    </bean>\n"
+msgstr ""
+"    <bean id=\"cxfKeycloakPaxWebIntegration\" class=\"org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"constraintMappings\">\n"
+"            <list>\n"
+"                <ref component-id=\"cxfConstraintMapping\" />\n"
+"            </list>\n"
+"        </property>\n"
+"    </bean>\n"
+
+#. type: Plain text
+msgid ""
+"As a result, all other CXF services running on the default CXF HTTP "
+"destination are also secured. Similarly, when the application is undeployed,"
+" the entire `/cxf` context becomes unsecured as well. For this reason, use "
+"your own undertow engine for your applications as described in "
+"<<_fuse7_adapter_cxf_separate,Secure CXF Application on separate Undertow "
+"Engine>> since that gives you more control over security for each individual"
+" application."
+msgstr ""
+"その結果、デフォルトのCXF HTTPの宛先で実行されている他のすべてのCXFサービスも保護されます。同様に、アプリケーションがアンデプロイされると、 "
+"`/cxf` "
+"コンテキスト全体がセキュリティー保護されなくなります。このため、<<_fuse7_adapter_cxf_separate,独立したUndertowエンジンでのApache"
+" "
+"CXFエンドポイントの保護>>で説明されているように、独自のUndertowエンジンをアプリケーションに使用すると、個々のアプリケーションのセキュリティーをより詳細に制御できます。"
+
+#. type: Plain text
+msgid ""
+"The `WEB-INF` directory might need to be inside your project (even if your "
+"project is not a web application). You might also need to edit the `/WEB-"
+"INF/keycloak.json` file similarly to <<_fuse7_adapter_classic_war,Classic "
+"WAR application>>.  Note that you do not need the `web.xml` file as the "
+"security constraints are declared in the blueprint configuration file."
+msgstr ""
+"`WEB-INF` ディレクトリーはプロジェクト内にある必要があります（プロジェクトがWebアプリケーションでない場合でも）。 "
+"また、<<_fuse7_adapter_classic_war,クラシックWARアプリケーション>>と同様に、 `/WEB-"
+"INF/keycloak.json` ファイルを編集する必要があります。セキュリティー制約がblueprint設定ファイルで宣言されているので、 "
+"`web.xml` ファイルは必要ないことに注意してください。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"javax.ws.rs;version=\"[2,3)\",\n"
+"META-INF.cxf;version=\"[2.7,3.3)\",\n"
+"META-INF.cxf.osgi;version=\"[2.7,3.3)\";resolution:=optional,\n"
+"org.apache.cxf.transport.http;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.*;version=\"[2.7,3.3)\",\n"
+"com.fasterxml.jackson.jaxrs.json;version=\"${jackson.version}\",\n"
+"org.keycloak.*;version=\"${project.version}\",\n"
+msgstr ""
+"javax.ws.rs;version=\"[2,3)\",\n"
+"META-INF.cxf;version=\"[2.7,3.3)\",\n"
+"META-INF.cxf.osgi;version=\"[2.7,3.3)\";resolution:=optional,\n"
+"org.apache.cxf.transport.http;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.*;version=\"[2.7,3.3)\",\n"
+"com.fasterxml.jackson.jaxrs.json;version=\"${jackson.version}\",\n"
+"org.keycloak.*;version=\"${project.version}\",\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-builtin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__cxf-builtin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
