### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/host.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/host.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/host.ja_JP.po
@@ -204,6 +204,18 @@ msgstr ""
 "がリクエストから受信されます。プロキシーが正しく設定されている限り、これを変更する必要はありません。固定プロバイダーに `httpPort` と "
 "`httpsPort` プロパティーを設定することで、必要に応じて固定ポートを設定することができます。"
 
+#. type: Plain text
+msgid ""
+"In most cases the scheme should be set correctly. This may not be true if "
+"the reverse proxy is unable to set the `X-Forwarded-For` header correctly, "
+"or if there is an internal application using non-https to invoke "
+"{project_name}. In such cases it is possible to set the `alwaysHttps` to "
+"`true`."
+msgstr ""
+"ほとんどの場合、スキームは正しく設定する必要があります。これは、リバース・プロキシーが `X-Forwarded-For` "
+"ヘッダーを正しく設定できない場合、または{project_name}を呼び出すためにhttps以外を使用する内部アプリケーションがある場合には当てはまりません。このような場合、"
+" `alwaysHttps` を `true` に設定することができます。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Custom provider"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/host.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__host
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
