### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po
@@ -42,7 +42,7 @@ msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's root directory.  "
 "Including adapter's jars within your WEB-INF/lib directory will not work!"
 msgstr ""
-"Jetty 9.x用の配布物をJetty 9.xのルートディレクトリーに解凍する必要があります。WEB-"
+"Jetty 9.x用の配布物をJetty 9.xのルート・ディレクトリーに解凍する必要があります。WEB-"
 "INF/libディレクトリー内にアダプターのjarを含めても動作しません！"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty9_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
