### PR TITLE
Translations for i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po
+++ b/i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po
@@ -35,7 +35,7 @@ msgstr ""
 #. type: delimited block =
 #, no-wrap
 msgid "*Entitlement API*\n"
-msgstr "*エンタイトルメントAPI*\n"
+msgstr "*Entitlement API*\n"
 
 #. type: delimited block =
 #, no-wrap
@@ -50,7 +50,7 @@ msgstr ""
 #. type: delimited block =
 #, no-wrap
 msgid "*Authorization API*\n"
-msgstr "*認可API*\n"
+msgstr "*Authorization API*\n"
 
 #. type: delimited block =
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/topics/templates/authz-service-deprecated-features.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/topics__templates__authz-service-deprecated-features
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
