### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -38,7 +42,8 @@ msgid ""
 " can be set to resources by resource servers on behalf of their users."
 msgstr ""
 "{project_name}はUMA Protection "
-"APIを利用して、リソースサーバーがユーザーのパーミッションを管理できるようにします。{project_name}はリソースAPIとパーミッションAPIに加えて、ユーザーの代わりにリソースサーバーによって、リソースにパーミッションを設定できるポリシーAPIを提供します。"
+"APIを利用して、リソースサーバーがユーザーのパーミッションを管理できるようにします。{project_name}はリソースAPIとパーミッションAPIに加えて、ユーザーの代わりにリソースサーバーによって、リソースにパーミッションを設定できるPolicy"
+" APIを提供します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
@@ -32,6 +32,16 @@ msgstr "*パーミッション管理*\n"
 
 #. type: Plain text
 msgid ""
+"{project_name} leverages the UMA Protection API to allow resource servers to"
+" manage permissions for their users. In addition to the Resource and "
+"Permission APIs, {project_name} provides a Policy API from where permissions"
+" can be set to resources by resource servers on behalf of their users."
+msgstr ""
+"{project_name}はUMA Protection "
+"APIを利用して、リソースサーバーがユーザーのパーミッションを管理できるようにします。{project_name}はリソースAPIとパーミッションAPIに加えて、ユーザーの代わりにリソースサーバーによって、リソースにパーミッションを設定できるポリシーAPIを提供します。"
+
+#. type: Plain text
+msgid ""
 "The Protection API provides a UMA-compliant set of endpoints providing:"
 msgstr "Protection APIは、UMA準拠のエンドポイントのセットを提供します。"
 
@@ -51,6 +61,11 @@ msgid ""
 "state of permissions and query permissions."
 msgstr ""
 "UMAプロトコルでは、リソースサーバーはこのエンドポイントにアクセスしてパーミッション・チケットを作成します。{project_name}には、パーミッションの状態やクエリー・パーミッションを管理するためのエンドポイントも用意されています。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Policy API*\n"
+msgstr "*Policy API*\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-protection-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
