### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -260,7 +260,7 @@ msgstr ""
 #. type: Title ==
 #, no-wrap
 msgid "Creating a Resource Using the Protection API"
-msgstr "保護APIを使用したリソースの作成"
+msgstr "Protection APIを使用したリソースの作成"
 
 #. type: Code block
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-client-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
