### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,15 +61,15 @@ msgstr "クライアントはユーザーに成り代わることができます
 #. type: Plain text
 msgid ""
 "Token exchange in {project_name} is a very loose implementation of the "
-"link:https://www.ietf.org/id/draft-ietf-oauth-token-exchange-15.txt[OAuth "
+"link:https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16[OAuth "
 "Token Exchange] specification at the IETF.  We have extended it a little, "
 "ignored some of it, and loosely interpreted other parts of the "
 "specification.  It is a simple grant type invocation on a realm's OpenID "
 "Connect token endpoint."
 msgstr ""
-"{project_name}のトークンの交換は、link:https://www.ietf.org/id/draft-ietf-oauth-token-"
-"exchange-15.txt[OAuth Token "
-"Exchange]の仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
+"{project_name}のトークンの交換は、 link:https://tools.ietf.org/html/draft-ietf-oauth-"
+"token-exchange-16[OAuth Token Exchange] "
+"の仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
 " Connectトークン・エンドポイントでの単純なグラントタイプの呼び出しです。"
 
 #. type: delimited block -
@@ -269,14 +273,15 @@ msgid ""
 "A successful response from an exchange invocation will return the HTTP 200 "
 "response code with a content type that depends on the `requested-token-type`"
 " and `requested_issuer` the client asks for.  OAuth requested token types "
-"will return a JSON document as described in the link:https://www.ietf.org/id"
-"/draft-ietf-oauth-token-exchange-15.txt[OAuth Token Exchange] specification."
+"will return a JSON document as described in the "
+"link:https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16[OAuth "
+"Token Exchange] specification."
 msgstr ""
 "トークン交換の呼び出しの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
 "`requested_issuer` に依存したコンテンツタイプとともにHTTP "
-"200レスポンスコードを返します。OAuthでリクエストされたトークンタイプの場合は、link:https://www.ietf.org/id"
-"/draft-ietf-oauth-token-exchange-15.txt[OAuth Token "
-"Exchange]の仕様に記載されているJSONドキュメントを返します。"
+"200レスポンスコードを返します。OAuthでリクエストされたトークンタイプの場合は、 link:https://tools.ietf.org/html"
+"/draft-ietf-oauth-token-exchange-16[OAuth Token Exchange] "
+"の仕様に記載されているJSONドキュメントを返します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
