### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -108,9 +108,9 @@ msgid ""
 "    <script src=\"keycloak.js\"></script>\n"
 "    <script>\n"
 "        var keycloak = Keycloak();\n"
-"        keycloak.init().then(function(authenticated) {\n"
+"        keycloak.init().success(function(authenticated) {\n"
 "            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
-"        }).catch(function() {\n"
+"        }).error(function() {\n"
 "            alert('failed to initialize');\n"
 "        });\n"
 "    </script>\n"
@@ -120,9 +120,9 @@ msgstr ""
 "    <script src=\"keycloak.js\"></script>\n"
 "    <script>\n"
 "        var keycloak = Keycloak();\n"
-"        keycloak.init().then(function(authenticated) {\n"
+"        keycloak.init().success(function(authenticated) {\n"
 "            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
-"        }).catch(function() {\n"
+"        }).error(function() {\n"
 "            alert('failed to initialize');\n"
 "        });\n"
 "    </script>\n"
@@ -274,15 +274,15 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.updateToken(30).then(function() {\n"
+"keycloak.updateToken(30).success(function() {\n"
 "    loadData();\n"
-"}).catch(function() {\n"
+"}).error(function() {\n"
 "    alert('Failed to refresh token');\n"
 "});\n"
 msgstr ""
-"keycloak.updateToken(30).then(function() {\n"
+"keycloak.updateToken(30).success(function() {\n"
 "    loadData();\n"
-"}).catch(function() {\n"
+"}).error(function() {\n"
 "    alert('Failed to refresh token');\n"
 "});\n"
 
@@ -602,11 +602,13 @@ msgstr "以前のブラウザー"
 
 #. type: Plain text
 msgid ""
-"The JavaScript adapter depends on Base64 (window.btoa and window.atob) and "
-"HTML5 History API.  If you need to support browsers that do not have these "
-"available (for example, IE9) you need to add polyfillers."
+"The JavaScript adapter depends on Base64 (window.btoa and window.atob), "
+"HTML5 History API and optionally the Promise API.  If you need to support "
+"browsers that do not have these available (for example, IE9) you need to add"
+" polyfillers."
 msgstr ""
-"JavaScriptアダプターは、Base64（window.btoaとwindow.atob）とHTML5 History "
+"JavaScriptアダプターは、Base64（window.btoaとwindow.atob）、HTML5 History "
+"API、およびオプションでPromise "
 "APIに依存しています。これらが利用できないブラウザー（IE9など）をサポートする必要がある場合は、Polyfillを追加する必要があります。"
 
 #. type: Plain text
@@ -614,30 +616,16 @@ msgid "Example polyfill libraries:"
 msgstr "Polyfillライブラリーの例："
 
 #. type: Plain text
-msgid "https://github.com/davidchambers/Base64.js"
-msgstr "https://github.com/davidchambers/Base64.js"
+msgid "Base64 - https://github.com/davidchambers/Base64.js"
+msgstr "Base64 - https://github.com/davidchambers/Base64.js"
 
 #. type: Plain text
-msgid "https://github.com/devote/HTML5-History-API"
-msgstr "https://github.com/devote/HTML5-History-API"
+msgid "HTML5 History - https://github.com/devote/HTML5-History-API"
+msgstr "HTML5 History - https://github.com/devote/HTML5-History-API"
 
 #. type: Plain text
-msgid ""
-"If available, the JavaScript adapter will use native Promise instances as "
-"return values from functions documented as returning promises.  To retain "
-"backwards compatibility, the `success()` and `error()` functions from "
-"previous versions of the adapter are retained.  These remain available "
-"whether or not native Promises are provided by the browser.  Promise API "
-"polyfills are available for browsers without support:"
-msgstr ""
-"利用可能な場合、JavaScriptアダプターは、Promiseを返すように書かれた関数から取得した戻り値として、ネイティブのPromiseインスタンスを使用します。下位互換性を保持するために、以前のバージョンのアダプターの"
-" `success()` と `error()` "
-"関数は保持されます。これは、ネイティブのPromiseがブラウザーによって提供されているかどうかにかかわらず利用可能です。以下のPromise API "
-"polyfillはサポートがないブラウザーで使用できます。"
-
-#. type: Plain text
-msgid "https://github.com/stefanpenner/es6-promise"
-msgstr "https://github.com/stefanpenner/es6-promise"
+msgid "Promise - https://github.com/stefanpenner/es6-promise"
+msgstr "Promise - https://github.com/stefanpenner/es6-promise"
 
 #. type: Title ====
 #, no-wrap
@@ -926,6 +914,15 @@ msgstr ""
 "flow - OpenID Connectのフローを設定します。有効な値は、standard、implicit、hybridのいずれかです。"
 
 #. type: Plain text
+msgid ""
+"promiseType - If set to `native` all methods returning a promise will return"
+" a native JavaScript promise. If not set will return Keycloak specific "
+"promise objects."
+msgstr ""
+"promiseType - `native` "
+"に設定すると、Promiseを返すすべてのメソッドはネイティブのJavaScriptのPromiseを返します。設定されていない場合は、Keycloak固有のPromiseオブジェクトが返されます。"
+
+#. type: Plain text
 msgid "Returns promise to set functions to be invoked on success or error."
 msgstr "成功またはエラー発生時に呼び出される関数を設定するPromiseを返します。"
 
@@ -1166,17 +1163,17 @@ msgstr "プロファイルが正常にロードされた場合、またはプロ
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.loadUserProfile().then(function(profile) {\n"
-"        alert(JSON.stringify(test, null, \"  \"));\n"
-"    }).catch(function() {\n"
+"keycloak.loadUserProfile().success(function(profile) {\n"
+"        alert(JSON.stringify(profile, null, \"  \"));\n"
+"    }).error(function() {\n"
 "        alert('Failed to load user profile');\n"
 "    });\n"
 msgstr ""
-"keycloak.loadUserProfile().then(function(profile) {\n"
-"        alert(JSON.stringify(test, null, \"  \"));\n"
-"    }).catch(function() {\n"
-"        alert('Failed to load user profile');\n"
-"    });\n"
+"keycloak.loadUserProfile().success(function(profile) {\n"
+" alert(JSON.stringify(profile, null, \" \"));\n"
+" }).error(function() {\n"
+" alert('Failed to load user profile');\n"
+" });\n"
 
 #. type: Title ======
 #, no-wrap
@@ -1212,23 +1209,23 @@ msgstr "トークンが有効な場合、またはトークンがもはや有効
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.updateToken(5).then(function(refreshed) {\n"
+"keycloak.updateToken(5).success(function(refreshed) {\n"
 "        if (refreshed) {\n"
 "            alert('Token was successfully refreshed');\n"
 "        } else {\n"
 "            alert('Token is still valid');\n"
 "        }\n"
-"    }).catch(function() {\n"
+"    }).error(function() {\n"
 "        alert('Failed to refresh the token, or the session has expired');\n"
 "    });\n"
 msgstr ""
-"keycloak.updateToken(5).then(function(refreshed) {\n"
+"keycloak.updateToken(5).success(function(refreshed) {\n"
 "        if (refreshed) {\n"
 "            alert('Token was successfully refreshed');\n"
 "        } else {\n"
 "            alert('Token is still valid');\n"
 "        }\n"
-"    }).catch(function() {\n"
+"    }).error(function() {\n"
 "        alert('Failed to refresh the token, or the session has expired');\n"
 "    });\n"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
