### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
@@ -295,7 +295,7 @@ msgid ""
 "applications deployed to the same {appserver_name} instance. This should not"
 " be enabled when using {project_name}."
 msgstr ""
-"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。{project_name}を使用しているときは、これを有効にしないでください。"
+"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。これは、{project_name}を使用しているときは有効にしないでください。"
 
 #. type: Title =====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
