### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -97,6 +97,33 @@ msgstr ""
 "オフライン・アクセス>>の場合、これはオフライン・トークンが取り消される前にセッションがアイドル状態を維持できる時間です。"
 
 #. type: Plain text
+msgid "Offline Session Max Limited"
+msgstr "Offline Session Max Limited"
+
+#. type: Plain text
+msgid ""
+"For <<_offline-access, offline access>>, if this flag is on, Offline Session"
+" Max is enabled to control the maximum time the offline token can remain "
+"active, regardless of activity."
+msgstr ""
+"<<_offline-access, "
+"オフライン・アクセス>>では、このフラグがオンの場合、オフライン・セッションの最大値を有効にして、アクティビティーに関係なくオフライン・トークンをアクティブなままにできる最大時間を制御します。"
+
+#. type: Plain text
+msgid "Offline Session Max"
+msgstr "Offline Session Max"
+
+#. type: Plain text
+msgid ""
+"For <<_offline-access, offline access>>, this is the maximum time before the"
+" corresponding offline token is revoked. This is a hard number and time. It "
+"controls the maximum time the offline token can remain active, regardless of"
+" activity."
+msgstr ""
+"<<_offline-access, "
+"オフライン・アクセス>>では、これは対応するオフライン・トークンが取り消されるまでの最大時間です。これは具体的な数字と時間です。アクティビティーに関係なく、オフライン・トークンがアクティブのままになる最大時間を制御します。"
+
+#. type: Plain text
 msgid "Access Token Lifespan"
 msgstr "Access Token Lifespan"
 

--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -107,7 +112,7 @@ msgid ""
 "active, regardless of activity."
 msgstr ""
 "<<_offline-access, "
-"オフライン・アクセス>>では、このフラグがオンの場合、オフライン・セッションの最大値を有効にして、アクティビティーに関係なくオフライン・トークンをアクティブなままにできる最大時間を制御します。"
+"オフライン・アクセス>>では、このフラグがオンの場合、オフライン・セッションの最大値を有効にして、アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。"
 
 #. type: Plain text
 msgid "Offline Session Max"
@@ -121,7 +126,7 @@ msgid ""
 " activity."
 msgstr ""
 "<<_offline-access, "
-"オフライン・アクセス>>では、これは対応するオフライン・トークンが取り消されるまでの最大時間です。これは具体的な数字と時間です。アクティビティーに関係なく、オフライン・トークンがアクティブのままになる最大時間を制御します。"
+"オフライン・アクセス>>では、これは対応するオフライントークンが取り消されるまでの最大時間です。これは具体的な数字と時間です。アクティビティーに関係なく、オフライントークンがアクティブのままになる最大時間を制御します。"
 
 #. type: Plain text
 msgid "Access Token Lifespan"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__timeouts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
