### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
@@ -29,6 +29,11 @@ msgstr ""
 "    ...\n"
 "}\n"
 
+#. type: delimited block -
+#, no-wrap
+msgid "import ...\n"
+msgstr "import ...\n"
+
 #. type: Title ==
 #, no-wrap
 msgid "Extending the Server"
@@ -125,11 +130,6 @@ msgstr ""
 #, no-wrap
 msgid "package org.keycloak.examples.domainextension.spi;\n"
 msgstr "package org.keycloak.examples.domainextension.spi;\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "import ...\n"
-msgstr "import ...\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -257,6 +257,12 @@ msgstr ""
 "独自のJPAエンティティーを追加するには、 `JpaEntityProviderFactory` と `JpaEntityProvider` "
 "を実装する必要があります。 `JpaEntityProvider` "
 "によって、カスタムJPAエンティティーのリストを返し、Liquibaseの変更履歴の場所とidを提供することができます。実装サンプルは、以下のとおりになります。"
+
+#. type: Plain text
+msgid ""
+"This is an unsupported API, which means you can use it but there is no "
+"guarantee that it will not be removed or changed without warning."
+msgstr "これはサポートされていないAPIです。つまり、使用することはできますが、警告なしで削除または変更される可能性があります。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
