### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -611,7 +611,7 @@ msgid ""
 "Now cut and paste the secret value into the _.../domain/configuration/host-"
 "slave.xml_ file as follows:"
 msgstr ""
-" _.../domain/configuration/host-slave.xml_ "
+"_.../domain/configuration/host-slave.xml_ "
 "ファイルにシークレットの値をカット・アンド・ペーストすると、以下のようになります。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
