### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,7 +18,7 @@ msgstr ""
 #. type: Title =
 #, no-wrap
 msgid "Client Authentication Methods"
-msgstr "クライアントの認証方法"
+msgstr "クライアントの認証方式"
 
 #. type: Plain text
 msgid ""
@@ -27,7 +27,7 @@ msgid ""
 "type, clients can use any of these authentication methods:"
 msgstr ""
 "クライアントは、RPTを取得するためにトークン・エンドポイントで認証する必要があります。 `urn:ietf:params:oauth:grant-"
-"type:uma-ticket` グラントタイプを使う際に、クライアントは以下の認証方法のどれかを使用できます："
+"type:uma-ticket` グラントタイプを使う際に、クライアントは以下の認証方式のどれかを使用できます。"
 
 #. type: Plain text
 #, no-wrap
@@ -47,7 +47,7 @@ msgstr ""
 msgid ""
 "Example: an authorization request using an access token to authenticate to "
 "the token endpoint"
-msgstr "例: アクセストークンを使用してトークン・エンドポイントで認証する認可リクエスト"
+msgstr "例：アクセストークンを使用してトークン・エンドポイントで認証する認可リクエスト"
 
 #. type: Code block
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
@@ -1,0 +1,101 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Client Authentication Methods"
+msgstr "クライアントの認証方法"
+
+#. type: Plain text
+msgid ""
+"Clients need to authenticate to the token endpoint in order to obtain an "
+"RPT. When using the `urn:ietf:params:oauth:grant-type:uma-ticket` grant "
+"type, clients can use any of these authentication methods:"
+msgstr ""
+"クライアントは、RPTを取得するためにトークン・エンドポイントで認証する必要があります。 `urn:ietf:params:oauth:grant-"
+"type:uma-ticket` グラントタイプを使う際に、クライアントは以下の認証方法のどれかを使用できます："
+
+#. type: Plain text
+#, no-wrap
+msgid "*Bearer Token*\n"
+msgstr "*ベアラートークン*\n"
+
+#. type: Plain text
+msgid ""
+"Clients should send an access token as a Bearer credential in an HTTP "
+"Authorization header to the token endpoint."
+msgstr ""
+"クライアントは、トークン・エンドポイントにHTTP "
+"Authorizationヘッダーのベアラー・クレデンシャルとしてアクセストークンを送信する必要があります。"
+
+#. type: Block title
+#, no-wrap
+msgid ""
+"Example: an authorization request using an access token to authenticate to "
+"the token endpoint"
+msgstr "例: アクセストークンを使用してトークン・エンドポイントで認証する認可リクエスト"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  -H \"Authorization: Bearer ${access_token}\" \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\"\n"
+msgstr ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  -H \"Authorization: Bearer ${access_token}\" \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\"\n"
+
+#. type: Plain text
+msgid ""
+"This method is especially useful when the client is acting on behalf of a "
+"user.  In this case, the bearer token is an access token previously issued "
+"by {project_name} to some client acting on behalf of a user (or on behalf of"
+" itself). Permissions will be evaluated considering the access context "
+"represented by the access token.  For instance, if the access token was "
+"issued to Client A acting on behalf of User A, permissions will be granted "
+"depending on the resources and scopes to which User A has access."
+msgstr ""
+"この方法は、クライアントがユーザーに代わって動作している場合に特に便利です。この場合、ベアラトークンは以前に{project_name}により、ユーザーの代わりに（またはそれ自体のために）動作しているクライアントに発行されたアクセストークンです。パーミッションは、アクセストークンによって表されるアクセス・コンテキストを考慮して評価されます。例えば、アクセストークンがユーザーAの代わりに動作するクライアントAに発行された場合、ユーザーAがアクセスするリソース及びスコープに応じてパーミッションが与えられます。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Client Credentials*\n"
+msgstr "*クライアント・クレデンシャル*\n"
+
+#. type: Plain text
+msgid ""
+"Client can use any of the client authentication methods supported by "
+"{project_name}. For instance, client_id/client_secret or JWT."
+msgstr ""
+"クライアントは、{project_name}でサポートされているクライアント認証方式を使用できます。たとえば、client_id / "
+"client_secretまたはJWTです。"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  -H \"Authorization: Basic cGhvdGg6L7Jl13RmfWgtkk==pOnNlY3JldA==\" \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\"\n"
+msgstr ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  -H \"Authorization: Basic cGhvdGg6L7Jl13RmfWgtkk==pOnNlY3JldA==\" \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\"\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission-authentication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
