### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -86,8 +90,12 @@ msgid ""
 " application side and show a custom error page to the user. See more details"
 " in the specification."
 msgstr ""
-"prompt - {project_name}は以下の設定をサポートしています：** `login` - SSOは無視され、ユーザーがすでに認証されていても{project_name}ログインページが常に表示されます\n"
-"** `none` - ログインページは表示されません。代わりにユーザーはアプリケーションにリダイレクトされ、ユーザーがまだ認証されていない場合はエラーが発生します。この設定により、アプリケーション側でフィルター/インターセプターを作成し、ユーザーにカスタム・エラーページを表示することができます。詳細については、仕様を参照してください。"
+"prompt - {project_name}は以下の設定をサポートしています： ** `login` - "
+"SSOは無視され、ユーザーがすでに認証されていても{project_name}ログインページが常に表示されます ** `consent` -  "
+"`Consent Required` "
+"のクライアントにのみ適用されます。これを使用すると、ユーザーが以前にこのクライアントに同意したとしても、常に同意ページが表示されます。 ** "
+"`none` - "
+"ログインページは表示されません。代わりにユーザーはアプリケーションにリダイレクトされ、ユーザーがまだ認証されていない場合はエラーが発生します。この設定により、アプリケーション側でフィルター/インターセプターを作成し、ユーザーにカスタム・エラーページを表示することができます。詳細については、仕様を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -126,8 +134,9 @@ msgid ""
 msgstr ""
 "ほとんどのパラメーターは https://openid.net/specs/openid-connect-core-"
 "1_0.html#AuthorizationEndpoint[OIDC仕様] に記載されています。唯一の例外はパラメーター `kc_idp_hint` "
-"です。これは{project_name}固有で、自動的に使用するアイデンティティー・プロバイダーの名前を含んでいます。詳細はlink:{adminguide_link}[{adminguide_name}]の"
-" `アイデンティティー・ブローカリング` のセクションを参照してください。"
+"です。これは{project_name}固有で、自動的に使用するアイデンティティー・プロバイダーの名前を含んでいます。詳細は "
+"link:{adminguide_link}[{adminguide_name}] の `アイデンティティー・ブローカリング` "
+"のセクションを参照してください。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/params_forwarding.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__params_forwarding
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
