### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/logout.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/logout.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/logout.ja_JP.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Identity broker logout"
+msgstr "アイデンティティー・ブローカー・ログアウト"
+
+#. type: Plain text
+msgid ""
+"When logout from {project_name} is triggered, {project_name} will send a "
+"request to the external identity provider that was used to login to "
+"Keycloak, and the user will be logged out from this identity provider as "
+"well.  It is possible to skip this behaviour and avoid logout at the "
+"external identity provider.  See link:{adapterguide_logout_link}[adapter "
+"logout documentation] for more details."
+msgstr ""
+"{project_name}からのログアウトがトリガーされると、{project_name}はKeycloakへのログインに使用されていた外部アイデンティティー・プロバイダーにリクエストを送信し、ユーザーはこのアイデンティティー・プロバイダーからもログアウトされます。この動作をスキップして外部アイデンティティー・プロバイダーでのログアウトを回避することは可能です。詳細については、"
+" link:{adapterguide_logout_link}[アダプター・ログアウトのドキュメント] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/logout.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__logout
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
