### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po
@@ -208,7 +208,7 @@ msgstr "</beans>\n"
 msgid ""
 "For the CXF JAX-RS application, the only difference might be in the "
 "configuration of the endpoint dependent on engine-factory:"
-msgstr "CXFのJAX-RSアプリケーションの場合、engine-factortyに依存するエンドポイントの設定にのみ違いがあります。"
+msgstr "CXFのJAX-RSアプリケーションの場合、engine-factortyに依存するエンドポイントの設定にのみ違いがある可能性があります。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-separate.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__cxf-separate
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
