### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po
@@ -55,8 +55,8 @@ msgid ""
 " project that is not deployed as a classic WAR application. Fuse uses Pax "
 "Web Whiteboard Extender to deploy such servlets as web applications."
 msgstr ""
-"クラシックなWARアプリケーションとしてデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、この方式を使用できます。"
-" FuseはPax Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
+"クラシックなWARアプリケーションとしてデプロイされていないOSGIバンドルされたプロジェクト内にサーブレット・クラスがある場合、この方式を使用できます。FuseはPax"
+" Web Whiteboard Extenderを使用して、サーブレットをWebアプリケーションとしてデプロイします。"
 
 #. type: Plain text
 #: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:8


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__servlet-whiteboard
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
