### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po
@@ -3,6 +3,11 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# katakura__pro <h.katakura@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""

--- a/i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,15 +15,15 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
-#, no-wrap
-msgid "Users"
-msgstr "ユーザー"
-
 #. type: Title ===
 #, no-wrap
 msgid "Impersonation"
 msgstr "代理ログイン"
+
+#. type: Title =====
+#, no-wrap
+msgid "Users"
+msgstr "ユーザー"
 
 #. type: Plain text
 msgid ""
@@ -43,12 +43,12 @@ msgstr "image:{project_images}/user-search.png[]"
 
 #. type: Plain text
 msgid ""
-"You can see here that the admin has searched for `jim`.  Next to Jim's "
+"You can see here that the admin has searched for `john`.  Next to John's "
 "account you can see an impersonate button.  Click that to impersonate the "
 "user."
 msgstr ""
-"ここでは管理者が `jim` "
-"を検索したことがわかります。Jimのアカウントの横に代理ログインのボタンが表示されます。ボタンをクリックすると、そのユーザーで代理ログインできます。"
+"ここでは管理者が `john` "
+"を検索したことがわかります。Johnのアカウントの横に代理ログインのボタンが表示されます。ボタンをクリックすると、そのユーザーで代理ログインできます。"
 
 #. type: Plain text
 msgid "Also, you can impersonate the user from the user `Details` tab."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__impersonation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
