### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
@@ -56,7 +56,7 @@ msgid ""
 "<<_service_protection_api, Protection API>>."
 msgstr ""
 "リソースサーバー、リソース、スコープ、パーミッション、およびポリシーを管理するための{project_name}管理コンソールに基づいたUIのセットを提供します。このうちの一部は、<<_service_protection_api,"
-" 保護API>>を使用してリモートでも実現できます。"
+" Protection API>>を使用してリモートでも実現できます。"
 
 #. type: Plain text
 #, no-wrap
@@ -193,8 +193,8 @@ msgid ""
 "the <<_service_protection_api, Protection API>>. In the latter case, "
 "resource servers are able to manage their resources remotely."
 msgstr ""
-"リソースは、{project_name}管理コンソールまたは<<_service_protection_api, "
-"保護API>>を使用して管理できます。後者の場合、リソースサーバーはリソースをリモートで管理できます。"
+"リソースは、{project_name}管理コンソールまたは<<_service_protection_api, Protection "
+"API>>を使用して管理できます。後者の場合、リソースサーバーはリソースをリモートで管理できます。"
 
 #. type: Plain text
 msgid ""
@@ -345,7 +345,7 @@ msgstr "詳細については、<<_service_obtaining_permissions, パーミッ�
 #. type: Title =
 #, no-wrap
 msgid "Protection API"
-msgstr "保護API"
+msgstr "Protection API"
 
 #. type: Plain text
 msgid ""
@@ -355,16 +355,16 @@ msgid ""
 " permissions, and policies associated with them. Only resource servers are "
 "allowed to access this API, which also requires a *uma_protection* scope."
 msgstr ""
-"*Protection API* はhttps://docs.kantarainitiative.org/uma/wg/oauth-uma-"
-"federated-"
-"authz-2.0-09.html[UMA準拠]のエンドポイントのセットであり、リソースサーバーがリソース、スコープ、パーミッション、およびそれらに関連付けられたポリシーを管理する上で役立つ操作を提供します。リソースサーバーだけがこのAPIにアクセスできますが、"
+"*Protection API* は https://docs.kantarainitiative.org/uma/wg/oauth-uma-"
+"federated-authz-2.0-09.html[UMA準拠] "
+"のエンドポイントのセットであり、リソースサーバーがリソース、スコープ、パーミッション、およびそれらに関連付けられたポリシーを管理する上で役立つ操作を提供します。リソースサーバーだけがこのAPIにアクセスできますが、"
 " *uma_protection* スコープも必要です。"
 
 #. type: Plain text
 msgid ""
 "The operations provided by the Protection API can be organized in two main "
 "groups:"
-msgstr "保護APIによって提供される操作は、次の2つの主要なグループに分けられます。"
+msgstr "Protection APIによって提供される操作は、次の2つの主要なグループに分けられます。"
 
 #. type: Plain text
 #, no-wrap
@@ -406,8 +406,9 @@ msgid ""
 "token with all permissions granted during the evaluation of the permissions "
 "and policies associated with the resources and scopes being requested."
 msgstr ""
-"UMAプロトコルを使用する場合、保護APIによるパーミッション・チケットの発行は、認可プロセス全体の重要な部分です。次のセクションで説明するように、これらはクライアントによって要求されたパーミッションを表し、要求されているリソースとスコープに関連付けられたパーミッションとポリシーの評価中に付与されたすべてのパーミッションを持つ最終的なトークンを取得するためにサーバーに送信されます。"
+"UMAプロトコルを使用する場合、Protection "
+"APIによるパーミッション・チケットの発行は、認可プロセス全体の重要な部分です。次のセクションで説明するように、これらはクライアントによって要求されたパーミッションを表し、要求されているリソースとスコープに関連付けられたパーミッションとポリシーの評価中に付与されたすべてのパーミッションを持つ最終的なトークンを取得するためにサーバーに送信されます。"
 
 #. type: Plain text
 msgid "For more information, see <<_service_protection_api, Protection API>>."
-msgstr "より詳細な情報は<<_service_protection_api, 保護API>>を参照してください。"
+msgstr "より詳細な情報は<<_service_protection_api, Protection API>>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-architecture
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
