### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/themes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/themes.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/themes.ja_JP.po
@@ -639,6 +639,12 @@ msgstr ""
 "# encoding: UTF-8\n"
 "usernameOrEmail=....\n"
 
+#. type: Plain text
+msgid ""
+"See <<_locale_selector,Locale Selector>> on details on how the current "
+"locale is selected."
+msgstr "現在のロケールの選択方法の詳細については、<<_locale_selector,ロケール・セレクター>>を参照してください。"
+
 #. type: Title ====
 #, no-wrap
 msgid "HTML Templates"
@@ -761,12 +767,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"To deploy a theme as an archive you need to create a ZIP archive with the "
+"To deploy a theme as an archive you need to create a JAR archive with the "
 "theme resources. You also need to add a file `META-INF/keycloak-themes.json`"
 " to the archive that lists the available themes in the archive as well as "
 "what types each theme provides."
 msgstr ""
-"テーマをアーカイブとしてデプロイするには、テーマのリソースを使用してZIPアーカイブを作成する必要があります。また、アーカイブで使用可能なテーマと各テーマが提供するタイプをリストするアーカイブに、"
+"テーマをアーカイブとしてデプロイするには、テーマのリソースを使用してJARアーカイブを作成する必要があります。また、アーカイブで使用可能なテーマと各テーマが提供するタイプをリストするアーカイブに、"
 " `META-INF/keycloak-themes.json` ファイルを追加することも必要です。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/themes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__themes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
