### PR TITLE
Translations for i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po
+++ b/i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po
@@ -1,0 +1,77 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: delimited block =
+msgid ""
+"In future releases we will update our User-Managed Access(UMA) "
+"implementation to conform to the latest version of the UMA specification, "
+"version 2.0."
+msgstr ""
+"今後のリリースでは、User-Managed "
+"Access(UMA)仕様の最新バージョンであるバージョン2.0に準拠するように、UMAの実装を更新します。"
+
+#. type: delimited block =
+msgid ""
+"Due to differences between versions 1.0 (currently supported) and 2.0 of "
+"UMA, we are deprecating specific functionalities, in order to keep "
+"compliance with the new version. Here is a list of deprecated features:"
+msgstr ""
+"UMAバージョン1.0（現在サポートされているバージョン）と2.0の違いにより、新しいバージョンへの準拠を維持するため、特定の機能を非推奨にしています。廃止された機能の一覧は次のとおりです。"
+
+#. type: delimited block =
+#, no-wrap
+msgid "*Entitlement API*\n"
+msgstr "*エンタイトルメントAPI*\n"
+
+#. type: delimited block =
+#, no-wrap
+msgid ""
+"This REST API will be removed in future releases in favor of a more OAuth2 based way to obtain permissions from the server using a specific grant type. This grant type\n"
+"is based on UMA 2.0 with extensions to make it work without permission tickets. This will have the same behavior as the Entitlement API.\n"
+msgstr ""
+"このREST "
+"APIは、将来のリリースでは削除され、特定の認可タイプを使用してサーバーからアクセス許可を取得するための、より多くのOAuth2ベースの方法が使用されます。この認可タイプは、UMA"
+" 2.0に基づいており、パーミッション・チケットなしで動作するようにしています。これは、エンタイトルメントAPIと同じ動作をします。\n"
+
+#. type: delimited block =
+#, no-wrap
+msgid "*Authorization API*\n"
+msgstr "*認可API*\n"
+
+#. type: delimited block =
+#, no-wrap
+msgid ""
+"This REST API was removed by UMA working group in version 2.0. As a consequence, we will be removing it too. It will\n"
+"be replaced by a specific OAuth2 grant type, as defined by UMA 2.0 specification.\n"
+msgstr ""
+"このREST APIは、バージョン2.0のUMAワーキンググループによって削除されました。その結果を受けて、これも取り除く予定です。これは、UMA "
+"2.0の仕様で定義されている特定のOAuth2認可タイプに置き換えられます。\n"
+
+#. type: delimited block =
+msgid ""
+"Other related changes will occur with the Policy Enforcer, Authorization "
+"Client Java API and configuration. Changes to these are minimal, specially "
+"regarding policy enforcer configuration."
+msgstr ""
+"その他の関連する変更が、ポリシー・エンフォーサー、認可クライアントJava "
+"APIおよび設定で発生します。これらに対する変更は最小限であり、特にポリシー・エンフォーサーの設定に関するものです。"
+
+#. type: delimited block =
+msgid ""
+"We'll be updating docs accordingly, specially on how to migrate to the new "
+"version."
+msgstr "新しいバージョンに移行する方法については、適宜ドキュメントを更新していきます。"

--- a/i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po
+++ b/i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po
@@ -22,7 +22,7 @@ msgid ""
 "version 2.0."
 msgstr ""
 "今後のリリースでは、User-Managed "
-"Access(UMA)仕様の最新バージョンであるバージョン2.0に準拠するように、UMAの実装を更新します。"
+"Access（UMA）仕様の最新バージョンであるバージョン2.0に準拠するように、UMAの実装を更新します。"
 
 #. type: delimited block =
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/topics__templates__authz-service-deprecated-features
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
