### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/keycloak/intro.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/keycloak/intro.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/keycloak/intro.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,5 +35,5 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Before upgrading make sure to read the instructions carefully and carefully "
-"review the changes listed in <<migration-changes,Migration Chanages>>."
+"review the changes listed in <<migration-changes,Migration Changes>>."
 msgstr "アップグレードする前に、手順をよく読み<<migration-changes,移行に伴う変更>>内に示された変更を十分に確認してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/keycloak/intro.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__keycloak__intro
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
