### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -193,6 +193,21 @@ msgstr ""
 msgid "    let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
 msgstr "    let keycloak = new Keycloak({ store: memoryStore }, kcConfig);\n"
 
+#. type: Plain text
+msgid ""
+"Applications can also redirect users to their preferred identity provider by"
+" using:"
+msgstr "アプリケーションは、次の方法を使用して、ユーザーを優先度の高いアイデンティティー・プロバイダーにリダイレクトすることもできます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    let keycloak = new Keycloak({ store: memoryStore, idpHint: myIdP }, "
+"kcConfig);\n"
+msgstr ""
+"    let keycloak = new Keycloak({ store: memoryStore, idpHint: myIdP }, "
+"kcConfig);\n"
+
 #. type: Labeled list
 #, no-wrap
 msgid "Configuring a web session store"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
