### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -27,9 +27,10 @@ msgstr "X.509クライアント証明書ユーザー認証"
 
 #. type: Plain text
 msgid ""
-"Keycloak supports login with a X.509 client certificate if the server is "
-"configured for mutual SSL authentication.\t"
-msgstr "Keycloakは、サーバーが相互SSL認証用に設定されている場合、X.509クライアント証明書によるログインをサポートします。\t"
+"{project_name} supports login with a X.509 client certificate if the server "
+"is configured for mutual SSL authentication."
+msgstr ""
+"{project_name}は、サーバーが相互SSL認証用に設定されている場合、X.509クライアント証明書によるログインをサポートします。"
 
 #. type: Plain text
 msgid "A typical workflow is as follows:"
@@ -47,9 +48,9 @@ msgstr "SSL/TLSハンドシェイク中に、サーバーとクライアント�
 
 #. type: Plain text
 msgid ""
-"The container (wildfly) validates the certificate PKIX path and the "
+"The container (WildFly) validates the certificate PKIX path and the "
 "certificate expiration"
-msgstr "コンテナー（WildFly）は、証明書のPKIXパスと有効期限を検証します。"
+msgstr "コンテナ（WildFly）は、証明書のPKIXパスと有効期限を検証します。"
 
 #. type: Plain text
 msgid ""
@@ -125,6 +126,13 @@ msgstr "正規表現を使用したSubjectDN一致"
 #. type: Plain text
 msgid "X500 Subject's e-mail attribute"
 msgstr "X500 Subject's e-mail属性"
+
+#. type: Plain text
+msgid ""
+"X500 Subject's e-mail from Subject Alternative Name Extension (RFC822Name "
+"General Name)"
+msgstr ""
+"Subject Alternative Name Extension (RFC822Name General Name)からの件名の電子メール"
 
 #. type: Plain text
 msgid "X500 Subject's Common Name attribute"
@@ -234,10 +242,10 @@ msgstr "X.509クライアント証明書のユーザー認証を有効にする"
 
 #. type: Plain text
 msgid ""
-"The following sections describe how to configure Wildfly/Undertow and the "
-"Keycloak Server to enable X.509 client certificate authentication."
+"The following sections describe how to configure WildFly/Undertow and the "
+"{project_name} Server to enable X.509 client certificate authentication."
 msgstr ""
-"以下のセクションでは、X.509クライアント証明書認証を有効にするためにWildfly/UndertowとKeycloakサーバーを設定する方法について説明します。"
+"以下のセクションでは、X.509クライアント証明書認証を有効にするためにWildFly/Undertowと{project_name}サーバーを設定する方法について説明します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -249,18 +257,18 @@ msgid ""
 "See link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
 "#AdminGuide-EnableSSL[Enable SSL] and "
 "link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide#AdminGuide-%7B%7B%3Cssl%2F%3E%7D%7D[SSL]"
-" for the instructions how to enable SSL in Wildfly."
+" for the instructions how to enable SSL in WildFly."
 msgstr ""
-"WildflyでSSLを有効にする方法については、link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
+"WildFlyでSSLを有効にする方法については、link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
 "#AdminGuide-EnableSSL[Enable "
 "SSL]とlink:https://docs.jboss.org/author/display/WFLY10/Admin+Guide#AdminGuide-%7B%7B%3Cssl%2F%3E%7D%7D[SSL]を参照してください。"
 
 #. type: Plain text
 msgid ""
-"Open $KEYCLOAK_HOME/standalone/configuration/standalone.xml and add a new "
+"Open {project_dirref}/standalone/configuration/standalone.xml and add a new "
 "realm:"
 msgstr ""
-"$KEYCLOAK_HOME/standalone/configuration/standalone.xmlを開き、新しいレルムを追加します。"
+"{project_dirref}/standalone/configuration/standalone.xmlを開き、新しいレルムを追加します。"
 
 #. type: Code block
 #, no-wrap
@@ -409,9 +417,9 @@ msgstr "httpsリスナーを有効にする"
 msgid ""
 "See link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
 "#AdminGuide-HTTPSlistener[HTTPS Listener] for the instructions how to enable"
-" HTTPS in Wildfly."
+" HTTPS in WildFly."
 msgstr ""
-"WildflyでHTTPSを有効にする方法については、link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
+"WildFlyでHTTPSを有効にする方法については、link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
 "#AdminGuide-HTTPSlistener[HTTPS Listener]を参照してください。"
 
 #. type: Plain text
@@ -475,7 +483,7 @@ msgstr "レルムを選択し、Authenticationのリンクをクリックし、\
 
 #. type: Plain text
 msgid ""
-"Make a copy of the buit-in \"Browser\" flow. You may want to give the new "
+"Make a copy of the built-in \"Browser\" flow. You may want to give the new "
 "flow a distinctive name, i.e. \"X.509 Browser\""
 msgstr ""
 "ビルトインの\"Browser\"フローのコピーを作成します。新しいフローに特有の名前、すなわち、\"X.509 "
@@ -483,7 +491,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Using the drop down, select the copied flow, and click on \"Add Execution\""
+"Using the drop down, select the copied flow, and click on \"Add execution\""
 msgstr "ドロップダウンを使用して、コピーされたフローを選択し、\"Add execution\"をクリックします。"
 
 #. type: Plain text
@@ -647,7 +655,7 @@ msgid ""
 "Verifies whether the certificate's KeyUsage extension bits are set. For "
 "example, \"digitalSignature,KeyEncipherment\" will verify if bits 0 and 2 in"
 " the KeyUsage extension are asserted. Leave the parameter empty to disable "
-"the Key Usage validaion. See "
+"the Key Usage validation. See "
 "link:https://tools.ietf.org/html/rfc5280#section-4.2.1.3[RFC5280, "
 "Section-4.2.1.3]. The server will raise an error only when flagged as "
 "critical by the issuing CA and there is a key usage extension mismatch."
@@ -683,7 +691,7 @@ msgstr "`Bypass identity confirmation`"
 #. type: Plain text
 msgid ""
 "If set, X.509 client certificate authentication will not prompt the user to "
-"confirm the certificate identity and will automatiocally sign in the user "
+"confirm the certificate identity and will automatically sign in the user "
 "upon successful authentication."
 msgstr ""
 "設定されている場合、X.509クライアント証明書認証は、ユーザーに証明書アイデンティティーの確認を促さず、ユーザーの認証に成功すると自動的にサインインします。"
@@ -695,9 +703,11 @@ msgstr "ダイレクト・グラント・フローへのX.509クライアント�
 
 #. type: Plain text
 msgid ""
-"Using keycloak admin console, click on \"Authentication\" and select the "
-"\"Direct Grant\" flow,"
-msgstr "Keycloak管理コンソールを使用して、\"Authentication\"をクリックし、\"Direct Grant\"フローを選択します。"
+"Using {project_name} admin console, click on \"Authentication\" and select "
+"the \"Direct Grant\" flow,"
+msgstr ""
+"{project_name}管理コンソールを使用して、\"Authentication\"をクリックし、\"Direct "
+"Grant\"フローを選択します。"
 
 #. type: Plain text
 msgid ""
@@ -708,12 +718,12 @@ msgstr ""
 "Grant\"を付けることをお勧めします。"
 
 #. type: Plain text
-msgid "Delete \"Validate Username\" and \"Password\" authenticators,"
-msgstr "\"Validate Username\"と\"Password\"のオーセンティケーターを削除します。"
+msgid "Delete \"Username Validation\" and \"Password\" authenticators,"
+msgstr "\"Username Validation\"と\"Password\"のオーセンティケーターを削除します。"
 
 #. type: Plain text
 msgid ""
-"Click on \"Execution\" and add \"X509/Validate Username\" and click on "
+"Click on \"Add execution\" and add \"X509/Validate Username\" and click on "
 "\"Save\" to add the execution step to the parent flow."
 msgstr ""
 "\"Add execution\"をクリックし、\"X509/Validate "
@@ -750,6 +760,181 @@ msgstr ""
 msgid "image:images/x509-directgrant-flow-bindings.png[]"
 msgstr "image:images/x509-directgrant-flow-bindings.png[]"
 
+#. type: Title ====
+#, no-wrap
+msgid "Client certificate lookup"
+msgstr "クライアント証明書検索"
+
+#. type: Plain text
+msgid ""
+"When an HTTP request is sent directly to {project_name} server, the "
+"{appserver_name} undertow subsystem will establish an SSL handshake and "
+"extract the client certificate. The client certificate will be then saved to"
+" the attribute `javax.servlet.request.X509Certificate` of the HTTP request, "
+"as specified in the servlet specification. The {project_name} X509 "
+"authenticator will be then able to lookup the certificate from this "
+"attribute."
+msgstr ""
+"HTTPリクエストが{project_name}サーバーに直接送信されると、{appserver_name} "
+"undertowサブシステムはSSLハンドシェイクを確立し、クライアント証明書を抽出します。クライアント証明書は、サーブレット仕様で指定されているHTTPリクエストの属性"
+" `javax.servlet.request.X509Certificate` に保存されます。 {project_name} "
+"X509オーセンティケーターは、この属性から証明書を検索できます。"
+
+#. type: Plain text
+msgid ""
+"However, when the {project_name} server listens to HTTP requests behind a "
+"load balancer or reverse proxy, it may be the proxy server which extracts "
+"the client certificate and establishes the mutual SSL connection. A reverse "
+"proxy usually puts the authenticated client certificate in the HTTP header "
+"of the underlying request and forwards it to the back end {project_name} "
+"server. In this case, {project_name} must be able to look up the X.509 "
+"certificate chain from the HTTP headers instead of from the attribute of "
+"HTTP request, as is done for Undertow."
+msgstr ""
+"ただし、{project_name}サーバーがロードバランサーまたはリバース・プロキシーの背後にあるHTTPリクエストをリッスンする場合、クライアント証明書を抽出して相互SSL接続を確立するのはプロキシー・サーバーであるかもしれません。リバース・プロキシーは通常、認証されたクライアント証明書を基礎となるもとのリクエストのHTTPヘッダーに入れ、バックエンドの{project_name}サーバーに転送します。この場合、{project_name}は、Undertowの場合と同様に、HTTPリクエストの属性ではなく、HTTPヘッダーからX.509証明書チェーンをルックアップできる必要があります。"
+
+#. type: Plain text
+msgid ""
+"If {project_name} is behind a reverse proxy, you usually need to configure "
+"alternative provider of the `x509cert-lookup` SPI in "
+"{project_dirref}/standalone/configuration/standalone.xml. Along with the "
+"`default` provider, which looks up the certificate from the HTTP header, we "
+"also have two additional built-in providers: `haproxy` and `apache`, which "
+"are described next."
+msgstr ""
+"{project_name}がリバース・プロキシーの背後にある場合、通常は{project_dirref}/standalone/configuration/standalone.xmlに"
+" `x509cert-lookup` SPIの代替プロバイダーを設定する必要があります。HTTPヘッダーから証明書を検索する `default` "
+"プロバイダーに加えて、`haproxy` と `apache`という2つの組み込みプロバイダーも追加されています。"
+
+#. type: Title =====
+#, no-wrap
+msgid "HAProxy certificate lookup provider"
+msgstr "HAProxy証明書検索プロバイダー"
+
+#. type: Plain text
+msgid ""
+"You can use this provider when your {project_name} server is behind an "
+"HAProxy reverse proxy. Configure the server like this:"
+msgstr ""
+"{project_name}サーバーがHAProxyリバース・プロキシーの背後にある場合、このプロバイダーを使用できます。 "
+"次のようにサーバーを構成します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<spi name=\"x509cert-lookup\">\n"
+"    <default-provider>haproxy</default-provider>\n"
+"    <provider name=\"haproxy\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"sslClientCert\" value=\"SSL_CLIENT_CERT\"/>\n"
+"            <property name=\"sslCertChainPrefix\" value=\"CERT_CHAIN\"/>\n"
+"            <property name=\"certificateChainLength\" value=\"10\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+msgstr ""
+"<spi name=\"x509cert-lookup\">\n"
+"    <default-provider>haproxy</default-provider>\n"
+"    <provider name=\"haproxy\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"sslClientCert\" value=\"SSL_CLIENT_CERT\"/>\n"
+"            <property name=\"sslCertChainPrefix\" value=\"CERT_CHAIN\"/>\n"
+"            <property name=\"certificateChainLength\" value=\"10\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+
+#. type: Plain text
+msgid ""
+"In this example configuration, the client certificate will be looked up from"
+" the HTTP header, `SSL_CLIENT_CERT`, and the other certificates from its "
+"chain will be looked up from HTTP headers like `CERT_CHAIN_0` , "
+"`CERT_CHAIN_1`, ..., `CERT_CHAIN_9` . The attribute `certificateChainLength`"
+" is the maximum length of the chain, so the last one tried attribute would "
+"be `CERT_CHAIN_9` ."
+msgstr ""
+"この設定例では、クライアント証明書はHTTPヘッダー `SSL_CLIENT_CERT` から検索され、チェーンの他の証明書は "
+"`CERT_CHAIN_0` 、 `CERT_CHAIN_1` 、…、` CERT_CHAIN_9' のようなHTTPヘッダーから検索されます。属性 "
+"`certificateChainLength` はチェーンの最大長です。最後に試した属性は `CERT_CHAIN_9` です。"
+
+#. type: Plain text
+msgid ""
+"Consult the HAProxy documentation for the details of how the HTTP Headers "
+"for the client certificate and client certificate chain can be configured "
+"and their proper names."
+msgstr ""
+"クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの構成方法と固有名詞の詳細については、HAProxyのドキュメントを参照してください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Apache certificate lookup provider"
+msgstr "Apache証明書検索プロバイダー"
+
+#. type: Plain text
+msgid ""
+"You can use this provider when your {project_name} server is behind an "
+"Apache reverse proxy. Configure the server like this:"
+msgstr ""
+"{project_name}サーバーがApacheリバース・プロキシーの背後にある場合、このプロバイダーを使用できます。次のようにサーバーを設定します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<spi name=\"x509cert-lookup\">\n"
+"    <default-provider>apache</default-provider>\n"
+"    <provider name=\"apache\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"sslClientCert\" value=\"SSL_CLIENT_CERT\"/>\n"
+"            <property name=\"sslCertChainPrefix\" value=\"CERT_CHAIN\"/>\n"
+"            <property name=\"certificateChainLength\" value=\"10\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+msgstr ""
+"<spi name=\"x509cert-lookup\">\n"
+"    <default-provider>apache</default-provider>\n"
+"    <provider name=\"apache\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"sslClientCert\" value=\"SSL_CLIENT_CERT\"/>\n"
+"            <property name=\"sslCertChainPrefix\" value=\"CERT_CHAIN\"/>\n"
+"            <property name=\"certificateChainLength\" value=\"10\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+
+#. type: Plain text
+msgid ""
+"The configuration is same as for the `haproxy` provider. Consult the Apache "
+"documentation for the details of how the HTTP Headers for the client "
+"certificate and client certificate chain can be configured and their proper "
+"names."
+msgstr ""
+"設定は `haproxy` "
+"プロバイダーと同じです。クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの設定方法とその固有名については、Apacheのドキュメントを参照してください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Other reverse proxy implementations"
+msgstr "その他のリバース・プロキシーの実装"
+
+#. type: Plain text
+msgid ""
+"We do not have built-in support for other reverse proxy implementations. "
+"However, it is possible that other reverse proxies can be made to behave in "
+"a similar way to `apache` or `haproxy` and that some of those providers can "
+"be used. If none of those works, you may need to create your own "
+"implementation of the "
+"`org.keycloak.services.x509.X509ClientCertificateLookupFactory` and "
+"`org.keycloak.services.x509.X509ClientCertificateLookup` provider. See the "
+"link:{developerguide_link}[{developerguide_name}] for the details on how to "
+"add your own provider."
+msgstr ""
+"他のリバース・プロキシーの実装のための組み込みサポートはありません。しかし、他のリバース・プロキシーを `apache` や `haproxy` "
+"と同様に動作させることができ、それらのプロバイダーの一部を使用することも可能です。これらのいずれの作業もない場合は、 "
+"`org.keycloak.services.x509.X509ClientCertificateLookupFactory` と "
+"`org.keycloak.services.x509.X509ClientCertificateLookup` "
+"プロバイダーの独自の実装を作成する必要があります。独自のプロバイダーを追加する方法については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+
 #. type: Labeled list
 #, no-wrap
 msgid "Direct Grant authentication with X.509"
@@ -783,11 +968,11 @@ msgstr "`[host][:port]`"
 
 #. type: Plain text
 msgid ""
-"The host and the port number of a remote Keycloak server that has been "
-"configured to allow users authenticate with x.509 client certificates using "
-"the Direct Grant Flow."
+"The host and the port number of a remote {project_name} server that has been"
+" configured to allow users authenticate with x.509 client certificates using"
+" the Direct Grant Flow."
 msgstr ""
-"ダイレクト・グラント・フローを使用してx.509クライアント証明書でユーザーを認証できるように設定されているリモートのKeycloakサーバーのホストとポート番号。"
+"ダイレクト・グラント・フローを使用してx.509クライアント証明書でユーザーを認証できるように設定されているリモートの{project_name}サーバーのホストとポート番号。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
