### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-separate.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-separate.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-separate.ja_JP.po
@@ -1,0 +1,167 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "</blueprint>\n"
+msgstr "</blueprint>\n"
+
+#. type: Plain text
+msgid ""
+"For the CXF JAX-RS application, the only difference might be in the "
+"configuration of the endpoint dependent on engine-factory:"
+msgstr "CXFのJAX-RSアプリケーションの場合、engine-factortyに依存するエンドポイントの設定にのみ違いがある可能性があります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<jaxrs:server serviceClass=\"org.keycloak.example.rs.CustomerService\" address=\"http://localhost:8282/rest\"\n"
+"    depends-on=\"kc-cxf-endpoint\">\n"
+"    <jaxrs:providers>\n"
+"        <bean class=\"com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider\" />\n"
+"    </jaxrs:providers>\n"
+"</jaxrs:server>\n"
+msgstr ""
+"<jaxrs:server serviceClass=\"org.keycloak.example.rs.CustomerService\" address=\"http://localhost:8282/rest\"\n"
+"    depends-on=\"kc-cxf-endpoint\">\n"
+"    <jaxrs:providers>\n"
+"        <bean class=\"com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider\" />\n"
+"    </jaxrs:providers>\n"
+"</jaxrs:server>\n"
+
+#. type: Plain text
+msgid ""
+"The `Import-Package` in `META-INF/MANIFEST.MF` must contain those imports:"
+msgstr "`META-INF/MANIFEST.MF` の `Import-Package` は以下のインポートを含まなければなりません。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"keycloakConfigResolver\" class=\"org.keycloak.adapters.osgi.BundleBasedKeycloakConfigResolver\" >\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"    </bean>\n"
+msgstr ""
+"    <bean id=\"keycloakConfigResolver\" class=\"org.keycloak.adapters.osgi.BundleBasedKeycloakConfigResolver\" >\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"    </bean>\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "Securing an Apache CXF Endpoint on a Separate Undertow Engine"
+msgstr "別のUndertowエンジンでのApache CXFエンドポイントのセキュリティー保護"
+
+#. type: Plain text
+msgid ""
+"To run your CXF endpoints secured by {project_name} on a separate Undertow "
+"engine, complete the following steps:"
+msgstr ""
+"別のUndertowエンジンで、{project_name}によってセキュリティー保護されたCXFエンドポイントを実行するには、以下の手順を実行します。"
+
+#. type: Plain text
+msgid ""
+"Add `OSGI-INF/blueprint/blueprint.xml` to your application, and in it, add "
+"the proper configuration resolver bean similarly to "
+"<<_fuse7_adapter_camel,Camel configuration>>.  In the `httpu:engine-factory`"
+" declare `org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler` "
+"handler using that camel configuration. The configuration for a CFX JAX-WS "
+"application might resemble this one:"
+msgstr ""
+"アプリケーションに `OSGI-INF/blueprint/blueprint.xml` "
+"を追加し、その中に<<_fuse7_adapter_camel, Camelの設定>>と同様の適切な設定リゾルバービーンを追加します。 `httpu"
+":engine-factory` の中で、そのCamelの設定を使って "
+"`org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler` ハンドラ−を宣言します。CFX"
+" JAX-WSアプリケーションの設定は、次のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxws=\"http://cxf.apache.org/blueprint/jaxws\"\n"
+"           xmlns:cxf=\"http://cxf.apache.org/blueprint/core\"\n"
+"           xmlns:httpu=\"http://cxf.apache.org/transports/http-undertow/configuration\".\n"
+"           xsi:schemaLocation=\"\n"
+"      http://cxf.apache.org/transports/http-undertow/configuration http://cxf.apache.org/schemas/configuration/http-undertow.xsd\n"
+"      http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd\n"
+"      http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd\">\n"
+msgstr ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxws=\"http://cxf.apache.org/blueprint/jaxws\"\n"
+"           xmlns:cxf=\"http://cxf.apache.org/blueprint/core\"\n"
+"           xmlns:httpu=\"http://cxf.apache.org/transports/http-undertow/configuration\".\n"
+"           xsi:schemaLocation=\"\n"
+"      http://cxf.apache.org/transports/http-undertow/configuration http://cxf.apache.org/schemas/configuration/http-undertow.xsd\n"
+"      http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd\n"
+"      http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd\">\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <httpu:engine-factory bus=\"cxf\" id=\"kc-cxf-endpoint\">\n"
+"        <httpu:engine port=\"8282\">\n"
+"            <httpu:handlers>\n"
+"                <bean class=\"org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler\">\n"
+"                    <property name=\"configResolver\" ref=\"keycloakConfigResolver\" />\n"
+"                </bean>\n"
+"            </httpu:handlers>\n"
+"        </httpu:engine>\n"
+"    </httpu:engine-factory>\n"
+msgstr ""
+"    <httpu:engine-factory bus=\"cxf\" id=\"kc-cxf-endpoint\">\n"
+"        <httpu:engine port=\"8282\">\n"
+"            <httpu:handlers>\n"
+"                <bean class=\"org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler\">\n"
+"                    <property name=\"configResolver\" ref=\"keycloakConfigResolver\" />\n"
+"                </bean>\n"
+"            </httpu:handlers>\n"
+"        </httpu:engine>\n"
+"    </httpu:engine-factory>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <jaxws:endpoint implementor=\"org.keycloak.example.ws.ProductImpl\"\n"
+"                    address=\"http://localhost:8282/ProductServiceCF\" depends-on=\"kc-cxf-endpoint\"/>\n"
+msgstr ""
+"    <jaxws:endpoint implementor=\"org.keycloak.example.ws.ProductImpl\"\n"
+"                    address=\"http://localhost:8282/ProductServiceCF\" depends-on=\"kc-cxf-endpoint\"/>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"META-INF.cxf;version=\"[2.7,3.3)\",\n"
+"META-INF.cxf.osgi;version=\"[2.7,3.3)\";resolution:=optional,\n"
+"org.apache.cxf.bus;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.bus.spring;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.bus.resource;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.transport.http;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.*;version=\"[2.7,3.3)\",\n"
+"org.springframework.beans.factory.config,\n"
+"org.keycloak.*;version=\"{project_versionMvn}\"\n"
+msgstr ""
+"META-INF.cxf;version=\"[2.7,3.3)\",\n"
+"META-INF.cxf.osgi;version=\"[2.7,3.3)\";resolution:=optional,\n"
+"org.apache.cxf.bus;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.bus.spring;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.bus.resource;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.transport.http;version=\"[2.7,3.3)\",\n"
+"org.apache.cxf.*;version=\"[2.7,3.3)\",\n"
+"org.springframework.beans.factory.config,\n"
+"org.keycloak.*;version=\"{project_versionMvn}\"\n"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-separate.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-separate.ja_JP.po
@@ -62,14 +62,14 @@ msgstr ""
 #. type: Title =====
 #, no-wrap
 msgid "Securing an Apache CXF Endpoint on a Separate Undertow Engine"
-msgstr "別のUndertowエンジンでのApache CXFエンドポイントのセキュリティー保護"
+msgstr "分離されたUndertowエンジンでのApache CXFエンドポイントのセキュリティー保護"
 
 #. type: Plain text
 msgid ""
 "To run your CXF endpoints secured by {project_name} on a separate Undertow "
 "engine, complete the following steps:"
 msgstr ""
-"別のUndertowエンジンで、{project_name}によってセキュリティー保護されたCXFエンドポイントを実行するには、以下の手順を実行します。"
+"分離されたUndertowエンジンで、{project_name}によってセキュリティー保護されたCXFエンドポイントを実行するには、以下の手順を実行します。"
 
 #. type: Plain text
 msgid ""
@@ -83,7 +83,7 @@ msgstr ""
 "アプリケーションに `OSGI-INF/blueprint/blueprint.xml` "
 "を追加し、その中に<<_fuse7_adapter_camel, Camelの設定>>と同様の適切な設定リゾルバービーンを追加します。 `httpu"
 ":engine-factory` の中で、そのCamelの設定を使って "
-"`org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler` ハンドラ−を宣言します。CFX"
+"`org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler` ハンドラーを宣言します。CFX"
 " JAX-WSアプリケーションの設定は、次のようになります。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/cxf-separate.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__cxf-separate
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
