### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -20,15 +20,19 @@ msgstr ""
 msgid "Linux/Unix"
 msgstr "Linux/Unix"
 
-#. type: delimited block -
-#, no-wrap
-msgid "$ .../bin/standalone.sh\n"
-msgstr "$ .../bin/standalone.sh\n"
-
 #. type: Block title
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd bin\n"
+"$ ./standalone.sh\n"
+msgstr ""
+"$ cd bin\n"
+"$ ./standalone.sh\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -98,8 +102,8 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "WildFly 11 and Linux/Unix"
-msgstr "WildFly 11とLinux/Unix"
+msgid "Wildfly 11 and Linux/Unix"
+msgstr "WildFly 11・Linux/Unix"
 
 #. type: delimited block -
 #, no-wrap
@@ -112,8 +116,8 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "WildFly 11 and Windows"
-msgstr "WildFly 11とWindows"
+msgid "Wildfly 11 and Windows"
+msgstr "WildFly 11・Windows"
 
 #. type: delimited block -
 #, no-wrap
@@ -128,10 +132,10 @@ msgstr ""
 msgid ""
 "This script will make the necessary edits to the "
 "`.../standalone/configuration/standalone.xml` file of your app server "
-"distribution."
+"distribution and may take some time to complete."
 msgstr ""
 "このスクリプトは、アプリケーション・サーバーの配布物の `.../standalone/configuration/standalone.xml` "
-"ファイルを必要に応じて編集します。"
+"ファイルを必要に応じて編集し、完了するまでに時間がかかることがあります。"
 
 #. type: Plain text
 msgid "Start the application server."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__install-client-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
