### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -95,7 +95,7 @@ msgid ""
 "that is lacking permissions to access a protected resource, the resource "
 "server responds with a *401* status code and a `WWW-Authenticate` header."
 msgstr ""
-"リソース・サーバーがポリシー・エンフォーサーによって保護されている場合、リソース・サーバーは、ベアラー・トークンとともに搬送されるパーミッションに基づいてクライアント・リクエストに応答します。通常、保護されたリソースにアクセスする権限がないベアラトークンを使用してリソースサーバーにアクセスしようとすると、リソースサーバーは"
+"リソースサーバーがポリシー・エンフォーサーによって保護されている場合、リソースサーバーは、ベアラートークンとともに搬送されるパーミッションに基づいてクライアント・リクエストに応答します。通常、保護されたリソースにアクセスする権限がないベアラトークンを使用してリソースサーバーにアクセスしようとすると、リソースサーバーは"
 " *401* ステータスコードと `WWW-Authenticate` ヘッダーで応答します。"
 
 #. type: Code block
@@ -115,9 +115,7 @@ msgstr ""
 msgid ""
 "See <<_service_uma_authorization_process, UMA Authorization Process>> for "
 "more information."
-msgstr ""
-"詳細については、<<_service_uma_authorization_process, UMA Authorization "
-"Process>>を参照してください。"
+msgstr "詳細については、<<_service_uma_authorization_process, UMAの認可プロセス>>を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -202,7 +200,7 @@ msgid ""
 "you can use to obtain an RPT from the server by providing the resources and "
 "scopes your client wants to access."
 msgstr ""
-"```keycloak-authz.js``` "
+"`keycloak-authz.js` "
 "ライブラリーは、クライアントがアクセスしたいリソースとスコープを提供することによって、サーバーからRPTを取得するために使用できる "
 "`entitlement` 関数を提供します。"
 
@@ -211,7 +209,7 @@ msgstr ""
 msgid ""
 "Example about how to obtain an RPT with permissions for all resources and "
 "scopes the user can access"
-msgstr "ユーザーがアクセスできるすべてのリソースとスコープに対するパーミッションを持つRPTを取得する方法の例"
+msgstr "ユーザーがアクセス可能なすべてのリソースとスコープに対するパーミッションを持つ、RPTを取得する方法の例"
 
 #. type: Code block
 #, no-wrap
@@ -233,7 +231,7 @@ msgstr ""
 msgid ""
 "Example about how to obtain an RPT with permissions for specific resources "
 "and scopes"
-msgstr "特定のリソースとスコープに対するパーミッションを持つRPTを取得する方法の例"
+msgstr "特定のリソースとスコープに対するパーミッションを持つ、RPTを取得する方法の例"
 
 #. type: Code block
 #, no-wrap
@@ -280,7 +278,7 @@ msgid ""
 "Both ```authorize``` and ```entitlement``` functions accept an authorization"
 " request object. This object can be set with the following properties:"
 msgstr ""
-"```authorize``` と ```entitlement``` "
+"`authorize` と ```entitlement``` "
 "の両方の関数は、認可リクエスト・オブジェクトを受け入れます。このオブジェクトは、次のプロパティーで設定できます。"
 
 #. type: Plain text
@@ -291,7 +289,7 @@ msgstr "*permissions*\n"
 #. type: Plain text
 msgid ""
 "An array of objects representing the resource and scopes. For instance:"
-msgstr "リソースとスコープを表すオブジェクトの配列。例えば"
+msgstr "リソースとスコープを表すオブジェクトの配列。以下に例を示します。"
 
 #. type: Code block
 #, no-wrap
@@ -323,7 +321,7 @@ msgstr "*metadata*\n"
 msgid ""
 "An object where its properties define how the authorization request should "
 "be processed by the server."
-msgstr "そのプロパティーが、サーバーによって認可リクエストを処理する方法を定義するオブジェクト。"
+msgstr "サーバーで認可リクエストをどのように処理するかを定義したプロパティーを持つオブジェクト。"
 
 #. type: Plain text
 #, no-wrap
@@ -336,8 +334,9 @@ msgid ""
 "included in the RPT's permissions. If false, only the resource identifier is"
 " included.  ** *response_permissions_limit*"
 msgstr ""
-"リソース名をRPTのパーミッションに含めるかどうかをサーバーに示すブール値。falseの場合、リソース識別子のみが含まれます。 ** "
-"*response_permissions_limit*"
+"リソース名をRPTのパーミッションに含めるかどうかをサーバーに示すブール値。falseの場合、リソース識別子のみが含まれます。\n"
+"\n"
+"** *response_permissions_limit*"
 
 #. type: Plain text
 msgid ""
@@ -360,7 +359,7 @@ msgid ""
 "This parameter will only take effect when used together with the `ticket` "
 "parameter as part of a UMA authorization process."
 msgstr ""
-"サーバーがリソースへのパーミッション・リクエストを作成する必要があるかどうかを示すブール値。パーミッション・チケットによって参照されるスコープ。このパラメーターは、UMA認証プロセスの一部として"
+"サーバーがリソースとパーミッション・チケットによって参照されるスコープへのパーミッション・リクエストを作成する必要があるかどうかを示すブール値。このパラメーターは、UMA認証プロセスの一部として"
 " `ticket` パラメーターとともに使用されるときにのみ有効になります。"
 
 #. type: Title ==


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-js-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
