### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -201,7 +206,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Automatically Link Existing First Login Flow"
-msgstr "Automatically Link Existing First Login Flow"
+msgstr "自動リンクの初回ログインフロー"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
@@ -197,3 +197,59 @@ msgid ""
 "account."
 msgstr ""
 "このオーセンティケーターは、電子メールのオーセンティケーターが無効であるか、または使用できない場合に使用されます（レルムに対してSMTPが設定されていない場合）。{project_name}アカウントとアイデンティティー・プロバイダーをリンクするために、パスワードで認証する必要があるログイン画面が表示されます。また、ユーザーは、自分の{project_name}アカウントにすでにリンクされている別のアイデンティティー・プロバイダーで再認証することもできます。ユーザーに強制的にOTPを使用させることもできます。それ以外の場合はオプションで、すでにOTPがユーザー・アカウントに設定されている場合にのみ使用されます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Automatically Link Existing First Login Flow"
+msgstr "Automatically Link Existing First Login Flow"
+
+#. type: Plain text
+msgid ""
+"The AutoLink authenticator would be dangerous in a generic environment where"
+" users can register themselves using arbitrary usernames/email addresses. Do"
+" not use this authenticator unless registration of users is carefully "
+"curated and usernames/email addresses are assigned, not requested."
+msgstr ""
+"AutoLinkオーセンティケーターは、ユーザーが任意のユーザー名/電子メールアドレスを使用して自分自身を登録できる一般的な環境では危険です。ユーザーの登録が慎重に行われ、ユーザー名/電子メールアドレスが（要求されるのではなく）割り当てられていない限り、このオーセンティケーターを使用しないでください。"
+
+#. type: Plain text
+msgid ""
+"In order to configure a first login flow in which users are automatically "
+"linked without being prompted, create a new flow with the following two "
+"authenticators:"
+msgstr ""
+"プロンプトを表示せずにユーザーを自動的にリンクする最初のログインフローを設定するには、次の2つのオーセンティケーターを使用して新しいフローを作成します。"
+
+#. type: Plain text
+msgid ""
+"This authenticator ensures unique users are handled. Set the authenticator "
+"requirement to \"Alternative\"."
+msgstr "このオーセンティケーターは、一意にユーザーが処理されることを保障します。オーセンティケーターの要件は\"Alternative\"に設定します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Automatically Link Existing Account"
+msgstr "Automatically Link Existing Account"
+
+#. type: Plain text
+msgid ""
+"Automatically link brokered identities without any validation with this "
+"authenticator. This is useful in an intranet environment of multiple user "
+"databases each with overlapping usernames/email addresses, but different "
+"passwords, and you want to allow users to use any password without having to"
+" validate. This is only reasonable if you manage all internal databases, and"
+" usernames/email addresses from one database matching those in another "
+"database belong to the same person. Set the authenticator requirement to "
+"\"Alternative\"."
+msgstr ""
+"このオーセンティケーターとともに検証無しで仲介されたアイデンティティーを自動的にリンクします。これは、重複するユーザー名/電子メールアドレスを持ち、パスワードが異なる複数のユーザー・データベースにあるイントラネット環境で便利です。ユーザーは、検証することなくパスワードを使用できるようにしたいと考えています。これは、すべての内部データベースを管理し、同じデータベースにあるユーザー名と電子メールアドレスが、同じ人物に属している場合にのみ妥当です。オーセンティケーターの要件は\"Alternative\"に設定します。"
+
+#. type: Plain text
+msgid ""
+"The described setup uses two authenticators, and is the simplest one, but it"
+" is possible to use other authenticators according to your needs. For "
+"example, you can add the Review Profile authenticator to the beginning of "
+"the flow if you still want end users to confirm their profile information."
+msgstr ""
+"記載されたセットアップでは2つのオーセンティケーターが使用され（最も簡単なもの）、必要に応じて他のオーセンティケーターを使用することもできます。たとえば、エンドユーザーにプロファイル情報の確認を依頼したい場合は、フローの先頭にReview"
+" Profileオーセンティケーターを追加することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__first-login-flow
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
