### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -251,3 +251,12 @@ msgstr ""
 "フィールドです。 このフィールドでは、プロバイダで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、 "
 "https://developers.google.com/oauthplayground/ を参照してください。 "
 "デフォルトでは、{project_name}は `openid` `profile` `email` のスコープを使用します。"
+
+#. type: Plain text
+msgid ""
+"If your organization uses the G Suite and you want to restrict access to "
+"only members of your organization, you must enter the domain that is used "
+"for the G Suite into the `Hosted Domain` field to enable it."
+msgstr ""
+"あなたの組織がG Suiteを使用していて、組織のメンバーだけにアクセスを制限したい場合は、G Suiteに対して使用するドメインを `Hosted "
+"Domain` フィールドに入力して有効にする必要があります。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
