### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
@@ -23,7 +23,7 @@ msgstr "*リソース管理*\n"
 #. type: Title =
 #, no-wrap
 msgid "Protection API"
-msgstr "保護API"
+msgstr "Protection API"
 
 #. type: Plain text
 #, no-wrap
@@ -33,7 +33,7 @@ msgstr "*パーミッション管理*\n"
 #. type: Plain text
 msgid ""
 "The Protection API provides a UMA-compliant set of endpoints providing:"
-msgstr "保護APIは、UMA準拠のエンドポイントのセットを提供します。"
+msgstr "Protection APIは、UMA準拠のエンドポイントのセットを提供します。"
 
 #. type: Plain text
 msgid ""
@@ -59,5 +59,5 @@ msgid ""
 " protection API token (PAT).  In UMA, a PAT is a token with the scope "
 "*uma_protection*."
 msgstr ""
-"このAPIの重要な要件は、保護APIトークン（PAT）と呼ばれる特別なOAuth2アクセストークンを使用して、リソースサーバー _だけ_ "
-"がエンドポイントにアクセスできることです。 UMAでは、PATはスコープ *uma_protection* を持つトークンです。"
+"このAPIの重要な要件は、Protection APIトークン（PAT）と呼ばれる特別なOAuth2アクセストークンを使用して、リソースサーバー "
+"_だけ_ がエンドポイントにアクセスできることです。 UMAでは、PATはスコープ *uma_protection* を持つトークンです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-protection-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
