### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_installation/topics/proxy.adoc:3
 #, no-wrap
 msgid "{project_name} Security Proxy"
 msgstr "{project_name}セキュリティー・プロキシー"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:8
 msgid ""
 "{project_name} has an HTTP(S) proxy that you can put in front of web "
 "applications and services where it is not possible to install the "
@@ -33,39 +31,33 @@ msgstr ""
 "{project_name}には、{project_name}アダプターをインストールすることができないwebアプリケーションとサービスのフロントに置くことができる、HTTP(S)プロキシがあります。ブラウザー・ログインとベアラー・トークン認証の両方、またはそのいずれかによって特定のURLが保護されるように、URLフィルターを設定することができます。また、アプリケーション内のURLパターンのためのロール制約を定義することもできます。"
 
 #. type: Title ===
-#: source/server_installation/topics/proxy.adoc:9
 #, no-wrap
 msgid "Proxy Install and Run"
 msgstr "プロキシーのインストールと実行"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:12
 msgid ""
 "Download the {project_name} proxy distribution from the {project_name} "
 "download pages and unzip it."
 msgstr "{project_name}のダウンロードページから{project_name}プロキシー配布物をダウンロードし、解凍します。"
 
 #. type: delimited block -
-#: source/server_installation/topics/proxy.adoc:16
 #, no-wrap
 msgid "$ unzip keycloak-proxy-dist.zip\n"
 msgstr "$ unzip keycloak-proxy-dist.zip\n"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:19
 msgid ""
 "To run it you must have a proxy config file (which we'll discuss in a "
 "moment)."
 msgstr "これを実行するには、プロキシー設定ファイルが必要です（このファイルについては、直後に説明します）。"
 
 #. type: delimited block -
-#: source/server_installation/topics/proxy.adoc:23
 #, no-wrap
 msgid "$ java -jar bin/launcher.jar [your-config.json]\n"
 msgstr "$ java -jar bin/launcher.jar [your-config.json]\n"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:26
 #, no-wrap
 msgid ""
 "If you do not specify a path to the proxy config file, the launcher will "
@@ -75,22 +67,20 @@ msgstr ""
 "プロキシー設定ファイルへのパスを指定しない場合、ランチャーは `proxy.json` という名前のファイルを現在の作業ディレクトリー内で探します。\n"
 
 #. type: Title ===
-#: source/server_installation/topics/proxy.adoc:27
 #, no-wrap
 msgid "Proxy Configuration"
 msgstr "プロキシー設定"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:30
 msgid "Here's an example configuration file."
 msgstr "設定ファイルのサンプルは以下のとおりです。"
 
 #. type: delimited block -
-#: source/server_installation/topics/proxy.adoc:83
 #, no-wrap
 msgid ""
 "{\n"
 "    \"target-url\": \"http://localhost:8082\",\n"
+"    \"target-request-timeout\": \"60000\",\n"
 "    \"send-access-token\": true,\n"
 "    \"bind-address\": \"localhost\",\n"
 "    \"http-port\": \"8080\",\n"
@@ -142,6 +132,7 @@ msgid ""
 msgstr ""
 "{\n"
 "    \"target-url\": \"http://localhost:8082\",\n"
+"    \"target-request-timeout\": \"60000\",\n"
 "    \"send-access-token\": true,\n"
 "    \"bind-address\": \"localhost\",\n"
 "    \"http-port\": \"8080\",\n"
@@ -192,98 +183,94 @@ msgstr ""
 "}\n"
 
 #. type: Title ====
-#: source/server_installation/topics/proxy.adoc:85
 #, no-wrap
 msgid "Basic Config"
 msgstr "基本設定"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:88
 msgid "The basic configuration options for the server are as follows:"
 msgstr "サーバー用の基本的な設定オプションは以下のとおりです。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:89
 #, no-wrap
 msgid "target-url"
 msgstr "target-url"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:91
-msgid "The URL this server is proxying _REQUIRED._."
+msgid "The URL this server is proxying. _REQUIRED_."
 msgstr "このサーバーがプロキシーするURL。 _REQUIRED_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:92
+#, no-wrap
+msgid "target-request-timeout"
+msgstr "target-request-timeout"
+
+#. type: Plain text
+msgid ""
+"The timeout (in ms) for the proxied request. _OPTIONAL_.  Default is 30000."
+msgstr "プロキシーされたリクエストのタイムアウト（ミリ秒）。 _OPTIONAL_ 。 デフォルトは30000です。"
+
+#. type: Labeled list
 #, no-wrap
 msgid "send-access-token"
 msgstr "send-access-token"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:96
 msgid ""
 "Boolean flag.  If true, this will send the access token via the "
-"KEYCLOAK_ACCESS_TOKEN header to the proxied server. _OPTIONAL._.  Default is"
-" false."
+"KEYCLOAK_ACCESS_TOKEN header to the proxied server. _OPTIONAL_.  Default is "
+"false."
 msgstr ""
 "Booleanフラグ。trueの場合、プロキシーされるサーバーにKEYCLOAK_ACCESS_TOKENヘッダーを介してアクセストークンが送信されます。"
 " _OPTIONAL_ 。デフォルトはfalseです。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:97
 #, no-wrap
 msgid "bind-address"
 msgstr "bind-address"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:100
 #, no-wrap
 msgid ""
-"DNS name or IP address to bind the proxy server's sockets to. _OPTIONAL._.\n"
+"DNS name or IP address to bind the proxy server's sockets to. _OPTIONAL_.\n"
 "The default value is _localhost_                        \n"
 msgstr ""
 "プロキシー・サーバーのソケットをバインドするDNS名またはIPアドレス。 _OPTIONAL_ 。デフォルト値は _localhost_ です。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:101
 #, no-wrap
 msgid "http-port"
 msgstr "http-port"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:104
 msgid ""
 "Port to listen for HTTP requests.  If you do not specify this value, then "
-"the proxy will not listen for regular HTTP requests. _OPTIONAL._."
+"the proxy will not listen for regular HTTP requests. _OPTIONAL_."
 msgstr ""
 "HTTPリクエストをリッスンするポート。この値を指定しないと、プロキシーは通常のHTTPリクエストをリッスンしません。 _OPTIONAL_ 。 "
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:105
 #, no-wrap
 msgid "https-port"
 msgstr "https-port"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:108
 msgid ""
 "Port to listen for HTTPS requests.  If you do not specify this value, then "
-"the proxy will not listen for HTTPS requests. _OPTIONAL._."
+"the proxy will not listen for HTTPS requests. _OPTIONAL_."
 msgstr ""
 "HTTPSリクエストをリッスンするポート。この値を指定しないと、プロキシーは通常のHTTPSリクエストをリッスンしません。 _OPTIONAL_ 。 "
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:109
 #, no-wrap
 msgid "keystore"
 msgstr "keystore"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:113
 #, no-wrap
 msgid ""
 "Path to a Java keystore file that contains private key and certificate for the server to be able to handle HTTPS requests.\n"
-"Can be a file path, or, if you prefix it with `classpath:`                            it will look for this file in the classpath. _OPTIONAL._.\n"
+"Can be a file path, or, if you prefix it with `classpath:`                            it will look for this file in the classpath. _OPTIONAL_.\n"
 "If you have enabled HTTPS, but have not defined a keystore, the proxy will auto-generate a self-signed certificate and use that. \n"
 msgstr ""
 "サーバーがHTTPSリクエストを処理できるようにする、秘密鍵と証明書を含むJavaキーストア・ファイルのパス。ファイルパスにすることは可能ですが、 "
@@ -291,131 +278,124 @@ msgstr ""
 "。キーストアを定義していない状態で、HTTPSを有効にした場合、プロキシーは自己署名証明書を自動生成して使用します。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:114
 #, no-wrap
 msgid "buffer-size"
 msgstr "buffer-size"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:117
 msgid ""
 "HTTP server socket buffer size.  Usually the default is good enough. "
-"_OPTIONAL._."
+"_OPTIONAL_."
 msgstr "HTTPサーバー・ソケットのバッファーサイズ。通常、デフォルトのままで十分です。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:118
 #, no-wrap
 msgid "buffers-per-region"
 msgstr "buffers-per-region"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:121
 msgid ""
 "HTTP server socket buffers per region.  Usually the default is good enough. "
-"_OPTIONAL._."
+"_OPTIONAL_."
 msgstr "リージョン毎のHTTPサーバー・ソケット・バッファー。通常、デフォルトのままで十分です。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:122
 #, no-wrap
 msgid "io-threads"
 msgstr "io-threads"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:125
 msgid "Number of threads to handle IO.  Usually default is good enough."
 msgstr "IOを処理するスレッド数。通常、デフォルトのままで十分です。"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:126
 #, no-wrap
-msgid "_OPTIONAL._.\n"
+msgid "_OPTIONAL_.\n"
 msgstr "_OPTIONAL_ 。\n"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:127
 #, no-wrap
 msgid "The default is the number of available processors * 2. \n"
 msgstr "デフォルトは使用できるプロセッサーの数 * 2です。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:128
 #, no-wrap
 msgid "worker-threads"
 msgstr "worker-threads"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:132
 #, no-wrap
 msgid ""
 "Number of threads to handle requests.\n"
-"Usually the default is good enough. _OPTIONAL._.\n"
+"Usually the default is good enough. _OPTIONAL_.\n"
 "The default is the number of available processors * 16.         \n"
 msgstr ""
 "要求を処理するスレッド数。通常、デフォルトのままで十分です。 _OPTIONAL_ 。デフォルトは使用できるプロセッサーの数 * 16です。\n"
 
 #. type: Title ===
-#: source/server_installation/topics/proxy.adoc:133
 #, no-wrap
 msgid "Application Config"
 msgstr "アプリケーション設定"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:136
 msgid ""
 "Next under the `applications` array attribute, you can define one or more "
 "applications per host you are proxying."
 msgstr "次に、 `applications` 配列の属性の下に、プロキシーしているホスト毎に1つ以上のアプリケーションを定義することができます。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:137
 #, no-wrap
 msgid "base-path"
 msgstr "base-path"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:140
 msgid ""
-"The base context root for the application.  Must start with '/' _REQUIRED._."
+"The base context root for the application.  Must start with '/'. _REQUIRED_."
 msgstr "アプリケーションのベース・コンテキスト・ルート。これは '/' で始まる必要があります。 _REQUIRED_ 。 "
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:141
 #, no-wrap
 msgid "error-page"
 msgstr "error-page"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:145
 msgid ""
 "If the proxy has an error, it will display the target application's error "
-"page relative URL _OPTIONAL._.  This is a relative path to the base-path.  "
+"page relative URL. _OPTIONAL_.  This is a relative path to the base-path.  "
 "In the example above it would be `/customer-portal/error.html`."
 msgstr ""
 "プロキシーにエラーがあると、ターゲット・アプリケーションのエラーページの相対URLが表示されます。 _OPTIONAL_ 。これは、base-"
 "pathへの相対パスです。上記のサンプルでは、 `/customer-portal/error.html` になります。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:146
 #, no-wrap
 msgid "adapter-config"
 msgstr "adapter-config"
 
 #.  See <<_adapter_config,Adapter Config>>
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:150
-msgid "_REQUIRED._.  Same configuration as any other {project_name} adapter."
+msgid "_REQUIRED_.  Same configuration as any other {project_name} adapter."
 msgstr "_REQUIRED_ 。他の{project_name}アダプターと同じ設定です。"
 
+#. type: Labeled list
+#, no-wrap
+msgid "proxy-address-forwarding"
+msgstr "proxy-address-forwarding"
+
+#. type: Plain text
+msgid ""
+"Enable usage of X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto when "
+"hosted behind another proxy/load-balancer."
+msgstr ""
+"他のプロキシー/ロードバランサーの背後に配置した場合は、X-Forwarded-For、X-Forwarded-Host、X-Forwarded-"
+"Protoを使用可能にします。"
+
 #. type: Title ====
-#: source/server_installation/topics/proxy.adoc:151
 #, no-wrap
 msgid "Constraint Config"
 msgstr "制約の設定"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:158
 msgid ""
 "Next under each application you can define one or more constraints in the "
 "`constraints` array attribute.  A constraint defines a URL pattern relative "
@@ -427,183 +407,154 @@ msgstr ""
 "pathを基準にしてURLパターンを定義します。特定のURLパターンに対しての拒否、許可または認証を要求することができます。また、そのパス用に許可される特定のロールも同様に指定することができます。具体的な制約は、一般的な制約より優先されます。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:159
 #, no-wrap
 msgid "pattern"
 msgstr "pattern"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:163
 msgid ""
 "URL pattern to match relative to the base-path of the application.  Must "
-"start with '/' _REQUIRED._ You may only have one wildcard and it must come "
+"start with '/'. _REQUIRED._ You may only have one wildcard and it must come "
 "at the end of the pattern."
 msgstr ""
 "アプリケーションのbase-pathを基準にして一致させるURLパターン。これは '/' で始まる必要があります。 _REQUIRED_ "
 "。ワイルドカードは1つだけ利用でき、パターンの末尾に入れなければなりません。"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:165
 msgid "Valid: [x-]`/foo/bar/*` and [x-]`/foo/*.txt`"
 msgstr "有効: [x-]`/foo/bar/*` と [x-]`/foo/*.txt`"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:166
 msgid "Not valid: [x-]`/*/foo/*`."
 msgstr "無効: [x-]`/*/foo/*`."
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:167
 #, no-wrap
 msgid "roles-allowed"
 msgstr "roles-allowed"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:169
 msgid ""
-"Array of strings of roles allowed to access this url pattern. _OPTIONAL._."
+"Array of strings of roles allowed to access this url pattern. _OPTIONAL_."
 msgstr "このURLパターンへのアクセスが許可されたロールの文字列配列。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:170
 #, no-wrap
 msgid "methods"
 msgstr "methods"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:172
 msgid ""
 "Array of strings of HTTP methods that will exclusively match this pattern "
-"and HTTP request. _OPTIONAL._."
+"and HTTP request. _OPTIONAL_."
 msgstr "このパターンとHTTPリクエストに対して完全に一致する、HTTPメソッドの文字列配列。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:173
 #, no-wrap
 msgid "excluded-methods"
 msgstr "excluded-methods"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:175
 msgid ""
 "Array of strings of HTTP methods that will be ignored when match this "
-"pattern. _OPTIONAL._."
+"pattern. _OPTIONAL_."
 msgstr "このパターンと一致すると無視されるHTTPメソッドの文字列配列。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:176
 #, no-wrap
 msgid "deny"
 msgstr "deny"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:178
-msgid "Deny all access to this URL pattern. _OPTIONAL._."
+msgid "Deny all access to this URL pattern. _OPTIONAL_."
 msgstr "このURLパターンへのすべてのアクセスを拒否します。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:179
 #, no-wrap
 msgid "permit"
 msgstr "permit"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:181
 msgid ""
 "Permit all access without requiring authentication or a role mapping. "
-"_OPTIONAL._."
+"_OPTIONAL_."
 msgstr "認証またはロール・マッピングを要求せずに、すべてのアクセスを許可します。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:182
 #, no-wrap
 msgid "permit-and-inject"
 msgstr "permit-and-inject"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:184
 msgid ""
-"Permit all access, but inject the headers, if user is already "
-"authenticated._OPTIONAL._."
+"Permit all access, but inject the headers, if user is already authenticated."
+" _OPTIONAL_."
 msgstr "すべてのアクセスを許可しますが、ユーザーがすでに認証されている場合はヘッダーを挿入します。 _OPTIONAL_ 。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:185
 #, no-wrap
 msgid "authenticate"
 msgstr "authenticate"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:187
 #, no-wrap
 msgid ""
-"Require authentication for this pattern, but no role mapping. _OPTIONAL._."
+"Require authentication for this pattern, but no role mapping. _OPTIONAL_."
 "                 \n"
 msgstr "このパターンに対して認証は要求しますが、ロールマッピングは要求しません。 _OPTIONAL_ 。\n"
 
 #. type: Title ====
-#: source/server_installation/topics/proxy.adoc:188
 #, no-wrap
 msgid "Header Names Config"
 msgstr "ヘッダー名の設定"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:191
 msgid ""
 "Next under the list of applications you can override the defaults for the "
-"names of the header fields injected by the proxy (see {project_name} "
-"Identity Headers). This mapping is optional."
+"names of the header fields injected by the proxy (see <<_identity_headers, "
+"{project_name} Identity Headers>>). This mapping is optional."
 msgstr ""
-"次に、アプリケーションのリストの下で、プロキシーによって挿入されたデフォルトのヘッダー・フィールド名を上書きすることができます（{project_name}アイデンティティー・ヘッダーを参照してください）。このマッピングはオプションです。"
+"次に、アプリケーションのリストの下で、プロキシーによって挿入されたデフォルトのヘッダー・フィールド名を上書きすることができます（<<_identity_headers,"
+" {project_name}アイデンティティー・ヘッダー>>を参照してください）。このマッピングはオプションです。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:192
 #, no-wrap
 msgid "keycloak-subject"
 msgstr "keycloak-subject"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:195
-#: source/server_installation/topics/proxy.adoc:207
 msgid "e.g.  MYAPP_USER_ID"
 msgstr "例：MYAPP_USER_ID"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:196
 #, no-wrap
 msgid "keycloak-username"
 msgstr "keycloak-username"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:199
 msgid "e.g.  MYAPP_USER_NAME"
 msgstr "例：MYAPP_USER_NAME"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:200
 #, no-wrap
 msgid "keycloak-email"
 msgstr "keycloak-email"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:203
 msgid "e.g.  MYAPP_USER_EMAIL"
 msgstr "例：MYAPP_USER_EMAIL"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:204
 #, no-wrap
 msgid "keycloak-name"
 msgstr "keycloak-name"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:208
 #, no-wrap
 msgid "keycloak-access-token"
 msgstr "keycloak-access-token"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:211
 #, no-wrap
 msgid ""
 "e.g.\n"
@@ -611,13 +562,11 @@ msgid ""
 msgstr "例：MYAPP_ACCESS_TOKEN\n"
 
 #. type: Title ===
-#: source/server_installation/topics/proxy.adoc:212
 #, no-wrap
 msgid "{project_name} Identity Headers"
 msgstr "{project_name}アイデンティティー・ヘッダー"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:215
 msgid ""
 "When forwarding requests to the proxied server, {project_name} Proxy will "
 "set some additional headers with values from the OIDC identity token it "
@@ -626,64 +575,54 @@ msgstr ""
 "プロキシー・サーバーにリクエストを転送する場合、{project_name}プロキシーは、認証のために受け取ったOIDCアイデンティティー・トークンから取得した値で、追加のヘッダーをいくつか設定します。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:216
 #, no-wrap
 msgid "KEYCLOAK_SUBJECT"
 msgstr "KEYCLOAK_SUBJECT"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:219
 msgid ""
 "User id.  Corresponds to JWT `sub` and will be the user id {project_name} "
 "uses to store this user."
 msgstr "ユーザーID。JWT `sub` に対応し、{project_name}がこのユーザーを保存するために使用するユーザーIDになります。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:220
 #, no-wrap
 msgid "KEYCLOAK_USERNAME"
 msgstr "KEYCLOAK_USERNAME"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:223
 #, no-wrap
 msgid ""
 "Username.\n"
-"Corresponds to JWT `preferred_username`                        \n"
+"Corresponds to JWT `preferred_username`.                        \n"
 msgstr ""
 "ユーザー名。\n"
 "JWT `preferred_username` に対応します。\n"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:224
 #, no-wrap
 msgid "KEYCLOAK_EMAIL"
 msgstr "KEYCLOAK_EMAIL"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:226
 msgid "Email address of user if set."
 msgstr "設定されている場合、ユーザーの電子メールアドレス。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:227
 #, no-wrap
 msgid "KEYCLOAK_NAME"
 msgstr "KEYCLOAK_NAME"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:229
 msgid "Full name of user if set."
 msgstr "設定されている場合、ユーザーのフルネーム。"
 
 #. type: Labeled list
-#: source/server_installation/topics/proxy.adoc:230
 #, no-wrap
 msgid "KEYCLOAK_ACCESS_TOKEN"
 msgstr "KEYCLOAK_ACCESS_TOKEN"
 
 #. type: Plain text
-#: source/server_installation/topics/proxy.adoc:233
 #, no-wrap
 msgid ""
 "Send the access token in this header if the proxy was configured to send it.\n"
@@ -693,7 +632,6 @@ msgstr ""
 " `header-names` のマップを使用して設定することができます。\n"
 
 #. type: delimited block -
-#: source/server_installation/topics/proxy.adoc:242
 #, no-wrap
 msgid ""
 "{\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__proxy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
