### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -85,7 +85,7 @@ msgstr "このトークンの *permissions* クレームから、サーバーに
 #. type: Plain text
 msgid ""
 "Also note that permissions are directly related with the resources/scopes "
-"you are protecting and complete decoupled from the access control methods "
+"you are protecting and completely decoupled from the access control methods "
 "that were used to actually grant and issue these same permissions."
 msgstr ""
 "パーミッションは保護されたリソース/スコープに直接関連していますが、アクセス・コントロール・メソッドからは完全に独立していることに注意してください。"

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-rpt-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
