### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -21,7 +21,7 @@ msgid ""
 "{project_name} is not set up by default to handle SSL/HTTPS.\n"
 "          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
 msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバースプロキシ上のいずれかでSSLを有効にすることを強くお勧めします。\n"
+"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバース・プロキシー上のいずれかでSSLを有効にすることを強くお勧めします。\n"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
