### PR TITLE
Translations for i18n/po/ja_JP/release_notes/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/master.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/master.ja_JP.po
@@ -3,6 +3,9 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""

--- a/i18n/po/ja_JP/release_notes/master.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/master.ja_JP.po
@@ -19,3 +19,18 @@ msgstr ""
 #, no-wrap
 msgid "{releasenotes_name}"
 msgstr "{releasenotes_name}"
+
+#. type: Title ==
+#, no-wrap
+msgid "{project_name_full} 7.3.CD04"
+msgstr "{project_name_full} 7.3.CD04"
+
+#. type: Title ==
+#, no-wrap
+msgid "{project_name_full} 7.3.CD03"
+msgstr "{project_name_full} 7.3.CD03"
+
+#. type: Title ==
+#, no-wrap
+msgid "{project_name_full} 7.3.CD02"
+msgstr "{project_name_full} 7.3.CD02"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
