### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
@@ -87,6 +87,13 @@ msgstr ""
 "クライアントは、{project_name}でサポートされているクライアント認証方式を使用できます。たとえば、client_id / "
 "client_secretまたはJWTです。"
 
+#. type: Block title
+#, no-wrap
+msgid ""
+"Example: an authorization request using client id and client secret to "
+"authenticate to the token endpoint"
+msgstr "例：クライアントIDとクライアント・シークレットを使用して、トークン・エンドポイントで認証する認可リクエスト"
+
 #. type: Code block
 #, no-wrap
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission-authentication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
