### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid ""
+"Follow the steps in <<_providers,Service Provider Interfaces>> for more "
+"details on how to create and deploy a custom provider."
+msgstr ""
+"カスタムプロバイダーを作成してデプロイする方法の詳細については、<<_providers,Service Provider "
+"Interfaces>>の手順に従ってください。"
+
+#. type: Title ===
+#, no-wrap
+msgid "Theme Selector"
+msgstr "テーマセレクター"
+
+#. type: Plain text
+msgid ""
+"By default the theme configured for the realm is used, with the exception of"
+" clients being able to override the login theme. This behavior can be "
+"changed through the Theme Selector SPI."
+msgstr ""
+"デフォルトでは、クライアントがログインテーマを上書きできる点を除き、レルムに設定されたテーマが使用されます。この動作は、テーマセレクターSPIによって変更できます。"
+
+#. type: Plain text
+msgid ""
+"This could be used to select different themes for desktop and mobile devices"
+" by looking at the user agent header, for example."
+msgstr ""
+"これは、ユーザー・エージェント・ヘッダーを見ることにより、デスクトップ・デバイスおよびモバイル・デバイス用の異なるテーマを選択するために使用することができます。たとえば、"
+
+#. type: Plain text
+msgid ""
+"To create a custom theme selector you need to implement "
+"`ThemeSelectorProviderFactory` and `ThemeSelectorProvider`."
+msgstr ""
+"To create a custom theme selector you need to implement `ThemeSelectorProviderFactory` and `ThemeSelectorProvider`.\n"
+"カスタムテーマセレクタを作成するには、 `ThemeSelectorProviderFactory` と `ThemeSelectorProvider` を実装する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__themes-selector
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
