### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# masahiro suzuki <suzmasah@fsi.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po
@@ -16,63 +16,52 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title =
-#: source/authorization_services/topics/resource-view.adoc:2
 #, no-wrap
 msgid "Viewing Resources"
 msgstr "リソースの表示"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:5
 msgid ""
 "On the *Resource* page, you see a list of the resources associated with a "
 "resource server."
 msgstr "*Resource* ページには、リソースサーバーに関連付けられているリソースの一覧が表示されます。"
 
 #. type: Block title
-#: source/authorization_services/topics/resource-view.adoc:6
 #, no-wrap
 msgid "Resources"
 msgstr "リソース"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:8
 msgid "image:{project_images}/resource/view.png[alt=\"Resources\"]"
 msgstr "image:{project_images}/resource/view.png[alt=\"Resources\"]"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:10
 msgid ""
 "The resource list provides information about the protected resources, such "
 "as:"
 msgstr "リソースリストには、次のような保護されたリソースに関する情報が表示されます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:12
 msgid "Type"
 msgstr "タイプ"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:13
-msgid "URI"
-msgstr "URI"
+msgid "URIS"
+msgstr "URIS"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:14
 msgid "Owner"
 msgstr "オーナー"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:15
 msgid "Associated scopes, if any"
 msgstr "関連スコープ（存在する場合）"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:16
 msgid "Associated permissions"
 msgstr "関連するパーミッション"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:18
 msgid ""
 "From this list, you can also directly create a permission by clicking "
 "*Create Permission* for the resource for which you want to create the "
@@ -82,7 +71,6 @@ msgstr ""
 "をクリックして、パーミッションを直接作成することもできます。"
 
 #. type: Plain text
-#: source/authorization_services/topics/resource-view.adoc:20
 msgid ""
 "Before creating permissions for your resources, be sure you have already "
 "defined the policies that you want to associate with the permission."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-view.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-view
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
