### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -19,7 +19,7 @@ msgstr ""
 msgid ""
 "(default mode) Requests are denied by default even when there is no policy "
 "associated with a given resource."
-msgstr "（デフォルトモード）特定のリソースに関連付けられたポリシーがない場合でも、デフォルトで要求は拒否されます。"
+msgstr "（デフォルトモード）特定のリソースに関連付けられたポリシーがない場合でも、デフォルトでリクエストは拒否されます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -25,7 +25,7 @@ msgstr "（デフォルトモード）特定のリソースに関連付けられ
 msgid ""
 "Requests are allowed even when there is no policy associated with a given "
 "resource."
-msgstr "特定のリソースに関連付けられたポリシーがない場合でも、要求は許可されます。"
+msgstr "特定のリソースに関連付けられたポリシーがない場合でも、リクエストは許可されます。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-enable-authorization
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
