### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
@@ -3,6 +3,11 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""

--- a/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
@@ -29,6 +29,52 @@ msgstr "image:{project_images}/clients.png[]"
 msgid "Add Client"
 msgstr "クライアントの追加"
 
+#. type: Plain text
+msgid "This will bring you to the `Add Client` page."
+msgstr "これにより、 `Add Client` ページが表示されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Client Settings"
+msgstr "クライアントの設定"
+
+#. type: Plain text
+msgid ""
+"This is the display name for the client whenever it is displayed in a "
+"{project_name} UI screen.  You can localize the value of this field by "
+"setting up a replacement string value i.e. $\\{myapp}.  See the "
+"link:{developerguide_link}[{developerguide_name}] for more information."
+msgstr ""
+"これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+
+#. type: Plain text
+msgid ""
+"This specifies the description of the client.  This can also be localized."
+msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
+
+#. type: Plain text
+msgid ""
+"If this is turned off, the client will not be allowed to request "
+"authentication."
+msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
+
+#. type: Plain text
+msgid ""
+"If this is on, then users will get a consent page which asks the user if "
+"they grant access to that application.  It will also display the metadata "
+"that the client is interested in so that the user knows exactly what "
+"information the client is getting access to.  If you've ever done a social "
+"login to Google, you'll often see a similar page.  {project_name} provides "
+"the same functionality."
+msgstr ""
+"これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
+
+#. type: Plain text
+msgid ""
+"If {project_name} uses any configured relative URLs, this value is prepended"
+" to them."
+msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
+
 #. type: Title ===
 #, no-wrap
 msgid "OIDC Clients"
@@ -51,10 +97,6 @@ msgstr ""
 "OIDCクライアントを作成するには、左側のメニュー項目 `Clients` に移動します。このページには右側に `Create` ボタンがあります。"
 
 #. type: Plain text
-msgid "This will bring you to the `Add Client` page."
-msgstr "これにより、 `Add Client` ページが表示されます。"
-
-#. type: Plain text
 msgid "image:{project_images}/add-client-oidc.png[]"
 msgstr "image:{project_images}/add-client-oidc.png[]"
 
@@ -72,11 +114,6 @@ msgstr ""
 " `Client Protocol` ドロップダウン・ボックスで `openid-connect` "
 "を選択します。最後に、アプリケーションのベースURLを `Root URL` フィールドに入力し、 `Save` "
 "をクリックします。これでクライアントが作成され、クライアントの `Settings` タブに移動します。"
-
-#. type: Block title
-#, no-wrap
-msgid "Client Settings"
-msgstr "クライアントの設定"
 
 #. type: Plain text
 msgid "image:{project_images}/client-settings-oidc.png[]"
@@ -103,23 +140,9 @@ msgid "*Name*\n"
 msgstr "*Name*\n"
 
 #. type: Plain text
-msgid ""
-"This is the display name for the client whenever it is displayed in a "
-"{project_name} UI screen.  You can localize the value of this field by "
-"setting up a replacement string value i.e. $\\{myapp}.  See the "
-"link:{developerguide_link}[{developerguide_name}] for more information."
-msgstr ""
-"これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
-
-#. type: Plain text
 #, no-wrap
 msgid "*Description*\n"
 msgstr "*Description*\n"
-
-#. type: Plain text
-msgid ""
-"This specifies the description of the client.  This can also be localized."
-msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
 
 #. type: Plain text
 #, no-wrap
@@ -127,26 +150,9 @@ msgid "*Enabled*\n"
 msgstr "*Enabled*\n"
 
 #. type: Plain text
-msgid ""
-"If this is turned off, the client will not be allowed to request "
-"authentication."
-msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
-
-#. type: Plain text
 #, no-wrap
 msgid "*Consent Required*\n"
 msgstr "*Consent Required*\n"
-
-#. type: Plain text
-msgid ""
-"If this is on, then users will get a consent page which asks the user if "
-"they grant access to that application.  It will also display the metadata "
-"that the client is interested in so that the user knows exactly what "
-"information the client is getting access to.  If you've ever done a social "
-"login to Google, you'll often see a similar page.  {project_name} provides "
-"the same functionality."
-msgstr ""
-"これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
 
 #. type: Plain text
 #, no-wrap
@@ -206,12 +212,6 @@ msgstr ""
 #, no-wrap
 msgid "*Root URL*\n"
 msgstr "*Root URL*\n"
-
-#. type: Plain text
-msgid ""
-"If {project_name} uses any configured relative URLs, this value is prepended"
-" to them."
-msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
 
 #. type: Plain text
 #, no-wrap
@@ -354,7 +354,7 @@ msgstr "*OAuth 2.0 Mutual TLS Client Certificate Bound Access Token*\n"
 msgid ""
 "Mutual TLS binds an access token and a refresh token with a client "
 "certificate exchanged during TLS handshake. This prevents an attacker who "
-"finds a way to steal these tokens from exercising the tokens. The type of "
+"finds a way to steal these tokens from exercising the tokens. This type of "
 "token is called a holder-of-key token. Unlike bearer tokens, the recipient "
 "of a holder-of-key token can verify whether the sender of the token is "
 "legitimate."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
