### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,39 +22,32 @@ msgstr "管理者アカウントの作成"
 
 #. type: Plain text
 msgid ""
-"After the server boots, open your browser and go to the "
-"http://localhost:8080/auth URL. The page should look like this:"
+"After the server boots, open http://localhost:8080/auth in your web browser."
+" The welcome page will indicate that the server is running."
 msgstr ""
-"サーバーが起動した後、ブラウザーを開きURL http://localhost:8080/auth へ移動します。ページは以下のようになります。"
-
-#. type: Block title
-#, no-wrap
-msgid "Welcome Page"
-msgstr "ウェルカムページ"
+"サーバーが起動した後、ブラウザーで http://localhost:8080/auth "
+"を開きます。ウェルカムページは、サーバーが実行中であることを示します。"
 
 #. type: Plain text
-msgid "image:{project_images}/initial-welcome-page.png[]"
-msgstr "image:{project_images}/initial-welcome-page.png[]"
+msgid "Enter a username and password to create an initial admin user."
+msgstr "ユーザー名とパスワードを入力して、最初の管理ユーザーを作成します。"
 
 #. type: Plain text
 msgid ""
-"{project_name} does not have a configured admin account by default. You must"
-" create one on the Welcome page.  This account will allow you to create an "
-"admin that can log into the _master_ realm's administration console so that "
-"you can start creating realms and users and registering applications to be "
-"secured by {project_name}."
+"This account will be permitted to log in to the `master` realm's "
+"administration console, from which you will create realms and users and "
+"register applications to be secured by {project_name}."
 msgstr ""
-"{project_name}にはデフォルト設定された管理者アカウントはありません。ウェルカムページにて作成する必要があります。当アカウントを使用して、 "
-"_master_ "
-"レルムの管理コンソールへのログインが可能となる管理者を作成できます。それにより、レルムとユーザーの作成および{project_name}に保護されるアプリケーションの登録を始めることができます。"
+"このアカウントは `master` "
+"レルムの管理コンソールにログインすることができます。レルムとユーザーを作成し、{project_name}によって保護されるアプリケーションを登録します。"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "You can only create an initial admin user on the Welcome Page if you connect using `localhost`. This is a security\n"
-"       precaution. You can also create the initial admin user at the command line with the `add-user-keycloak.sh` script. For more details see\n"
-"       link:{installguide_link}[{installguide_name}] and link:{adminguide_link}[{adminguide_name}].\n"
+"       precaution. You can create the initial admin user at the command line with the `add-user-keycloak.sh` script. For more information, see the\n"
+"       link:{installguide_link}[{installguide_name}] and the link:{adminguide_link}[{adminguide_name}].\n"
 msgstr ""
-"`localhost` を使用して接続する場合は、初期管理者ユーザーのみを作成できます。これはセキュリティー対策のためです。また、スクリプト `add-"
+"`localhost` を使用して接続する場合は、初期管理者ユーザーのみを作成できます。これはセキュリティー対策のためです。スクリプト `add-"
 "user-keycloak.sh` "
-"を使用してコマンドラインにて初期管理者ユーザーの作成をすることも可能です。詳しくはlink:{installguide_link}[{installguide_name}]ならびにlink:{adminguide_link}[{adminguide_name}]を参照してください。\n"
+"を使用してコマンドラインにて初期管理者ユーザーの作成をすることも可能です。詳しくはlink:{installguide_link}[{installguide_name}]とlink:{adminguide_link}[{adminguide_name}]を参照してください。\n"

--- a/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,6 +52,7 @@ msgid ""
 "       precaution. You can create the initial admin user at the command line with the `add-user-keycloak.sh` script. For more information, see the\n"
 "       link:{installguide_link}[{installguide_name}] and the link:{adminguide_link}[{adminguide_name}].\n"
 msgstr ""
-"`localhost` を使用して接続する場合は、初期管理者ユーザーのみを作成できます。これはセキュリティー対策のためです。スクリプト `add-"
-"user-keycloak.sh` "
-"を使用してコマンドラインにて初期管理者ユーザーの作成をすることも可能です。詳しくはlink:{installguide_link}[{installguide_name}]とlink:{adminguide_link}[{adminguide_name}]を参照してください。\n"
+"`localhost` を使用して接続する場合のみ、ウェルカムページにて初期管理者ユーザーを作成できます。これはセキュリティー対策のためです。スクリプト"
+" `add-user-keycloak.sh` を使用してコマンドラインにて初期管理者ユーザーを作成することも可能です。詳しくは "
+"link:{installguide_link}[{installguide_name}] と "
+"link:{adminguide_link}[{adminguide_name}] を参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/initial-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__initial-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
