### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -33,14 +33,14 @@ msgid ""
 "platform you might opt to use a generic OpenID Connect Resource Provider "
 "(RP) library instead. This chapter describes details specific to "
 "{project_name} and does not contain specific protocol details. For more "
-"information see the http://openid.net/connect/[OpenID Connect "
+"information see the https://openid.net/connect/[OpenID Connect "
 "specifications] and https://tools.ietf.org/html/rfc6749[OAuth2 "
 "specification]."
 msgstr ""
 "{project_name}は、使いやすくて、{project_name}と統合しやすい付属のアダプターにより、セキュリティー保護できます。ただし、使用するプログラミング言語、フレームワーク、プラットフォームでアダプターが使用できない場合は、代わりに一般的なOpenID"
 " Connect Resource "
 "Provider（RP）ライブラリーを使用することができます。この章では、{project_name}固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。詳細については、"
-" http://openid.net/connect/[OpenID Connect specifications] と "
+" https://openid.net/connect/[OpenID Connect specifications] と "
 "https://tools.ietf.org/html/rfc6749[OAuth2 specification] を参照してください。"
 
 #. type: Title ====
@@ -104,11 +104,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details see the http://openid.net/specs/openid-connect-core-"
+"For more details see the https://openid.net/specs/openid-connect-core-"
 "1_0.html#AuthorizationEndpoint[Authorization Endpoint] section in the OpenID"
 " Connect specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
 "1_0.html#AuthorizationEndpoint[Authorization Endpoint] を参照してください。"
 
 #. type: Title ===
@@ -132,11 +132,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details see the http://openid.net/specs/openid-connect-core-"
+"For more details see the https://openid.net/specs/openid-connect-core-"
 "1_0.html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
 "1_0.html#TokenEndpoint[Token Endpoint] を参照してください。"
 
 #. type: Title =====
@@ -157,11 +157,11 @@ msgstr "UserInfoエンドポイントは、認証されたユーザーに関す�
 
 #. type: Plain text
 msgid ""
-"For more details see the http://openid.net/specs/openid-connect-core-"
+"For more details see the https://openid.net/specs/openid-connect-core-"
 "1_0.html#UserInfo[Userinfo Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
 "1_0.html#UserInfo[Userinfo Endpoint]を参照してください。"
 
 #. type: Title =====
@@ -333,11 +333,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details refer to the http://openid.net/specs/openid-connect-core-"
+"For more details refer to the https://openid.net/specs/openid-connect-core-"
 "1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
 "1_0.html#CodeFlowAuth[Authorization Code Flow] を参照してください。"
 
 #. type: Title =====
@@ -377,11 +377,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details refer to the http://openid.net/specs/openid-connect-core-"
+"For more details refer to the https://openid.net/specs/openid-connect-core-"
 "1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の http://openid.net/specs/openid-connect-core-"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
 "1_0.html#ImplicitFlowAuth[Implicit Flow] を参照してください。"
 
 #. type: Title =====


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
