### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po
@@ -104,3 +104,17 @@ msgstr ""
 "JAAS Subjectに添付されているロール・プリンシパルの代替クラスを設定します。デフォルト値は "
 "`org.keycloak.adapters.jaas.RolePrincipal` です。注意：クラスには、単一の `String` "
 "引数を持つコンストラクタが必要です。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "`scope`"
+msgstr "`scope`"
+
+#. type: Plain text
+msgid ""
+"This option is only applicable to the `DirectAccessGrantsLoginModule`. The "
+"specified value will be used as the OAuth2 `scope` parameter in the Resource"
+" Owner Password Credentials Grant request."
+msgstr ""
+"このオプションは `DirectAccessGrantsLoginModule`にのみ適用されます。 "
+"指定された値は、リソース所有者パスワード資格認可要求のOAuth2 `scope`パラメータとして使用されます。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -116,5 +120,6 @@ msgid ""
 "specified value will be used as the OAuth2 `scope` parameter in the Resource"
 " Owner Password Credentials Grant request."
 msgstr ""
-"このオプションは `DirectAccessGrantsLoginModule`にのみ適用されます。 "
-"指定された値は、リソース所有者パスワード資格認可要求のOAuth2 `scope`パラメータとして使用されます。"
+"このオプションは `DirectAccessGrantsLoginModule` "
+"にのみ適用されます。指定された値は、リソース・オーナー・パスワード・クレデンシャル・グラント・リクエストのOAuth2 `scope` "
+"パラメーターとして使用されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jaas.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jaas
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
