### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -178,7 +178,7 @@ msgid ""
 "on <<_proxymappings, Proxy Mappings for Outgoing HTTP Requests>> for more "
 "details."
 msgstr ""
-"送信するHTTPリクエストのDennotesプロキシー設定。 詳細については、<<_proxymappings, "
+"送信するHTTPリクエストのプロキシー設定を示します。詳細については、<<_proxymappings, "
 "送信HTTPリクエストのプロキシー・マッピング>>のセクションを参照してください。"
 
 #. type: Title ====
@@ -194,7 +194,7 @@ msgid ""
 " the form of `hostnamePattern;proxyUri`, e.g.:"
 msgstr ""
 "{project_name}によって送信された送信HTTPリクエストは、プロキシー・マッピングのカンマで区切られたリストに基づいて、オプションでプロキシー・サーバーを使用できます。プロキシー・マッピングは、正規表現ベースのホスト名パターンと"
-" `hostnamePattern;proxyUri` 形式のproxy-uriの組み合わせを示します。例:"
+" `hostnamePattern;proxyUri` 形式のproxy-uriの組み合わせを示します。例："
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -16,19 +16,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/server_installation/topics/database/hibernate.adoc:26
-#: source/server_installation/topics/network/outgoing.adoc:21
 msgid "Possible configuration options are:"
 msgstr "設定可能なオプションは、以下のとおりです。"
 
 #. type: Title ===
-#: source/server_installation/topics/network/outgoing.adoc:2
 #, no-wrap
 msgid "Outgoing HTTP Requests"
 msgstr "外部へのHTTPリクエスト"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:8
 msgid ""
 "The {project_name} server often needs to make non-browser HTTP requests to "
 "the applications and services it secures.  The auth server manages these "
@@ -42,13 +38,11 @@ msgstr ""
 "内で少し設定する必要があります。このファイルの場所は、<<_operating-mode, 動作モード>>によって異なります。"
 
 #. type: Block title
-#: source/server_installation/topics/network/outgoing.adoc:9
 #, no-wrap
 msgid "HTTP client Config example"
 msgstr "HTTPクライアント設定のサンプル"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/outgoing.adoc:19
 #, no-wrap
 msgid ""
 "<spi name=\"connectionsHttpClient\">\n"
@@ -68,71 +62,58 @@ msgstr ""
 "</spi>\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:22
 #, no-wrap
 msgid "establish-connection-timeout-millis"
 msgstr "establish-connection-timeout-millis"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:24
 msgid "Timeout for establishing a socket connection."
 msgstr "ソケット接続を確立する際のタイムアウトです。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:25
 #, no-wrap
 msgid "socket-timeout-millis"
 msgstr "socket-timeout-millis"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:27
 msgid ""
 "If an outgoing request does not receive data for this amount of time, "
 "timeout the connection."
 msgstr "外部へのリクエストがこの時間の間にデータを受信しない場合、接続をタイムアウトします。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:28
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:142
 #, no-wrap
 msgid "connection-pool-size"
 msgstr "connection-pool-size"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:30
 msgid "How many connections can be in the pool (128 by default)."
 msgstr "プールされる接続数です（デフォルトでは128）。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:31
 #, no-wrap
 msgid "max-pooled-per-route"
 msgstr "max-pooled-per-route"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:33
 msgid "How many connections can be pooled per host (64 by default)."
 msgstr "ホストごとにプールされる接続数です（デフォルトでは64）。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:34
 #, no-wrap
 msgid "connection-ttl-millis"
 msgstr "connection-ttl-millis"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:37
 msgid "Maximum connection time to live in milliseconds.  Not set by default."
 msgstr "ミリ秒単位での最大接続時間です。デフォルトでは設定されていません。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:38
 #, no-wrap
 msgid "max-connection-idle-time-millis"
 msgstr "max-connection-idle-time-millis"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:41
 msgid ""
 "Maximum time the connection might stay idle in the connection pool (900 "
 "seconds by default). Will start background cleaner thread of Apache HTTP "
@@ -143,41 +124,32 @@ msgstr ""
 "にセットすると、このチェックとバックグラウンドスレッドは無効になります。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:42
 #, no-wrap
 msgid "disable-cookies"
 msgstr "disable-cookies"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:45
 msgid ""
 "`true` by default.  When set to true, this will disable any cookie caching."
 msgstr "デフォルトでは `true` です。trueを設定した場合、Cookieキャッシュは無効になります。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:46
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:178
 #, no-wrap
 msgid "client-keystore"
 msgstr "client-keystore"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:49
 msgid ""
 "This is the file path to a Java keystore file.  This keystore contains "
 "client certificate for two-way SSL."
 msgstr "これはJavaキーストア・ファイルへのファイルパスです。このキーストアには、双方向SSL用のクライアント証明書を含めます。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:50
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:183
 #, no-wrap
 msgid "client-keystore-password"
 msgstr "client-keystore-password"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:53
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:186
 msgid ""
 "Password for the client keystore.  This is _REQUIRED_ if `client-keystore` "
 "is set."
@@ -185,28 +157,169 @@ msgstr ""
 "クライアント・キーストア用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:54
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:187
 #, no-wrap
 msgid "client-key-password"
 msgstr "client-key-password"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:57
-#: source/securing_apps/topics/oidc/java/java-adapter-config.adoc:190
 msgid ""
 "Password for the client's key.  This is _REQUIRED_ if `client-keystore` is "
 "set."
 msgstr "クライアントキー用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
+#. type: Labeled list
+#, no-wrap
+msgid "proxy-mappings"
+msgstr "proxy-mappings"
+
+#. type: Plain text
+msgid ""
+"Dennotes proxy configurations for outgoing HTTP requests.  See the section "
+"on <<_proxymappings, Proxy Mappings for Outgoing HTTP Requests>> for more "
+"details."
+msgstr ""
+"送信するHTTPリクエストのDennotesプロキシー設定。 詳細については、<<_proxymappings, "
+"送信HTTPリクエストのプロキシー・マッピング>>のセクションを参照してください。"
+
 #. type: Title ====
-#: source/server_installation/topics/network/outgoing.adoc:59
+#, no-wrap
+msgid "Proxy Mappings for Outgoing HTTP Requests"
+msgstr "送信HTTPリクエストのプロキシー・マッピング"
+
+#. type: Plain text
+msgid ""
+"Outgoing HTTP requests sent by {project_name} can optionally use a proxy "
+"server based on a comma delimited list of proxy-mappings.  A proxy-mapping "
+"denotes the combination of a regex based hostname pattern and a proxy-uri in"
+" the form of `hostnamePattern;proxyUri`, e.g.:"
+msgstr ""
+"{project_name}によって送信された送信HTTPリクエストは、プロキシー・マッピングのカンマで区切られたリストに基づいて、オプションでプロキシー・サーバーを使用できます。プロキシー・マッピングは、正規表現ベースのホスト名パターンと"
+" `hostnamePattern;proxyUri` 形式のproxy-uriの組み合わせを示します。例:"
+
+#. type: delimited block -
+#, no-wrap
+msgid ".*\\.(google|googleapis)\\.com;http://www-proxy.acme.com:8080\n"
+msgstr ".*\\.(google|googleapis)\\.com;http://www-proxy.acme.com:8080\n"
+
+#. type: Plain text
+msgid ""
+"To determine the proxy for an outgoing HTTP request the target hostname is "
+"matched against the configured hostname patterns. The first matching pattern"
+" determines the proxy-uri to use.  If none of the configured patterns match "
+"for the given hostname then no proxy is used."
+msgstr ""
+"送信するHTTPリクエストのプロキシーを判別するために、ターゲットホスト名が、設定されたホスト名パターンと照合されます。最初に一致するパターンで"
+"、使用するproxy-uriが決定します。指定されたホスト名と一致する設定済みのパターンが無い場合、プロキシーは使用されません。"
+
+#. type: Plain text
+msgid ""
+"The special value `NO_PROXY` for the proxy-uri can be used to indicate that "
+"no proxy should be used for hosts matching the associated hostname pattern."
+"  It is possible to specify a catch-all pattern at the end of the proxy-"
+"mappings to define a default proxy for all outgoing requests."
+msgstr ""
+"proxy-uriに対する特別な値 `NO_PROXY` "
+"は、関連するホスト名パターンと一致するホストに対して、プロキシーを使用しないことを示すために使用できます。プロキシー・マッピングの終わりにcatch-"
+"allパターンを指定して、送信するすべてのリクエストのデフォルト・プロキシーを定義することが可能です。"
+
+#. type: Plain text
+msgid "The following example demonstrates the proxy-mapping configuration."
+msgstr "次の例は、プロキシー・マッピングの設定を示しています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# All requests to Google APIs should use http://www-proxy.acme.com:8080 as proxy\n"
+".*\\.(google|googleapis)\\.com;http://www-proxy.acme.com:8080\n"
+msgstr ""
+"# All requests to Google APIs should use http://www-proxy.acme.com:8080 as proxy\n"
+".*\\.(google|googleapis)\\.com;http://www-proxy.acme.com:8080\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# All requests to internal systems should use no proxy\n"
+".*\\.acme\\.com;NO_PROXY\n"
+msgstr ""
+"# All requests to internal systems should use no proxy\n"
+".*\\.acme\\.com;NO_PROXY\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# All other requests should use http://fallback:8080 as proxy\n"
+".*;http://fallback:8080\n"
+msgstr ""
+"# All other requests should use http://fallback:8080 as proxy\n"
+".*;http://fallback:8080\n"
+
+#. type: Plain text
+msgid ""
+"This can be configured via the following `jboss-cli` command.  Note that you"
+" need to properly escape the regex-pattern as shown below."
+msgstr ""
+"これは、以下の `jboss-cli` コマンドで設定できます。以下に示す正規表現パターンを適切にエスケープする必要があることに注意してください。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "echo SETUP: Configure proxy routes for HttpClient SPI\n"
+msgstr "echo SETUP: Configure proxy routes for HttpClient SPI\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# In case there is no connectionsHttpClient definition yet\n"
+"/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:add(enabled=true)\n"
+msgstr ""
+"# In case there is no connectionsHttpClient definition yet\n"
+"/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:add(enabled=true)\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# Configure the proxy-mappings\n"
+"/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:write-attribute(name=properties.proxy-mappings,value=[\".*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080\",\".*\\\\.acme\\\\.com;NO_PROXY\",\".*;http://fallback:8080\"])\n"
+msgstr ""
+"# Configure the proxy-mappings\n"
+"/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:write-attribute(name=properties.proxy-mappings,value=[\".*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080\",\".*\\\\.acme\\\\.com;NO_PROXY\",\".*;http://fallback:8080\"])\n"
+
+#. type: Plain text
+msgid ""
+"The `jboss-cli` command results in the following subsystem configuration.  "
+"Note that one needs to encode `\"` characters with `&quot;`."
+msgstr ""
+"`jboss-cli` コマンドの結果、以下のサブシステム設定になります。 `&quot;` で `\"` "
+"文字をエンコードする必要があることに注意してください。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<spi name=\"connectionsHttpClient\">\n"
+"    <provider name=\"default\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property \n"
+"            name=\"proxy-mappings\" \n"
+"            value=\"[&quot;.*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080&quot;,&quot;.*\\\\.acme\\\\.com;NO_PROXY&quot;,&quot;.*;http://fallback:8080&quot;]\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+msgstr ""
+"<spi name=\"connectionsHttpClient\">\n"
+"    <provider name=\"default\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property \n"
+"            name=\"proxy-mappings\" \n"
+"            value=\"[&quot;.*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080&quot;,&quot;.*\\\\.acme\\\\.com;NO_PROXY&quot;,&quot;.*;http://fallback:8080&quot;]\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+
+#. type: Title ====
 #, no-wrap
 msgid "Outgoing HTTPS Request Truststore"
 msgstr "外部へのHTTPSリクエストのトラストストア"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:64
 msgid ""
 "When {project_name} invokes on remote HTTPS endpoints, it has to validate "
 "the remote server's certificate in order to ensure it is connecting to a "
@@ -218,7 +331,6 @@ msgstr ""
 "{project_name}がリモートのHTTPSエンドポイントを呼び出す場合、信頼できるサーバーへの接続かどうかを確認するために、リモートサーバーの証明書を検証する必要があります。これは、中間者攻撃を防ぐために必要です。リモートサーバーや署名した認証局の証明書は、トラストストアに保存されている必要があります。このトラストストアは、{project_name}サーバーによって管理されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:66
 msgid ""
 "The truststore is used when connecting securely to identity brokers, LDAP "
 "identity providers, when sending emails, and for backchannel communication "
@@ -227,20 +339,18 @@ msgstr ""
 "トラストストアは、アイデンティティー・ブローカーやLDAPアイデンティティー・プロバイダーに安全に接続する場合、電子メールを送信する場合、およびクライアント・アプリケーションとのバックチャネル通信をする場合に使用されます。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:70
 #, no-wrap
 msgid ""
 "By default, a truststore provider is not configured, and any https connections fall back to standard java truststore configuration as described in\n"
 "          https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[Java's JSSE Reference Guide].  If there is no trust\n"
-"          establised, then these outgoing HTTPS requests will fail.\n"
+"          established, then these outgoing HTTPS requests will fail.\n"
 msgstr ""
-"デフォルトでは、トラストストア・プロバイダーは設定されておらず、 https接続は、 "
-"https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[Java's"
-" JSSE Reference Guide] "
-"の説明のとおり、標準javaトラストストア設定に戻ります。認証されていない場合は、これらのHTTPSリクエスト発信はエラーになります。\n"
+"デフォルトでは、トラストストア・プロバイダーは設定されておらず、https接続は "
+"https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html[Javaの"
+" JSSE Reference "
+"Guide]で説明されている標準のJavaトラストストア設定にフォールバックします。信頼が確立されていない場合、これらの送信するHTTPSリクエストはエラーになります。\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:72
 msgid ""
 "You can use _keytool_ to create a new truststore file or add trusted host "
 "certificates to an existing one:"
@@ -249,7 +359,6 @@ msgstr ""
 "を使用し、新しいトラストストア・ファイルを作成、または信頼できるホスト証明書を既存のトラストストア・ファイルに追加することができます。"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/outgoing.adoc:77
 #, no-wrap
 msgid ""
 "$ keytool -import -alias HOSTDOMAIN -keystore truststore.jks -file host-"
@@ -259,7 +368,6 @@ msgstr ""
 "certificate.cer\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:83
 msgid ""
 "The truststore is configured within the `standalone.xml`, `standalone-"
 "ha.xml`, or `domain.xml` file in your distribution.  The location of this "
@@ -271,7 +379,6 @@ msgstr ""
 "動作モード>>によって異なります。以下のテンプレートを使用して、トラストストア設定を追加することができます。"
 
 #. type: delimited block -
-#: source/server_installation/topics/network/outgoing.adoc:96
 #, no-wrap
 msgid ""
 "<spi name=\"truststore\">\n"
@@ -297,19 +404,15 @@ msgstr ""
 "</spi>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:100
 msgid "Possible configuration options for this setting are:"
 msgstr "設定可能なオプションは以下のとおりです。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:101
-#: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:23
 #, no-wrap
 msgid "file"
 msgstr "file"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:108
 msgid ""
 "The path to a Java keystore file.  HTTPS requests need a way to verify the "
 "host of the server they are talking to.  This is what the trustore does.  "
@@ -321,33 +424,27 @@ msgstr ""
 " `disabled` がtrueでない場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:109
-#: source/securing_apps/topics/saml/java/general-config/sp-keys/keystore_element.adoc:30
 #, no-wrap
 msgid "password"
 msgstr "password"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:112
 msgid ""
 "Password for the truststore.  This is _REQUIRED_ if `disabled` is not true."
 msgstr "トラストストア用のパスワードです。 `disabled` がtrueでない場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:113
 #, no-wrap
 msgid "hostname-verification-policy"
 msgstr "hostname-verification-policy"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:116
 msgid ""
 "`WILDCARD` by default.  For HTTPS requests, this verifies the hostname of "
 "the server's certificate."
 msgstr "デフォルトでは `WILDCARD` です。HTTPSリクエストを行うために、サーバー証明書のホスト名を検証します。"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:117
 #, no-wrap
 msgid ""
 "`ANY` means that the hostname is not verified. `WILDCARD` Allows wildcards "
@@ -357,19 +454,16 @@ msgstr ""
 "によって、サブドメイン名にワイルドカードが使用できるようになります。サンプルとしては、\n"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:118
 #, no-wrap
 msgid "*.foo.com. `STRICT` CN must match hostname exactly.\n"
 msgstr "*.foo.comです。 `STRICT` の場合、CNはホスト名と正確に一致する必要があります。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/network/outgoing.adoc:119
 #, no-wrap
 msgid "disabled"
 msgstr "disabled"
 
 #. type: Plain text
-#: source/server_installation/topics/network/outgoing.adoc:122
 msgid ""
 "If true (default value), truststore configuration will be ignored, and "
 "certificate checking will fall back to JSSE configuration as described.  If "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__outgoing
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
