### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-aggregated-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-aggregated-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-aggregated-policy.ja_JP.po
@@ -49,7 +49,7 @@ msgstr "*Unanimous*\n"
 msgid ""
 "The default strategy if none is provided. In this case, _all_ policies must "
 "evaluate to a positive decision for the final decision to be also positive."
-msgstr "デフォルトの戦略。この場合、最終的に全てのポリシー評価結果が肯定と判断される必要があります。"
+msgstr "デフォルトの戦略。この場合、最終的に _全て_ のポリシー判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/policy-aggregated-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-aggregated-policy.ja_JP.po
@@ -156,7 +156,7 @@ msgstr "*Logic*\n"
 msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
-msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, Logic>>。"
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-aggregated-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-aggregated-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
