### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,7 +40,7 @@ msgstr "左側のメニューで、 `My Resources` オプションを選択す�
 
 #. type: Plain text
 msgid "Manage Permission Requests that *Need my approval*"
-msgstr "*認可が必要な* パーミッション・リクエストの管理"
+msgstr "*Need my approval* パーミッション・リクエストの管理"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
@@ -1,0 +1,126 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Managing Access to Users Resources"
+msgstr "ユーザーリソースへのアクセスの管理"
+
+#. type: Plain text
+msgid ""
+"Users can manage access to their resources using the {project_name} User "
+"Account Service."
+msgstr "ユーザーは、{project_name}ユーザー・アカウント・サービスを使用して、リソースへのアクセスを管理できます。"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/service/account-my-resource.png[alt=\"My Resources\"]"
+msgstr ""
+"image:{project_images}/service/account-my-resource.png[alt=\"My Resources\"]"
+
+#. type: Plain text
+msgid ""
+"On the left side menu, the `My Resources` option leads to a page where users"
+" are able to:"
+msgstr "左側のメニューで、 `My Resources` オプションを選択すると、ユーザーは次のことができます。"
+
+#. type: Plain text
+msgid "Manage Permission Requests that *Need my approval*"
+msgstr "*認可が必要な* パーミッション・リクエストの管理"
+
+#. type: Plain text
+msgid ""
+"This section contains a list of all permission requests awaiting approval. "
+"These requests are connected to the parties (users) requesting access to a "
+"particular resource. Users are allowed to approve or deny these requests."
+msgstr ""
+"このセクションには、承認待ちのすべてのパーミッション・リクエストの一覧が含まれています。これらのリクエストは、特定のリソースへのアクセスを要求している当事者（ユーザー）に接続されています。ユーザーはこれらのリクエストを承認または拒否することができます。"
+
+#. type: Plain text
+msgid "Manage *My resources*"
+msgstr "*My resources* の管理"
+
+#. type: Plain text
+msgid ""
+"This section contains a list of all resources owned by the user. Users can "
+"click on a resource for more details and share the resource with others."
+msgstr ""
+"このセクションには、ユーザーが所有するすべてのリソースのリストが含まれています。ユーザーはリソースをクリックして詳細を表示したり、リソースを他のユーザーと共有することができます。"
+
+#. type: Plain text
+msgid "Managed *Resources shared with me*"
+msgstr "*Resources shared with me* の管理"
+
+#. type: Plain text
+msgid "This section contains a list of all resources shared with the user."
+msgstr "このセクションには、ユーザーと共有するすべてのリソースのリストが含まれています。"
+
+#. type: Plain text
+msgid "Manage *Your requests waiting approval*"
+msgstr "*Your requests waiting approval* の管理"
+
+#. type: Plain text
+msgid ""
+"This section contains a list of permission requests sent by the user that "
+"are waiting for the approval of another user or resource owner."
+msgstr ""
+"このセクションには、別のユーザーまたはリソースオーナーの承認を待っている、ユーザーから送信されたパーミッション・リクエストの一覧が含まれています。"
+
+#. type: Plain text
+msgid ""
+"When the user choose to detail own of his resources by clicking on any "
+"resource in the \"My resources\" listing, he is redirect to a page as "
+"follows:"
+msgstr ""
+"ユーザーが \"My resources\" "
+"のリスト内の任意のリソースをクリックして自分のリソースの詳細を選択すると、次のようにページにリダイレクトされます。"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/service/account-my-resource-detail.png[alt=\"Resource"
+" Detail\"]"
+msgstr ""
+"image:{project_images}/service/account-my-resource-detail.png[alt=\"Resource"
+" Detail\"]"
+
+#. type: Plain text
+msgid "From this page the users are able to:"
+msgstr "このページから、ユーザーは以下を行うことができます。"
+
+#. type: Plain text
+msgid "Manage *People with access to the resource*"
+msgstr "*People with access to the resource* の管理"
+
+#. type: Plain text
+msgid ""
+"This section contains a list of people with access to the resource. Users "
+"are allowed to revoke access by clicking on the `Revoke` button or by "
+"removing a specific `Permission`."
+msgstr ""
+"このセクションには、リソースにアクセスできるユーザーのリストが含まれています。 ユーザーは、 `Revoke` ボタンをクリックするか、特定の "
+"`Permission` を削除することによって、アクセスを取り消すことができます。"
+
+#. type: Plain text
+msgid "Share the resource with others"
+msgstr "他の人とリソースを共有する"
+
+#. type: Plain text
+msgid ""
+"By typing the username or e-mail of another user, the user is able to share "
+"the resource and select the permissions he want to grant access."
+msgstr ""
+"別のユーザーのユーザー名または電子メールを入力することにより、ユーザーはリソースを共有し、アクセスを許可するパーミッションを選択することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-account-my-resources
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
