### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po
@@ -53,6 +53,24 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"Permissions are enforced depending on the protocol you are using. When using"
+" UMA, the policy enforcer always expects an RPT as a bearer token in order "
+"to decide whether or not a request can be served. That means clients should "
+"first obtain an RPT from {project_name} before sending requests to the "
+"resource server."
+msgstr ""
+"パーミッションは、使用しているプロトコルによって異なります。UMAを使用する場合、ポリシー・エンフォーサーは、リクエストを処理できるかどうかを決定するために、RPTをベアラートークンとして常に想定しています。つまり、クライアントは、リソースサーバーにリクエストを送信する前に、まず{project_name}からRPTを取得する必要があります。"
+
+#. type: Plain text
+msgid ""
+"However, if you are not using UMA, you can also send regular access tokens "
+"to the resource server. In this case, the policy enforcer will try to obtain"
+" permissions directly from the server."
+msgstr ""
+"ただし、UMAを使用していない場合は、通常のアクセストークンをリソースサーバーに送信することもできます。この場合、ポリシー・エンフォーサーはサーバーから直接パーミッションを取得しようとします。"
+
+#. type: Plain text
+msgid ""
 "If you are using any of the {project_name} OIDC adapters, you can easily "
 "enable the policy enforcer by adding the following property to your "
 "*keycloak.json* file:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
