### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -44,7 +44,7 @@ msgstr "クライアント・アダプターのインストール"
 msgid ""
 "Download the {appserver_name} distribution and extract it from the "
 "compressed file into a directory on your machine."
-msgstr "{appserver_name} の配布物をダウンロードし、圧縮ファイルをマシンのディレクトリーに展開します。"
+msgstr "{appserver_name}の配布物をダウンロードし、圧縮ファイルをマシンのディレクトリーに展開します。"
 
 #. type: Plain text
 msgid ""
@@ -56,13 +56,13 @@ msgstr ""
 
 #. type: Plain text
 msgid "Download the RH-SSO-{project_version}-eap7-adapter.zip distribution."
-msgstr "RH-SSO-{project_version}-eap7-adapter.zip の配布物をダウンロードします。"
+msgstr "RH-SSO-{project_version}-eap7-adapter.zipの配布物をダウンロードします。"
 
 #. type: Plain text
 msgid ""
 "Extract the contents of this file into the root directory of your "
 "{appserver_name} distribution."
-msgstr "{appserver_name} 配布物のルートディレクトリーに、このファイルを解凍します。"
+msgstr "{appserver_name}配布物のルートディレクトリーに、このファイルを解凍します。"
 
 #. type: Plain text
 msgid "Run the appropriate script for your platform:"
@@ -130,7 +130,7 @@ msgid ""
 "`.../standalone/configuration/standalone.xml` file of your app server "
 "distribution."
 msgstr ""
-"このスクリプトは、アプリケーション・サーバー配布の `.../standalone/configuration/standalone.xml` "
+"このスクリプトは、アプリケーション・サーバーの配布物の `.../standalone/configuration/standalone.xml` "
 "ファイルを必要に応じて編集します。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,101 +16,64 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:11
-#: source/getting_started/topics/secure-jboss-app/before.adoc:14
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:52
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:11
-#: source/server_installation/topics/operating-mode/domain.adoc:187
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:37
-#: source/server_installation/topics/operating-mode/standalone.adoc:20
-#: source/server_installation/topics/manage.adoc:15
-#: source/server_admin/topics/initialization.adoc:27
-#: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
 
 #. type: delimited block -
-#: source/getting_started/topics/first-boot/boot.adoc:15
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:56
-#: source/server_installation/topics/operating-mode/standalone.adoc:24
 #, no-wrap
 msgid "$ .../bin/standalone.sh\n"
 msgstr "$ .../bin/standalone.sh\n"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:17
-#: source/getting_started/topics/secure-jboss-app/before.adoc:20
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:58
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:17
-#: source/server_installation/topics/operating-mode/domain.adoc:193
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:43
-#: source/server_installation/topics/operating-mode/standalone.adoc:26
-#: source/server_installation/topics/manage.adoc:21
-#: source/server_admin/topics/initialization.adoc:33
-#: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
 
 #. type: delimited block -
-#: source/getting_started/topics/first-boot/boot.adoc:21
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:62
-#: source/server_installation/topics/operating-mode/standalone.adoc:30
 #, no-wrap
 msgid "> ...\\bin\\standalone.bat\n"
 msgstr "> ...\\bin\\standalone.bat\n"
 
 #. type: Title ===
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:2
 #, no-wrap
 msgid "Installing the Client Adapter"
 msgstr "クライアント・アダプターのインストール"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:6
 msgid ""
-"Download the {appserver_name} distribution and unzip it into a directory on "
-"your machine."
-msgstr "{appserver_name} の配布物をダウンロードし、マシンのディレクトリーに解凍します。"
+"Download the {appserver_name} distribution and extract it from the "
+"compressed file into a directory on your machine."
+msgstr "{appserver_name} の配布物をダウンロードし、圧縮ファイルをマシンのディレクトリーに展開します。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:9
 msgid ""
-"Next download the WildFly OpenID Connect adapter distribution from "
-"link:http://www.keycloak.org/downloads.html[keycloak.org]."
+"Download the WildFly OpenID Connect adapter distribution from "
+"link:https://www.keycloak.org/downloads.html[keycloak.org]."
 msgstr ""
-"次に、link:http://www.keycloak.org/downloads.html[keycloak.org]からWildFly OpenID"
-" Connectアダプターの配布物をダウンロードします。"
+"link:https://www.keycloak.org/downloads.html[keycloak.org]からWildFly OpenID "
+"Connectアダプターの配布物をダウンロードします。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:13
-msgid ""
-"Next download the RH-SSO-{project_version}-eap7-adapter.zip distribution."
-msgstr "次に、RH-SSO-{project_version}-eap7-adapter.zip の配布物をダウンロードします。"
+msgid "Download the RH-SSO-{project_version}-eap7-adapter.zip distribution."
+msgstr "RH-SSO-{project_version}-eap7-adapter.zip の配布物をダウンロードします。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:16
 msgid ""
-"Unzip this file into the root directory of your {appserver_name} "
-"distribution."
+"Extract the contents of this file into the root directory of your "
+"{appserver_name} distribution."
 msgstr "{appserver_name} 配布物のルートディレクトリーに、このファイルを解凍します。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:18
-msgid "Next perform the following actions:"
-msgstr "次に、以下の操作を実行します。"
+msgid "Run the appropriate script for your platform:"
+msgstr "次のように、使用しているプラットフォームに適したスクリプトを実行します。"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:19
 #, no-wrap
 msgid "WildFly 10 and Linux/Unix"
 msgstr "WildFly 10・Linux/Unix"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:24
 #, no-wrap
 msgid ""
 "$ cd bin\n"
@@ -120,13 +83,11 @@ msgstr ""
 "$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:26
 #, no-wrap
 msgid "WildFly 10 and Windows"
 msgstr "WildFly 10・Windows"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:31
 #, no-wrap
 msgid ""
 "> cd bin\n"
@@ -136,13 +97,11 @@ msgstr ""
 "> jboss-cli.bat --file=adapter-install-offline.cli\n"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:34
 #, no-wrap
-msgid "Wildfly 11 and Linux/Unix"
-msgstr "WildFly 11・Linux/Unix"
+msgid "WildFly 11 and Linux/Unix"
+msgstr "WildFly 11とLinux/Unix"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:39
 #, no-wrap
 msgid ""
 "$ cd bin\n"
@@ -152,13 +111,11 @@ msgstr ""
 "$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
 
 #. type: Block title
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:41
 #, no-wrap
-msgid "Wildfly 11 and Windows"
-msgstr "WildFly 11・Windows"
+msgid "WildFly 11 and Windows"
+msgstr "WildFly 11とWindows"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:46
 #, no-wrap
 msgid ""
 "> cd bin\n"
@@ -168,12 +125,14 @@ msgstr ""
 "> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:51
 msgid ""
-"This script will make the appropriate edits to the "
-"_.../standalone/configuration/standalone.xml_ file of your app server "
-"distribution.  Finally, boot the application server."
+"This script will make the necessary edits to the "
+"`.../standalone/configuration/standalone.xml` file of your app server "
+"distribution."
 msgstr ""
-"このスクリプトにより、アプリケーション・サーバーの配布物に含まれる "
-"_.../standalone/configuration/standalone.xml_ "
-"が適切に編集されます。最後に、アプリケーション・サーバーを起動します。"
+"このスクリプトは、アプリケーション・サーバー配布の `.../standalone/configuration/standalone.xml` "
+"ファイルを必要に応じて編集します。"
+
+#. type: Plain text
+msgid "Start the application server."
+msgstr "アプリケーション・サーバーを起動します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__install-client-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
