### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -34,7 +34,7 @@ msgstr "Node.jsアダプター"
 msgid ""
 "{project_name} provides a Node.js adapter built on top of "
 "https://github.com/senchalabs/connect[Connect] to protect server-side "
-"JavaScript apps — the goal was to be flexible enough to integrate with "
+"JavaScript apps - the goal was to be flexible enough to integrate with "
 "frameworks like https://expressjs.com/[Express.js]."
 msgstr ""
 "{project_name}は、サーバーサイドのJavaScriptアプリケーションを保護するために、 "
@@ -300,10 +300,10 @@ msgstr "*別の* アプリケーションのアプリケーション・ロール
 #. type: Plain text
 #, no-wrap
 msgid ""
-"    app.get( '/extra-special', keycloak.protect('other-app:special', "
+"    app.get( '/extra-special', keycloak.protect('other-app:special'), "
 "extraSpecialHandler );\n"
 msgstr ""
-"    app.get( '/extra-special', keycloak.protect('other-app:special', "
+"    app.get( '/extra-special', keycloak.protect('other-app:special'), "
 "extraSpecialHandler );\n"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
