### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,46 +16,44 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:2
 #, no-wrap
 msgid "Configuring the Subsystem"
 msgstr "サブシステムの設定"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:6
 msgid ""
-"Now that you have copied the XML template from the Installation page, you "
-"need to paste this into the _standalone.xml_ file that resides in the "
-"_standalone/configuration_ directory of the application server instance on "
-"which your application is deployed."
+"To configure the {appserver_name} instance that the application is deployed "
+"on so that this app is secured by {project_name}, complete the following "
+"steps."
 msgstr ""
-"今インストール・ページからXMLテンプレートをコピーしたところですが、これを _standalone.xml_ "
-"ファイルにペーストする必要があります。_standalone.xml_ "
-"ファイルはアプリケーションをデプロイしたアプリケーション・サーバー・インスタンスの _standalone/configuration_ "
-"ディレクトリーにあります。"
+"このアプリケーションが{project_name}によって保護されるように、アプリケーションがデプロイされている{appserver_name}インスタンスを構成するには、次の手順を実行します。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:8
 msgid ""
-"Open the standalone/configuration/standalone.xml file and search for the "
-"following text:"
-msgstr "standalone/configuration/standalone.xml ファイルを開き、以下のテキストを検索します。"
+"Open the `standalone/configuration/standalone.xml` file in the "
+"{appserver_name} instance that the application is deployed on and search for"
+" the following text:"
+msgstr ""
+"アプリケーションがデプロイされた {appserver_name}インスタンス内の "
+"`standalone/configuration/standalone.xml` ファイルを開き、以下のテキストを検索します。"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:12
 #, no-wrap
 msgid "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\"/>\n"
 msgstr "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\"/>\n"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:15
 msgid ""
-"Modify this to prepare it for pasting in your template from the Installation"
-" page:"
-msgstr "インストール・ページからテンプレートをペーストするために、以下のとおりに修正します。"
+"Modify this text to prepare the file for pasting in contents from the "
+"*Keycloak OIDC JBoss Subsystem XML* template we obtained {project_name} "
+"admin console *Installation* tab by changing the XML entry from self-closing"
+" to using a pair of opening and closing tags:"
+msgstr ""
+"このテキストを変更して、{project_name}管理コンソールの *Installation* タブで取得した *Keycloak OIDC "
+"JBoss Subsystem XML* テンプレートの内容をファイルにペーストする準備をします。XMLエントリーを自己クローズ（self-"
+"closing）から一対の開始タグと終了タグに変更します。"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:20
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\">\n"
@@ -65,14 +63,12 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:23
 msgid ""
-"Within the <subsystem> element, paste in the template. It will look "
-"something like this:"
-msgstr "<subsystem> 要素内で、テンプレートを貼り付けます。そうすると、以下のようになります。"
+"Paste the contents of the template within the `<subsystem>` element, as "
+"shown in this example:"
+msgstr "この例に示すように、 `<subsystem>` の要素内のテンプレートの内容をペーストします。"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:35
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\">\n"
@@ -96,12 +92,10 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:38
-msgid "Change the *WAR MODULE NAME* text to *vanilla* as follows:"
-msgstr "*WAR MODULE NAME* を *vanilla* に書き換えます。そうすると、以下のとおりになります。"
+msgid "Change the `name` to `vanilla.war`:"
+msgstr "次のように `name` を `vanilla.war` に変更してください。"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:45
 #, no-wrap
 msgid ""
 "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\">\n"
@@ -115,17 +109,15 @@ msgstr ""
 "</subsystem>\n"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:48
-msgid "Reboot your application server."
-msgstr "アプリケーション・サーバーを起動します。"
+msgid "Reboot the application server."
+msgstr "アプリケーション・サーバーを再起動します。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/subsystem.adoc:50
 msgid ""
-"Go to http://localhost:8080/vanilla and click *login*. The {project_name} "
-"login page opens. You can log in using the user you created in the "
-"<<_create-new-user, Creating a New User>> chapter."
+"Go to http://localhost:8080/vanilla and click *Login*. When the "
+"{project_name} login page opens, log in using the user you created in "
+"<<_create-new-user, Creating a New User>>."
 msgstr ""
-"http://localhost:8080/vanilla に移動して *login* "
-"をクリックします。{project_name}ログインページが開きます。<<_create-new-user, "
-"新規ユーザーの作成>>の章で作成したユーザーを使用してログインすることができます。"
+"http://localhost:8080/vanilla に移動して *Login* "
+"をクリックします。{project_name}ログインページが開いたら、<<_create-new-user, "
+"新規ユーザーの作成>>で作成したユーザーを使用してログインします。"

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
@@ -34,7 +34,7 @@ msgid ""
 "{appserver_name} instance that the application is deployed on and search for"
 " the following text:"
 msgstr ""
-"アプリケーションがデプロイされた {appserver_name}インスタンス内の "
+"アプリケーションがデプロイされた{appserver_name}インスタンス内の "
 "`standalone/configuration/standalone.xml` ファイルを開き、以下のテキストを検索します。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
