### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -133,7 +137,7 @@ msgid ""
 "cookie name or contents, such as Amazon ALB. For these, it is recommended to"
 " set the `shouldAttachRoute` option to `false`."
 msgstr ""
-"一部のロードバランサーは、スティッキー・セッションCookieの名前や内容（Amazon ALBなど）の設定を許可しません。これらのために、 "
+"一部のロードバランサーは、スティッキー・セッションCookieの名前や内容の設定を許可しません（Amazon ALBなど）。これらのために、 "
 "`shouldAttachRoute` オプションを `false` に設定することが推奨されます。"
 
 #. type: Title =====

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -127,6 +127,15 @@ msgstr ""
 "）を開始すると、問題なく動作します。 "
 "ただし、別のアプリケーションからの初期化されたバックチャネル・ログアウトは、{project_name}によってCookieストアを使用するアプリケーションに伝播されません。したがって、アクセストークンのタイムアウトに短い値（たとえば1分）を使用することをお勧めします。"
 
+#. type: Plain text
+msgid ""
+"Some load balancers do not allow any configuration of the sticky session "
+"cookie name or contents, such as Amazon ALB. For these, it is recommended to"
+" set the `shouldAttachRoute` option to `false`."
+msgstr ""
+"一部のロードバランサーは、スティッキー・セッションCookieの名前や内容（Amazon ALBなど）の設定を許可しません。これらのために、 "
+"`shouldAttachRoute` オプションを `false` に設定することが推奨されます。"
+
 #. type: Title =====
 #, no-wrap
 msgid "Relative URI optimization"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__application-clustering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
