### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -15,36 +15,21 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Labeled list
-#: source/getting_started/topics/first-realm/account.adoc:13
-#: source/server_admin/topics/events/login.adoc:87
-#: source/server_admin/topics/users/required-actions.adoc:8
-#, no-wrap
-msgid "Update Password"
-msgstr "パスワードの更新"
-
 #. type: Block title
-#: source/server_admin/topics/events/admin.adoc:10
-#: source/server_admin/topics/events/login.adoc:9
 #, no-wrap
 msgid "Event Configuration"
 msgstr "イベント設定"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:12
-#: source/server_admin/topics/events/login.adoc:11
 msgid "image:{project_images}/login-events-config.png[]"
 msgstr "image:{project_images}/login-events-config.png[]"
 
 #. type: Block title
-#: source/server_admin/topics/events/login.adoc:2
-#: source/server_admin/topics/events/login.adoc:24
 #, no-wrap
 msgid "Login Events"
 msgstr "ログインイベント"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:8
 msgid ""
 "Login events occur for things like when a user logs in successfully, when "
 "somebody enters in a bad password, or when a user account is updated.  Every"
@@ -58,7 +43,6 @@ msgstr ""
 " `Events` メニュー項目に行き、 `Config` タブを選択してください。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:13
 msgid ""
 "To start storing events you'll need to turn the `Save Events` switch to on "
 "under the `Login Events Settings`."
@@ -66,18 +50,15 @@ msgstr ""
 "イベントの保存を開始するには、 `Login Events Settings` の `Save Events` スイッチをオンにする必要があります。"
 
 #. type: Block title
-#: source/server_admin/topics/events/login.adoc:14
 #, no-wrap
 msgid "Save Events"
 msgstr "イベントの保存"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:16
 msgid "image:{project_images}/login-events-settings.png[]"
 msgstr "image:{project_images}/login-events-settings.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:21
 msgid ""
 "The `Saved Types` field allows you to specify which event types you want to "
 "store in the event store.  The `Clear events` button allows you to delete "
@@ -92,17 +73,14 @@ msgstr ""
 " ボタンをクリックすることを忘れないでください。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:23
 msgid "To view events, go to the `Login Events` tab."
 msgstr "イベントを表示するには、 `Login Events` タブに移動します。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:26
 msgid "image:{project_images}/login-events.png[]"
 msgstr "image:{project_images}/login-events.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:29
 msgid ""
 "As you can see, there's a lot of information stored and, if you are storing "
 "every event, there are a lot of events stored for each login action.  The "
@@ -113,18 +91,15 @@ msgstr ""
 " `Filter` ボタンを使用すると、実際に関心のあるイベントをフィルタリングすることができます。"
 
 #. type: Block title
-#: source/server_admin/topics/events/login.adoc:30
 #, no-wrap
 msgid "Login Event Filter"
 msgstr "ログインイベント・フィルター"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:32
 msgid "image:{project_images}/login-events-filter.png[]"
 msgstr "image:{project_images}/login-events-filter.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:34
 msgid ""
 "In this screenshot, we're filtering only `Login` events.  Clicking the "
 "`Update` button runs the filter."
@@ -133,111 +108,90 @@ msgstr ""
 "ボタンをクリックするとフィルターが実行されます。"
 
 #. type: Title ====
-#: source/server_admin/topics/events/login.adoc:36
 #, no-wrap
 msgid "Event Types"
 msgstr "イベントの種類"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:39
 msgid "Login events:"
 msgstr "ログインイベント："
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:41
 msgid "Login - A user has logged in."
 msgstr "Login - ユーザーがログインしました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:42
 msgid "Register - A user has registered."
 msgstr "Register - ユーザーが登録しました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:43
 msgid "Logout - A user has logged out."
 msgstr "Logout - ユーザーがログアウトしました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:44
 msgid ""
 "Code to Token - An application/client has exchanged a code for a token."
 msgstr "Code to Token - アプリケーション/クライアントがコードをトークンに交換しました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:45
 msgid "Refresh Token - An application/client has refreshed a token."
 msgstr "Refresh Token - アプリケーション/クライアントがトークンをリフレッシュしました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:47
 msgid "Account events:"
 msgstr "アカウントイベント："
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:49
 msgid "Social Link - An account has been linked to a social provider."
 msgstr "Social Link - アカウントはソーシャル・プロバイダーにリンクされました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:50
 msgid ""
 "Remove Social Link - A social provider has been removed from an account."
 msgstr "Remove Social Link - ソーシャル・プロバイダーがアカウントから削除されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:51
 msgid "Update Email - The email address for an account has changed."
 msgstr "Update Email - アカウントのメールアドレスが変更されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:52
 msgid "Update Profile - The profile for an account has changed."
 msgstr "Update Profile - アカウントのプロファイルが変更されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:53
 msgid "Send Password Reset - A password reset email has been sent."
 msgstr "Send Password Reset - パスワードリセット・メールが送信されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:54
 msgid "Update Password - The password for an account has changed."
 msgstr "Update Password - アカウントのパスワードが変更されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:55
 msgid "Update TOTP - The TOTP settings for an account have changed."
 msgstr "Update TOTP - アカウントのTOTP設定が変更されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:56
 msgid "Remove TOTP - TOTP has been removed from an account."
 msgstr "Remove TOTP - TOTPがアカウントから削除されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:57
 msgid "Send Verify Email - An email verification email has been sent."
 msgstr "Send Verify Email - メールアドレス検証のメールが送信されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:58
 msgid "Verify Email - The email address for an account has been verified."
 msgstr "Verify Email - アカウントのメールアドレスが検証されました。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:60
 msgid "For all events there is a corresponding error event."
 msgstr "すべてのイベントに対応するエラーイベントがあります。"
 
 #. type: Title ====
-#: source/server_admin/topics/events/login.adoc:61
 #, no-wrap
 msgid "Event Listener"
 msgstr "イベントリスナー"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:65
 msgid ""
 "Event listeners listen for events and perform an action based on that event."
 "  There are two built-in listeners that come with {project_name}: Logging "
@@ -247,7 +201,6 @@ msgstr ""
 "{project_name}にはロギング・イベントリスナーと電子メール・イベントリスナーの2つのビルトインのリスナーがあります。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:68
 msgid ""
 "The Logging Event Listener writes to a log file whenever an error event "
 "occurs and is enabled by default.  Here's an example log message:"
@@ -255,7 +208,6 @@ msgstr ""
 "ロギング・イベントリスナーは、エラーイベントが発生したときにログファイルに書き込みます。デフォルトで有効になっています。次に、ログメッセージの例を示します。"
 
 #. type: delimited block -
-#: source/server_admin/topics/events/login.adoc:76
 #, no-wrap
 msgid ""
 "11:36:09,965 WARN  [org.keycloak.events] (default task-51) type=LOGIN_ERROR, realmId=master,\n"
@@ -273,7 +225,6 @@ msgstr ""
 " code_id=b669da14-cdbb-41d0-b055-0810a0334607, username=admin\n"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:81
 msgid ""
 "This logging is very useful if you want to use a tool like Fail2Ban to "
 "detect if there is a hacker bot somewhere that is trying to guess user "
@@ -286,7 +237,6 @@ msgstr ""
 "のログファイルを解析してIPアドレスを抜き出すことができます。その後、攻撃を防ぐことができるように、この情報をFail2Banに与えます。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:84
 msgid ""
 "The Email Event Listener sends an email to the user's account when an event "
 "occurs.  The Email Event Listener only supports the following events at the "
@@ -295,22 +245,23 @@ msgstr ""
 "電子メール・イベントリスナーは、イベントが発生したときにユーザーのアカウントに電子メールを送信します。電子メール・イベントリスナーは、現時点で次のイベントのみをサポートしています。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:86
 msgid "Login Error"
-msgstr "ログインエラー"
+msgstr "Login Error"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Update Password"
+msgstr "Update Password"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:88
 msgid "Update TOTP"
-msgstr "TOTPの更新"
+msgstr "Update TOTP"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:89
 msgid "Remove TOTP"
-msgstr "TOTPの削除"
+msgstr "Remove TOTP"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:92
 msgid ""
 "To enable the Email Listener go to the `Config` tab and click on the `Event "
 "Listeners` field.  This will show a drop down list box where you can select "
@@ -320,17 +271,15 @@ msgstr ""
 "フィールドをクリックしてください。これにより、電子メールを選択できるドロップダウン・リストボックスが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:95
 msgid ""
 "You can exclude one or more events by editing the `standalone.xml`, "
 "`standalone-ha.xml`, or `domain.xml` that comes with your distribution and "
 "adding for example:"
 msgstr ""
-"1つまたは複数のイベントを除外するには、配布物に付属している`standalone.xml`、` standalone-ha.xml`、 "
-"`domain.xml`を編集して、次のように追加します。"
+"1つまたは複数のイベントを除外するには、配布物に付属している `standalone.xml` 、` standalone-ha.xml` 、 "
+"`domain.xml` を編集して、次のように追加します。"
 
 #. type: delimited block -
-#: source/server_admin/topics/events/login.adoc:105
 #, no-wrap
 msgid ""
 "<spi name=\"eventsListener\">\n"
@@ -350,7 +299,6 @@ msgstr ""
 "</spi>\n"
 
 #. type: Plain text
-#: source/server_admin/topics/events/login.adoc:108
 msgid ""
 "See the link:{installguide_link}[{installguide_name}] for more details on "
 "where the `standalone.xml`, `standalone-ha.xml`, or `domain.xml` file lives."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
