### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/servlet-whiteboard.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/servlet-whiteboard.ja_JP.po
@@ -1,0 +1,163 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "Securing a Servlet Deployed as an OSGI Service"
+msgstr "OSGIサービスとしてデプロイされたサーブレットのセキュリティー保護"
+
+#. type: Plain text
+msgid ""
+"You can use this method if you have a servlet class inside your OSGI bundled"
+" project that is not deployed as a classic WAR application. Fuse uses Pax "
+"Web Whiteboard Extender to deploy such servlets as web applications."
+msgstr ""
+"クラシックなWARアプリケーションとしてデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、この方式を使用できます。"
+" FuseはPax Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
+
+#. type: Plain text
+msgid ""
+"To secure your servlet with {project_name}, complete the following steps:"
+msgstr "{project_name}でサーブレットをセキュリティー保護するには、次の手順を実行します。"
+
+#. type: Plain text
+msgid ""
+"Contrary to the Fuse 6 adapter, there are no special OSGi imports needed in "
+"MANIFEST.MF."
+msgstr "Fuse 6アダプターとは異なり、MANIFEST.MFには特別なOSGiのインポートは必要ありません。"
+
+#. type: Plain text
+msgid ""
+"{project_name} provides "
+"`org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService`, which allows"
+" configuring authentication method and security constraints for your "
+"application. You need to declare such services in the `OSGI-"
+"INF/blueprint/blueprint.xml` file inside your application. Note that your "
+"servlet needs to depend on it.  An example configuration:"
+msgstr ""
+"{project_name}は "
+"`org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService` "
+"を提供します。これにより、アプリケーションに認証方法とセキュリティー制約の設定を設定できます。アプリケーション内の `OSGI-"
+"INF/blueprint/blueprint.xml` "
+"ファイルでそのようなサービスを宣言する必要があります。サーブレットはそれに依存する必要があることに注意してください。設定例は次のとおりです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xsi:schemaLocation=\"http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\">\n"
+msgstr ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xsi:schemaLocation=\"http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\">\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"servletConstraintMapping\" class=\"org.keycloak.adapters.osgi.PaxWebSecurityConstraintMapping\">\n"
+"        <property name=\"roles\">\n"
+"            <list>\n"
+"                <value>user</value>\n"
+"            </list>\n"
+"        </property>\n"
+"        <property name=\"authentication\" value=\"true\"/>\n"
+"        <property name=\"url\" value=\"/product-portal/*\"/>\n"
+"    </bean>\n"
+msgstr ""
+"    <bean id=\"servletConstraintMapping\" class=\"org.keycloak.adapters.osgi.PaxWebSecurityConstraintMapping\">\n"
+"        <property name=\"roles\">\n"
+"            <list>\n"
+"                <value>user</value>\n"
+"            </list>\n"
+"        </property>\n"
+"        <property name=\"authentication\" value=\"true\"/>\n"
+"        <property name=\"url\" value=\"/product-portal/*\"/>\n"
+"    </bean>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <!-- This handles the integration and setting the login-config and security-constraints parameters -->\n"
+"    <bean id=\"keycloakPaxWebIntegration\" class=\"org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"constraintMappings\">\n"
+"            <list>\n"
+"                <ref component-id=\"servletConstraintMapping\" />\n"
+"            </list>\n"
+"        </property>\n"
+"    </bean>\n"
+msgstr ""
+"    <!-- This handles the integration and setting the login-config and security-constraints parameters -->\n"
+"    <bean id=\"keycloakPaxWebIntegration\" class=\"org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService\"\n"
+"          init-method=\"start\" destroy-method=\"stop\">\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"        <property name=\"constraintMappings\">\n"
+"            <list>\n"
+"                <ref component-id=\"servletConstraintMapping\" />\n"
+"            </list>\n"
+"        </property>\n"
+"    </bean>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"productServlet\" "
+"class=\"org.keycloak.example.ProductPortalServlet\" depends-"
+"on=\"keycloakPaxWebIntegration\" />\n"
+msgstr ""
+"    <bean id=\"productServlet\" "
+"class=\"org.keycloak.example.ProductPortalServlet\" depends-"
+"on=\"keycloakPaxWebIntegration\" />\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <service ref=\"productServlet\" interface=\"javax.servlet.Servlet\">\n"
+"        <service-properties>\n"
+"            <entry key=\"alias\" value=\"/product-portal\" />\n"
+"            <entry key=\"servlet-name\" value=\"ProductServlet\" />\n"
+"            <entry key=\"keycloak.config.file\" value=\"/keycloak.json\" />\n"
+"        </service-properties>\n"
+"    </service>\n"
+"</blueprint>\n"
+msgstr ""
+"    <service ref=\"productServlet\" interface=\"javax.servlet.Servlet\">\n"
+"        <service-properties>\n"
+"            <entry key=\"alias\" value=\"/product-portal\" />\n"
+"            <entry key=\"servlet-name\" value=\"ProductServlet\" />\n"
+"            <entry key=\"keycloak.config.file\" value=\"/keycloak.json\" />\n"
+"        </service-properties>\n"
+"    </service>\n"
+"</blueprint>\n"
+
+#. type: Plain text
+msgid ""
+"You might need to have the `WEB-INF` directory inside your project (even if "
+"your project is not a web application) and create the `/WEB-"
+"INF/keycloak.json` file as described in the "
+"<<_fuse7_adapter_classic_war,Classic WAR application>> section.  Note you "
+"don't need the `web.xml` file as the security-constraints are declared in "
+"the blueprint configuration file."
+msgstr ""
+"プロジェクト内に `WEB-INF` "
+"ディレクトリー（プロジェクトがWebアプリケーションでない場合でも）を用意し、<<_fuse7_adapter_classic_war, "
+"クラシックWARアプリケーション>>のセクションのような `/WEB-INF/keycloak.json` ファイルを作成する必要があります"
+"。security-constraintsがblueprint設定ファイルで宣言されているので、 `web.xml` ファイルは必要ありません。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/servlet-whiteboard.ja_JP.po
@@ -26,8 +26,8 @@ msgid ""
 " project that is not deployed as a classic WAR application. Fuse uses Pax "
 "Web Whiteboard Extender to deploy such servlets as web applications."
 msgstr ""
-"クラシックなWARアプリケーションとしてデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、この方式を使用できます。"
-" FuseはPax Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
+"クラシックなWARアプリケーションとしてデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、この方式を使用できます。FuseはPax"
+" Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/servlet-whiteboard.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__servlet-whiteboard
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
