### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -16,29 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/authorization_services/topics/permission-create-resource.adoc:11
-#: source/authorization_services/topics/permission-create-scope.adoc:11
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:19
-#: source/authorization_services/topics/policy-client-policy.adoc:11
-#: source/authorization_services/topics/policy-drools-policy.adoc:13
-#: source/authorization_services/topics/policy-group-policy.adoc:11
-#: source/authorization_services/topics/policy-js-policy.adoc:12
-#: source/authorization_services/topics/policy-role-policy.adoc:15
-#: source/authorization_services/topics/policy-time-policy.adoc:11
-#: source/authorization_services/topics/policy-user-policy.adoc:11
-#: source/authorization_services/topics/service-client-api.adoc:21
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
 
 #. type: Title =
-#: source/authorization_services/topics/service-client-api.adoc:2
 #, no-wrap
 msgid "Authorization Client Java API"
 msgstr "認可クライアントJava API"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:6
 msgid ""
 "Depending on your requirements, a resource server should be able to manage "
 "resources remotely or even check for permissions programmatically.  If you "
@@ -48,22 +35,19 @@ msgstr ""
 "要件に応じて、リソースサーバーはリソースをリモートで管理したり、プログラムでパーミッションをチェックしたりすることもできます。Javaを使用している場合は、認可クライアントAPIを使用して{project_name}認可サービスにアクセスできます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:8
 msgid ""
-"It is targeted for resource servers that want to access the different APIs "
-"provided by the server such as the Protection, Authorization and Entitlement"
-" APIs."
+"It is targeted for resource servers that want to access the different "
+"endpoints provided by the server such as the Token Endpoint, Resource, and "
+"Permission management endpoints."
 msgstr ""
-"これは、保護API、認可API、エンタイトルメントAPIなど、サーバーが提供するさまざまなAPIにアクセスするリソースサーバーを対象としています。"
+"これは、トークン・エンドポイント、リソース、およびパーミッション管理エンドポイントなど、サーバーが提供するさまざまなエンドポイントにアクセスするリソース・サーバーを対象としています。"
 
 #. type: Title ==
-#: source/authorization_services/topics/service-client-api.adoc:9
 #, no-wrap
 msgid "Maven Dependency"
 msgstr "Maven依存関係"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:19
 #, no-wrap
 msgid ""
 "<dependencies>\n"
@@ -83,13 +67,11 @@ msgstr ""
 "</dependencies>\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:24
 msgid ""
 "The client configuration is defined in a ``keycloak.json`` file as follows:"
 msgstr "クライアントの設定は、 ``keycloak.json`` ファイルで次のように定義されています。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:34
 #, no-wrap
 msgid ""
 "{\n"
@@ -111,24 +93,20 @@ msgstr ""
 "}\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:37
 #, no-wrap
 msgid "*realm* (required)\n"
 msgstr "*realm* (required)\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:39
 msgid "The name of the realm."
 msgstr "レルムの名前。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:41
 #, no-wrap
 msgid "*auth-server-url* (required)\n"
 msgstr "*auth-server-url* (required)\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:43
 msgid ""
 "The base URL of the {project_name} server. All other {project_name} pages "
 "and REST service endpoints are derived from this. It is usually in the form "
@@ -138,30 +116,30 @@ msgstr ""
 "他のすべての{project_name}ページとRESTサービス・エンドポイントは、これから派生しています。通常、https://host:port/authという形式です。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:45
 #, no-wrap
 msgid "*resource* (required)\n"
 msgstr "*resource* (required)\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:47
 msgid ""
 "The client-id of the application. Each application has a client-id that is "
 "used to identify the application."
 msgstr "アプリケーションのクライアントID。各アプリケーションには、アプリケーションを識別するために使用されるクライアントIDがあります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:50
 #, no-wrap
-msgid ""
-"*credentials* (required)\n"
-"Specifies the credentials of the application. This is an object notation where the key is the credential type and the value is the value of the credential type.\n"
-msgstr ""
-"*credentials* (required)\n"
-"アプリケーションのクレデンシャルを指定します。これは、キーがクレデンシャル・タイプであり、値がクレデンシャル・タイプの値であるオブジェクトの表記法です。\n"
+msgid "*credentials* (required)\n"
+msgstr "*credentials* (required)\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:52
+msgid ""
+"Specifies the credentials of the application. This is an object notation "
+"where the key is the credential type and the value is the value of the "
+"credential type."
+msgstr ""
+"アプリケーションのクレデンシャルを指定します。これは、キーがクレデンシャル・タイプであり、値がクレデンシャル・タイプの値であるオブジェクトの表記法です。"
+
+#. type: Plain text
 msgid ""
 "The configuration file is usually located in your application's classpath, "
 "the default location from where the client is going to try to find a "
@@ -171,13 +149,11 @@ msgstr ""
 "ファイルを見つける際のデフォルトのローケーションであるアプリケーションのクラスパスにあります。"
 
 #. type: Title ==
-#: source/authorization_services/topics/service-client-api.adoc:53
 #, no-wrap
 msgid "Creating the Authorization Client"
 msgstr "認可クライアントの作成"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:56
 msgid ""
 "Considering you have a ```keycloak.json``` file in your classpath, you can "
 "create a new ```AuthzClient``` instance as follows:"
@@ -186,7 +162,6 @@ msgstr ""
 "インスタンスを作成することができます。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:60
 #, no-wrap
 msgid ""
 "    // create a new instance based on the configuration defined in a keycloak.json located in your classpath\n"
@@ -196,115 +171,98 @@ msgstr ""
 "    AuthzClient authzClient = AuthzClient.create();\n"
 
 #. type: Title ==
-#: source/authorization_services/topics/service-client-api.adoc:62
 #, no-wrap
 msgid "Obtaining User Entitlements"
 msgstr "ユーザー・エンタイトルメントの取得"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:65
 msgid "Here is an example illustrating how to obtain user entitlements:"
 msgstr "ユーザー・エンタイトルメントを取得する方法の例を示します。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:81
 #, no-wrap
 msgid ""
 "// create a new instance based on the configuration defined in keycloak-authz.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
-"// obtain an Entitlement API Token to get access to the Entitlement API.\n"
-"// this token is an access token issued to a client on behalf of an user\n"
-"// with a uma_authorization scope\n"
-"String eat = getEntitlementAPIToken(authzClient);\n"
+"// create an authorization request\n"
+"AuthorizationRequest request = new AuthorizationRequest();\n"
 "\n"
-"// send the entitlement request to the server to\n"
+"// send the entitlement request to the server in order to\n"
 "// obtain an RPT with all permissions granted to the user\n"
-"EntitlementResponse response = authzClient.entitlement(eat).getAll(\"hello-world-authz-service\");\n"
-"String rpt = response.getRpt();\n"
+"AuthorizationResponse response = authzClient.authorization(\"alice\", \"alice\").authorize(request);\n"
+"String rpt = response.getToken();\n"
+"\n"
+"System.out.println(\"You got an RPT: \" + rpt);\n"
 "\n"
 "// now you can use the RPT to access protected resources on the resource server\n"
 msgstr ""
 "// create a new instance based on the configuration defined in keycloak-authz.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
-"// obtain an Entitlement API Token to get access to the Entitlement API.\n"
-"// this token is an access token issued to a client on behalf of an user\n"
-"// with a uma_authorization scope\n"
-"String eat = getEntitlementAPIToken(authzClient);\n"
+"// create an authorization request\n"
+"AuthorizationRequest request = new AuthorizationRequest();\n"
 "\n"
-"// send the entitlement request to the server to\n"
+"// send the entitlement request to the server in order to\n"
 "// obtain an RPT with all permissions granted to the user\n"
-"EntitlementResponse response = authzClient.entitlement(eat).getAll(\"hello-world-authz-service\");\n"
-"String rpt = response.getRpt();\n"
+"AuthorizationResponse response = authzClient.authorization(\"alice\", \"alice\").authorize(request);\n"
+"String rpt = response.getToken();\n"
+"\n"
+"System.out.println(\"You got an RPT: \" + rpt);\n"
 "\n"
 "// now you can use the RPT to access protected resources on the resource server\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/service-client-api.adoc:84
 msgid ""
 "Here is an example illustrating how to obtain user entitlements for a set of"
 " one or more resources:"
 msgstr "1つ以上のリソースのセットに対してユーザー・エンタイトルメントを取得する方法の例を示します。"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:108
 #, no-wrap
 msgid ""
 "// create a new instance based on the configuration defined in keycloak-authz.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
-"// obtain an Entitlement API Token to get access to the Entitlement API.\n"
-"// this token is an access token issued to a client on behalf of an user\n"
-"// with a uma_authorization scope\n"
-"String eat = getEntitlementAPIToken(authzClient);\n"
+"// create an authorization request\n"
+"AuthorizationRequest request = new AuthorizationRequest();\n"
 "\n"
-"// create an entitlement request\n"
-"EntitlementRequest request = new EntitlementRequest();\n"
-"PermissionRequest permission = new PermissionRequest();\n"
+"// add permissions to the request based on the resources and scopes you want to check access\n"
+"request.addPermission(\"Default Resource\");\n"
 "\n"
-"permission.setResourceSetName(\"Hello World Resource\");\n"
+"// send the entitlement request to the server in order to\n"
+"// obtain an RPT with permissions for a single resource\n"
+"AuthorizationResponse response = authzClient.authorization(\"alice\", \"alice\").authorize(request);\n"
+"String rpt = response.getToken();\n"
 "\n"
-"request.addPermission(permission);\n"
-"\n"
-"// send the entitlement request to the server to obtain an RPT\n"
-"// with all permissions granted to the user\n"
-"EntitlementResponse response = authzClient.entitlement(eat).get(\"hello-world-authz-service\", request);\n"
-"String rpt = response.getRpt();\n"
+"System.out.println(\"You got an RPT: \" + rpt);\n"
 "\n"
 "// now you can use the RPT to access protected resources on the resource server\n"
 msgstr ""
 "// create a new instance based on the configuration defined in keycloak-authz.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
-"// obtain an Entitlement API Token to get access to the Entitlement API.\n"
-"// this token is an access token issued to a client on behalf of an user\n"
-"// with a uma_authorization scope\n"
-"String eat = getEntitlementAPIToken(authzClient);\n"
+"// create an authorization request\n"
+"AuthorizationRequest request = new AuthorizationRequest();\n"
 "\n"
-"// create an entitlement request\n"
-"EntitlementRequest request = new EntitlementRequest();\n"
-"PermissionRequest permission = new PermissionRequest();\n"
+"// add permissions to the request based on the resources and scopes you want to check access\n"
+"request.addPermission(\"Default Resource\");\n"
 "\n"
-"permission.setResourceSetName(\"Hello World Resource\");\n"
+"// send the entitlement request to the server in order to\n"
+"// obtain an RPT with permissions for a single resource\n"
+"AuthorizationResponse response = authzClient.authorization(\"alice\", \"alice\").authorize(request);\n"
+"String rpt = response.getToken();\n"
 "\n"
-"request.addPermission(permission);\n"
-"\n"
-"// send the entitlement request to the server to obtain an RPT\n"
-"// with all permissions granted to the user\n"
-"EntitlementResponse response = authzClient.entitlement(eat).get(\"hello-world-authz-service\", request);\n"
-"String rpt = response.getRpt();\n"
+"System.out.println(\"You got an RPT: \" + rpt);\n"
 "\n"
 "// now you can use the RPT to access protected resources on the resource server\n"
 
 #. type: Title ==
-#: source/authorization_services/topics/service-client-api.adoc:110
 #, no-wrap
 msgid "Creating a Resource Using the Protection API"
 msgstr "保護APIを使用したリソースの作成"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:137
 #, no-wrap
 msgid ""
 "// create a new instance based on the configuration defined in keycloak-authz.json\n"
@@ -319,18 +277,20 @@ msgid ""
 "newResource.addScope(new ScopeRepresentation(\"urn:hello-world-authz:scopes:view\"));\n"
 "\n"
 "ProtectedResource resourceClient = authzClient.protection().resource();\n"
-"Set<String> existingResource = resourceClient.findByFilter(\"name=\" + newResource.getName());\n"
+"ResourceRepresentation existingResource = resourceClient.findByName(newResource.getName());\n"
 "\n"
-"if (!existingResource.isEmpty()) {\n"
-"    resourceClient.delete(existingResource.iterator().next());\n"
+"if (existingResource != null) {\n"
+"    resourceClient.delete(existingResource.getId());\n"
 "}\n"
 "\n"
 "// create the resource on the server\n"
-"RegistrationResponse response = resourceClient.create(newResource);\n"
+"ResourceRepresentation response = resourceClient.create(newResource);\n"
 "String resourceId = response.getId();\n"
 "\n"
 "// query the resource using its newly generated id\n"
-"ResourceRepresentation resource = resourceClient.findById(resourceId).getResourceDescription();\n"
+"ResourceRepresentation resource = resourceClient.findById(resourceId);\n"
+"\n"
+"System.out.println(resource);\n"
 msgstr ""
 "// create a new instance based on the configuration defined in keycloak-authz.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
@@ -344,45 +304,61 @@ msgstr ""
 "newResource.addScope(new ScopeRepresentation(\"urn:hello-world-authz:scopes:view\"));\n"
 "\n"
 "ProtectedResource resourceClient = authzClient.protection().resource();\n"
-"Set<String> existingResource = resourceClient.findByFilter(\"name=\" + newResource.getName());\n"
+"ResourceRepresentation existingResource = resourceClient.findByName(newResource.getName());\n"
 "\n"
-"if (!existingResource.isEmpty()) {\n"
-"    resourceClient.delete(existingResource.iterator().next());\n"
+"if (existingResource != null) {\n"
+"    resourceClient.delete(existingResource.getId());\n"
 "}\n"
 "\n"
 "// create the resource on the server\n"
-"RegistrationResponse response = resourceClient.create(newResource);\n"
+"ResourceRepresentation response = resourceClient.create(newResource);\n"
 "String resourceId = response.getId();\n"
 "\n"
 "// query the resource using its newly generated id\n"
-"ResourceRepresentation resource = resourceClient.findById(resourceId).getResourceDescription();\n"
+"ResourceRepresentation resource = resourceClient.findById(resourceId);\n"
+"\n"
+"System.out.println(resource);\n"
 
 #. type: Title ==
-#: source/authorization_services/topics/service-client-api.adoc:139
 #, no-wrap
-msgid "Introspecting a RPT"
+msgid "Introspecting an RPT"
 msgstr "RPTのイントロスペクション"
 
 #. type: Code block
-#: source/authorization_services/topics/service-client-api.adoc:151
 #, no-wrap
 msgid ""
-"    AuthzClient authzClient = AuthzClient.create();\n"
-"    String rpt = getRequestingPartyToken(authzClient);\n"
-"    TokenIntrospectionResponse requestingPartyToken = authzClient.protection().introspectRequestingPartyToken(rpt);\n"
+"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
-"    if (requestingPartyToken.getActive()) {\n"
-"        for (Permission granted : requestingPartyToken.getPermissions()) {\n"
-"            // iterate over the granted permissions\n"
-"        }\n"
-"    }\n"
+"// send the authorization request to the server in order to\n"
+"// obtain an RPT with all permissions granted to the user\n"
+"AuthorizationResponse response = authzClient.authorization(\"alice\", \"alice\").authorize();\n"
+"String rpt = response.getToken();\n"
+"\n"
+"// introspect the token\n"
+"TokenIntrospectionResponse requestingPartyToken = authzClient.protection().introspectRequestingPartyToken(rpt);\n"
+"\n"
+"System.out.println(\"Token status is: \" + requestingPartyToken.getActive());\n"
+"System.out.println(\"Permissions granted by the server: \");\n"
+"\n"
+"for (Permission granted : requestingPartyToken.getPermissions()) {\n"
+"    System.out.println(granted);\n"
+"}\n"
 msgstr ""
-"    AuthzClient authzClient = AuthzClient.create();\n"
-"    String rpt = getRequestingPartyToken(authzClient);\n"
-"    TokenIntrospectionResponse requestingPartyToken = authzClient.protection().introspectRequestingPartyToken(rpt);\n"
+"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
-"    if (requestingPartyToken.getActive()) {\n"
-"        for (Permission granted : requestingPartyToken.getPermissions()) {\n"
-"            // iterate over the granted permissions\n"
-"        }\n"
-"    }\n"
+"// send the authorization request to the server in order to\n"
+"// obtain an RPT with all permissions granted to the user\n"
+"AuthorizationResponse response = authzClient.authorization(\"alice\", \"alice\").authorize();\n"
+"String rpt = response.getToken();\n"
+"\n"
+"// introspect the token\n"
+"TokenIntrospectionResponse requestingPartyToken = authzClient.protection().introspectRequestingPartyToken(rpt);\n"
+"\n"
+"System.out.println(\"Token status is: \" + requestingPartyToken.getActive());\n"
+"System.out.println(\"Permissions granted by the server: \");\n"
+"\n"
+"for (Permission granted : requestingPartyToken.getPermissions()) {\n"
+"    System.out.println(granted);\n"
+"}\n"

--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -40,7 +40,7 @@ msgid ""
 "endpoints provided by the server such as the Token Endpoint, Resource, and "
 "Permission management endpoints."
 msgstr ""
-"これは、トークン・エンドポイント、リソース、およびパーミッション管理エンドポイントなど、サーバーが提供するさまざまなエンドポイントにアクセスするリソース・サーバーを対象としています。"
+"これは、トークン・エンドポイント、リソースエンドポイント、およびパーミッション管理エンドポイントなど、サーバーが提供するさまざまなエンドポイントに、アクセスするリソースサーバーを対象としています。"
 
 #. type: Title ==
 #, no-wrap
@@ -95,7 +95,7 @@ msgstr ""
 #. type: Plain text
 #, no-wrap
 msgid "*realm* (required)\n"
-msgstr "*realm* (required)\n"
+msgstr "*realm* （必須）\n"
 
 #. type: Plain text
 msgid "The name of the realm."
@@ -104,7 +104,7 @@ msgstr "レルムの名前。"
 #. type: Plain text
 #, no-wrap
 msgid "*auth-server-url* (required)\n"
-msgstr "*auth-server-url* (required)\n"
+msgstr "*auth-server-url* （必須）\n"
 
 #. type: Plain text
 msgid ""
@@ -118,7 +118,7 @@ msgstr ""
 #. type: Plain text
 #, no-wrap
 msgid "*resource* (required)\n"
-msgstr "*resource* (required)\n"
+msgstr "*resource* （必須）\n"
 
 #. type: Plain text
 msgid ""
@@ -129,7 +129,7 @@ msgstr "アプリケーションのクライアントID。各アプリケーシ�
 #. type: Plain text
 #, no-wrap
 msgid "*credentials* (required)\n"
-msgstr "*credentials* (required)\n"
+msgstr "*credentials* （必須）\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-client-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
