### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -426,7 +430,7 @@ msgid ""
 "modes for this: `cordova` and `cordova-native`:"
 msgstr ""
 "Keycloakは https://cordova.apache.org/[Apache Cordova] "
-"で開発されたhybirdモバイルアプリをサポートしています。JavaScriptアダプターには、 `cordova` と `cordova-"
+"で開発されたハイブリッド・モバイルアプリをサポートしています。JavaScriptアダプターには、 `cordova` と `cordova-"
 "native` の2つのモードがあります。"
 
 #. type: Plain text
@@ -442,7 +446,7 @@ msgid ""
 msgstr ""
 "デフォルトはcordovaで、アダプタータイプが設定されておらず、window.cordovaが存在する場合、アダプターは自動的に選択します。ログインすると、"
 " https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-"
-"inappbrowser/[InApp Browser] が開き、ユーザーは{project_name}とやり取りした後、 appを "
+"inappbrowser/[InApp Browser] が開き、ユーザーは{project_name}とやり取りした後、アプリを "
 "`http://localhost` "
 "にリダイレクトします。そのため、管理コンソールのクライアント設定のセクションで、このURLを有効なリダイレクトURIとしてホワイトリストに登録する必要があります。"
 
@@ -472,14 +476,14 @@ msgid ""
 "user, as it has full control of the browser rendering the login page, so do "
 "not allow its use in apps you do not trust."
 msgstr ""
-"このモードを使用する前に、アプリがユーザーのクレデンシャルにアクセスする可能性があることなど、セキュリティーを考慮する必要があります。それがログインページをレンダリングするブラウザーを完全に制御しているため、信頼できないアプリでは使用を許可しないでください。"
+"このモードを使用する前に、アプリがログインページをレンダリングするブラウザーを完全に制御しているため、ユーザーのクレデンシャルにアクセスする可能性があるなど、セキュリティーを考慮する必要があります。そのため、信頼できないアプリでは使用を許可しないでください。"
 
 #. type: Plain text
 msgid ""
 "Use this example app to help you get started: "
 "https://github.com/keycloak/keycloak/tree/master/examples/cordova"
 msgstr ""
-"このサンプル・アプリケーションを使用して、開始します: "
+"このサンプル・アプリケーションを使用して、開始します： "
 "https://github.com/keycloak/keycloak/tree/master/examples/cordova"
 
 #. type: Plain text
@@ -515,7 +519,7 @@ msgid ""
 "browsertab]: allows the app to open webpages in the system's browser"
 msgstr ""
 "https://github.com/google/cordova-plugin-browsertab[cordova-plugin-"
-"browsertab]: アプリがシステムのブラウザーでウェブページを開くことができます"
+"browsertab]：アプリがシステムのブラウザーでウェブページを開くことができます"
 
 #. type: Plain text
 msgid ""
@@ -523,7 +527,7 @@ msgid ""
 "deeplinks]: allow the browser to redirect back to your app by special URLs"
 msgstr ""
 "https://github.com/e-imaxina/cordova-plugin-deeplinks[cordova-plugin-"
-"deeplinks]: ブラウザーが特別なURLでアプリにリダイレクトできるようにします"
+"deeplinks]：ブラウザーが特別なURLでアプリにリダイレクトできるようにします"
 
 #. type: Plain text
 msgid ""
@@ -535,7 +539,7 @@ msgid ""
 msgstr ""
 "アプリにリンクするための技術的詳細は、各プラットフォームで異なり、特別な設定が必要です。詳しい手順については、 "
 "https://github.com/e-imaxina/cordova-plugin-"
-"deeplinks/blob/master/README.md[deeplinksプラグインのドキュメント] "
+"deeplinks/blob/master/README.md[ディープリンク・プラグインのドキュメント] "
 "のAndroidおよびiOSのセクションを参照してください。"
 
 #. type: Plain text
@@ -551,11 +555,11 @@ msgid ""
 " recommend that you use universal links, combined with a fallback site with "
 "a custom-url link on it for best reliability."
 msgstr ""
-"アプリを開くためのリンクには、カスタムスキーマ（つまり、`myapp://login` または `android-"
-"app://com.example.myapp/https/example.com/login`）とhttps://developer.apple.com/ios"
-"/universal-links/[Universal Links (iOS)]）/ "
-"https://developer.android.com/training/app-links/deep-linking[Deep Links "
-"(Android)]をクリックします。前者は設定が容易で、より確実に動作する傾向がありますが、後者はセキュリティーが強化されます。ドメインの所有者のみが登録できます。カスタムURLはiOSでは推奨されていません。最良の信頼性を得るために、ユニバーサル"
+"アプリを開くためのリンクには、カスタムスキーマ（つまり、 `myapp://login` または `android-"
+"app://com.example.myapp/https/example.com/login` ）と "
+"https://developer.apple.com/ios/universal-links/[ユニバーサル・リンク（iOS）]）/ "
+"https://developer.android.com/training/app-links/deep-"
+"linking[ディープリンク（Android）]をクリックします。前者は設定が容易で、より確実に動作する傾向がありますが、後者はセキュリティーが強化され、ドメインの所有者のみが登録できます。カスタムURLはiOSでは推奨されていません。最良の信頼性を得るために、ユニバーサル"
 "・リンクとそれにcustom-urlリンクを持つ代替サイトを組み合わせて使用することをお勧めします。"
 
 #. type: Plain text
@@ -588,8 +592,8 @@ msgid ""
 "There is an example app that shows how to use the native-mode: "
 "https://github.com/keycloak/keycloak/tree/master/examples/cordova-native"
 msgstr ""
-"ネイティブモードを使用する方法を示すサンプル・アプリケーションがあります: "
-"https://github.com/keycloak/keycloak/tree/master/examples/cordova-native"
+"ネイティブモードを使用する方法を示すサンプル・アプリケーションがあります：https://github.com/keycloak/keycloak/tree/master/examples"
+"/cordova-native"
 
 #. type: Title ====
 #, no-wrap
@@ -820,8 +824,8 @@ msgid ""
 "apps-with-cordova>>)."
 msgstr ""
 "\"cordova-native\" - ライブラリーはBrowserTabs "
-"cordovaプラグインを使用して、電話のシステムブラウザーを使用してログインページと登録ページを開こうとします。これには、アプリケーションにリダイレクトするための特別な設定が必要です"
-"（<<hybrid-apps-with-cordova>>を参照）。"
+"cordovaプラグインを使用して、電話のシステム・ブラウザーを使用してログインページと登録ページを開こうとします。これには、アプリケーションにリダイレクトするための特別な設定が必要です"
+"（<<hybrid-apps-with-cordova>>を参照してください）。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -313,10 +313,10 @@ msgstr "インプリシット・フローとハイブリッド・フロー"
 
 #. type: Plain text
 msgid ""
-"By default, the JavaScript adapter uses the http://openid.net/specs/openid-"
+"By default, the JavaScript adapter uses the https://openid.net/specs/openid-"
 "connect-core-1_0.html#CodeFlowAuth[Authorization Code] flow."
 msgstr ""
-"デフォルトで、JavaScriptアダプターは http://openid.net/specs/openid-connect-core-"
+"デフォルトで、JavaScriptアダプターは https://openid.net/specs/openid-connect-core-"
 "1_0.html#CodeFlowAuth[認可コード] フローを使用します。"
 
 #. type: Plain text
@@ -331,7 +331,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"{project_name} also supports the http://openid.net/specs/openid-connect-"
+"{project_name} also supports the https://openid.net/specs/openid-connect-"
 "core-1_0.html#ImplicitFlowAuth[Implicit] flow where an access token is sent "
 "immediately after successful authentication with {project_name}. This may "
 "have better performance than standard flow, as there is no additional "
@@ -339,7 +339,7 @@ msgid ""
 "access token expires."
 msgstr ""
 "{project_name}は、{project_name}での認証が成功した直後にアクセス・トークンが送信される "
-"http://openid.net/specs/openid-connect-core-"
+"https://openid.net/specs/openid-connect-core-"
 "1_0.html#ImplicitFlowAuth[インプリシット] "
 "フローもサポートしています。これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに影響があります。"
 
@@ -376,10 +376,10 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"{project_name} also supports the http://openid.net/specs/openid-connect-"
+"{project_name} also supports the https://openid.net/specs/openid-connect-"
 "core-1_0.html#HybridFlowAuth[Hybrid] flow."
 msgstr ""
-"{project_name}は http://openid.net/specs/openid-connect-core-"
+"{project_name}は https://openid.net/specs/openid-connect-core-"
 "1_0.html#HybridFlowAuth[ハイブリッド] ・フローもサポートしています。"
 
 #. type: Plain text
@@ -413,6 +413,183 @@ msgstr ""
 #, no-wrap
 msgid "keycloak.init({ flow: 'hybrid' })\n"
 msgstr "keycloak.init({ flow: 'hybrid' })\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Hybrid Apps with Cordova"
+msgstr "ハイブリッド・アプリとCordova"
+
+#. type: Plain text
+msgid ""
+"Keycloak support hybird mobile apps developed with "
+"https://cordova.apache.org/[Apache Cordova]. The Javascript adapter has two "
+"modes for this: `cordova` and `cordova-native`:"
+msgstr ""
+"Keycloakは https://cordova.apache.org/[Apache Cordova] "
+"で開発されたhybirdモバイルアプリをサポートしています。JavaScriptアダプターには、 `cordova` と `cordova-"
+"native` の2つのモードがあります。"
+
+#. type: Plain text
+msgid ""
+"The default is cordova, which the adapter will automatically select if no "
+"adapter type has been configured and window.cordova is present.  When "
+"logging in, it will open an "
+"https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-"
+"inappbrowser/[InApp Browser] that lets the user interact with {project_name}"
+" and afterwards returns to the app by redirecting to `http://localhost`. "
+"Because of this, you must whitelist this URL as a valid redirect-uri in the "
+"client configuration section of the Administration Console."
+msgstr ""
+"デフォルトはcordovaで、アダプタータイプが設定されておらず、window.cordovaが存在する場合、アダプターは自動的に選択します。ログインすると、"
+" https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-"
+"inappbrowser/[InApp Browser] が開き、ユーザーは{project_name}とやり取りした後、 appを "
+"`http://localhost` "
+"にリダイレクトします。そのため、管理コンソールのクライアント設定のセクションで、このURLを有効なリダイレクトURIとしてホワイトリストに登録する必要があります。"
+
+#. type: Plain text
+msgid "While this mode is easy to setup, it also has some disadvantages:"
+msgstr "このモードはセットアップが簡単ですが、いくつかの欠点もあります。"
+
+#. type: Plain text
+msgid ""
+"The InApp-Browser is a browser embedded in the app and is not the phone's "
+"default browser. Therefore it will have different settings and stored "
+"credentials will not be available."
+msgstr ""
+"InApp-"
+"Browserは、アプリに組み込まれたブラウザーであり、携帯電話のデフォルトブラウザではありません。したがって、設定が異なり、保存されたクレデンシャルは利用できません。"
+
+#. type: Plain text
+msgid ""
+"The InApp-Browser might also be slower, especially when rendering more "
+"complex themes."
+msgstr "特に複雑なテーマをレンダリングする場合、InApp-Browserの方が処理速度が遅くなる可能性があります。"
+
+#. type: Plain text
+msgid ""
+"There are security concerns to consider, before using this mode, such as "
+"that it is possible for the app to gain access to the credentials of the "
+"user, as it has full control of the browser rendering the login page, so do "
+"not allow its use in apps you do not trust."
+msgstr ""
+"このモードを使用する前に、アプリがユーザーのクレデンシャルにアクセスする可能性があることなど、セキュリティーを考慮する必要があります。それがログインページをレンダリングするブラウザーを完全に制御しているため、信頼できないアプリでは使用を許可しないでください。"
+
+#. type: Plain text
+msgid ""
+"Use this example app to help you get started: "
+"https://github.com/keycloak/keycloak/tree/master/examples/cordova"
+msgstr ""
+"このサンプル・アプリケーションを使用して、開始します: "
+"https://github.com/keycloak/keycloak/tree/master/examples/cordova"
+
+#. type: Plain text
+msgid ""
+"The alternative mode `cordova-nativei` takes a different approach.  It opens"
+" the login page using the system's browser.  After the user has "
+"authenticated, the browser redirects back into the app using a special URL."
+"  From there, the {project_name} adapter can finish the login by reading the"
+" code or token from the URL."
+msgstr ""
+"代替モード `cordova-nativei` "
+"は異なるアプローチをとっています。システムのブラウザーを使用してログインページを開きます。ユーザーが認証されると、特別なURLを使用して、ブラウザーがアプリにリダイレクトされます。そこから、{project_name}アダプターは、URLからコードまたはトークンを読み取ってログインを完了できます。"
+
+#. type: Plain text
+msgid ""
+"You can activate the native mode by passing the adater type `cordova-native`"
+" to the `init` method:"
+msgstr ""
+"ネイティブモードをアクティブにするには、次のようにアダプタータイプ `cordova-native` を `init` メソッドに渡します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "keycloak.init({ adapter: 'cordova-native' })\n"
+msgstr "keycloak.init({ adapter: 'cordova-native' })\n"
+
+#. type: Plain text
+msgid "This adapter required two additional plugins:"
+msgstr "このアダプターには、次の2つの追加プラグインが必要でした。"
+
+#. type: Plain text
+msgid ""
+"https://github.com/google/cordova-plugin-browsertab[cordova-plugin-"
+"browsertab]: allows the app to open webpages in the system's browser"
+msgstr ""
+"https://github.com/google/cordova-plugin-browsertab[cordova-plugin-"
+"browsertab]: アプリがシステムのブラウザーでウェブページを開くことができます"
+
+#. type: Plain text
+msgid ""
+"https://github.com/e-imaxina/cordova-plugin-deeplinks[cordova-plugin-"
+"deeplinks]: allow the browser to redirect back to your app by special URLs"
+msgstr ""
+"https://github.com/e-imaxina/cordova-plugin-deeplinks[cordova-plugin-"
+"deeplinks]: ブラウザーが特別なURLでアプリにリダイレクトできるようにします"
+
+#. type: Plain text
+msgid ""
+"The technical details for linking to an app differ on each plattform and "
+"special setup is needed.  Please refer to the Android and iOS sections of "
+"the https://github.com/e-imaxina/cordova-plugin-"
+"deeplinks/blob/master/README.md[deeplinks plugin documentation] for further "
+"instructions."
+msgstr ""
+"アプリにリンクするための技術的詳細は、各プラットフォームで異なり、特別な設定が必要です。詳しい手順については、 "
+"https://github.com/e-imaxina/cordova-plugin-"
+"deeplinks/blob/master/README.md[deeplinksプラグインのドキュメント] "
+"のAndroidおよびiOSのセクションを参照してください。"
+
+#. type: Plain text
+msgid ""
+"There are different kinds of links for opening apps: custom schemes (i.e. "
+"`myapp://login` or `android-"
+"app://com.example.myapp/https/example.com/login`) and "
+"https://developer.apple.com/ios/universal-links/[Universal Links (iOS)]) / "
+"https://developer.android.com/training/app-links/deep-linking[Deep Links "
+"(Android)].  While the former are easier to setup and tend to work more "
+"reliably, the later offer extra security as they are unique and only the "
+"owner of a domain can register them.  Custom-URLs are deprecated on iOS.  We"
+" recommend that you use universal links, combined with a fallback site with "
+"a custom-url link on it for best reliability."
+msgstr ""
+"アプリを開くためのリンクには、カスタムスキーマ（つまり、`myapp://login` または `android-"
+"app://com.example.myapp/https/example.com/login`）とhttps://developer.apple.com/ios"
+"/universal-links/[Universal Links (iOS)]）/ "
+"https://developer.android.com/training/app-links/deep-linking[Deep Links "
+"(Android)]をクリックします。前者は設定が容易で、より確実に動作する傾向がありますが、後者はセキュリティーが強化されます。ドメインの所有者のみが登録できます。カスタムURLはiOSでは推奨されていません。最良の信頼性を得るために、ユニバーサル"
+"・リンクとそれにcustom-urlリンクを持つ代替サイトを組み合わせて使用することをお勧めします。"
+
+#. type: Plain text
+msgid ""
+"Furthermore, we recommend the following steps to improve compatibility with "
+"the Keycloak Adapter:"
+msgstr "さらに、Keycloakアダプターとの互換性を向上させるには、以下の手順を実行することをお勧めします。"
+
+#. type: Plain text
+msgid ""
+"Universal Links on iOS seem to work more reliably with `response-mode` set "
+"to `query`"
+msgstr "iOS上のユニバーサル・リンクは、 `query-mode` に設定された `response-mode` でより確実に動作するようです。"
+
+#. type: Plain text
+msgid ""
+"To prevent Android from opening a new instance of your app on redirect add "
+"the following snippet to `config.xml`:"
+msgstr ""
+"Androidがリダイレクト時にアプリケーションの新しいインスタンスをオープンすることを防ぐには、次のスニペットを `config.xml` "
+"に追加します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "<preference name=\"AndroidLaunchMode\" value=\"singleTask\" /> \n"
+msgstr "<preference name=\"AndroidLaunchMode\" value=\"singleTask\" /> \n"
+
+#. type: Plain text
+msgid ""
+"There is an example app that shows how to use the native-mode: "
+"https://github.com/keycloak/keycloak/tree/master/examples/cordova-native"
+msgstr ""
+"ネイティブモードを使用する方法を示すサンプル・アプリケーションがあります: "
+"https://github.com/keycloak/keycloak/tree/master/examples/cordova-native"
 
 #. type: Title ====
 #, no-wrap
@@ -637,6 +814,17 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"\"cordova-native\" - the library tries to open the login and registration "
+"page using the phone's system browser using the BrowserTabs cordova plugin. "
+"This requires extra setup for redirecting back to the app (see <<hybrid-"
+"apps-with-cordova>>)."
+msgstr ""
+"\"cordova-native\" - ライブラリーはBrowserTabs "
+"cordovaプラグインを使用して、電話のシステムブラウザーを使用してログインページと登録ページを開こうとします。これには、アプリケーションにリダイレクトするための特別な設定が必要です"
+"（<<hybrid-apps-with-cordova>>を参照）。"
+
+#. type: Plain text
+msgid ""
 "custom - allows you to implement a custom adapter (only for advanced use "
 "cases)"
 msgstr "custom - カスタム・アダプターを実装することができます（高度なユースケースのみ）"
@@ -755,15 +943,15 @@ msgstr "redirectUri - ログイン後にリダイレクトするURIを指定し�
 
 #. type: Plain text
 msgid ""
-"prompt - By default the login screen is displayed if the user is not logged-"
-"in to {project_name}. To only authenticate to the application if the user is"
-" already logged-in and not display the login page if the user is not logged-"
-"in, set this option to `none`. To always require re-authentication and "
-"ignore SSO, set this option to `login` ."
+"prompt - This parameter allows to slightly customize the login flow on the "
+"{project_name} server side.  For example enforce displaying the login screen"
+" in case of value `login`. See link:#_params_forwarding[Parameters "
+"Forwarding Section] for the details and all the possible values of the "
+"`prompt` parameter."
 msgstr ""
-"prompt - "
-"ユーザーが{project_name}にログインしていない場合、デフォルトでログイン画面が表示されます。ユーザーがすでにログインしている場合にのみアプリケーションを認証し、ログインしていない場合にログイン・ページを表示しないようにするには、このオプションを"
-" `none` に設定します。 常に再認証が必要でSSOを無視するには、このオプションを `login` に設定します。"
+"prompt - このパラメーターを使用すると、{project_name}サーバー側のログインフローを少しだけカスタマイズできます。たとえば、値が "
+"`login` の場合は、ログイン画面を表示するようにします。 `prompt` パラメーターの詳細とすべての値については、 "
+"link:#_params_forwarding[パラメータ転送のセクション] を参照してください。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
