### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
@@ -16,45 +16,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-overview.adoc:9
-#: source/authorization_services/topics/resource-server-import-config.adoc:9
 #, no-wrap
 msgid "Permissions"
 msgstr "パーミッション"
 
 #. type: Plain text
-#: source/authorization_services/topics/policy-overview.adoc:8
-#: source/authorization_services/topics/resource-server-import-config.adoc:8
 #, no-wrap
 msgid "Policies"
 msgstr "ポリシー"
 
-#. type: Block title
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:11
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:41
-#: source/authorization_services/topics/resource-server-import-config.adoc:16
-#, no-wrap
-msgid "Resource Server Settings"
-msgstr "リソースサーバーの設定"
-
-#. type: Plain text
-#: source/authorization_services/topics/resource-server-enable-authorization.adoc:13
-#: source/authorization_services/topics/resource-server-import-config.adoc:18
-msgid ""
-"image:{project_images}/resource-server/authz-settings.png[alt=\"Resource "
-"Server Settings\"]"
-msgstr ""
-"image:{project_images}/resource-server/authz-"
-"settings.png[alt=\"リソースサーバーの設定\"]"
-
 #. type: Title =
-#: source/authorization_services/topics/resource-server-import-config.adoc:2
 #, no-wrap
 msgid "Export and Import Authorization Configuration"
 msgstr "認可設定のエクスポートおよびインポート"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:5
 msgid ""
 "The configuration settings for a resource server (or client) can be exported"
 " and downloaded. You can also import an existing configuration file for a "
@@ -66,39 +42,36 @@ msgstr ""
 "リソースサーバー（またはクライアント）の構成設定をエクスポートおよびダウンロードできます。また、リソースサーバーの既存の設定ファイルをインポートすることもできます。設定ファイルのインポートとエクスポートは、リソースサーバーの初期設定を作成したり、既存の設定を更新する場合に役立ちます。設定ファイルには次の定義が含まれています。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:7
 msgid "Protected resources and scopes"
 msgstr "保護されたリソースとスコープ"
 
 #. type: Title ==
-#: source/authorization_services/topics/resource-server-import-config.adoc:10
 #, no-wrap
 msgid "Exporting a Configuration File"
 msgstr "設定ファイルのエクスポート"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:13
 msgid "To export a configuration file, complete the following steps:"
 msgstr "設定ファイルをエクスポートするには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:15
 msgid "Navigate to the *Resource Server Settings* page."
 msgstr "*Resource Server Settings* ページに移動します。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:20
-msgid "On this page, in the Export Settings section, click *Export*."
-msgstr "このページのエクスポート設定のセクションで、 *Export* をクリックします。"
+msgid "Click the *Export Settings* tab."
+msgstr " *Export Settings* タブをクリックします。"
+
+#. type: Plain text
+msgid "On this page, click *Export*."
+msgstr "このページで、 *Export* をクリックします。"
 
 #. type: Block title
-#: source/authorization_services/topics/resource-server-import-config.adoc:21
 #, no-wrap
 msgid "Export Settings"
 msgstr "エクスポートの設定"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:23
 msgid ""
 "image:{project_images}/resource-server/authz-export.png[alt=\"Export "
 "Settings\"]"
@@ -106,7 +79,6 @@ msgstr ""
 "image:{project_images}/resource-server/authz-export.png[alt=\"エクスポートの設定\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:25
 msgid ""
 "The configuration file is exported in JSON format and displayed in a text "
 "area, from which you can copy and paste. You can also click *Download* to "
@@ -116,13 +88,24 @@ msgstr ""
 "をクリックし、設定ファイルをダウンロードして保存することもできます。"
 
 #. type: Title ==
-#: source/authorization_services/topics/resource-server-import-config.adoc:26
 #, no-wrap
 msgid "Importing a Configuration File"
 msgstr "設定ファイルのインポート"
 
+#. type: Block title
+#, no-wrap
+msgid "Import Settings"
+msgstr "インポート設定"
+
 #. type: Plain text
-#: source/authorization_services/topics/resource-server-import-config.adoc:28
+msgid ""
+"image:{project_images}/resource-server/authz-settings.png[alt=\"Import "
+"Settings\"]"
+msgstr ""
+"image:{project_images}/resource-server/authz-settings.png[alt=\"Import "
+"Settings\"]"
+
+#. type: Plain text
 msgid ""
 "To import a configuration file for a resource server, click *Select file* to"
 " select a file containing the configuration you want to import."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-import-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
