### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-72.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-72.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-72.ja_JP.po
@@ -1,0 +1,200 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "**Templates**\n"
+msgstr "**テンプレート**\n"
+
+#. type: Plain text
+msgid "Account: account.ftl"
+msgstr "アカウント：account.ftl"
+
+#. type: Plain text
+msgid "Account: federatedIdentity.ftl"
+msgstr "アカウント：federatedIdentity.ftl"
+
+#. type: Plain text
+msgid "Account: totp.ftl"
+msgstr "アカウント：totp.ftl"
+
+#. type: Plain text
+msgid "Login: info.ftl"
+msgstr "ログイン：info.ftl"
+
+#. type: Plain text
+msgid "Login: login-config-totp.ftl"
+msgstr "ログイン：login-config-totp.ftl"
+
+#. type: Plain text
+msgid "Login: login-reset-password.ftl"
+msgstr "ログイン：login-reset-password.ftl"
+
+#. type: Plain text
+#, no-wrap
+msgid "**Messages**\n"
+msgstr "**メッセージ**\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "**Styles**\n"
+msgstr "**スタイル**\n"
+
+#. type: Plain text
+msgid "Account: account.css"
+msgstr "アカウント：account.css"
+
+#. type: Plain text
+msgid "Login: login.css"
+msgstr "ログイン：login.css"
+
+#. type: Title =====
+#, no-wrap
+msgid "Theme changes RH-SSO 7.2"
+msgstr "RH-SSO 7.2でのテーマの変更"
+
+#. type: Plain text
+msgid "Account: applications.ftl"
+msgstr "Account: applications.ftl"
+
+#. type: Plain text
+msgid "Account: password.ftl"
+msgstr "Account: password.ftl"
+
+#. type: Plain text
+msgid "Account: sessions.ftl"
+msgstr "Account: sessions.ftl"
+
+#. type: Plain text
+msgid "Account: template.ftl"
+msgstr "Account: template.ftl"
+
+#. type: Plain text
+msgid "Admin: index.ftl"
+msgstr "Admin: index.ftl"
+
+#. type: Plain text
+msgid "Email: email-test.ftl (new)"
+msgstr "Email: email-test.ftl (新規)"
+
+#. type: Plain text
+msgid "Email: email-verification.ftl"
+msgstr "Email: email-verification.ftl"
+
+#. type: Plain text
+msgid "Email: event-login_error.ftl"
+msgstr "Email: event-login_error.ftl"
+
+#. type: Plain text
+msgid "Email: event-removed_totp.ftl"
+msgstr "Email: event-removed_totp.ftl"
+
+#. type: Plain text
+msgid "Email: event-update_password.ftl"
+msgstr "Email: event-update_password.ftl"
+
+#. type: Plain text
+msgid "Email: event-update_totp.ftl"
+msgstr "Email: event-update_totp.ftl"
+
+#. type: Plain text
+msgid "Email: executeActions.ftl"
+msgstr "Email: executeActions.ftl"
+
+#. type: Plain text
+msgid "Email: identity-provider-link.ftl"
+msgstr "Email: identity-provider-link.ftl"
+
+#. type: Plain text
+msgid "Email: password-reset.ftl"
+msgstr "Email: password-reset.ftl"
+
+#. type: Plain text
+msgid "Login: bypass_kerberos.ftl (removed)"
+msgstr "Login: bypass_kerberos.ftl (removed)"
+
+#. type: Plain text
+msgid "Login: error.ftl"
+msgstr "Login: error.ftl"
+
+#. type: Plain text
+msgid "Login: login-idp-link-email.ftl"
+msgstr "Login: login-idp-link-email.ftl"
+
+#. type: Plain text
+msgid "Login: login-oauth-grant.ftl"
+msgstr "Login: login-oauth-grant.ftl"
+
+#. type: Plain text
+msgid "Login: login-page-expired.ftl (new)"
+msgstr "Login: login-page-expired.ftl (new)"
+
+#. type: Plain text
+msgid "Login: login-totp.ftl"
+msgstr "Login: login-totp.ftl"
+
+#. type: Plain text
+msgid "Login: login-update-password.ftl"
+msgstr "Login: login-update-password.ftl"
+
+#. type: Plain text
+msgid "Login: login-update-profile.ftl"
+msgstr "Login: login-update-profile.ftl"
+
+#. type: Plain text
+msgid "Login: login-verify-email.ftl"
+msgstr "Login: login-verify-email.ftl"
+
+#. type: Plain text
+msgid "Login: login-x509-info.ftl (new)"
+msgstr "Login: login-x509-info.ftl (新規)"
+
+#. type: Plain text
+msgid "Login: login.ftl (new)"
+msgstr "Login: login.ftl (新規)"
+
+#. type: Plain text
+msgid "Login: register.ftl (new)"
+msgstr "Login: register.ftl (新規)"
+
+#. type: Plain text
+msgid "Login: template.ftl (new)"
+msgstr "Login: template.ftl (新規)"
+
+#. type: Plain text
+msgid "Login: terms.ftl (new)"
+msgstr "Login: terms.ftl (新規)"
+
+#. type: Plain text
+msgid "Account: messages_en.properties"
+msgstr "Account: messages_en.properties"
+
+#. type: Plain text
+msgid "Admin: admin-messages_en.properties"
+msgstr "Admin: admin-messages_en.properties"
+
+#. type: Plain text
+msgid "Admin: messages_en.properties"
+msgstr "Admin: messages_en.properties"
+
+#. type: Plain text
+msgid "Email: messages_en.properties"
+msgstr "Email: messages_en.properties"
+
+#. type: Plain text
+msgid "Login: messages_en.properties"
+msgstr "Login: messages_en.properties"

--- a/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-72.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-72.ja_JP.po
@@ -22,27 +22,27 @@ msgstr "**テンプレート**\n"
 
 #. type: Plain text
 msgid "Account: account.ftl"
-msgstr "アカウント：account.ftl"
+msgstr "Account: account.ftl"
 
 #. type: Plain text
 msgid "Account: federatedIdentity.ftl"
-msgstr "アカウント：federatedIdentity.ftl"
+msgstr "Account: federatedIdentity.ftl"
 
 #. type: Plain text
 msgid "Account: totp.ftl"
-msgstr "アカウント：totp.ftl"
+msgstr "Account: totp.ftl"
 
 #. type: Plain text
 msgid "Login: info.ftl"
-msgstr "ログイン：info.ftl"
+msgstr "Login: info.ftl"
 
 #. type: Plain text
 msgid "Login: login-config-totp.ftl"
-msgstr "ログイン：login-config-totp.ftl"
+msgstr "Login: login-config-totp.ftl"
 
 #. type: Plain text
 msgid "Login: login-reset-password.ftl"
-msgstr "ログイン：login-reset-password.ftl"
+msgstr "Login: login-reset-password.ftl"
 
 #. type: Plain text
 #, no-wrap
@@ -56,11 +56,11 @@ msgstr "**スタイル**\n"
 
 #. type: Plain text
 msgid "Account: account.css"
-msgstr "アカウント：account.css"
+msgstr "Account: account.css"
 
 #. type: Plain text
 msgid "Login: login.css"
-msgstr "ログイン：login.css"
+msgstr "Login: login.css"
 
 #. type: Title =====
 #, no-wrap
@@ -89,7 +89,7 @@ msgstr "Admin: index.ftl"
 
 #. type: Plain text
 msgid "Email: email-test.ftl (new)"
-msgstr "Email: email-test.ftl (新規)"
+msgstr "Email: email-test.ftl （新規）"
 
 #. type: Plain text
 msgid "Email: email-verification.ftl"
@@ -125,7 +125,7 @@ msgstr "Email: password-reset.ftl"
 
 #. type: Plain text
 msgid "Login: bypass_kerberos.ftl (removed)"
-msgstr "Login: bypass_kerberos.ftl (removed)"
+msgstr "Login: bypass_kerberos.ftl （削除）"
 
 #. type: Plain text
 msgid "Login: error.ftl"
@@ -141,7 +141,7 @@ msgstr "Login: login-oauth-grant.ftl"
 
 #. type: Plain text
 msgid "Login: login-page-expired.ftl (new)"
-msgstr "Login: login-page-expired.ftl (new)"
+msgstr "Login: login-page-expired.ftl （新規）"
 
 #. type: Plain text
 msgid "Login: login-totp.ftl"
@@ -161,23 +161,23 @@ msgstr "Login: login-verify-email.ftl"
 
 #. type: Plain text
 msgid "Login: login-x509-info.ftl (new)"
-msgstr "Login: login-x509-info.ftl (新規)"
+msgstr "Login: login-x509-info.ftl （新規）"
 
 #. type: Plain text
 msgid "Login: login.ftl (new)"
-msgstr "Login: login.ftl (新規)"
+msgstr "Login: login.ftl （新規）"
 
 #. type: Plain text
 msgid "Login: register.ftl (new)"
-msgstr "Login: register.ftl (新規)"
+msgstr "Login: register.ftl （新規）"
 
 #. type: Plain text
 msgid "Login: template.ftl (new)"
-msgstr "Login: template.ftl (新規)"
+msgstr "Login: template.ftl （新規）"
 
 #. type: Plain text
 msgid "Login: terms.ftl (new)"
-msgstr "Login: terms.ftl (新規)"
+msgstr "Login: terms.ftl （新規）"
 
 #. type: Plain text
 msgid "Account: messages_en.properties"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-72.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__rhsso__migrate_themes-changes-72
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
