### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po
@@ -41,8 +41,7 @@ msgid ""
 "specification, a permission ticket is:"
 msgstr ""
 "<<_overview_terminology_permission_ticket, "
-"パーミッション・チケット>>は、パーミッション・リクエストを表す特殊なセキュリティー・トークン・タイプです。 "
-"UMA仕様では、パーミッション・チケットは次のとおりです。"
+"パーミッション・チケット>>は、パーミッション・リクエストを表す特殊なセキュリティー・トークン・タイプです。UMA仕様では、パーミッション・チケットは次のとおりです。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-permission-api-papi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
