### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -15,6 +15,11 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
 #. type: Plain text
 msgid ""
 "With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
@@ -22,11 +27,6 @@ msgid ""
 msgstr ""
 "Red Hat Enterprise Linux "
 "7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
-
-#. type: Title ==
-#, no-wrap
-msgid "Prerequisites"
-msgstr "前提条件"
 
 #. type: Plain text
 msgid ""
@@ -84,6 +84,15 @@ msgstr ""
 ">-server-rpms\n"
 
 #. type: Plain text
+msgid "Install the EAP 7 adapters for SAML using the following command:"
+msgstr "次のコマンドを使用して、SAML用のEAP 7アダプターをインストールします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
+msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
+
+#. type: Plain text
 msgid ""
 "The default EAP_HOME path for the RPM installation is "
 "/opt/rh/eap7/root/usr/share/wildfly."
@@ -92,6 +101,19 @@ msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/
 #. type: Plain text
 msgid "Run the appropriate module installation script."
 msgstr "適切なモジュール・インストール・スクリプトを実行します。"
+
+#. type: Plain text
+msgid "For the SAML module, enter the following command:"
+msgstr "SAMLモジュールの場合は、次のコマンドを実行します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install-"
+"saml.cli\n"
+msgstr ""
+"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install-"
+"saml.cli\n"
 
 #. type: Plain text
 msgid "Your installation is complete."
@@ -127,34 +149,6 @@ msgstr ""
 ">-server-rpms\n"
 
 #. type: Plain text
-msgid ""
-"The default EAP_HOME path for the RPM installation is "
-"/opt/rh/eap6/root/usr/share/wildfly."
-msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"
-
-#. type: Plain text
-msgid "Install the EAP 7 adapters for SAML using the following command:"
-msgstr "次のコマンドを使用して、SAML用のEAP 7アダプターをインストールします。"
-
-#. type: delimited block -
-#, no-wrap
-msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
-msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
-
-#. type: Plain text
-msgid "For the SAML module, enter the following command:"
-msgstr "SAMLモジュールの場合は、次のコマンドを実行します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ {EAP_HOME}/bin/jboss-cli.sh -c --file=${EAP_HOME}/bin/adapter-install-"
-"saml.cli\n"
-msgstr ""
-"$ {EAP_HOME}/bin/jboss-cli.sh -c --file=${EAP_HOME}/bin/adapter-install-"
-"saml.cli\n"
-
-#. type: Plain text
 msgid "Install the EAP 6 adapters for SAML using the following command:"
 msgstr "次のコマンドを使用して、SAML用のEAP 6アダプターをインストールします。"
 
@@ -162,3 +156,9 @@ msgstr "次のコマンドを使用して、SAML用のEAP 6アダプターをイ
 #, no-wrap
 msgid "$ sudo yum install keycloak-saml-adapter-sso7_2-eap6\n"
 msgstr "$ sudo yum install keycloak-saml-adapter-sso7_2-eap6\n"
+
+#. type: Plain text
+msgid ""
+"The default EAP_HOME path for the RPM installation is "
+"/opt/rh/eap6/root/usr/share/wildfly."
+msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
