### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
@@ -16,17 +16,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_installation/topics/cache.adoc:2
 #, no-wrap
 msgid "Server Cache Configuration"
 msgstr "サーバー・キャッシュ設定"
 
 #. type: Plain text
-#: source/server_installation/topics/cache.adoc:11
 #, no-wrap
 msgid ""
 "{project_name} has two types of caches.  One type of cache sits in front of the database to decrease load on the DB\n"
-"and to increase overall response times by keeping data in memory.  Realm, client, role, and user metadata is kept in this type of cache.\n"
+"and to decrease overall response times by keeping data in memory.  Realm, client, role, and user metadata is kept in this type of cache.\n"
 "This cache is a local cache.  Local caches do not use replication even if you are in the cluster with more {project_name} servers.\n"
 "Instead, they only keep copies locally and if the entry is updated an invalidation message is sent to the rest of the cluster\n"
 "and the entry is evicted. There is separate replicated cache `work`, which task is to send the invalidation messages to the whole cluster about what entries\n"
@@ -38,7 +36,6 @@ msgstr ""
 "がありますが、このタスクは、何のエントリーがローカル・キャッシュから取り除かれるかについて、クラスター全体に無効化メッセージを送信するタスクになります。これによって、ネットワーク・トラフィックがかなり減り、効率化され、機密性の高いメタデータ通信の送信が回避されます。\n"
 
 #. type: Plain text
-#: source/server_installation/topics/cache.adoc:15
 msgid ""
 "The second type of cache handles managing user sessions, offline tokens, and"
 " keeping track of login failures so that the server can detect password "
@@ -48,14 +45,12 @@ msgstr ""
 "2つ目のキャッシュは、ユーザー・セッション、オフライン・トークン、ログイン・エラーの履歴保持の管理を担当し、サーバーがパスワード・フィッシングやその他の攻撃を検出できるようにします。これらのキャッシュ内のデータは一時的で、メモリーにのみ保持されるものですが、クラスター全体にレプリケーションされる可能性があります。"
 
 #. type: Plain text
-#: source/server_installation/topics/cache.adoc:17
 msgid ""
 "This chapter discusses some configuration options for these caches for both "
 "clustered a non-clustered deployments."
 msgstr "この章では、クラスター構成と非クラスター構成の両方のためのキャッシュ用設定オプションについて説明します。"
 
 #. type: Plain text
-#: source/server_installation/topics/cache.adoc:18
 msgid ""
 "More advanced configuration of these caches can be found in the "
 "link:{appserver_caching_link}[Infinispan] section of the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
