### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -20,37 +20,26 @@ msgstr ""
 msgid "Adapter Installation"
 msgstr "アダプターのインストール"
 
-#. type: Block title
-#, no-wrap
-msgid "WildFly 11"
-msgstr "WildFly 11"
-
-#. type: Block title
-#, no-wrap
-msgid "JBoss EAP 7.1"
-msgstr "JBoss EAP 7.1"
-
-#. type: Title =====
-#, no-wrap
-msgid "JBoss SSO"
-msgstr "JBoss SSO"
-
-#. type: Plain text
-msgid ""
-"{appserver_name} has built-in support for single sign-on for web "
-"applications deployed to the same {appserver_name} instance. This should not"
-" be enabled when using {project_name}."
-msgstr ""
-"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。これは、{project_name}を使用しているときは有効にしないでください。"
-
 #. type: Plain text
 msgid ""
 "Each adapter is a separate download on the {project_name} download site."
 msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードできます。"
 
 #. type: Plain text
-msgid "Install on WildFly 9 or 10, 11 or JBoss EAP 7:"
-msgstr "WildFly 9、10、11、またはJBoss EAP 7へのインストールは次のとおりです。"
+msgid ""
+"We only test and maintain adapter with the most recent version of WildFly "
+"available upon the release. Once new version of WildFly is released, the "
+"current adapters become deprecated and support for them will be removed "
+"after next WildFly release.  The other alternative is to switch your "
+"applications from WildFly to the JBoss EAP, as the JBoss EAP adapter is "
+"supported for much longer period."
+msgstr ""
+"今回のリリースでは、WildFlyの最新バージョンでアダプターのテストとメンテナンスを行っています。WildFlyの新しいバージョンがリリースされると、現在のアダプターは非推奨になり、WildFlyの次のリリース後にサポートが削除されます。もう一つの選択肢は、JBoss"
+" EAPアダプターがより長期間サポートされるように、アプリケーションをWildFlyからJBoss EAPに切り替えることです。"
+
+#. type: Plain text
+msgid "Install on WildFly 9 or newer or on JBoss EAP 7:"
+msgstr "WildFly 9以上、またはJBoss EAP 7へのインストールは次のとおりです。"
 
 #. type: delimited block -
 #, no-wrap
@@ -119,6 +108,11 @@ msgid ""
 "Start the server and run the script from the server's bin directory:"
 msgstr "サーバー設定の変更に役立つCLIスクリプトがあります。サーバーを起動し、サーバーの `bin` ディレクトリーからスクリプトを実行します。"
 
+#. type: Block title
+#, no-wrap
+msgid "WildFly 11 or newer"
+msgstr "WildFly 11以上"
+
 #. type: delimited block -
 #, no-wrap
 msgid "$ ./bin/jboss-cli.sh --file=adapter-elytron-install-saml.cli\n"
@@ -140,10 +134,33 @@ msgstr ""
 "$ cd $JBOSS_HOME/bin\n"
 "$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
 
+#. type: Plain text
+msgid ""
+"It is possible to use the legacy non-Elytron adapter on WildFly 11 or newer "
+"as well, meaning you can use `adapter-install-saml.cli` even on those "
+"versions. However, we recommend to use the newer Elytron adapter."
+msgstr ""
+"WildFly 11以上でもレガシーな非Elytronアダプターが使用できます。つまり、それらのバージョンでも `adapter-install-"
+"saml.cli` を使用することができます。ただし、新しいElytronアダプターを使用することをお勧めします。"
+
+#. type: Block title
+#, no-wrap
+msgid "JBoss EAP 7.1 or newer"
+msgstr "JBoss EAP 7.1以上"
+
 #. type: Block title
 #, no-wrap
 msgid "JBoss EAP 7.0 and EAP 6"
 msgstr "JBoss EAP 7.0とEAP 6"
+
+#. type: Plain text
+msgid ""
+"It is possible to use the legacy non-Elytron adapter on JBoss EAP 7.1 or "
+"newer as well, meaning you can use `adapter-install-saml.cli` even on those "
+"versions. However, we recommend to use the newer Elytron adapter."
+msgstr ""
+"JBoss EAP 7.1以上でもレガシーな非Elytronアダプターが使用できます。つまり、それらのバージョンでも `adapter-install-"
+"saml.cli` を使用することができます。ただし、新しいElytronアダプターを使用することをお勧めします。"
 
 #. type: Plain text
 msgid ""
@@ -309,3 +326,16 @@ msgid ""
 msgstr ""
 "`keycloak` セキュリティー・コンテキストをEJB層に伝播するときに、 `@SecurityDomain` "
 "アノテーションを指定する必要がないように、今後の統合を改善したいと考えています。"
+
+#. type: Title =====
+#, no-wrap
+msgid "JBoss SSO"
+msgstr "JBoss SSO"
+
+#. type: Plain text
+msgid ""
+"{appserver_name} has built-in support for single sign-on for web "
+"applications deployed to the same {appserver_name} instance. This should not"
+" be enabled when using {project_name}."
+msgstr ""
+"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。これは、{project_name}を使用しているときは有効にしないでください。"

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
