### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
@@ -75,7 +75,7 @@ msgstr ""
 #. type: Block title
 #, no-wrap
 msgid "{project_name} denies the authorization request"
-msgstr "{project_name}は認可リクエストを拒否します"
+msgstr "{project_name}の認可リクエストの拒否"
 
 #. type: Code block
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-authz-process
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
