### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -170,4 +170,4 @@ msgstr ""
 
 #. type: Plain text
 msgid "This client secret will be used to sign the JWT by the client."
-msgstr "このクライアントシークレットは、クライアントによってJWTに署名するために使用されます。"
+msgstr "このクライアント・シークレットは、クライアントによってJWTに署名するために使用されます。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/server_admin/topics/clients/oidc/confidential.adoc:3
 #, no-wrap
 msgid "Confidential Client Credentials"
 msgstr "コンフィデンシャル・クライアントのクレデンシャル"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:8
 msgid ""
 "If you've set the client's <<_access-type, access type>> to `confidential` "
 "in the client's `Settings` tab, a new `Credentials` tab will show up. As "
@@ -34,18 +32,15 @@ msgstr ""
 "タブが表示されます。このタイプのクライアントを扱う際には、クライアントのクレデンシャルを設定する必要があります。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/oidc/confidential.adoc:9
 #, no-wrap
 msgid "Credentials Tab"
 msgstr "Credentialsタブ"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:11
 msgid "image:{project_images}/client-credentials.png[]"
 msgstr "image:{project_images}/client-credentials.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:15
 msgid ""
 "The `Client Authenticator` list box specifies the type of credential you are"
 " going to use for your confidential client.  It defaults to client ID and "
@@ -57,25 +52,21 @@ msgstr ""
 " `Regenerate Secret` ボタンを使用して、必要に応じてこのシークレットを再生成することができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:17
 msgid ""
 "Alternatively, you can opt to use a signed Json Web Token (JWT) instead of a"
 " secret."
 msgstr "また、シークレットではなく署名付きJson Webトークン（JWT）を使用することもできます。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/oidc/confidential.adoc:18
 #, no-wrap
 msgid "Signed JWT"
 msgstr "署名付きJWT"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:20
 msgid "image:{project_images}/client-credentials-jwt.png[]"
 msgstr "image:{project_images}/client-credentials-jwt.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:24
 msgid ""
 "When choosing this credential type you will have to also generate a private "
 "key and certificate for the client.  The private key will be used to sign "
@@ -87,18 +78,15 @@ msgstr ""
 " `Generate new keys and certificate` ボタンをクリックしてください。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/oidc/confidential.adoc:25
 #, no-wrap
 msgid "Generate Keys"
 msgstr "鍵を生成する"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:27
 msgid "image:{project_images}/generate-client-keys.png[]"
 msgstr "image:{project_images}/generate-client-keys.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:31
 msgid ""
 "When you generate these keys, {project_name} will store the certificate, and"
 " you'll need to download the private key and certificate for your client to "
@@ -108,25 +96,21 @@ msgstr ""
 "これらの鍵を生成すると、{project_name}が証明書を保管するので、使用するクライアントの秘密鍵と証明書をダウンロードする必要があります。必要なアーカイブ形式を選択し、秘密鍵とストアのパスワードを指定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:34
 msgid ""
 "You can also opt to generate these via an external tool and just import the "
 "client's certificate."
 msgstr "また、外部ツールを使用してこれらを生成し、クライアントの証明書をインポートすることもできます。"
 
 #. type: Block title
-#: source/server_admin/topics/clients/oidc/confidential.adoc:35
 #, no-wrap
 msgid "Import Certificate"
 msgstr "証明書のインポート"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:37
 msgid "image:{project_images}/import-client-cert.png[]"
 msgstr "image:{project_images}/import-client-cert.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:40
 msgid ""
 "There are multiple formats you can import from, just choose the archive "
 "format you have the certificate stored in, select the file, and click the "
@@ -136,7 +120,6 @@ msgstr ""
 "ボタンをクリックします。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:44
 msgid ""
 "Finally note that you don't even need to import certificate if you choose to"
 " `Use JWKS URL` . In that case, you can provide the URL where client "
@@ -151,7 +134,6 @@ msgstr ""
 "形式で指定することができます。クライアントが鍵を変更すると、{project_name}が自動的にダウンロードするため、{project_name}側で再インポートする必要がなく、柔軟性があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:47
 msgid ""
 "If you use client secured by {project_name} adapter, you can configure the "
 "JWKS URL like https://myhost.com/myapp/k_jwks assuming that "
@@ -163,7 +145,6 @@ msgstr ""
 "URLを設定できます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/clients/oidc/confidential.adoc:51
 msgid ""
 "For the performance purposes, {project_name} caches the public keys of the "
 "OIDC clients. If you think that private key of your client was compromised, "
@@ -173,3 +154,20 @@ msgid ""
 msgstr ""
 "パフォーマンスのために、{project_name}はOIDCクライアントの公開鍵をキャッシュします。クライアントの秘密鍵が侵害されたと思われる場合は、鍵を更新するのは明らかに良いことですが、鍵キャッシュをクリアするのも良いことです。詳細については"
 "、<<_clear-cache, キャッシュのクリア>>の節を参照してください。"
+
+#. type: Block title
+#, no-wrap
+msgid "Signed JWT with Client Secret"
+msgstr "クライアントシークレットで署名されたJWT"
+
+#. type: Plain text
+msgid ""
+"If you select this option in the `Client Authenticator` list box, you can "
+"use a JWT signed by client secret instead of the private key."
+msgstr ""
+"`Client Authenticator` "
+"リストボックスでこのオプションを選択すると、秘密鍵の代わりにクライアント・シークレットで署名されたJWTを使うことができます。"
+
+#. type: Plain text
+msgid "This client secret will be used to sign the JWT by the client."
+msgstr "このクライアントシークレットは、クライアントによってJWTに署名するために使用されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__confidential
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
