### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -29,7 +29,7 @@ msgstr "Bitbucket"
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "Bitbucket."
-msgstr "Bitbucketにログインするには、いくつかのステップを完了しなければなりません。"
+msgstr "Bitbucketにログインできるようにするには、いくつかのステップを完了しなければなりません。"
 
 #. type: Plain text
 msgid ""
@@ -69,7 +69,7 @@ msgid ""
 "project in https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-"
 "cloud-238027431.html[OAuth on Bitbucket Cloud]."
 msgstr ""
-"Bitbucketでログインできるようにするには、まずアプリケーションプロジェクトをhttps://confluence.atlassian.com/bitbucket"
+"Bitbucketでログインできるようにするには、まずアプリケーション・プロジェクトをhttps://confluence.atlassian.com/bitbucket"
 "/oauth-on-bitbucket-cloud-238027431.html[OAuth on Bitbucket "
 "Cloud]に登録する必要があります。"
 
@@ -131,8 +131,8 @@ msgid ""
 "management page in Bitbucket. Find the client ID and secret from this page "
 "so you can enter them into the {project_name} `Add identity provider` page."
 msgstr ""
-"登録が完了したら、 `Save` をクリックしてください。 "
-"これにより、Bitbucketのアプリケーション管理ページが開きます。このページからクライアントIDとシークレットを取得し、{project_name}の"
+"登録が完了したら、 `Save` "
+"をクリックしてください。これにより、Bitbucketのアプリケーション管理ページが開きます。このページからクライアントIDとシークレットを取得し、{project_name}の"
 " `Add identity provider` ページに入力する必要があります。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -1,0 +1,140 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Identity Provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Title ====
+#, no-wrap
+msgid "Bitbucket"
+msgstr "Bitbucket"
+
+#. type: Plain text
+msgid ""
+"There are a number of steps you have to complete to be able to login to "
+"Bitbucket."
+msgstr "Bitbucketにログインするには、いくつかのステップを完了しなければなりません。"
+
+#. type: Plain text
+msgid ""
+"First, open the `Identity Providers` left menu item and select `Bitbucket` "
+"from the `Add provider` drop down list. This will bring you to the `Add "
+"identity provider` page."
+msgstr ""
+"まず、 `Identity Providers` の左メニュー項目に移動し、`Add provider` ドロップダウン・リストから "
+"`Bitbucket` を選択します。これにより、 `Add identity provider` ページが表示されます。"
+
+#. type: Plain text
+msgid "image:{project_images}/bitbucket-add-identity-provider.png[]"
+msgstr "image:{project_images}/bitbucket-add-identity-provider.png[]"
+
+#. type: Plain text
+msgid ""
+"Before you can click `Save`, you must obtain a `Client ID` and `Client "
+"Secret` from Bitbucket."
+msgstr ""
+"`Save` をクリックする前に、Bitbucketから `Client ID` と `Client Secret` を取得する必要があります。"
+
+#. type: Plain text
+msgid ""
+"You will the `Redirect URI` from this page in a later step, which you will "
+"provide to Bitbucket when you register {project_name} as a client there."
+msgstr ""
+"後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をBitbucketに提供します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add a New App"
+msgstr "新しいアプリケーションの追加"
+
+#. type: Plain text
+msgid ""
+"To enable login with Bitbucket you must first register an application "
+"project in https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-"
+"cloud-238027431.html[OAuth on Bitbucket Cloud]."
+msgstr ""
+"Bitbucketでログインできるようにするには、まずアプリケーションプロジェクトをhttps://confluence.atlassian.com/bitbucket"
+"/oauth-on-bitbucket-cloud-238027431.html[OAuth on Bitbucket "
+"Cloud]に登録する必要があります。"
+
+#. type: Plain text
+msgid ""
+"Bitbucket often changes the look and feel of application registration, so "
+"what you see on the Bitbucket site may differ. If in doubt, see the "
+"Bitbucket documentation."
+msgstr ""
+"Bitbucketはアプリケーション登録のデザインを変更することが多いため、Bitbucketのサイトに表示される内容は異なる場合があります。疑わしい場合は、Bitbucketのドキュメントを参照してください。"
+
+#. type: Plain text
+msgid "image:images/bitbucket-developer-applications.png[]"
+msgstr "image:images/bitbucket-developer-applications.png[]"
+
+#. type: Plain text
+msgid "Click the `Add consumer` button."
+msgstr "`Add consumer` ボタンをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Register App"
+msgstr "アプリケーションの登録"
+
+#. type: Plain text
+msgid "image:images/bitbucket-register-app.png[]"
+msgstr "image:images/bitbucket-register-app.png[]"
+
+#. type: Plain text
+msgid ""
+"Copy the `Redirect URI` from the {project_name} `Add Identity Provider` page"
+" and enter it into the `Authorization callback URL` field on the Bitbucket "
+"`Register a new OAuth application` page."
+msgstr ""
+"{project_name}の `Add Identity Provider` ページから `Redirect URI` "
+"をコピーし、Bitbucketの `Register a new OAuth application` ページの `Authorization "
+"callback URL` フィールドに入力します。"
+
+#. type: Plain text
+msgid ""
+"On the same page, mark the `Email` and `Read` boxes under `Account` to allow"
+" your application to read user email."
+msgstr ""
+"同じページで、 `Account` の下の `Email` と `Read` "
+"のチェックボックスをマークして、アプリケーションがユーザーの電子メールを読めるようにします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Bitbucket App Page"
+msgstr "Bitbucketアプリケーション・ページ"
+
+#. type: Plain text
+msgid "image:images/bitbucket-app-page.png[]"
+msgstr "image:images/bitbucket-app-page.png[]"
+
+#. type: Plain text
+msgid ""
+"When you are done registering, click `Save`. This will open the application "
+"management page in Bitbucket. Find the client ID and secret from this page "
+"so you can enter them into the {project_name} `Add identity provider` page."
+msgstr ""
+"登録が完了したら、 `Save` をクリックしてください。 "
+"これにより、Bitbucketのアプリケーション管理ページが開きます。このページからクライアントIDとシークレットを取得し、{project_name}の"
+" `Add identity provider` ページに入力する必要があります。"
+
+#. type: Plain text
+msgid "+To finish, return to {project_name} and enter them. Click `Save`."
+msgstr "終了するには、{project_name}に戻り、それらを入力してください。 `Save` をクリックします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__bitbucket
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
