### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -59,8 +59,8 @@ msgid ""
 "<<_policy_evaluation_api, Evaluation API>>."
 msgstr ""
 "このタイプのポリシーでは、ルール評価環境である http://www.drools.org[Drools] "
-"を使用してパーミッションの条件を定義できます。これは{project_name}でサポートされている _ルールベース_ "
-"のポリシー・タイプの1つであり、<<_policy_evaluation_api, 評価API>>に基づいたポリシーを柔軟に作成できます。"
+"を使用してパーミッションの条件を定義できます。これは{project_name}でサポートされている _ルールベース_ のポリシー・タイプの1つであり、"
+" <<_policy_evaluation_api, Evaluation API>> に基づいたポリシーを柔軟に作成できます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-drools-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
