### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -15,21 +15,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Labeled list
-#: source/server_admin/topics/clients/client-saml.adoc:49
-#: source/server_admin/topics/clients/protocol-mappers.adoc:32
-#, no-wrap
-msgid "Consent Required"
-msgstr "Consent Required"
-
 #. type: Title ===
-#: source/server_admin/topics/clients/protocol-mappers.adoc:3
 #, no-wrap
 msgid "OIDC Token and SAML Assertion Mappings"
 msgstr "OIDCトークンとSAMLアサーションのマッピング"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:11
 msgid ""
 "Applications that receive ID Tokens, Access Tokens, or SAML assertions may "
 "need or want different user metadata and roles.  {project_name} allows you "
@@ -41,7 +32,6 @@ msgstr ""
 "IDトークン、アクセストークン、またはSAMLアサーションを受け取るアプリケーションでは、異なるユーザーのメタデータとロールが必要または求める場合があります。{project_name}では、正確に何が転送されるかを定義することができます。ロール、クレーム、カスタム属性をハードコードすることができます。ユーザー・メタデータをトークンまたはアサーションに取り込むことができます。ロールの名前を変更できます。基本的に、正確に何がクライアントに戻るのかをコントロールできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:14
 msgid ""
 "Within the Admin Console, if you go to an application you've registered, "
 "you'll see a `Mappers` tab.  Here's one for an OIDC based client."
@@ -50,31 +40,29 @@ msgstr ""
 "タブが表示されます。ここには、OIDCベースのクライアントの一例があります。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/protocol-mappers.adoc:15
 #, no-wrap
 msgid "Mappers Tab"
 msgstr "Mappersタブ"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:17
 msgid "image:{project_images}/mappers-oidc.png[]"
 msgstr "image:{project_images}/mappers-oidc.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:22
 msgid ""
-"Each client has several built-in mappers that are created for it by default."
-"  They map things like, for example, email address to a specific claim in "
-"the identity and access token.  Their function should each be self "
-"explanatory from their name.  There are additional pre-configured mappers "
-"that are not attached to the client that you can add by clicking the `Add "
-"Builtin` button."
+"The new client does not have any built-in mappers, however it usually "
+"inherits some mappers from the client scopes as described in the "
+"<<_client_scopes, client scopes section>>. Protocol mappers map things like,"
+" for example, email address to a specific claim in the identity and access "
+"token.  Their function should each be self explanatory from their name.  "
+"There are additional pre-configured mappers that are not attached to the "
+"client that you can add by clicking the `Add Builtin` button."
 msgstr ""
-"各クライアントには、そのためにデフォルトで作成されたいくつかのビルトイン・マッパーがあります。それらのマッパーは、たとえば、メールアドレスをアイデンティティー・トークンとアクセストークンの特定のクレームにマッピングします。それらの機能はそれぞれの名前から自明でなければなりません。クライアントにアタッチされていない追加の事前設定されたマッパーがあり、"
+"新しいクライアントにはビルトインマッパーはありませんが、通常、<<_client_scopes, "
+"クライアント・スコープのセクション>>で説明されているように、クライアント・スコープからいくつかのマッパーを継承します。それらのマッパーは、たとえば、メールアドレスをアイデンティティー・トークンとアクセストークンの特定のクレームにマッピングします。それらの機能はそれぞれの名前から自明でなければなりません。クライアントにアタッチされていない追加の事前設定されたマッパーがあり、"
 " `Add Builtin` ボタンをクリックすることで追加できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:25
 msgid ""
 "Each mapper has common settings as well as additional ones depending on "
 "which type of mapper you are adding.  Click the `Edit` button next to one of"
@@ -84,53 +72,20 @@ msgstr ""
 "ボタンをクリックして、設定画面を表示します。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/protocol-mappers.adoc:26
 #, no-wrap
 msgid "Mapper Config"
 msgstr "マッパーの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:28
 msgid "image:{project_images}/mapper-config.png[]"
 msgstr "image:{project_images}/mapper-config.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:31
 msgid ""
-"The best way to learn about a config option is to hover over its tooltip.  "
-"There are a few config options that are common to all mappers:"
-msgstr ""
-"設定オプションについて学ぶ最も良い方法は、ツールチップにカーソルを合わせることです。すべてのマッパーに共通の設定オプションがいくつかあります。"
+"The best way to learn about a config option is to hover over its tooltip."
+msgstr "設定オプションについて学ぶ最も良い方法は、ツールチップにカーソルを合わせることです。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:34
-msgid ""
-"If your client requires consent, this mapper will be displayed on the "
-"consent screen shown to the user."
-msgstr "クライアントが同意する必要がある場合、このマッパーがユーザーに表示される同意画面に表示されます。"
-
-#. type: Labeled list
-#: source/server_admin/topics/clients/protocol-mappers.adoc:34
-#, no-wrap
-msgid "Consent Text"
-msgstr "Consent Text"
-
-#. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:39
-msgid ""
-"If your client requires consent and the `Consent` switch is on, this is the "
-"text that will be displayed by the user.  The value for this text is "
-"localizable by specifying a substitution variable with `$\\{var-name}` "
-"strings.  The localized value is then configured within property files in "
-"your theme.  See the link:{developerguide_link}[{developerguide_name}] for "
-"more information on localization."
-msgstr ""
-"クライアントが同意を必要とし、 `Consent Required` スイッチがオンの場合、このテキストがユーザーに表示されます。このテキストの値は、 "
-"`$\\{var-name}` "
-"文字列で置換変数を指定することによってローカライズ可能です。ローカライズされた値は、テーマのプロパティー・ファイル内で設定されます。ローカリゼーションの詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
-
-#. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:42
 msgid ""
 "Most OIDC mappers also allow you to control where the claim gets put.  You "
 "can opt to include or exclude the claim from both the _id_ and _access_ "
@@ -142,25 +97,21 @@ msgstr ""
 "トークンの両方にクレームを含めるかどうかを制御することができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:44
 msgid ""
 "Finally, you can also add other mapper types.  If you go back to the "
 "`Mappers` tab, click the `Create` button."
 msgstr "最後に、他のマッパータイプを追加することもできます。 `Mappers` タブに戻ったら、 `Create` ボタンをクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/protocol-mappers.adoc:45
 #, no-wrap
 msgid "Add Mapper"
 msgstr "マッパーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:47
 msgid "image:{project_images}/add-mapper.png[]"
 msgstr "image:{project_images}/add-mapper.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/protocol-mappers.adoc:49
 msgid ""
 "Pick a `Mapper Type` from the list box.  If you hover over the tooltip, "
 "you'll see a description of what that mapper type does.  Different config "

--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -58,7 +58,7 @@ msgid ""
 "There are additional pre-configured mappers that are not attached to the "
 "client that you can add by clicking the `Add Builtin` button."
 msgstr ""
-"新しいクライアントにはビルトインマッパーはありませんが、通常、<<_client_scopes, "
+"新しいクライアントにはビルトイン・マッパーはありませんが、通常、<<_client_scopes, "
 "クライアント・スコープのセクション>>で説明されているように、クライアント・スコープからいくつかのマッパーを継承します。それらのマッパーは、たとえば、メールアドレスをアイデンティティー・トークンとアクセストークンの特定のクレームにマッピングします。それらの機能はそれぞれの名前から自明でなければなりません。クライアントにアタッチされていない追加の事前設定されたマッパーがあり、"
 " `Add Builtin` ボタンをクリックすることで追加できます。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
