### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
@@ -17,26 +17,8 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Standalone Boot Scripts"
-msgstr "スタンドアローン起動スクリプト"
-
-#. type: Plain text
-msgid "image:{project_images}/standalone-boot-files.png[]"
-msgstr "image:{project_images}/standalone-boot-files.png[]"
-
-#. type: Plain text
-msgid "To boot the server:"
-msgstr "サーバーを起動するには下記を実行します"
-
-#. type: Block title
-#, no-wrap
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
-
-#. type: delimited block -
-#, no-wrap
-msgid "$ .../bin/standalone.sh\n"
-msgstr "$ .../bin/standalone.sh\n"
 
 #. type: Block title
 #, no-wrap
@@ -48,19 +30,14 @@ msgstr "Windows"
 msgid "> ...\\bin\\standalone.bat\n"
 msgstr "> ...\\bin\\standalone.bat\n"
 
-#. type: Title ===
+#. type: Plain text
+msgid "To boot the server:"
+msgstr "サーバーを起動するには下記を実行します。"
+
+#. type: Block title
 #, no-wrap
 msgid "Standalone Mode"
 msgstr "スタンドアローン・モード"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
-"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
-"      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
-msgstr ""
-"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"
 
 #. type: Plain text
 msgid ""
@@ -87,6 +64,20 @@ msgid ""
 msgstr ""
 "スタンドアローン・モードでサーバーを実行する場合、オペレーティング・システム固有の起動スクリプトを実行する必要があります。これらのスクリプトはサーバー配布物の"
 " _bin/_ ディレクトリーにあります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Standalone Boot Scripts"
+msgstr "スタンドアローン起動スクリプト"
+
+#. type: Plain text
+msgid "image:{project_images}/standalone-boot-files.png[]"
+msgstr "image:{project_images}/standalone-boot-files.png[]"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ .../bin/standalone.sh\n"
+msgstr "$ .../bin/standalone.sh\n"
 
 #. type: Title ====
 #, no-wrap
@@ -115,3 +106,12 @@ msgstr "スタンドアローン設定ファイル"
 #. type: Plain text
 msgid "image:{project_images}/standalone-config-file.png[]"
 msgstr "image:{project_images}/standalone-config-file.png[]"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
+"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
+"      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
+msgstr ""
+"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
