### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
@@ -1,0 +1,1290 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Title ====
+#, no-wrap
+msgid "Endpoints"
+msgstr "エンドポイント"
+
+#. type: Title ===
+#, no-wrap
+msgid "{generic_adapter_name_full}"
+msgstr "{generic_adapter_name_full}"
+
+#. type: Plain text
+msgid ""
+"{project_name} provides a Go programming language adapter for use with "
+"OpenID Connect (OIDC) that supports both access tokens in a browser cookie "
+"or bearer tokens."
+msgstr ""
+"{project_name}は、ブラウザー・クッキーのアクセストークンまたはベアラートークンの両方をサポートするOpenID "
+"Connect（OIDC）で使用するGoプログラミング言語のアダプターを提供します。"
+
+#. type: Plain text
+msgid ""
+"This documentation details how to build and configure {generic_adapter_name}"
+" followed by details of how to use each of its features."
+msgstr "このドキュメントでは、{generic_adapter_name}をビルドして設定する方法と、その機能の使い方の詳細について説明します。"
+
+#. type: Plain text
+msgid ""
+"For further information, see the included help file which includes a full "
+"list of commands and switches. View the file by entering the following at "
+"the command line (modify the location to match where you install "
+"{generic_adapter_name}):"
+msgstr ""
+"詳細は、含まれているヘルプファイルを参照してください。このヘルプファイルには、コマンドとスイッチの完全なリストが含まれています。コマンドラインで次のように入力してファイルを表示します（{generic_adapter_name}をインストールする場所に合わせて変更します）。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    $ bin/keycloak-gatekeeper help\n"
+msgstr "    $ bin/keycloak-gatekeeper help\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Building"
+msgstr "ビルド"
+
+#. type: Plain text
+msgid "Golang must be installed."
+msgstr "Go言語をインストールする必要があります。"
+
+#. type: Plain text
+msgid "Make must be installed."
+msgstr "Makeをインストールする必要があります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Run `make dep-install` to install all needed dependencies."
+msgstr "必要なすべての依存関係をインストールするために `make dep-install` を実行してください。"
+
+#. type: Plain text
+msgid "Run `make test` to run the included tests."
+msgstr "付属のテストを実行するには `make test` を実行します。"
+
+#. type: Plain text
+msgid ""
+"Run `make` to build the project. You can instead use `make static` if you "
+"prefer to build a binary that includes within it all of the required "
+"dependencies."
+msgstr ""
+"プロジェクトをビルドするために `make` を実行してください。必要なすべての依存関係を内部に含むバイナリーをビルドする場合は、代わりに `make "
+"static` を使用することができます。"
+
+#. type: Plain text
+msgid ""
+"You can also build via docker container: `make docker-build`. A Docker image"
+" is available at link:https://hub.docker.com/r/keycloak/keycloak-"
+"gatekeeper/[https://hub.docker.com/r/keycloak/keycloak-gatekeeper/]."
+msgstr ""
+"Dockerコンテナーを使ってビルドすることもできます： `make docker-build` 。Dockerイメージは、 "
+"link:https://hub.docker.com/r/keycloak/keycloak-"
+"gatekeeper/[https://hub.docker.com/r/keycloak/keycloak-gatekeeper/] "
+"から入手できます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Configuration options"
+msgstr "設定オプション"
+
+#. type: Plain text
+msgid ""
+"Configuration can come from a yaml/json file or by using command line "
+"options. Here is a list of options."
+msgstr "設定は、 yaml/jsonファイルまたはコマンドライン・オプションを使用して行うことができます。ここにオプションのリストがあります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# is the url for retrieve the OpenID configuration - normally the <server>/auth/realm/<realm_name>\n"
+"discovery-url: https://keycloak.example.com/auth/realms/<REALM_NAME>\n"
+"# the client id for the 'client' application\n"
+"client-id: <CLIENT_ID>\n"
+"# the secret associated to the 'client' application\n"
+"client-secret: <CLIENT_SECRET>\n"
+"# the interface definition you wish the proxy to listen, all interfaces is specified as ':<port>', unix sockets as unix://<REL_PATH>|</ABS PATH>\n"
+"listen: 127.0.0.1:3000\n"
+"# whether to enable refresh tokens\n"
+"enable-refresh-tokens: true\n"
+"# the location of a certificate you wish the proxy to use for TLS support\n"
+"tls-cert:\n"
+"# the location of a private key for TLS\n"
+"tls-private-key:\n"
+"# the redirection url, essentially the site url, note: /oauth/callback is added at the end\n"
+"redirection-url: http://127.0.0.1:3000\n"
+"# the encryption key used to encode the session state\n"
+"encryption-key: <ENCRYPTION_KEY>\n"
+"# the upstream endpoint which we should proxy request\n"
+"upstream-url: http://127.0.0.1:80\n"
+"# additional scopes to add to add to the default (openid+email+profile)\n"
+"scopes:\n"
+"- vpn-user\n"
+"# a collection of resource i.e. urls that you wish to protect\n"
+"resources:\n"
+"- uri: /admin/test\n"
+"  # the methods on this url that should be protected, if missing, we assuming all\n"
+"  methods:\n"
+"  - GET\n"
+"  # a list of roles the user must have in order to access urls under the above\n"
+"  # If all you want is authentication ONLY, simply remove the roles array - the user must be authenticated but\n"
+"  # no roles are required\n"
+"  roles:\n"
+"  - openvpn:vpn-user\n"
+"  - openvpn:prod-vpn\n"
+"  - test\n"
+"- uri: /admin/*\n"
+"  methods:\n"
+"  - GET\n"
+"  roles:\n"
+"  - openvpn:vpn-user\n"
+"  - openvpn:commons-prod-vpn\n"
+msgstr ""
+"# is the url for retrieve the OpenID configuration - normally the <server>/auth/realm/<realm_name>\n"
+"discovery-url: https://keycloak.example.com/auth/realms/<REALM_NAME>\n"
+"# the client id for the 'client' application\n"
+"client-id: <CLIENT_ID>\n"
+"# the secret associated to the 'client' application\n"
+"client-secret: <CLIENT_SECRET>\n"
+"# the interface definition you wish the proxy to listen, all interfaces is specified as ':<port>', unix sockets as unix://<REL_PATH>|</ABS PATH>\n"
+"listen: 127.0.0.1:3000\n"
+"# whether to enable refresh tokens\n"
+"enable-refresh-tokens: true\n"
+"# the location of a certificate you wish the proxy to use for TLS support\n"
+"tls-cert:\n"
+"# the location of a private key for TLS\n"
+"tls-private-key:\n"
+"# the redirection url, essentially the site url, note: /oauth/callback is added at the end\n"
+"redirection-url: http://127.0.0.1:3000\n"
+"# the encryption key used to encode the session state\n"
+"encryption-key: <ENCRYPTION_KEY>\n"
+"# the upstream endpoint which we should proxy request\n"
+"upstream-url: http://127.0.0.1:80\n"
+"# additional scopes to add to add to the default (openid+email+profile)\n"
+"scopes:\n"
+"- vpn-user\n"
+"# a collection of resource i.e. urls that you wish to protect\n"
+"resources:\n"
+"- uri: /admin/test\n"
+"  # the methods on this url that should be protected, if missing, we assuming all\n"
+"  methods:\n"
+"  - GET\n"
+"  # a list of roles the user must have in order to access urls under the above\n"
+"  # If all you want is authentication ONLY, simply remove the roles array - the user must be authenticated but\n"
+"  # no roles are required\n"
+"  roles:\n"
+"  - openvpn:vpn-user\n"
+"  - openvpn:prod-vpn\n"
+"  - test\n"
+"- uri: /admin/*\n"
+"  methods:\n"
+"  - GET\n"
+"  roles:\n"
+"  - openvpn:vpn-user\n"
+"  - openvpn:commons-prod-vpn\n"
+
+#. type: Plain text
+msgid ""
+"Options issued at the command line have a higher priority and will override "
+"or merge with options referenced in a config file. Examples of each style "
+"are shown here."
+msgstr ""
+"コマンドラインで発行されるオプションの方が優先度が高く、設定ファイルで参照されるオプションを上書きまたはマージします。各スタイルの例をここに示します。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Example usage and configuration"
+msgstr "使用例と設定"
+
+#. type: Plain text
+msgid ""
+"Assuming you have some web service you wish protected by {project_name}:"
+msgstr "{project_name}によって保護されることを望むいくつかのWebサービスがあると仮定します。"
+
+#. type: Plain text
+msgid ""
+"Create the *client* using the {project_name} GUI or CLI; the client protocol"
+" is *'openid-connect'*, access-type: *confidential*."
+msgstr ""
+"{project_name}のGUIまたはCLIを使用して *クライアント* を作成します。クライアント・プロトコルは *'openid-"
+"connect'*, access-type: *confidential* です。"
+
+#. type: Plain text
+msgid "Add a Valid Redirect URI of *http://127.0.0.1:3000/oauth/callback*."
+msgstr "*http://127.0.0.1:3000/oauth/callback* の有効なリダイレクトURIを追加します。"
+
+#. type: Plain text
+msgid "Grab the client id and client secret."
+msgstr "クライアントIDとクライアント・シークレットを取得します。"
+
+#. type: Plain text
+msgid ""
+"Create the various roles under the client or existing clients for "
+"authorization purposes."
+msgstr "認可の目的で、クライアントまたは既存のクライアントの下にさまざまなロールを作成します。"
+
+#. type: Plain text
+msgid "Here is an example configuration file."
+msgstr "設定ファイルのサンプルは以下のとおりです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"client-id: <CLIENT_ID>\n"
+"client-secret: <CLIENT_SECRET> # require for access_type: confidential\n"
+"# Note the redirection-url is optional, it will default to the X-Forwarded-Proto / X-Forwarded-Host r the URL scheme and host not found\n"
+"discovery-url: https://keycloak.example.com/auth/realms/<REALM_NAME>\n"
+"enable-default-deny: true\n"
+"encryption_key: AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j\n"
+"listen: 127.0.0.1:3000\n"
+"redirection-url: http://127.0.0.1:3000\n"
+"upstream-url: http://127.0.0.1:80\n"
+"resources:\n"
+"- uri: /admin*\n"
+"  methods:\n"
+"  - GET\n"
+"  roles:\n"
+"  - client:test1\n"
+"  - client:test2\n"
+"  require-any-role: true\n"
+"  groups:\n"
+"  - admins\n"
+"  - users\n"
+"- uri: /backend*\n"
+"  roles:\n"
+"  - client:test1\n"
+"- uri: /public/*\n"
+"  white-listed: true\n"
+"- uri: /favicon\n"
+"  white-listed: true\n"
+"- uri: /css/*\n"
+"  white-listed: true\n"
+"- uri: /img/*\n"
+"  white-listed: true\n"
+msgstr ""
+"client-id: <CLIENT_ID>\n"
+"client-secret: <CLIENT_SECRET> # require for access_type: confidential\n"
+"# Note the redirection-url is optional, it will default to the X-Forwarded-Proto / X-Forwarded-Host r the URL scheme and host not found\n"
+"discovery-url: https://keycloak.example.com/auth/realms/<REALM_NAME>\n"
+"enable-default-deny: true\n"
+"encryption_key: AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j\n"
+"listen: 127.0.0.1:3000\n"
+"redirection-url: http://127.0.0.1:3000\n"
+"upstream-url: http://127.0.0.1:80\n"
+"resources:\n"
+"- uri: /admin*\n"
+"  methods:\n"
+"  - GET\n"
+"  roles:\n"
+"  - client:test1\n"
+"  - client:test2\n"
+"  require-any-role: true\n"
+"  groups:\n"
+"  - admins\n"
+"  - users\n"
+"- uri: /backend*\n"
+"  roles:\n"
+"  - client:test1\n"
+"- uri: /public/*\n"
+"  white-listed: true\n"
+"- uri: /favicon\n"
+"  white-listed: true\n"
+"- uri: /css/*\n"
+"  white-listed: true\n"
+"- uri: /img/*\n"
+"  white-listed: true\n"
+
+#. type: Plain text
+msgid ""
+"Anything defined in a configuration file can also be configured using "
+"command line options, such as in this example."
+msgstr "設定ファイルに定義されているものは、この例のようなコマンドライン・オプションを使用して設定することもできます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"bin/{generic_adapter_name} \\\n"
+"    --discovery-url=https://keycloak.example.com/auth/realms/<REALM_NAME> \\\n"
+"    --client-id=<CLIENT_ID> \\\n"
+"    --client-secret=<SECRET> \\\n"
+"    --listen=127.0.0.1:3000 \\ # unix sockets format unix://path\n"
+"    --redirection-url=http://127.0.0.1:3000 \\\n"
+"    --enable-refresh-tokens=true \\\n"
+"    --encryption-key=AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j \\\n"
+"    --upstream-url=http://127.0.0.1:80 \\\n"
+"    --enable-default-deny=true \\\n"
+"    --resources=\"uri=/admin*|roles=test1,test2\" \\\n"
+"    --resources=\"uri=/backend*|roles=test1\" \\\n"
+"    --resources=\"uri=/css/*|white-listed=true\" \\\n"
+"    --resources=\"uri=/img/*|white-listed=true\" \\\n"
+"    --resources=\"uri=/public/*|white-listed=true\"\n"
+msgstr ""
+"bin/{generic_adapter_name} \\\n"
+"    --discovery-url=https://keycloak.example.com/auth/realms/<REALM_NAME> \\\n"
+"    --client-id=<CLIENT_ID> \\\n"
+"    --client-secret=<SECRET> \\\n"
+"    --listen=127.0.0.1:3000 \\ # unix sockets format unix://path\n"
+"    --redirection-url=http://127.0.0.1:3000 \\\n"
+"    --enable-refresh-tokens=true \\\n"
+"    --encryption-key=AgXa7xRcoClDEU0ZDSH4X0XhL5Qy2Z2j \\\n"
+"    --upstream-url=http://127.0.0.1:80 \\\n"
+"    --enable-default-deny=true \\\n"
+"    --resources=\"uri=/admin*|roles=test1,test2\" \\\n"
+"    --resources=\"uri=/backend*|roles=test1\" \\\n"
+"    --resources=\"uri=/css/*|white-listed=true\" \\\n"
+"    --resources=\"uri=/img/*|white-listed=true\" \\\n"
+"    --resources=\"uri=/public/*|white-listed=true\"\n"
+
+#. type: Plain text
+msgid ""
+"By default the roles defined on a resource perform a logical `AND` so all "
+"roles specified must be present in the claims, this behavior can be altered "
+"by the `require-any-role` option, however, so as long as one role is present"
+" the permission is granted."
+msgstr ""
+"デフォルトでは、リソース上に定義されたロールは論理的な `AND` "
+"を実行するので、指定されたすべてのロールがクレームに存在しなければなりません。この動作は `require-any-role` "
+"オプションによって変更できますが、1つのロールが存在する限り、パーミッションが与えられます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "HTTP routing"
+msgstr "HTTPルーティング"
+
+#. type: Plain text
+msgid ""
+"By default all requests will be proxyed on to the upstream, if you wish to "
+"ensure all requests are authentication you can use this:"
+msgstr ""
+"デフォルトでは、すべてのリクエストがアップストリームにプロキシーされます。すべてのリクエストが認証であることを確認したい場合は、これを使用できます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"--resource=uri=/* # note, unless specified the method is assumed to be "
+"'any|ANY'\n"
+msgstr "--resource=uri=/* # 注意、指定されていない限り、メソッドは 'any|ANY' とみなされます。\n"
+
+#. type: Plain text
+msgid ""
+"The HTTP routing rules follow the guidelines from link:https://github.com"
+"/go-chi/chi#router-design[chi]. The ordering of the resources do not matter,"
+" the router will handle that for you."
+msgstr ""
+"HTTPルーティング・ルールは、 link:https://github.com/go-chi/chi#router-design[chi] "
+"のガイドラインに従います。リソースの順序は関係ありませんが、ルーターがそれを処理します。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Session-only cookies"
+msgstr "セッションのみのクッキー"
+
+#. type: Plain text
+msgid ""
+"By default the access and refresh cookies are session-only and disposed of "
+"on browser close; you can disable this feature using the `--enable-session-"
+"cookies` option."
+msgstr ""
+"デフォルトでは、アクセス・クッキーとリフレッシュ・クッキーはセッションのみで、ブラウザーの終了時に処分されます。 `--enable-session-"
+"cookies` オプションを使ってこの機能を無効にすることができます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Forward-signing proxy"
+msgstr "フォワード署名プロキシー"
+
+#. type: Plain text
+msgid ""
+"Forward-signing provides a mechanism for authentication and authorization "
+"between services using tokens issued from the IdP. When operating in this "
+"mode the proxy will automatically acquire an access token (handling the "
+"refreshing or logins on your behalf) and tag outbound requests with a "
+"Authorization header. You can control which domains are tagged with the "
+"--forwarding-domains option. Note, this option use a **contains** comparison"
+" on domains. So, if you wanted to match all domains under "
+"*.svc.cluster.local you can use: --forwarding-domain=svc.cluster.local."
+msgstr ""
+"フォワード署名は、IdPから発行されたトークンを使用してサービス間の認証および認可のメカニズムを提供します。このモードで動作している場合、プロキシーはアクセストークン（自動的にリフレッシュまたはログインを処理する）を取得し、アウトバウンド・リクエストにAuthorizationヘッダーを付加します。"
+" --forwarding-domainsオプションでタグ付けするドメインを制御することができます。このオプションは、ドメインで "
+"**contains** 比較を使用することに注意してください。したがって、* "
+".svc.cluster.localの下のすべてのドメインを一致させたい場合、--forwarding-"
+"domain=svc.cluster.localを使用できます。"
+
+#. type: Plain text
+msgid ""
+"At present the service performs a login using oauth client_credentials grant"
+" type, so your IdP service must support direct (username/password) logins."
+msgstr ""
+"現在、サービスはOAuthのclient_credentialsグラントタイプを使用してログインを実行するため、IdPサービスは直接（ユーザー名/パスワードでの）ログインをサポートする必要があります。"
+
+#. type: Plain text
+msgid "Example setup:"
+msgstr "設定例"
+
+#. type: Plain text
+msgid ""
+"You have collection of micro-services which are permitted to speak to one "
+"another; you have already set up the credentials, roles, and clients in "
+"Keycloak, providing granular role controls over issue tokens."
+msgstr ""
+"相互に通信することを許可されているマイクロサービスのコレクションがあります。すでにKeycloakでクレデンシャル、ロール、およびクライアントをセットアップしています（トークンを発行を超えた詳細なロール制御の提供）。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"- name: {generic_adapter_name}\n"
+"  image: quay.io/gambol99/keycloak-generic-adapter:latest\n"
+"  args:\n"
+"  - --enable-forwarding=true\n"
+"  - --forwarding-username=projecta\n"
+"  - --forwarding-password=some_password\n"
+"  - --forwarding-domains=projecta.svc.cluster.local\n"
+"  - --forwarding-domains=projectb.svc.cluster.local\n"
+"  - --tls-ca-certificate=/etc/secrets/ca.pem\n"
+"  - --tls-ca-key=/etc/secrets/ca-key.pem\n"
+"  # Note: if you don't specify any forwarding domains, all domains will be signed; Also the code checks is the\n"
+"  # domain 'contains' the value (it's not a regex) so if you wanted to sign all requests to svc.cluster.local, just use\n"
+"  # svc.cluster.local\n"
+"  volumeMounts:\n"
+"  - name: keycloak-socket\n"
+"    mountPoint: /var/run/keycloak\n"
+"- name: projecta\n"
+"  image: some_images\n"
+msgstr ""
+"- name: {generic_adapter_name}\n"
+"  image: quay.io/gambol99/keycloak-generic-adapter:latest\n"
+"  args:\n"
+"  - --enable-forwarding=true\n"
+"  - --forwarding-username=projecta\n"
+"  - --forwarding-password=some_password\n"
+"  - --forwarding-domains=projecta.svc.cluster.local\n"
+"  - --forwarding-domains=projectb.svc.cluster.local\n"
+"  - --tls-ca-certificate=/etc/secrets/ca.pem\n"
+"  - --tls-ca-key=/etc/secrets/ca-key.pem\n"
+"  # Note: if you don't specify any forwarding domains, all domains will be signed; Also the code checks is the\n"
+"  # domain 'contains' the value (it's not a regex) so if you wanted to sign all requests to svc.cluster.local, just use\n"
+"  # svc.cluster.local\n"
+"  volumeMounts:\n"
+"  - name: keycloak-socket\n"
+"    mountPoint: /var/run/keycloak\n"
+"- name: projecta\n"
+"  image: some_images\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# test the forward proxy\n"
+"$ curl -k --proxy http://127.0.0.1:3000 https://test.projesta.svc.cluster.local\n"
+msgstr ""
+"# test the forward proxy\n"
+"$ curl -k --proxy http://127.0.0.1:3000 https://test.projesta.svc.cluster.local\n"
+
+#. type: Plain text
+msgid ""
+"On the receiver side you could set up the {generic_adapter_name_full} "
+"(--no=redirects=true) and permit this to verify and handle admission for "
+"you. Alternatively, the access token can found as a bearer token in the "
+"request."
+msgstr ""
+"受信側では、{generic_adapter_name_full} "
+"(--no=redirects=true)をセットアップし、これを確認してあなたのために自認を処理することができます。あるいは、アクセストークンは、リクエスト内のベアラートークンとして見つけることができます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Forwarding signed HTTPS connections"
+msgstr "署名付きHTTPSコネクションの転送"
+
+#. type: Plain text
+msgid ""
+"Handling HTTPS requires a man-in-the-middle sort of TLS connection. By "
+"default, if no `--tls-ca-certificate` and `--tls-ca-key` are provided the "
+"proxy will use the default certificate. If you wish to verify the trust, "
+"you'll need to generate a CA, for example."
+msgstr ""
+"HTTPSの処理には、中間者型のTLSコネクションが必要です。デフォルトで `--tls-ca-certificate` と `--tls-ca-"
+"key` が指定されていない場合、プロキシーはデフォルトの証明書を使用します。信頼を検証する場合は、たとえば、CAを生成する必要があります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ca.key -out ca.pem\n"
+"$ bin/{generic_adapter_name} \\\n"
+"  --enable-forwarding \\\n"
+"  --forwarding-username=USERNAME \\\n"
+"  --forwarding-password=PASSWORD \\\n"
+"  --client-id=CLIENT_ID \\\n"
+"  --client-secret=SECRET \\\n"
+"  --discovery-url=https://keycloak.example.com/auth/realms/test \\\n"
+"  --tls-ca-certificate=ca.pem \\\n"
+"  --tls-ca-key=ca-key.pem\n"
+msgstr ""
+"$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ca.key -out ca.pem\n"
+"$ bin/{generic_adapter_name} \\\n"
+"  --enable-forwarding \\\n"
+"  --forwarding-username=USERNAME \\\n"
+"  --forwarding-password=PASSWORD \\\n"
+"  --client-id=CLIENT_ID \\\n"
+"  --client-secret=SECRET \\\n"
+"  --discovery-url=https://keycloak.example.com/auth/realms/test \\\n"
+"  --tls-ca-certificate=ca.pem \\\n"
+"  --tls-ca-key=ca-key.pem\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "HTTPS redirect"
+msgstr "HTTPSリダイレクト"
+
+#. type: Plain text
+msgid ""
+"The proxy supports an HTTP listener, so the only real requirement here is to"
+" perform an HTTP -> HTTPS redirect. You can enable the option like this:"
+msgstr ""
+"プロキシーはHTTPリスナーをサポートしているので、HTTP -> "
+"HTTPSのリダイレクトを実行することが、唯一の実際の要件です。次のようにオプションを有効にすることができます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"--listen-http=127.0.0.1:80\n"
+"--enable-security-filter=true  # is required for the https redirect\n"
+"--enable-https-redirection\n"
+msgstr ""
+"--listen-http=127.0.0.1:80\n"
+"--enable-security-filter=true  # is required for the https redirect\n"
+"--enable-https-redirection\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Let's Encrypt configuration"
+msgstr "Let's Encryptの設定"
+
+#. type: Plain text
+msgid ""
+"Here is an example of the required configuration for Let's Encrypt support:"
+msgstr "Let's Encryptサポートに必要な設定の例を次に示します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"listen: 0.0.0.0:443\n"
+"enable-https-redirection: true\n"
+"enable-security-filter: true\n"
+"use-letsencrypt: true\n"
+"letsencrypt-cache-dir: ./cache/\n"
+"redirection-url: https://domain.tld:443/\n"
+"hostnames:\n"
+"  - domain.tld\n"
+msgstr ""
+"listen: 0.0.0.0:443\n"
+"enable-https-redirection: true\n"
+"enable-security-filter: true\n"
+"use-letsencrypt: true\n"
+"letsencrypt-cache-dir: ./cache/\n"
+"redirection-url: https://domain.tld:443/\n"
+"hostnames:\n"
+"  - domain.tld\n"
+
+#. type: Plain text
+msgid "Listening on port 443 is mandatory."
+msgstr "443ポートでリッスンする必要があります。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Access token encryption"
+msgstr "アクセストークンの暗号化"
+
+#. type: Plain text
+msgid ""
+"By default, the session token is placed into a cookie in plaintext. If you "
+"prefer to encrypt the session cookie, use the `--enable-encrypted-token` and"
+" `--encryption-key` options. Note that the access token forwarded in the X"
+"-Auth-Token header to upstream is unaffected."
+msgstr ""
+"デフォルトでは、セッション・トークンはプレーンテキストでクッキーに格納されます。セッション・クッキーを暗号化したい場合は、 `--enable-"
+"encrypted-token` と `--encryption-key` オプションを使います。アップストリームへX-Auth-"
+"Tokenヘッダーで転送されたアクセストークンは影響を受けないことに注意してください。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Upstream headers"
+msgstr "アップストリーム・ヘッダー"
+
+#. type: Plain text
+msgid ""
+"On protected resources, the upstream endpoint will receive a number of "
+"headers added by the proxy, along with custom claims, like this:"
+msgstr ""
+"保護されたリソースでは、アップストリーム・エンドポイントは、次のようなカスタムクレームと共に、プロキシーによって追加されたいくつかのヘッダーを受け取ります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"# add the header to the upstream endpoint\n"
+"id := user.(*userContext)\n"
+"cx.Request().Header.Set(\"X-Auth-Email\", id.email)\n"
+"cx.Request().Header.Set(\"X-Auth-ExpiresIn\", id.expiresAt.String())\n"
+"cx.Request().Header.Set(\"X-Auth-Groups\", strings.Join(id.groups, \",\"))\n"
+"cx.Request().Header.Set(\"X-Auth-Roles\", strings.Join(id.roles, \",\"))\n"
+"cx.Request().Header.Set(\"X-Auth-Subject\", id.id)\n"
+"cx.Request().Header.Set(\"X-Auth-Token\", id.token.Encode())\n"
+"cx.Request().Header.Set(\"X-Auth-Userid\", id.name)\n"
+"cx.Request().Header.Set(\"X-Auth-Username\", id.name)\n"
+"// step: add the authorization header if requested\n"
+"if r.config.EnableAuthorizationHeader {\n"
+"\tcx.Request().Header.Set(\"Authorization\", fmt.Sprintf(\"Bearer %s\", id.token.Encode()))\n"
+"}\n"
+msgstr ""
+"# add the header to the upstream endpoint\n"
+"id := user.(*userContext)\n"
+"cx.Request().Header.Set(\"X-Auth-Email\", id.email)\n"
+"cx.Request().Header.Set(\"X-Auth-ExpiresIn\", id.expiresAt.String())\n"
+"cx.Request().Header.Set(\"X-Auth-Groups\", strings.Join(id.groups, \",\"))\n"
+"cx.Request().Header.Set(\"X-Auth-Roles\", strings.Join(id.roles, \",\"))\n"
+"cx.Request().Header.Set(\"X-Auth-Subject\", id.id)\n"
+"cx.Request().Header.Set(\"X-Auth-Token\", id.token.Encode())\n"
+"cx.Request().Header.Set(\"X-Auth-Userid\", id.name)\n"
+"cx.Request().Header.Set(\"X-Auth-Username\", id.name)\n"
+"// step: add the authorization header if requested\n"
+"if r.config.EnableAuthorizationHeader {\n"
+"\tcx.Request().Header.Set(\"Authorization\", fmt.Sprintf(\"Bearer %s\", id.token.Encode()))\n"
+"}\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Custom claim headers"
+msgstr "カスタム・クレーム・ヘッダー"
+
+#. type: Plain text
+msgid ""
+"You can inject additional claims from the access token into the "
+"authorization headers with the `--add-claims` option. For example, a token "
+"from a {project_name} provider might include the following claims:"
+msgstr ""
+"`--add-claims` "
+"オプションを使用して、アクセストークンから追加のクレームを認可ヘッダーに追加することができます。たとえば、{project_name}のあるプロバイダーから取得したトークンには、次のようなクレームが含まれています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"\"resource_access\": {},\n"
+"\"name\": \"Beloved User\",\n"
+"\"preferred_username\": \"beloved.user\",\n"
+"\"given_name\": \"Beloved\",\n"
+"\"family_name\": \"User\",\n"
+"\"email\": \"beloved@example.com\"\n"
+msgstr ""
+"\"resource_access\": {},\n"
+"\"name\": \"Beloved User\",\n"
+"\"preferred_username\": \"beloved.user\",\n"
+"\"given_name\": \"Beloved\",\n"
+"\"family_name\": \"User\",\n"
+"\"email\": \"beloved@example.com\"\n"
+
+#. type: Plain text
+msgid ""
+"In order to request you receive the given_name, family_name and name in the "
+"authentication header we would add `--add-claims=given_name` and `--add-"
+"claims=family_name` and so on, or we can do it in the configuration file, "
+"like this:"
+msgstr ""
+"認証given_name、family_nameおよびnameを認可ヘッダーで受け取るように要求するには、 `--add-"
+"claims=given_name` と `--add-claims=family_name` "
+"などを追加するか、次のように設定ファイルでそれを行うことができます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"add-claims:\n"
+"- given_name\n"
+"- family_name\n"
+"- name\n"
+msgstr ""
+"add-claims:\n"
+"- given_name\n"
+"- family_name\n"
+"- name\n"
+
+#. type: Plain text
+msgid ""
+"This would add the additional headers to the authenticated request along "
+"with standard ones."
+msgstr "これにより、追加のヘッダーが標準のものと一緒に認証されたリクエストに追加されます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"X-Auth-Family-Name: User\n"
+"X-Auth-Given-Name: Beloved\n"
+"X-Auth-Name: Beloved User\n"
+msgstr ""
+"X-Auth-Family-Name: User\n"
+"X-Auth-Given-Name: Beloved\n"
+"X-Auth-Name: Beloved User\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Encryption key"
+msgstr "暗号化鍵"
+
+#. type: Plain text
+msgid ""
+"In order to remain stateless and not have to rely on a central cache to "
+"persist the refresh_tokens, the refresh token is encrypted and added as a "
+"cookie using *crypto/aes*. The key must be the same if you are running "
+"behind a load balancer. The key length should be either 16 or 32 bytes, "
+"depending or whether you want AES-128 or AES-256."
+msgstr ""
+"ステートレスのままで、refresh_tokensを永続化するために中央キャッシュに依存する必要を無くすため、リフレッシュトークンは暗号化され、 "
+"*crypto/aes* を使用したCookieとして追加されます。ロードバランサーの背後で実行している場合、鍵は同じでなければなりません。鍵の長さは"
+"、AES-128またはAES-256を使用するかどうかに応じて、16バイトか32バイトのいずれかにする必要があります。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Claim matching"
+msgstr "クレーム・マッチング"
+
+#. type: Plain text
+msgid ""
+"The proxy supports adding a variable list of claim matches against the "
+"presented tokens for additional access control. You can match the 'iss' or "
+"'aud' to the token or custom attributes; each of the matches are regex's. "
+"For example, `--match-claims 'aud=sso.\\*'` or `--claim iss=https://.*'` or "
+"via the configuration file, like this:"
+msgstr ""
+"プロキシーは、追加のアクセス制御のために、提示されたトークンに対して一致するクレームの可変リストを追加することをサポートします。 'iss' または  "
+"'aud' をトークン属性またはカスタム属性に一致させることができます。それぞれの一致は正規表現です。 例えば、 `--match-claims "
+"'aud=sso.\\*'` や `--claim iss=https://.*'` や以下のような設定ファイルを介するか、"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"match-claims:\n"
+"  aud: openvpn\n"
+"  iss: https://keycloak.example.com/auth/realms/commons\n"
+msgstr ""
+"match-claims:\n"
+"  aud: openvpn\n"
+"  iss: https://keycloak.example.com/auth/realms/commons\n"
+
+#. type: Plain text
+msgid "or via the CLI, like this:"
+msgstr "またはCLI経由で次のように入力します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"--match-claims=auth=openvpn\n"
+"--match-claims=iss=http://keycloak.example.com/realms/commons\n"
+msgstr ""
+"--match-claims=auth=openvpn\n"
+"--match-claims=iss=http://keycloak.example.com/realms/commons\n"
+
+#. type: Plain text
+msgid ""
+"You can limit the email domain permitted; for example if you want to limit "
+"to only users on the example.com domain:"
+msgstr ""
+"許可される電子メールドメインを制限することができます。たとえば、example.comドメイン上のユーザーのみに制限したい場合は次のようにします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"match-claims:\n"
+"  email: ^.*@example.com$\n"
+msgstr ""
+"match-claims:\n"
+"  email: ^.*@example.com$\n"
+
+#. type: Plain text
+msgid ""
+"The adapter supports matching on multi-value strings claims. The match will "
+"succeed if one of the values matches, for example:"
+msgstr "アダプターは、複数値の文字列のクレームに対する一致をサポートします。値のいずれかが一致すると、成功します。たとえば、次のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"match-claims:\n"
+"  perms: perm1\n"
+msgstr ""
+"match-claims:\n"
+"  perms: perm1\n"
+
+#. type: Plain text
+msgid "will successfully match"
+msgstr "は、次に正常に一致します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"{\n"
+"  \"iss\": \"https://sso.example.com\",\n"
+"  \"sub\": \"\",\n"
+"  \"perms\": [\"perm1\", \"perm2\"]\n"
+"}\n"
+msgstr ""
+"{\n"
+"  \"iss\": \"https://sso.example.com\",\n"
+"  \"sub\": \"\",\n"
+"  \"perms\": [\"perm1\", \"perm2\"]\n"
+"}\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Group claims"
+msgstr "グループクレーム"
+
+#. type: Plain text
+msgid ""
+"You can match on the group claims within a token via the `groups` parameter "
+"available within the resource. While roles are implicitly required, such as "
+"`roles=admin,user` where the user MUST have roles 'admin' AND 'user', groups"
+" are applied with an OR operation, so `groups=users,testers` requires that "
+"the user MUST be within either 'users' OR 'testers'. The claim name is hard-"
+"coded to `groups`, so a JWT token would look like this:"
+msgstr ""
+"トークン内のグループクレームは、リソース内で利用可能な `groups` パラメーターを使って照合することができます。 "
+"`roles=admin,user` のようにロールが 'admin' と 'user' "
+"のロールを持たなければならないロールは暗黙的に必要ですが、グループはOR操作で適用されるので、 `groups=users,testers` "
+"の場合はユーザーが 'users' または 'testers' のいずれかにいなければなりません。クレーム名は `groups` "
+"にハードコードされているので、JWTトークンは次のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"{\n"
+"  \"iss\": \"https://sso.example.com\",\n"
+"  \"sub\": \"\",\n"
+"  \"aud\": \"test\",\n"
+"  \"exp\": 1515269245,\n"
+"  \"iat\": 1515182845,\n"
+"  \"email\": \"beloved@example.com\",\n"
+"  \"groups\": [\n"
+"    \"group_one\",\n"
+"    \"group_two\"\n"
+"  ],\n"
+"  \"name\": \"Beloved\"\n"
+"}\n"
+msgstr ""
+"{\n"
+"  \"iss\": \"https://sso.example.com\",\n"
+"  \"sub\": \"\",\n"
+"  \"aud\": \"test\",\n"
+"  \"exp\": 1515269245,\n"
+"  \"iat\": 1515182845,\n"
+"  \"email\": \"beloved@example.com\",\n"
+"  \"groups\": [\n"
+"    \"group_one\",\n"
+"    \"group_two\"\n"
+"  ],\n"
+"  \"name\": \"Beloved\"\n"
+"}\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Custom pages"
+msgstr "カスタムページ"
+
+#. type: Plain text
+msgid ""
+"By default, {generic_adapter_name_full} will immediately redirect you for "
+"authentication and hand back a 403 for access denied. Most users will "
+"probably want to present the user with a more friendly sign-in and access "
+"denied page. You can pass the command line options (or via config file) "
+"paths to the files with `--signin-page=PATH`. The sign-in page will have a "
+"'redirect' variable passed into the scope and holding the oauth redirection "
+"url. If you wish to pass additional variables into the templates, such as "
+"title, sitename and so on, you can use the -`-tags key=pair` option, like "
+"this: `--tags title=\"This is my site\"` and the variable would be "
+"accessible from `{{ .title }}`."
+msgstr ""
+"デフォルトでは、{generic_adapter_name_full}は認証のために即座にリダイレクトし、アクセス拒否のために403を返します。ほとんどのユーザーは、ユーザーにフレンドリーなサインインとアクセス拒否のページを提示したいと思うでしょう。"
+" `--signin-page=PATH` "
+"を使ってコマンドライン・オプション（または設定ファイル経由）パスをファイルに渡すことができます。サインインページには、「リダイレクト」変数がスコープに渡され、OAuthリダイレクトURLが保持されます。titleやsitenameなどの追加変数をテンプレートに渡したい場合は、"
+" `--tags title=\"This is my site\"` のように -`-tags key=pair` オプションを使用できます。変数は "
+"`{{ .title }}` からアクセス可能です。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<html>\n"
+"<body>\n"
+"<a href=\"{{ .redirect }}\">Sign-in</a>\n"
+"</body>\n"
+"</html>\n"
+msgstr ""
+"<html>\n"
+"<body>\n"
+"<a href=\"{{ .redirect }}\">Sign-in</a>\n"
+"</body>\n"
+"</html>\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "White-listed URL's"
+msgstr "ホワイトリストに登録されたURL"
+
+#. type: Plain text
+msgid ""
+"Depending on how the application URL's are laid out, you might want protect "
+"the root / url but have exceptions on a list of paths, for example "
+"`/health`. While this is best solved by adjusting the paths, you can add "
+"exceptions to the protected resources, like this:"
+msgstr ""
+"アプリケーションのURLの配置方法によっては、ルート（/）URLを保護したいが、パスのリストに例外（たとえば `/health` "
+"など）を置くことが望ましいかもしれません。パスを調整することによってこれを解決するのが最もよいですが、保護されたリソースには次のように例外を追加できます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"  resources:\n"
+"  - uri: /some_white_listed_url\n"
+"    white-listed: true\n"
+"  - uri: /*\n"
+"    methods:\n"
+"      - GET\n"
+"    roles:\n"
+"      - <CLIENT_APP_NAME>:<ROLE_NAME>\n"
+"      - <CLIENT_APP_NAME>:<ROLE_NAME>\n"
+msgstr ""
+"  resources:\n"
+"  - uri: /some_white_listed_url\n"
+"    white-listed: true\n"
+"  - uri: /*\n"
+"    methods:\n"
+"      - GET\n"
+"    roles:\n"
+"      - <CLIENT_APP_NAME>:<ROLE_NAME>\n"
+"      - <CLIENT_APP_NAME>:<ROLE_NAME>\n"
+
+#. type: Plain text
+msgid "Or on the command line"
+msgstr "またはコマンドライン上で"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"  --resources \"uri=/some_white_listed_url|white-listed=true\"\n"
+"  --resources \"uri=/*\"  # requires authentication on the rest\n"
+"  --resources \"uri=/admin*|roles=admin,superuser|methods=POST,DELETE\"\n"
+msgstr ""
+"  --resources \"uri=/some_white_listed_url|white-listed=true\"\n"
+"  --resources \"uri=/*\"  # requires authentication on the rest\n"
+"  --resources \"uri=/admin*|roles=admin,superuser|methods=POST,DELETE\"\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Mutual TLS"
+msgstr "Mutual TLS"
+
+#. type: Plain text
+msgid ""
+"The proxy support enforcing mutual TLS for the clients by adding the `--tls-"
+"ca-certificate` command line option or configuration file option. All "
+"clients connecting must present a certificate which was signed by the CA "
+"being used."
+msgstr ""
+"プロキシーは、 `--tls-ca-certificate` "
+"コマンドライン・オプションまたは設定ファイル・オプションを追加することで、クライアントのMutual "
+"TLSの強制をサポートします。接続しているすべてのクライアントは、使用されているCAによって署名された証明書を提示する必要があります。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Certificate rotation"
+msgstr "証明書ローテーション"
+
+#. type: Plain text
+msgid ""
+"The proxy will automatically rotate the server certificates if the files "
+"change on disk. Note, no down time will occur as the change is made inline. "
+"Clients who connected prior to the certificate rotation will be unaffected "
+"and will continue as normal with all new connections presented with the new "
+"certificate."
+msgstr ""
+"ファイルがディスク上で変更された場合、プロキシーはサーバー証明書を自動的にローテーションします。変更がインラインで行われるため、ダウンタイムは発生しません。証明書ローテーションの前に接続したクライアントは影響を受けず、新しい証明書が提示された新しい接続すべてで通常どおりに続行されます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Refresh tokens"
+msgstr "リフレッシュトークン"
+
+#. type: Plain text
+msgid ""
+"If a request for an access token contains a refresh token and `--enable-"
+"refresh-tokens` is set to `true`, the proxy will automatically refresh the "
+"access token for you. The tokens themselves are kept either as an encrypted "
+"*(--encryption-key=KEY)* cookie *(cookie name: kc-state).* or a store "
+"*(still requires encryption key)*."
+msgstr ""
+"アクセストークンのリクエストにリフレッシュトークンが含まれ、 `--enable-refresh-tokens` が` true` "
+"に設定されている場合、プロキシーは自動的にアクセストークンをリフレッシュします。トークン自体は、暗号化された *(--encryption-"
+"key=KEY)* クッキー *（クッキー名：kc-state）* またはストア *（暗号化キーが必要です）* のいずれかとして保持されます。"
+
+#. type: Plain text
+msgid ""
+"At present the only store options supported are "
+"link:https://github.com/antirez/redis[Redis] and "
+"link:https://github.com/boltdb/bolt[Boltdb]."
+msgstr ""
+"現在サポートされているストアオプションは、 link:https://github.com/antirez/redis[Redis] と "
+"link:https://github.com/boltdb/bolt[Boltdb] のみです。"
+
+#. type: Plain text
+msgid ""
+"To enable a local boltdb store use `--store-url boltdb:///PATH` or using a "
+"relative path `boltdb://PATH`."
+msgstr ""
+"ローカルboltdbストアを有効にするには `--store-url boltdb:///PATH` を使うか、相対パス `boltdb://PATH`"
+" を使います。"
+
+#. type: Plain text
+msgid ""
+"To enable a local redis store use `redis://[USER:PASSWORD@]HOST:PORT`. In "
+"both cases the refresh token is encrypted before being placed into the "
+"store."
+msgstr ""
+"ローカルRedisストアを有効にするには、 `redis://[USER:PASSWORD@]HOST:PORT` "
+"を使用します。どちらの場合も、リフレッシュトークンはストアに保存される前に暗号化されます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Logout endpoint"
+msgstr "ログアウト・エンドポイント"
+
+#. type: Plain text
+msgid ""
+"A */oauth/logout?redirect=url* is provided as a helper to log users out. In "
+"addition to dropping any session cookies, we also attempt to revoke access "
+"via revocation url (config *revocation-url* or *--revocation-url*) with the "
+"provider. For Keycloak, the url for this would be "
+"https://keycloak.example.com/auth/realms/REALM_NAME/protocol/openid-"
+"connect/logout. If the url is not specified we will attempt to grab the url "
+"from the OpenID discovery response."
+msgstr ""
+"*/oauth/logout?redirect=url* "
+"は、ユーザーをログアウトするヘルパーとして提供されています。セッション・クッキーを削除するだけでなく、プロバイダーに対して取り消しURL（設定 "
+"*revocation-url* または *--revocation-url* "
+"）を介してアクセスを取り消そうとします。Keycloakの場合、このURLはhttps://keycloak.example.com/auth/realms/REALM_NAME/protocol"
+"/openid-"
+"connect/logoutになります。urlが指定されていない場合、OpenIDディスカバリー・レスポンスからurlを取得しようとします。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Cross-origin resource sharing (CORS)"
+msgstr "Cross-origin resource sharing (CORS)"
+
+#. type: Plain text
+msgid ""
+"You can add a CORS header via the `--cors-[method]` with these configuration"
+" options."
+msgstr "これらの設定オプションとともに `--cors-[method]` でCORSヘッダーを追加することができます。"
+
+#. type: Plain text
+msgid "Access-Control-Allow-Origin"
+msgstr "Access-Control-Allow-Origin"
+
+#. type: Plain text
+msgid "Access-Control-Allow-Methods"
+msgstr "Access-Control-Allow-Methods"
+
+#. type: Plain text
+msgid "Access-Control-Allow-Headers"
+msgstr "Access-Control-Allow-Headers"
+
+#. type: Plain text
+msgid "Access-Control-Expose-Headers"
+msgstr "Access-Control-Expose-Headers"
+
+#. type: Plain text
+msgid "Access-Control-Allow-Credentials"
+msgstr "Access-Control-Allow-Credentials"
+
+#. type: Plain text
+msgid "Access-Control-Max-Age"
+msgstr "Access-Control-Max-Age"
+
+#. type: Plain text
+msgid "You can add using the config file:"
+msgstr "次のように、設定ファイルを使用して追加できます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"cors-origins:\n"
+"- '*'\n"
+"cors-methods:\n"
+"- GET\n"
+"- POST\n"
+msgstr ""
+"cors-origins:\n"
+"- '*'\n"
+"cors-methods:\n"
+"- GET\n"
+"- POST\n"
+
+#. type: Plain text
+msgid "or via the command line:"
+msgstr "またはコマンドラインで次のようにします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"--cors-origins [--cors-origins option]                  a set of origins to add to the CORS access control (Access-Control-Allow-Origin)\n"
+"--cors-methods [--cors-methods option]                  the method permitted in the access control (Access-Control-Allow-Methods)\n"
+"--cors-headers [--cors-headers option]                  a set of headers to add to the CORS access control (Access-Control-Allow-Headers)\n"
+"--cors-exposes-headers [--cors-exposes-headers option]  set the expose cors headers access control (Access-Control-Expose-Headers)\n"
+msgstr ""
+"--cors-origins [--cors-origins option]                  a set of origins to add to the CORS access control (Access-Control-Allow-Origin)\n"
+"--cors-methods [--cors-methods option]                  the method permitted in the access control (Access-Control-Allow-Methods)\n"
+"--cors-headers [--cors-headers option]                  a set of headers to add to the CORS access control (Access-Control-Allow-Headers)\n"
+"--cors-exposes-headers [--cors-exposes-headers option]  set the expose cors headers access control (Access-Control-Expose-Headers)\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Upstream URL"
+msgstr "アップストリームURL"
+
+#. type: Plain text
+msgid ""
+"You can control the upstream endpoint via the `--upstream-url` option. Both "
+"HTTP and HTTPS are supported with TLS verification and keep-alive support "
+"configured via the `--skip-upstream-tls-verify` / `--upstream-keepalives` "
+"option. Note, the proxy can also upstream via a UNIX socket, `--upstream-url"
+" unix://path/to/the/file.sock`."
+msgstr ""
+"アップストリームのエンドポイントは `--upstream-url` オプションで制御できます。HTTPとHTTPSの両方がTLS検証と "
+"`--skip-upstream-tls-verify` / `--upstream-keepalives` "
+"オプションで設定されたキープアライブでサポートされています。なお、プロキシーはUNIXのソケット（ `--upstream-url "
+"unix://path/to/the/file.sock` ）を介してアップストリームにすることもできます。"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"**/oauth/authorize** is authentication endpoint which will generate the "
+"OpenID redirect to the provider\n"
+msgstr "**/oauth/authorize** はプロバイダーへのOpenIDリダイレクトを生成する認証エンドポイントです\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "**/oauth/callback** is provider OpenID callback endpoint\n"
+msgstr "**/oauth/callback** はプロバイダーのOpenIDコールバックエンドポイントです\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"**/oauth/expired** is a helper endpoint to check if a access token has "
+"expired, 200 for ok and, 401 for no token and 401 for expired\n"
+msgstr ""
+"**/oauth/expired** "
+"は、アクセストークンが期限切れになったかどうかをチェックするヘルパー・エンドポイントです。200はOK、401はトークンなし、401は期限切れです。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"**/oauth/health** is the health checking endpoint for the proxy, you can "
+"also grab version from headers\n"
+msgstr "**/oauth/health** はプロキシーのヘルスチェック・エンドポイントです。ヘッダーからバージョンを取得することもできます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"**/oauth/login** provides a relay endpoint to login via "
+"`grant_type=password`, for example, `POST /oauth/login` form values are "
+"`username=USERNAME&password=PASSWORD` (must be enabled)\n"
+msgstr ""
+"**/oauth/login** は `grant_type=password` でログインするためのリレーエンドポイントを提供します。たとえば、 "
+"`POST /oauth/login` フォームの値は `username=USERNAME&password=PASSWORD` (must be "
+"enabled) です（有効にする必要があります）\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"**/oauth/logout** provides a convenient endpoint to log the user out, it "
+"will always attempt to perform a back channel log out of offline tokens\n"
+msgstr ""
+"**/oauth/logout** "
+"は、ユーザーをログアウトさせるための便利なエンドポイントを提供します。常にオフライン・トークンからバックチャネル・ログアウトを実行しようとします。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"**/oauth/token** is a helper endpoint which will display the current access "
+"token for you\n"
+msgstr "**/oauth/token** は現在のアクセストークンを表示するヘルパー・エンドポイントです。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "**/oauth/metrics** is a Prometheus metrics handler\n"
+msgstr "**/oauth/metrics** はPrometheusメトリクス・ハンドラーです。\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Metrics"
+msgstr "メトリクス"
+
+#. type: Plain text
+msgid ""
+"Assuming `--enable-metrics` has been set, a Prometheus endpoint can be found"
+" on */oauth/metrics*; at present the only metric being exposed is a counter "
+"per HTTP code."
+msgstr ""
+"`--enable-metrics` が設定されていると仮定すると、Prometheusエンドポイントは */oauth/metrics* "
+"にあります。現在公開されている唯一のメトリックはHTTPコードごとのカウンターです。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Limitations"
+msgstr "制限事項"
+
+#. type: Plain text
+msgid ""
+"Keep in mind link:http://browsercookielimits.squawky.net/[browser cookie "
+"limits] if you use access or refresh tokens in the browser cookie. Keycloak-"
+"generic-adapter divides the cookie automatically if your cookie is longer "
+"than 4093 bytes. Real size of the cookie depends on the content of the "
+"issued access token. Also, encryption might add additional bytes to the "
+"cookie size. If you have large cookies (>200 KB), you might reach browser "
+"cookie limits."
+msgstr ""
+"ブラウザーのCookieでアクセストークンまたはリフレッシュトークンを使用する場合は、 "
+"link:http://browsercookielimits.squawky.net/[ブラウザCookieの制限] に注意してください"
+"。Keycloak-generic-"
+"adapterは、Cookieが4093バイトよりも長い場合、Cookieを自動的に分割します。Cookieの実際のサイズは、発行されたアクセストークンの内容によって異なります。また、暗号化によってCookieサイズがさらに増加する可能性があります。大きなCookie（>"
+" 200 KB）の場合は、ブラウザーのCookie制限に達する可能性があります。"
+
+#. type: Plain text
+msgid ""
+"All cookies are part of the header request, so you might find a problem with"
+" the max headers size limits in your infrastructure (some load balancers "
+"have very low this value, such as 8 KB). Be sure that all network devices "
+"have sufficient header size limits. Otherwise, your users won't be able to "
+"obtain an access token."
+msgstr ""
+"すべてのCookieはリクエスト・ヘッダーの一部であるため、インフラストラクチャーの最大ヘッダーサイズの制限で問題になる可能性があります（一部のロードバランサーは、8"
+" "
+"KBのようにこの値が非常に低いです）。すべてのネットワーク・デバイスに十分なヘッダーサイズ制限があることを確認してください。そうしなければ、ユーザーはアクセストークンを取得できない可能性があります。"

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -286,6 +287,9 @@ msgid ""
 "  white-listed: true\n"
 "- uri: /img/*\n"
 "  white-listed: true\n"
+"headers:\n"
+"  myheader1: value_1\n"
+"  myheader2: value_2\n"
 msgstr ""
 "client-id: <CLIENT_ID>\n"
 "client-secret: <CLIENT_SECRET> # require for access_type: confidential\n"
@@ -318,6 +322,9 @@ msgstr ""
 "  white-listed: true\n"
 "- uri: /img/*\n"
 "  white-listed: true\n"
+"headers:\n"
+"  myheader1: value_1\n"
+"  myheader2: value_2\n"
 
 #. type: Plain text
 msgid ""
@@ -342,7 +349,9 @@ msgid ""
 "    --resources=\"uri=/backend*|roles=test1\" \\\n"
 "    --resources=\"uri=/css/*|white-listed=true\" \\\n"
 "    --resources=\"uri=/img/*|white-listed=true\" \\\n"
-"    --resources=\"uri=/public/*|white-listed=true\"\n"
+"    --resources=\"uri=/public/*|white-listed=true\" \\\n"
+"    --headers=\"myheader1=value1\" \\\n"
+"    --headers=\"myheader2=value2\"\n"
 msgstr ""
 "bin/{generic_adapter_name} \\\n"
 "    --discovery-url=https://keycloak.example.com/auth/realms/<REALM_NAME> \\\n"
@@ -358,7 +367,9 @@ msgstr ""
 "    --resources=\"uri=/backend*|roles=test1\" \\\n"
 "    --resources=\"uri=/css/*|white-listed=true\" \\\n"
 "    --resources=\"uri=/img/*|white-listed=true\" \\\n"
-"    --resources=\"uri=/public/*|white-listed=true\"\n"
+"    --resources=\"uri=/public/*|white-listed=true\" \\\n"
+"    --headers=\"myheader1=value1\" \\\n"
+"    --headers=\"myheader2=value2\"\n"
 
 #. type: Plain text
 msgid ""
@@ -370,6 +381,23 @@ msgstr ""
 "デフォルトでは、リソース上に定義されたロールは論理的な `AND` "
 "を実行するので、指定されたすべてのロールがクレームに存在しなければなりません。この動作は `require-any-role` "
 "オプションによって変更できますが、1つのロールが存在する限り、パーミッションが与えられます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "OpenID Provider Communication"
+msgstr "OpenIDプロバイダーとの通信"
+
+#. type: Plain text
+msgid ""
+"By default the communication with the OpenID provider is direct. If you "
+"wish, you can specify a forwarding proxy server in your configuration file:"
+msgstr ""
+"デフォルトでは、OpenIDプロバイダーとの通信は直接行われます。必要に応じて、次のように設定ファイルに転送プロキシー・サーバーを指定できます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "openid-provider-proxy: http://proxy.example.com:8080\n"
+msgstr "openid-provider-proxy: http://proxy.example.com:8080\n"
 
 #. type: Title ====
 #, no-wrap
@@ -402,7 +430,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Session-only cookies"
-msgstr "セッションのみのクッキー"
+msgstr "セッションのみのCookie"
 
 #. type: Plain text
 msgid ""
@@ -410,8 +438,8 @@ msgid ""
 "on browser close; you can disable this feature using the `--enable-session-"
 "cookies` option."
 msgstr ""
-"デフォルトでは、アクセス・クッキーとリフレッシュ・クッキーはセッションのみで、ブラウザーの終了時に処分されます。 `--enable-session-"
-"cookies` オプションを使ってこの機能を無効にすることができます。"
+"デフォルトでは、アクセスCookieとリフレッシュCookieはセッションのみで、ブラウザーの終了時に処分されます。 `--enable-"
+"session-cookies` オプションを使ってこの機能を無効にすることができます。"
 
 #. type: Title ====
 #, no-wrap
@@ -452,7 +480,7 @@ msgid ""
 "another; you have already set up the credentials, roles, and clients in "
 "Keycloak, providing granular role controls over issue tokens."
 msgstr ""
-"相互に通信することを許可されているマイクロサービスのコレクションがあります。すでにKeycloakでクレデンシャル、ロール、およびクライアントをセットアップしています（トークンを発行を超えた詳細なロール制御の提供）。"
+"相互に通信することを許可されているマイクロサービスのコレクションがあります。すでにKeycloakでクレデンシャル、ロール、およびクライアントをセットアップしており、発行トークンに対してきめ細かいロール制御を提供しています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -511,8 +539,8 @@ msgid ""
 "you. Alternatively, the access token can found as a bearer token in the "
 "request."
 msgstr ""
-"受信側では、{generic_adapter_name_full} "
-"(--no=redirects=true)をセットアップし、これを確認してあなたのために自認を処理することができます。あるいは、アクセストークンは、リクエスト内のベアラートークンとして見つけることができます。"
+"受信側では、{generic_adapter_name_full} （--no-"
+"redirects=true）をセットアップして検証を許可しアクセスを処理することができます。あるいは、アクセストークンは、リクエスト内のベアラートークンとして見つけることができます。"
 
 #. type: Title ====
 #, no-wrap
@@ -526,8 +554,8 @@ msgid ""
 "proxy will use the default certificate. If you wish to verify the trust, "
 "you'll need to generate a CA, for example."
 msgstr ""
-"HTTPSの処理には、中間者型のTLSコネクションが必要です。デフォルトで `--tls-ca-certificate` と `--tls-ca-"
-"key` が指定されていない場合、プロキシーはデフォルトの証明書を使用します。信頼を検証する場合は、たとえば、CAを生成する必要があります。"
+"HTTPSの処理には、中間者型のTLSコネクションが必要です。デフォルトでは、 `--tls-ca-certificate` と `--tls-ca-"
+"key` が指定されていない場合、プロキシーはデフォルトの証明書を使用します。トラストを検証する場合は、たとえば、CAを生成する必要があります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -564,7 +592,7 @@ msgid ""
 "The proxy supports an HTTP listener, so the only real requirement here is to"
 " perform an HTTP -> HTTPS redirect. You can enable the option like this:"
 msgstr ""
-"プロキシーはHTTPリスナーをサポートしているので、HTTP -> "
+"プロキシーはHTTPリスナーをサポートしているため、HTTP -> "
 "HTTPSのリダイレクトを実行することが、唯一の実際の要件です。次のようにオプションを有効にすることができます。"
 
 #. type: delimited block -
@@ -639,7 +667,7 @@ msgid ""
 "On protected resources, the upstream endpoint will receive a number of "
 "headers added by the proxy, along with custom claims, like this:"
 msgstr ""
-"保護されたリソースでは、アップストリーム・エンドポイントは、次のようなカスタムクレームと共に、プロキシーによって追加されたいくつかのヘッダーを受け取ります。"
+"保護されたリソースであるアップストリーム・エンドポイントは、次のようなカスタムクレームと共に、プロキシーによって追加されたいくつかのヘッダーを受け取ります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -673,6 +701,16 @@ msgstr ""
 "if r.config.EnableAuthorizationHeader {\n"
 "\tcx.Request().Header.Set(\"Authorization\", fmt.Sprintf(\"Bearer %s\", id.token.Encode()))\n"
 "}\n"
+
+#. type: Plain text
+msgid ""
+"To control the `Authorization` header use the `enable-authorization-header` "
+"yaml configuration or the `--enable-authorization-header` command line "
+"option. By default this option is set to `true`."
+msgstr ""
+"`Authorization` ヘッダーを制御するには、`enable-authorization-header` YAMLの設定または "
+"`--enable-authorization-header` コマンドライン・オプションを使用してください。デフォルトでは、このオプションは "
+"`true` に設定されています。"
 
 #. type: Title ====
 #, no-wrap
@@ -712,7 +750,7 @@ msgid ""
 "claims=family_name` and so on, or we can do it in the configuration file, "
 "like this:"
 msgstr ""
-"認証given_name、family_nameおよびnameを認可ヘッダーで受け取るように要求するには、 `--add-"
+"given_name、family_nameおよびnameを認可ヘッダーで受け取るように要求するには、 `--add-"
 "claims=given_name` と `--add-claims=family_name` "
 "などを追加するか、次のように設定ファイルでそれを行うことができます。"
 
@@ -748,6 +786,26 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
+msgid "Custom headers"
+msgstr "カスタムヘッダー"
+
+#. type: Plain text
+msgid ""
+"You can inject custom headers using the `--headers=\"name=value\"` option or"
+" the configuration file:"
+msgstr "`--headers=\"name=value\"` オプションか次のように設定ファイルを使用して、カスタムヘッダーを挿入することができます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"headers:\n"
+"  name: value\n"
+msgstr ""
+"headers:\n"
+"  name: value\n"
+
+#. type: Title ====
+#, no-wrap
 msgid "Encryption key"
 msgstr "暗号化鍵"
 
@@ -759,7 +817,7 @@ msgid ""
 "behind a load balancer. The key length should be either 16 or 32 bytes, "
 "depending or whether you want AES-128 or AES-256."
 msgstr ""
-"ステートレスのままで、refresh_tokensを永続化するために中央キャッシュに依存する必要を無くすため、リフレッシュトークンは暗号化され、 "
+"ステートレスのままで、refresh_tokenを永続化するために中央キャッシュに依存する必要を無くすため、リフレッシュトークンは暗号化され、 "
 "*crypto/aes* を使用したCookieとして追加されます。ロードバランサーの背後で実行している場合、鍵は同じでなければなりません。鍵の長さは"
 "、AES-128またはAES-256を使用するかどうかに応じて、16バイトか32バイトのいずれかにする必要があります。"
 
@@ -777,7 +835,7 @@ msgid ""
 "via the configuration file, like this:"
 msgstr ""
 "プロキシーは、追加のアクセス制御のために、提示されたトークンに対して一致するクレームの可変リストを追加することをサポートします。 'iss' または  "
-"'aud' をトークン属性またはカスタム属性に一致させることができます。それぞれの一致は正規表現です。 例えば、 `--match-claims "
+"'aud' をトークン属性またはカスタム属性に一致させることができます。それぞれの一致は正規表現です。例えば、 `--match-claims "
 "'aud=sso.\\*'` や `--claim iss=https://.*'` や以下のような設定ファイルを介するか、"
 
 #. type: delimited block -
@@ -1042,8 +1100,8 @@ msgid ""
 "*(still requires encryption key)*."
 msgstr ""
 "アクセストークンのリクエストにリフレッシュトークンが含まれ、 `--enable-refresh-tokens` が` true` "
-"に設定されている場合、プロキシーは自動的にアクセストークンをリフレッシュします。トークン自体は、暗号化された *(--encryption-"
-"key=KEY)* クッキー *（クッキー名：kc-state）* またはストア *（暗号化キーが必要です）* のいずれかとして保持されます。"
+"に設定されている場合、プロキシーは自動的にアクセストークンをリフレッシュします。トークン自体は、暗号化された *（--encryption-"
+"key=KEY）* クッキー *（クッキー名：kc-state）* またはストア *（暗号化キーが必要です）* のいずれかとして保持されます。"
 
 #. type: Plain text
 msgid ""
@@ -1089,14 +1147,14 @@ msgstr ""
 "*/oauth/logout?redirect=url* "
 "は、ユーザーをログアウトするヘルパーとして提供されています。セッション・クッキーを削除するだけでなく、プロバイダーに対して取り消しURL（設定 "
 "*revocation-url* または *--revocation-url* "
-"）を介してアクセスを取り消そうとします。Keycloakの場合、このURLはhttps://keycloak.example.com/auth/realms/REALM_NAME/protocol"
-"/openid-"
-"connect/logoutになります。urlが指定されていない場合、OpenIDディスカバリー・レスポンスからurlを取得しようとします。"
+"）を介してアクセスを取り消そうとします。Keycloakの場合、このURLは "
+"https://keycloak.example.com/auth/realms/REALM_NAME/protocol/openid-"
+"connect/logout になります。urlが指定されていない場合、OpenIDディスカバリー・レスポンスからurlを取得しようとします。"
 
 #. type: Title ====
 #, no-wrap
 msgid "Cross-origin resource sharing (CORS)"
-msgstr "Cross-origin resource sharing (CORS)"
+msgstr "Cross-origin resource sharing（CORS）"
 
 #. type: Plain text
 msgid ""
@@ -1192,7 +1250,7 @@ msgstr "**/oauth/authorize** はプロバイダーへのOpenIDリダイレクト
 #. type: Plain text
 #, no-wrap
 msgid "**/oauth/callback** is provider OpenID callback endpoint\n"
-msgstr "**/oauth/callback** はプロバイダーのOpenIDコールバックエンドポイントです\n"
+msgstr "**/oauth/callback** はプロバイダーのOpenIDコールバック・エンドポイントです\n"
 
 #. type: Plain text
 #, no-wrap
@@ -1218,8 +1276,8 @@ msgid ""
 "`username=USERNAME&password=PASSWORD` (must be enabled)\n"
 msgstr ""
 "**/oauth/login** は `grant_type=password` でログインするためのリレーエンドポイントを提供します。たとえば、 "
-"`POST /oauth/login` フォームの値は `username=USERNAME&password=PASSWORD` (must be "
-"enabled) です（有効にする必要があります）\n"
+"`POST /oauth/login` フォームの値は `username=USERNAME&password=PASSWORD` "
+"です（有効にする必要があります）\n"
 
 #. type: Plain text
 #, no-wrap
@@ -1228,7 +1286,7 @@ msgid ""
 "will always attempt to perform a back channel log out of offline tokens\n"
 msgstr ""
 "**/oauth/logout** "
-"は、ユーザーをログアウトさせるための便利なエンドポイントを提供します。常にオフライン・トークンからバックチャネル・ログアウトを実行しようとします。\n"
+"は、ユーザーをログアウトさせるための便利なエンドポイントを提供します。常にオフライントークンからバックチャネル・ログアウトを実行しようとします。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -1288,3 +1346,23 @@ msgstr ""
 "すべてのCookieはリクエスト・ヘッダーの一部であるため、インフラストラクチャーの最大ヘッダーサイズの制限で問題になる可能性があります（一部のロードバランサーは、8"
 " "
 "KBのようにこの値が非常に低いです）。すべてのネットワーク・デバイスに十分なヘッダーサイズ制限があることを確認してください。そうしなければ、ユーザーはアクセストークンを取得できない可能性があります。"
+
+#. type: Title =
+#, no-wrap
+msgid "Known Issues"
+msgstr "既知の問題"
+
+#. type: Plain text
+msgid ""
+"There is a known issue with the Keycloak server 4.7.0.Final in which "
+"Gatekeeper is unable to find the _client_id_ in the _aud_ claim. This is due"
+" to the fact the _client_id_ is not in the audience anymore. The workaround "
+"is to add the \"Audience\" protocol mapper to the client with the audience "
+"pointed to the _client_id_. For more information, see "
+"link:https://issues.jboss.org/browse/KEYCLOAK-8954[KEYCLOAK-8954]."
+msgstr ""
+"Keycloak Server 4.7.0.Finalには、Gatekeeperが _aud_ クレームで _client_id_ "
+"を見つけることができない既知の問題があります。これは、 _client_id_ がもうAudienceに含まれないためです。これを回避するには、 "
+"\"Audience\" プロトコル・マッパーをそのクライアントに追加し、 _client_id_ "
+"を指すようにAudienceを設定します。詳細については、 "
+"link:https：//issues.jboss.org/browse/KEYCLOAK-8954[KEYCLOAK-8954] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__keycloak-gatekeeper
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
