### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -15,11 +15,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
-#, no-wrap
-msgid "Declare Your JDBC Drivers"
-msgstr "JDBCドライバーの宣言"
-
 #. type: Title ===
 #, no-wrap
 msgid "Package the JDBC Driver"
@@ -157,7 +152,7 @@ msgstr "JDBCドライバー"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"  <subsystem xmlns=\"urn:jboss:domain:datasources:4.0\">\n"
+"  <subsystem xmlns=\"{subsystem_datasources_xml_urn}\">\n"
 "     <datasources>\n"
 "       ...\n"
 "       <drivers>\n"
@@ -168,7 +163,7 @@ msgid ""
 "     </datasources>\n"
 "  </subsystem>\n"
 msgstr ""
-"  <subsystem xmlns=\"urn:jboss:domain:datasources:4.0\">\n"
+"  <subsystem xmlns=\"{subsystem_datasources_xml_urn}\">\n"
 "     <datasources>\n"
 "       ...\n"
 "       <drivers>\n"
@@ -192,10 +187,15 @@ msgstr ""
 "を付けて、必要時に選択できるようにします。ドライバーのJAR用に以前作成した `module` パッケージを指す、 `module` "
 "属性を指定します。最後に、ドライバーのJavaクラスを指定します。サンプルとして、この章で以前定義したモジュールのサンプル内にある、PostgreSQLドライバーをインストールすると下記のとおりになります。"
 
+#. type: Block title
+#, no-wrap
+msgid "Declare Your JDBC Drivers"
+msgstr "JDBCドライバーの宣言"
+
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"  <subsystem xmlns=\"urn:jboss:domain:datasources:4.0\">\n"
+"  <subsystem xmlns=\"{subsystem_datasources_xml_urn}\">\n"
 "     <datasources>\n"
 "       ...\n"
 "       <drivers>\n"
@@ -209,7 +209,7 @@ msgid ""
 "     </datasources>\n"
 "  </subsystem>\n"
 msgstr ""
-"  <subsystem xmlns=\"urn:jboss:domain:datasources:4.0\">\n"
+"  <subsystem xmlns=\"{subsystem_datasources_xml_urn}\">\n"
 "     <datasources>\n"
 "       ...\n"
 "       <drivers>\n"

--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__jdbc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
