### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -450,7 +450,7 @@ msgstr "image:{project_images}/domain-boot-files.png[]"
 
 #. type: Plain text
 msgid "To boot the server:"
-msgstr "サーバーを起動するには下記を実行します"
+msgstr "サーバーを起動するには下記を実行します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -15,10 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-msgid "To boot the server:"
-msgstr "サーバーを起動するには下記を実行します"
-
 #. type: Block title
 #, no-wrap
 msgid "Linux/Unix"
@@ -452,6 +448,10 @@ msgstr ""
 msgid "image:{project_images}/domain-boot-files.png[]"
 msgstr "image:{project_images}/domain-boot-files.png[]"
 
+#. type: Plain text
+msgid "To boot the server:"
+msgstr "サーバーを起動するには下記を実行します"
+
 #. type: delimited block -
 #, no-wrap
 msgid "$ .../bin/domain.sh --host-config=host-master.xml\n"
@@ -459,8 +459,8 @@ msgstr "$ .../bin/domain.sh --host-config=host-master.xml\n"
 
 #. type: delimited block -
 #, no-wrap
-msgid "> ...\\bin\\domain.bat --host-config=host-slave.xml\n"
-msgstr "> ...\\bin\\domain.bat --host-config=host-slave.xml\n"
+msgid "> ...\\bin\\domain.bat --host-config=host-master.xml\n"
+msgstr "> ...\\bin\\domain.bat --host-config=host-master.xml\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
