### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,26 +16,38 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/server_installation/topics/profiles.adoc:19
-#: source/server_installation/topics/profiles.adoc:66
-#: source/authorization_services/topics/auth-services-architecture.adoc:84
-#: source/authorization_services/topics/service-overview.adoc:2
 #, no-wrap
 msgid "Authorization Services"
 msgstr "認可サービス"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-overview.adoc:5
 msgid ""
-"{project_name} Authorization Services are based on OAuth2's User-Managed "
-"Access (UMA) Profile."
-msgstr "{project_name}認可サービスは、OAuth2のUser-Managed Access（UMA）プロファイルに基づいています。"
+"OAuth2 clients (such as front end applications) can obtain access tokens "
+"from the server using the token endpoint and use these same tokens to access"
+" resources protected by a resource server (such as back end services). In "
+"the same way, {project_name} Authorization Services provide extensions to "
+"OAuth2 to allow access tokens to be issued based on the processing of all "
+"policies associated with the resource(s) or scope(s) being requested. This "
+"means that resource servers can enforce access to their protected resources "
+"based on the permissions granted by the server and held by an access token. "
+"In {project_name} Authorization Services the access token with permissions "
+"is called a Requesting Party Token or RPT for short."
+msgstr ""
+"OAuth2クライアント（フロントエンド・アプリケーションなど）は、トークン・エンドポイントを使用してサーバーからアクセストークンを取得し、これらのトークンを使用してリソースサーバーによって保護されたリソース（バックエンド・サービスなど）にアクセスできます。同様に、{project_name}認可サービスは、要求されているリソースまたはスコープに関連するすべてのポリシーの処理に基づいてアクセストークンを発行できるように、OAuth2の拡張機能を提供します。つまり、リソースサーバーは、サーバーによって付与され、アクセストークンによって保持されているアクセス許可に基づいて、保護されたリソースへのアクセスを強制できます。{project_name}認可サービスでは、アクセス権を持つアクセストークンはリクエスティング・パーティー・トークンまたはRPTと呼ばれます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-overview.adoc:7
 msgid ""
-"This section describes the different RESTful endpoints that you can interact"
-" with to enable fine-grained authorization for your applications and "
-"services."
+"{project_name} Authorization Services are built on top of well-known "
+"standards such as the OAuth2 and User-Managed Access specifications."
 msgstr ""
-"このセクションでは、アプリケーションとサービスのきめ細かな認可を可能にするために対話できる、さまざまなRESTfulエンドポイントについて説明します。"
+"{project_name}認可サービスは、OAuth2やUser-Managed Accessなどのよく知られている標準をベースに構築されています。"
+
+#. type: Plain text
+msgid ""
+"In addition to the issuance of RPTs, {project_name} Authorization Services "
+"also provides a set of RESTful endpoints that allow resources servers to "
+"manage their protected resources, scopes, permissions and policies, helping "
+"developers to extend or integrate these capabilities into their applications"
+" in order to support fine-grained authorization."
+msgstr ""
+"RPTの発行に加えて、{project_name}認可サービスには、細かい認可をサポートするための、保護されたリソース、スコープ、アクセス許可、ポリシーをリソースサーバーが管理できるようにする一連のRESTfulエンドポイントが用意されています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
