### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
@@ -34,7 +34,7 @@ msgstr "GitLab"
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "GitLab."
-msgstr "GitLabにログインするには、いくつかのステップを完了しなければなりません。"
+msgstr "GitLabにログインできるようにするには、いくつかのステップを完了しなければなりません。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
@@ -1,0 +1,118 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Identity Provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Block title
+#, no-wrap
+msgid "Add a New App"
+msgstr "新しいアプリケーションの追加"
+
+#. type: Title ====
+#, no-wrap
+msgid "GitLab"
+msgstr "GitLab"
+
+#. type: Plain text
+msgid ""
+"There are a number of steps you have to complete to be able to login to "
+"GitLab."
+msgstr "GitLabにログインするには、いくつかのステップを完了しなければなりません。"
+
+#. type: Plain text
+msgid ""
+"First, go to the `Identity Providers` left menu item and select `GitLab` "
+"from the `Add provider` drop down list. This will bring you to the `Add "
+"identity provider` page."
+msgstr ""
+"まず、 `Identity Providers` の左メニュー項目に移動し、`Add provider` ドロップダウン・リストから `GitLab` "
+"を選択します。これにより、 `Add identity provider` ページが表示されます。"
+
+#. type: Plain text
+msgid "image:{project_images}/gitlab-add-identity-provider.png[]"
+msgstr "image:{project_images}/gitlab-add-identity-provider.png[]"
+
+#. type: Plain text
+msgid ""
+"Before you can click `Save`, you must obtain a `Client ID` and `Client "
+"Secret` from GitLab."
+msgstr "`Save` をクリックする前に、GitLabから `Client ID` と `Client Secret` を取得する必要があります。"
+
+#. type: Plain text
+msgid ""
+"You will the `Redirect URI` from this page in a later step, which you will "
+"provide to GitLab when you register {project_name} as a client there."
+msgstr ""
+"後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をGitLabに提供します。"
+
+#. type: Plain text
+msgid ""
+"To enable login with GitLab you first have to register an application "
+"project in https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab"
+" as OAuth2 authentication service provider]."
+msgstr ""
+"GitHubでログインを可能にするには、まずアプリケーション・プロジェクトをhttps://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab"
+" as OAuth2 authentication service provider]に登録する必要があります。"
+
+#. type: Plain text
+msgid ""
+"GitLab often changes the look and feel of application registration, so what "
+"you see on the GitLab site may differ. If in doubt, see the GitLab "
+"documentation."
+msgstr ""
+"GitLabはアプリケーション登録のデザインを変更することが多いため、GitLabのサイトに表示される内容は異なる場合があります。疑わしい場合は、GitLabのドキュメントを参照してください。"
+
+#. type: Plain text
+msgid "image:images/gitlab-developer-applications.png[]"
+msgstr "image:images/gitlab-developer-applications.png[]"
+
+#. type: Plain text
+msgid ""
+"Copy the `Redirect URI` from the {project_name} `Add Identity Provider` page"
+" and enter it into the `Authorization callback URL` field on the GitLab "
+"`Register a new OAuth application` page."
+msgstr ""
+"{project_name}の `Add Identity Provider` ページから `Redirect URI` をコピーし、GitLabの "
+"`Register a new OAuth application` ページの `Authorization callback URL` "
+"フィールドに入力します。"
+
+#. type: Block title
+#, no-wrap
+msgid "GitLab App Page"
+msgstr "GitLabアプリケーション・ページ "
+
+#. type: Plain text
+msgid "image:images/gitlab-app-page.png[]"
+msgstr "image:images/gitlab-app-page.png[]"
+
+#. type: Plain text
+msgid ""
+"When you are done registering, click `Save application`. This will open the "
+"application management page in GitLab. Find the client ID and secret from "
+"this page so you can enter them into the {project_name} `Add identity "
+"provider` page."
+msgstr ""
+"登録が完了したら、 `Save application` をクリックしてください。 "
+"これにより、GitLabのアプリケーション管理ページが開きます。このページからクライアントIDとシークレットを取得し、{project_name}の "
+"`Add identity provider` ページに入力する必要があります。"
+
+#. type: Plain text
+msgid "To finish, return to {project_name} and enter them. Click `Save`."
+msgstr "終了するには、{project_name}に戻り、それらを入力してください。 `Save` をクリックします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__gitlab
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
