### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po
@@ -28,7 +28,7 @@ msgid ""
 "You must unzip the Jetty 8.1.x distro into Jetty 8.1.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
-"Jetty 8.1.x用の配布物をJetty 8.1.xのルートディレクトリーに解凍する必要があります。 `WEB-INF/lib` "
+"Jetty 8.1.x用の配布物をJetty 8.1.xのルート・ディレクトリーに解凍する必要があります。 `WEB-INF/lib` "
 "ディレクトリー内にアダプターのjarを含めても動作しません！"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty8-installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty8-installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
