### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/import.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/import.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/import.ja_JP.po
@@ -277,7 +277,7 @@ msgid ""
 "additional interface you can implement to deal with this, "
 "`org.keycloak.storage.user.ImportSynchronization`:"
 msgstr ""
-"インポート戦略を使用すると、ローカルユーザーのコピーが外部ストレージと同期しない可能性があるということがわかります。たとえば、ユーザーが外部ストアから削除されている可能性があります。ユーザー・ストレージSPIには、"
+"インポート・ストラテジーを使用すると、ローカルユーザーのコピーが外部ストレージと同期しない可能性があるということがわかります。たとえば、ユーザーが外部ストアから削除されている可能性があります。ユーザー・ストレージSPIには、"
 " これに対処するために実装可能な追加のインターフェイス、 "
 "`org.keycloak.storage.user.ImportSynchronization` があります。"
 

--- a/i18n/po/ja_JP/server_development/topics/user-storage/import.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/import.ja_JP.po
@@ -74,7 +74,7 @@ msgid ""
 "that you can implement to support synchronization, but this can quickly "
 "become painful and messy."
 msgstr ""
-"インポートのアプローチでは、ローカルkeycloakストレージと外部ストレージを同期させておく必要があります。ユーザー・ストレージSPIには、実装させると同期をサポートできるようになる、インターフェイス機能がありますが、これはすぐにやっかいで面倒なものになります。"
+"インポートのアプローチでは、ローカルのkeycloakストレージと外部ストレージを同期させておく必要があります。ユーザー・ストレージSPIには、同期をサポートできるために実装できるケーパビリティー・インターフェイスがありますが、これはすぐにやっかいで面倒なものになります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/import.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__import
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
