### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,33 +22,23 @@ msgstr "管理コンソールへのログイン"
 
 #. type: Plain text
 msgid ""
-"After you create the initial admin account, you can log in to the Admin "
-"Console by completing the following steps:"
-msgstr "初期管理者アカウントを作成した後、以下の手順に沿って、管理コンソールにログインすることができます。"
+"After you create the initial admin account, use the following steps to log "
+"in to the admin console:"
+msgstr "最初の管理者アカウントを作成したら、次の手順を実行して管理コンソールにログインします。"
 
 #. type: Plain text
 msgid ""
-"At the bottom of the Welcome page click the _Administration Console_ link.  "
-"Alternatively you can go to the console URL directly at "
-"http://localhost:8080/auth/admin/"
+"Click the *Administration Console* link on the *Welcome* page or go directly"
+" to the console URL http://localhost:8080/auth/admin/"
 msgstr ""
-"ウェルカムページの一番下にある _管理コンソール_ のリンクをクリックします。もしくは、 "
-"http://localhost:8080/auth/admin/ にてコンソールのURLに直接アクセスすることも可能です。"
-
-#. type: Block title
-#, no-wrap
-msgid "Login Page"
-msgstr "ログインページ"
-
-#. type: Plain text
-msgid "image:{project_images}/login-page.png[]"
-msgstr "image:{project_images}/login-page.png[]"
+"*Welcome* ページの *Administration Console* リンクをクリックするか、コンソールURLの "
+"http://localhost:8080/auth/admin/ に直接アクセスします。"
 
 #. type: Plain text
 msgid ""
-"Type the username and password you created on the Welcome page. The "
-"{project_name} Admin Console page opens."
-msgstr "ウェルカムページにて作成したユーザー名とパスワードを入力します。{project_name}管理コンソールページが開きます。"
+"Type the username and password you created on the *Welcome* page to open the"
+" *{project_name} Admin Console*."
+msgstr "*Welcome* ページで作成したユーザー名とパスワードを入力して、 *{project_name}管理コンソール* を開きます。"
 
 #. type: Block title
 #, no-wrap
@@ -58,13 +48,3 @@ msgstr "管理コンソール"
 #. type: Plain text
 msgid "image:{project_images}/admin-console.png[]"
 msgstr "image:{project_images}/admin-console.png[]"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"If you are curious about a certain feature, button, or field within the Admin Console, hover your mouse\n"
-"      over the question mark `?` icon.  This will pop up tooltip text to describe the area of the console you are interested in.\n"
-"      The image above shows the tooltip in action.\n"
-msgstr ""
-"管理コンソール内の機能、ボタンまたはフィールドについて知りたい場合は、クエスチョンマーク `?` のアイコンにマウスオーバーします。そうすると、興味のある項目を説明するツールチップ・テキストがポップアップ表示されます。\n"
-"このとおり実行すると、ツールチップは上記のようになります。\n"

--- a/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po
@@ -3,6 +3,10 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-boot/admin-console.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-boot__admin-console
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
