### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-submiting-permission-requests.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-submiting-permission-requests.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-submiting-permission-requests.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,7 +18,7 @@ msgstr ""
 #. type: Block title
 #, no-wrap
 msgid "{project_name} denies the authorization request"
-msgstr "{project_name}は認可リクエストを拒否します"
+msgstr "{project_name}の認可リクエストの拒否"
 
 #. type: Code block
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-submiting-permission-requests.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-submiting-permission-requests
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
