### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po
@@ -15,15 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
-#, no-wrap
-msgid "Login Tab"
-msgstr "Loginタブ"
-
-#. type: Plain text
-msgid "image:{project_images}/login-tab.png[]"
-msgstr "image:{project_images}/login-tab.png[]"
-
 #. type: Title ===
 #, no-wrap
 msgid "User Registration"
@@ -40,10 +31,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "When user self registration is enabled it is possible to use the "
-"registration form to detect valid usernames and emails.  To prevent this "
-"enable <<_recaptcha,reCAPTCHA Support>>."
+"registration form to detect valid usernames and emails.  It is also possible"
+" to enable <<_recaptcha,reCAPTCHA Support>>."
 msgstr ""
-"ユーザーの自己登録が有効になっている場合、登録フォームを使用して有効なユーザー名と電子メールを検出することができます。これを回避するには、<<_recaptcha,reCAPTCHAのサポート>>を有効にします。"
+"ユーザーの自己登録が有効になっている場合、登録フォームを使用して有効なユーザー名と電子メールを検出することができます。<<_recaptcha,reCAPTCHAのサポート>>を有効にすることもできます。"
 
 #. type: Plain text
 msgid ""
@@ -54,6 +45,15 @@ msgstr ""
 "登録を有効にするのは簡単です。 左メニューの `Realm Settings` をクリックし、移動します。次に、 `Login` "
 "タブに移動します。このタブには `User Registration` スイッチがあります。それをオンにしてから、 `Save` "
 "ボタンをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Login Tab"
+msgstr "Loginタブ"
+
+#. type: Plain text
+msgid "image:{project_images}/login-tab.png[]"
+msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/user-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__user-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
