### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/4_6_0_final.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/4_6_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_6_0_final.ja_JP.po
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Upgrade to WildFly 14"
+msgstr "WildFly 14へのアップグレード"
+
+#. type: Plain text
+msgid ""
+"The {project_name} server was upgraded to use WildFly 14 under the covers."
+msgstr "{project_name}サーバーはWildFly 14をカバーするようにアップグレードされました。"
+
+#. type: Attribute :generic_adapter_name_full:
+#, no-wrap
+msgid "Keycloak Gatekeeper"
+msgstr "Keycloak Gatekeeper"
+
+#. type: Plain text
+msgid ""
+"Keycloak Gatekeeper provides a security proxy that can be used to secure "
+"applications and services without an adapter.  It can be installed locally "
+"alongside your application or as a sidecar on OpenShift or Kubernetes."
+msgstr ""
+"Keycloak "
+"Gatekeeperは、アダプターなしでアプリケーションとサービスを保護するために使用できるセキュリティー・プロキシーを提供します。アプリケーションと並行してローカルにインストールすることも、OpenShiftまたはKubernetesのサイドカーとしてインストールすることもできます。"
+
+#. type: Plain text
+msgid ""
+"Huge thanks to <a href=\"https://github.com/gambol99\">gambol99</a> for "
+"contributing this work to Keycloak."
+msgstr ""
+"この作業をKeycloakに提供してくれた <a href=\"https://github.com/gambol99\">gambol99</a> "
+"に大きな感謝をします。"

--- a/i18n/po/ja_JP/release_notes/topics/4_6_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_6_0_final.ja_JP.po
@@ -4,6 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # 
 #, fuzzy
@@ -26,7 +27,7 @@ msgstr "WildFly 14へのアップグレード"
 #. type: Plain text
 msgid ""
 "The {project_name} server was upgraded to use WildFly 14 under the covers."
-msgstr "{project_name}サーバーはWildFly 14をカバーするようにアップグレードされました。"
+msgstr "{project_name}サーバーは内部でWildFly 14を使用するようにアップグレードされました。"
 
 #. type: Attribute :generic_adapter_name_full:
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/4_6_0_final.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__4_6_0_final
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
