### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po
@@ -15,6 +15,11 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
 #. type: Plain text
 msgid ""
 "With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
@@ -22,11 +27,6 @@ msgid ""
 msgstr ""
 "Red Hat Enterprise Linux "
 "7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
-
-#. type: Title ==
-#, no-wrap
-msgid "Prerequisites"
-msgstr "前提条件"
 
 #. type: Plain text
 msgid ""
@@ -84,15 +84,6 @@ msgstr ""
 ">-server-rpms\n"
 
 #. type: Plain text
-msgid "Install the EAP 7 adapters for OIDC using the following command:"
-msgstr "次のコマンドを使用して、OIDC用のEAP 7アダプターをインストールします。"
-
-#. type: delimited block -
-#, no-wrap
-msgid "$ sudo yum install eap7-keycloak-adapter-sso7_2\n"
-msgstr "$ sudo yum install eap7-keycloak-adapter-sso7_2\n"
-
-#. type: Plain text
 msgid ""
 "The default EAP_HOME path for the RPM installation is "
 "/opt/rh/eap7/root/usr/share/wildfly."
@@ -101,19 +92,6 @@ msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/
 #. type: Plain text
 msgid "Run the appropriate module installation script."
 msgstr "適切なモジュール・インストール・スクリプトを実行します。"
-
-#. type: Plain text
-msgid "For the OIDC module, enter the following command:"
-msgstr "OIDCモジュールの場合は、次のコマンドを実行します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ {EAP_HOME}/bin/jboss-cli.sh -c --file=${EAP_HOME}/bin/adapter-"
-"install.cli\n"
-msgstr ""
-"$ {EAP_HOME}/bin/jboss-cli.sh -c --file=${EAP_HOME}/bin/adapter-"
-"install.cli\n"
 
 #. type: Plain text
 msgid "Your installation is complete."
@@ -149,6 +127,32 @@ msgstr ""
 ">-server-rpms\n"
 
 #. type: Plain text
+msgid ""
+"The default EAP_HOME path for the RPM installation is "
+"/opt/rh/eap6/root/usr/share/wildfly."
+msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"
+
+#. type: Plain text
+msgid "Install the EAP 7 adapters for OIDC using the following command:"
+msgstr "次のコマンドを使用して、OIDC用のEAP 7アダプターをインストールします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo yum install eap7-keycloak-adapter-sso7_2\n"
+msgstr "$ sudo yum install eap7-keycloak-adapter-sso7_2\n"
+
+#. type: Plain text
+msgid "For the OIDC module, enter the following command:"
+msgstr "OIDCモジュールの場合は、次のコマンドを実行します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install.cli\n"
+msgstr ""
+"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install.cli\n"
+
+#. type: Plain text
 msgid "Install the EAP 6 adapters for OIDC using the following command:"
 msgstr "次のコマンドを使用して、OIDC用のEAP 6アダプターをインストールします。"
 
@@ -156,9 +160,3 @@ msgstr "次のコマンドを使用して、OIDC用のEAP 6アダプターをイ
 #, no-wrap
 msgid "$ sudo yum install keycloak-adapter-sso7_2-eap6\n"
 msgstr "$ sudo yum install keycloak-adapter-sso7_2-eap6\n"
-
-#. type: Plain text
-msgid ""
-"The default EAP_HOME path for the RPM installation is "
-"/opt/rh/eap6/root/usr/share/wildfly."
-msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
