### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
@@ -68,8 +68,9 @@ msgid ""
 "project in https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab"
 " as OAuth2 authentication service provider]."
 msgstr ""
-"GitHubでログインを可能にするには、まずアプリケーション・プロジェクトをhttps://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab"
-" as OAuth2 authentication service provider]に登録する必要があります。"
+"GitHubでログインを可能にするには、まずアプリケーション・プロジェクトを "
+"https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab as OAuth2 "
+"authentication service provider] に登録する必要があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__gitlab
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
