### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -16,39 +16,28 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:84
-#: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:134
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:52
 msgid ""
 "(default mode) Requests are denied by default even when there is no policy "
 "associated with a given resource."
 msgstr "（デフォルトモード）特定のリソースに関連付けられたポリシーがない場合でも、デフォルトで要求は拒否されます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/enforcer-keycloak-enforcement-filter.adoc:88
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:56
 msgid ""
 "Requests are allowed even when there is no policy associated with a given "
 "resource."
 msgstr "特定のリソースに関連付けられたポリシーがない場合でも、要求は許可されます。"
 
 #. type: Block title
-#: source/authorization_services/topics/hello-world-create-resource-server.adoc:2
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:2
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:6
 #, no-wrap
 msgid "Enabling Authorization Services"
 msgstr "認可サービスの有効化"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-create-scope.adoc:23
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:21
 #, no-wrap
 msgid "*Resource*\n"
 msgstr "*Resource*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:5
 msgid ""
 "To turn your OIDC Client Application into a resource server and enable fine-"
 "grained authorization, click the *Authorization Enabled* switch to *ON* and "
@@ -58,7 +47,6 @@ msgstr ""
 "*ON* にして *Save* をクリックします。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:8
 msgid ""
 "image:{project_images}/resource-server/client-enable-"
 "authz.png[alt=\"Enabling Authorization Services\"]"
@@ -67,7 +55,6 @@ msgstr ""
 "authz.png[alt=\"認可サービスの有効化\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:10
 msgid ""
 "A new Authorization tab is displayed for this client. Click the "
 "*Authorization* tab and a page similar to the following is displayed:"
@@ -75,17 +62,12 @@ msgstr ""
 "クライアントに新しいAuthorizationタブが表示されます。 *Authorization* "
 "タブをクリックすると、次のようなページが表示されます。"
 
-#. type: Block title
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:11
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:41
-#: source/authorization_services/topics/resource-server-import-config.adoc:16
+#. type: Title ==
 #, no-wrap
 msgid "Resource Server Settings"
 msgstr "リソースサーバーの設定"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:13
-#: source/authorization_services/topics/resource-server-import-config.adoc:18
 msgid ""
 "image:{project_images}/resource-server/authz-settings.png[alt=\"Resource "
 "Server Settings\"]"
@@ -94,7 +76,6 @@ msgstr ""
 "settings.png[alt=\"リソースサーバーの設定\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:15
 msgid ""
 "The Authorization tab contains additional sub-tabs covering the different "
 "steps that you must follow to actually protect your application's resources."
@@ -104,13 +85,11 @@ msgstr ""
 "Authorizationタブには、アプリケーションのリソースを実際に保護するために従わなければならないさまざまなステップを補う追加のサブタブが含まれています。各タブは、このドキュメントの特定のトピックで個別に補足されています。ここではそれぞれについて簡単に説明します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:17
 #, no-wrap
 msgid "*Settings*\n"
 msgstr "*Settings*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:19
 msgid ""
 "General settings for your resource server. For more details about this page "
 "see the xref:resource_server_settings[Resource Server Settings] section."
@@ -118,44 +97,37 @@ msgstr ""
 "リソースサーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソースサーバーの設定]のセクションを参照してください。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:23
 msgid ""
 "From this page, you can manage your application's <<_resource_overview, "
 "resources>>."
 msgstr "このページから、アプリケーションの<<_resource_overview, リソース>>を管理できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:25
 #, no-wrap
-msgid "*Scope*\n"
-msgstr "*Scope*\n"
+msgid "*Authorization Scopes*\n"
+msgstr "*Authorization Scopes*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:27
 msgid "From this page, you can manage <<_resource_overview, scopes>>."
 msgstr "このページから、<<_resource_overview, スコープ>>を管理できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:29
 #, no-wrap
 msgid "*Policies*\n"
 msgstr "*Policies*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:31
 msgid ""
 "From this page, you can manage <<_policy_overview, authorization policies>> "
 "and define the conditions that must be met to grant a permission."
 msgstr "このページから、<<_policy_overview, 認可ポリシー>>を管理し、許可を得るために必要な条件を定義することができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:33
 #, no-wrap
 msgid "*Permissions*\n"
 msgstr "*Permissions*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:35
 msgid ""
 "From this page, you can manage the <<_permission_overview, permissions>> for"
 " your protected resources and scopes by linking them with the policies you "
@@ -165,13 +137,11 @@ msgstr ""
 "権限>>を、作成したポリシーとリンクさせることにより管理できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:37
 #, no-wrap
 msgid "*Evaluate*\n"
 msgstr "*Evaluate*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:39
 msgid ""
 "From this page, you can <<_policy_evaluation_overview, simulate "
 "authorization requests>> and view the result of the evaluation of the "
@@ -181,7 +151,17 @@ msgstr ""
 "認可リクエストのシミュレート>>、および定義した権限と認可ポリシーの評価結果を表示できます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:44
+#, no-wrap
+msgid "*Export Settings*\n"
+msgstr "*Export Settings*\n"
+
+#. type: Plain text
+msgid ""
+"From this page, you can <<_resource_server_import_config, export>> the "
+"authorization settings to a JSON file."
+msgstr "このページから、認可設定をJSONファイルに<<_resource_server_import_config, エクスポート>>できます。"
+
+#. type: Plain text
 msgid ""
 "On the Resource Server Settings page, you can configure the policy "
 "enforcement mode, allow remote resource management, and export the "
@@ -189,68 +169,43 @@ msgid ""
 msgstr "リソースサーバー設定ページでは、ポリシーの強制モードの設定や、リモートリソース管理の許可、認可構成の設定のエクスポートができます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:46
 #, no-wrap
 msgid "*Policy Enforcement Mode*\n"
 msgstr "*Policy Enforcement Mode*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:48
 msgid ""
 "Specifies how policies are enforced when processing authorization requests "
 "sent to the server."
 msgstr "サーバーに送信された認可要求を処理するときに、ポリシーがどのように強制されるかを指定します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:50
 #, no-wrap
 msgid "** *Enforcing*\n"
 msgstr "** *Enforcing*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:54
 #, no-wrap
 msgid "** *Permissive*\n"
 msgstr "** *Permissive*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:58
 #, no-wrap
 msgid "** *Disabled*\n"
 msgstr "** *Disabled*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:60
 msgid ""
 "Disables the evaluation of all policies and allows access to all resources."
 msgstr "すべてのポリシーの評価を無効にし、すべてのリソースへのアクセスを許可します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:62
 #, no-wrap
-msgid "*Allow Remote Resource Management*\n"
-msgstr "*Allow Remote Resource Management*\n"
+msgid "*Remote Resource Management*\n"
+msgstr "*Remote Resource Management*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:64
 msgid ""
 "Specifies whether resources can be managed remotely by the resource server. "
 "If false, resources can be managed only from the administration console."
 msgstr "リソースサーバーによってリソースをリモート管理できるかどうかを指定します。falseの場合、リソースは管理コンソールからのみ管理できます。"
-
-#. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:67
-#, no-wrap
-msgid "*Export Settings*\n"
-msgstr "*Export Settings*\n"
-
-#. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:68
-msgid ""
-"You can export the authorization configuration settings to a JSON file. "
-"Click *Export* to display the complete JSON configuration for download. The "
-"configuration file contains everything defined for a resource server: "
-"protected resources, scopes, permissions, and policies."
-msgstr ""
-"認可構成の設定をJSONファイルにエクスポートできます。 *Export* "
-"をクリックするとダウンロード用のJSON設定がすべて表示されます。設定ファイルには、リソースサーバーに対して定義されているすべてのもの（保護されたリソース、スコープ、アクセス許可、およびポリシー）が含まれています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-enable-authorization
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
