### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po
@@ -15,6 +15,11 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Title ==
+#, no-wrap
+msgid "Configuration"
+msgstr "設定"
+
 #. type: Plain text
 #, no-wrap
 msgid "*Name*\n"
@@ -25,10 +30,9 @@ msgstr "*Name*\n"
 msgid "*Description*\n"
 msgstr "*Description*\n"
 
-#. type: Title ==
-#, no-wrap
-msgid "Configuration"
-msgstr "設定"
+#. type: Plain text
+msgid "A string containing details about this policy."
+msgstr "このポリシーに関する詳細情報を含む文字列。"
 
 #. type: Plain text
 #, no-wrap
@@ -42,8 +46,12 @@ msgid ""
 msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
 
 #. type: Plain text
-msgid "A string containing details about this policy."
-msgstr "このポリシーに関する詳細情報を含む文字列。"
+msgid ""
+"A human-readable and unique string describing the policy. A best practice is"
+" to use names that are closely related to your business and security "
+"requirements, so you can identify them more easily."
+msgstr ""
+"ポリシーを説明する、人が判読可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
 
 #. type: Title =
 #, no-wrap
@@ -75,14 +83,6 @@ msgid ""
 msgstr "image:{project_images}/policy/create-group.png[alt=\"グループ・ベース・ポリシーの追加\"]"
 
 #. type: Plain text
-msgid ""
-"A human-readable and unique string describing the policy. A best practice is"
-" to use names that are closely related to your business and security "
-"requirements, so you can identify them more easily."
-msgstr ""
-"ポリシーを説明する、人が判読可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
-
-#. type: Plain text
 #, no-wrap
 msgid "*Groups Claim*\n"
 msgstr "*Groups Claim*\n"
@@ -92,10 +92,11 @@ msgid ""
 "Specifies the name of the claim in the token holding the group names and/or "
 "paths. Usually, authorization requests are processed based on an ID Token or"
 " Access Token previously issued to a client acting on behalf of some user. "
-"The token must include a claim from where this policy is going to obtain the"
-" groups the user is a member."
+"If defined, the token must include a claim from where this policy is going "
+"to obtain the groups the user is a member of. If not defined, user's groups "
+"are obtained from your realm configuration."
 msgstr ""
-"グループ名および/またはパスを保持するトークン内のクレームの名前を指定します。通常、認可リクエストは、以前に一部のユーザーに代わって動作するクライアントに発行されたIDトークンまたはアクセストークンに基づいて処理されます。トークンには、このポリシーがユーザーの所属するグループを取得する場所からのクレームが含まれている必要があります。"
+"グループ名および/またはパスを保持するトークン内のクレームの名前を指定します。通常、認可リクエストは、一部のユーザーに代わって動作するクライアントに、以前に発行されたIDトークンまたはアクセストークンに基づいて処理されます。これが定義されている場合、トークンには、このポリシーがユーザーの所属するグループを取得する場所を示すクレームが含まれている必要があります。定義されていない場合、ユーザーのグループはレルム設定から取得されます。"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po
@@ -3,11 +3,17 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# KojiNose <knose.dev@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-group-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
