### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
@@ -188,8 +188,8 @@ msgid ""
 "No. Just like a regular access token issued by a {project_name} server, RPTs also use the\n"
 " https://tools.ietf.org/html/rfc7519[JSON web token (JWT)] specification as the default format.\n"
 msgstr ""
-"いいえ。RPTは、{project_name}サーバーが発行する通常のアクセストークンと同様に、デフォルトフォーマットとしてhttps://tools.ietf.org/html/rfc7519[JSON"
-" web token (JWT)] の仕様を使用します。\n"
+"いいえ。RPTは、{project_name}サーバーが発行する通常のアクセストークンと同様に、デフォルトフォーマットとして "
+"https://tools.ietf.org/html/rfc7519[JSON web token（JWT）] の仕様を使用します。\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-rpt-token-introspection
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
