### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po
@@ -98,9 +98,9 @@ msgid ""
 "The implementation allows customization by overriding methods.\n"
 "While its use is not required, it greatly simplifies your security context configuration.\n"
 msgstr ""
-"Keycloakは、https://docs.spring.io/spring-"
-"security/site/docs/4.0.x/apidocs/org/springframework/security/config/annotation/web/WebSecurityConfigurer.html[WebSecurityConfigurer]を作成するための便利な基本クラスとして、"
-" `KeycloakWebSecurityConfigurerAdapter` "
+"Keycloakは、 https://docs.spring.io/spring-"
+"security/site/docs/4.0.x/apidocs/org/springframework/security/config/annotation/web/WebSecurityConfigurer.html[WebSecurityConfigurer]"
+" を作成するための便利な基本クラスとして、 `KeycloakWebSecurityConfigurerAdapter` "
 "を提供します。この実装では、メソッドのオーバーライドによるカスタマイズが可能です。その使用は必須ではありませんが、セキュリティー・コンテキストの設定が大幅に簡素化されます。\n"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-security-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__spring-security-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
