### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -36,7 +36,7 @@ msgid ""
 "installation of {project_name} and create the initial admin user as shown in"
 " <<_install-boot, Installing and Booting>>."
 msgstr ""
-"Javaサーブレットアプリケーションをセキュリティー保護するには、まず{project_name}のインストールを完了し、<<_install-"
+"Javaサーブレット・アプリケーションをセキュリティー保護するには、まず{project_name}のインストールを完了し、<<_install-"
 "boot, インストールと起動>>に沿って初期管理者ユーザーを作成する必要があります。"
 
 #. type: Plain text
@@ -46,7 +46,7 @@ msgid ""
 "application. Run the {project_name} using a different port than the "
 "{appserver_name}, to avoid port conflicts."
 msgstr ""
-"1つの注意点があります。Javaサーブレットアプリケーションを実行するには、{project_name}サーバーと同じマシン上で別の{appserver_name}インスタンスを実行する必要があります。ポートの競合を避けるため、{appserver_name}とは異なるポートを使用して{project_name}を実行します。"
+"1つの注意点があります。Javaサーブレット・アプリケーションを実行するには、{project_name}サーバーと同じマシン上で別の{appserver_name}インスタンスを実行する必要があります。ポートの競合を避けるため、{appserver_name}とは異なるポートを使用して{project_name}を実行します。"
 
 #. type: Plain text
 msgid ""
@@ -55,7 +55,7 @@ msgid ""
 "value of this property is a number that will be added to the base value of "
 "every port opened by the {project_name} server."
 msgstr ""
-"使用するポートを調整するには、コマンドラインからサーバーを起動するときに `jboss.socket.binding.port-offset` "
+"使用するポートを調整するには、コマンドラインからサーバーを起動する際に `jboss.socket.binding.port-offset` "
 "システム・プロパティーの値を変更します。このプロパティーの値は、{project_name}サーバーによって開かれたすべてのポートの基本値に追加される数値です。"
 
 #. type: Plain text
@@ -77,4 +77,5 @@ msgid ""
 "After starting {project_name}, go to http://localhost:8180/auth/admin/ to "
 "access the admin console."
 msgstr ""
-"{project_name}を起動したら、管理コンソールにアクセスして、http://localhost:8180/auth/admin/に遷移します。"
+"{project_name}を起動したら、管理コンソールにアクセスして、 http://localhost:8180/auth/admin/ "
+"に遷移します。"

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -16,89 +16,65 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:11
-#: source/getting_started/topics/secure-jboss-app/before.adoc:14
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:52
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:11
-#: source/server_installation/topics/operating-mode/domain.adoc:187
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:37
-#: source/server_installation/topics/operating-mode/standalone.adoc:20
-#: source/server_installation/topics/manage.adoc:15
-#: source/server_admin/topics/initialization.adoc:27
-#: source/server_admin/topics/initialization.adoc:41
-#: source/authorization_services/topics/getting-started-overview.adoc:9
 #, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
 
 #. type: Block title
-#: source/getting_started/topics/first-boot/boot.adoc:17
-#: source/getting_started/topics/secure-jboss-app/before.adoc:20
-#: source/getting_started/topics/secure-jboss-app/install-client-adapter.adoc:58
-#: source/server_installation/topics/config-subsystem/start-cli.adoc:17
-#: source/server_installation/topics/operating-mode/domain.adoc:193
-#: source/server_installation/topics/operating-mode/standalone-ha.adoc:43
-#: source/server_installation/topics/operating-mode/standalone.adoc:26
-#: source/server_installation/topics/manage.adoc:21
-#: source/server_admin/topics/initialization.adoc:33
-#: source/server_admin/topics/initialization.adoc:47
-#: source/authorization_services/topics/getting-started-overview.adoc:15
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
 
 #. type: Title =
-#: source/getting_started/topics/first-realm/before.adoc:2
-#: source/getting_started/topics/secure-jboss-app/before.adoc:2
-#: source/authorization_services/topics/hello-world-before-start.adoc:1
 #, no-wrap
 msgid "Before You Start"
 msgstr "始める前に"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/before.adoc:11
 msgid ""
-"Before you can participate in this tutorial, you need to complete the "
+"Before you can secure a Java servlet application, you must complete the "
 "installation of {project_name} and create the initial admin user as shown in"
-" the <<_install-boot, Installing and Booting>> tutorial.  There is one "
-"caveat to this.  You have to run a separate {appserver_name} instance on the"
-" same machine as the {project_name} server.  This separate instance will run"
-" your Java Servlet application.  Because of this you will have to run the "
-"{project_name} under a different port so that there are no port conflicts "
-"when running on the same machine.  Use the `jboss.socket.binding.port-"
-"offset` system property on the command line.  The value of this property is "
-"a number that will be added to the base value of every port opened by the "
-"{project_name} server."
+" <<_install-boot, Installing and Booting>>."
 msgstr ""
-"このチュートリアルの操作を始める前に、{project_name}のインストールを完了し、<<_install-boot, "
-"インストールと起動>>のチュートリアルに沿って初期管理者ユーザーを作成する必要があります。これには注意事項があります。{project_name}サーバーと同じマシンで、別途{appserver_name}インスタンスを起動する必要があります。この別インスタンスではJavaサーブレット・アプリケーションを起動します。そのため、同じマシンで起動させる際にポートが競合しないように、異なるポートで{project_name}を起動する必要があります。コマンドラインで"
-" `jboss.socket.binding.port-offset` "
-"システム・プロパティーを使います。当プロパティーの値は、{project_name}サーバーで開いた全ポートの基準値に加算される数値です。"
+"Javaサーブレットアプリケーションをセキュリティー保護するには、まず{project_name}のインストールを完了し、<<_install-"
+"boot, インストールと起動>>に沿って初期管理者ユーザーを作成する必要があります。"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/before.adoc:13
-msgid "To boot the {project_name} server:"
-msgstr "{project_name}サーバーを起動するには下記を実行します。"
+msgid ""
+"There is one caveat: you must run a separate {appserver_name} instance on "
+"the same machine as the {project_name} server to run your Java servlet "
+"application. Run the {project_name} using a different port than the "
+"{appserver_name}, to avoid port conflicts."
+msgstr ""
+"1つの注意点があります。Javaサーブレットアプリケーションを実行するには、{project_name}サーバーと同じマシン上で別の{appserver_name}インスタンスを実行する必要があります。ポートの競合を避けるため、{appserver_name}とは異なるポートを使用して{project_name}を実行します。"
+
+#. type: Plain text
+msgid ""
+"To adjust the port used, change the value of the `jboss.socket.binding.port-"
+"offset` system property when starting the server from the command line. The "
+"value of this property is a number that will be added to the base value of "
+"every port opened by the {project_name} server."
+msgstr ""
+"使用するポートを調整するには、コマンドラインからサーバーを起動するときに `jboss.socket.binding.port-offset` "
+"システム・プロパティーの値を変更します。このプロパティーの値は、{project_name}サーバーによって開かれたすべてのポートの基本値に追加される数値です。"
+
+#. type: Plain text
+msgid "To start the {project_name} server while also adjusting the port:"
+msgstr "ポートを調整して{project_name}サーバーを起動するには、以下を実行します。"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/before.adoc:18
-#: source/authorization_services/topics/getting-started-overview.adoc:13
 #, no-wrap
 msgid "$ .../bin/standalone.sh -Djboss.socket.binding.port-offset=100\n"
 msgstr "$ .../bin/standalone.sh -Djboss.socket.binding.port-offset=100\n"
 
 #. type: delimited block -
-#: source/getting_started/topics/secure-jboss-app/before.adoc:24
-#: source/authorization_services/topics/getting-started-overview.adoc:19
 #, no-wrap
 msgid "> ...\\bin\\standalone.bat -Djboss.socket.binding.port-offset=100\n"
 msgstr "> ...\\bin\\standalone.bat -Djboss.socket.binding.port-offset=100\n"
 
 #. type: Plain text
-#: source/getting_started/topics/secure-jboss-app/before.adoc:27
 msgid ""
-"After booting up {project_name}, you can then access the admin console at "
-"http://localhost:8180/auth/admin/"
+"After starting {project_name}, go to http://localhost:8180/auth/admin/ to "
+"access the admin console."
 msgstr ""
-"{project_name}を起動した後、http://localhost:8180/auth/admin/ "
-"にて管理コンソールにアクセスすることができます。"
+"{project_name}を起動したら、管理コンソールにアクセスして、http://localhost:8180/auth/admin/に遷移します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
