### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # 
 #, fuzzy
@@ -143,24 +143,32 @@ msgid ""
 "of your route. For example, `-Djboss.node.name=node1` will use `node1` to "
 "identify the route. This route will be used by Infinispan caches and will be"
 " attached to the AUTH_SESSION_ID cookie when the node is the owner of the "
-"particular key. An example of the start up command with this system property"
-" can be seen in <<_example-setup-with-mod-cluster,Mod Cluster Example>>."
+"particular key. Here is an example of the start up command using this system"
+" property:"
 msgstr ""
 "{project_name}側では、起動時にシステム・プロパティー `jboss.node.name` "
 "を使用し、経路名に対応する値を使用することをお勧めします。たとえば、 `-Djboss.node.name=node1` は経路を識別するために "
 "`node1` "
 "を使います。この経路はInfinispanのキャッシュで使用され、ノードが特定のキーの所有者である場合は、`AUTH_SESSION_ID` "
-"Cookieに関連付けられます。このシステム・プロパティーを使用した起動コマンドの例は、<<_example-setup-with-mod-"
-"cluster,Mod Clusterの例>>を参照してください。"
+"Cookieに関連付けられます。このシステム・プロパティーを使用した起動コマンドの例を以下に示します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"cd $RHSSO_NODE1\n"
+"./standalone.sh -c standalone-ha.xml -Djboss.socket.binding.port-offset=100 -Djboss.node.name=node1\n"
+msgstr ""
+"cd $RHSSO_NODE1\n"
+"./standalone.sh -c standalone-ha.xml -Djboss.socket.binding.port-offset=100 -Djboss.node.name=node1\n"
 
 #. type: Plain text
 msgid ""
-"Typically, the route name should be the same name as your backend host, but "
-"it is not necessary. You can use a different route name, for example if you "
-"want to hide the host name of your {project_name} server inside your private"
-" network."
+"Typically in production environment the route name should use the same name "
+"as your backend host, but it is not required. You can use a different route "
+"name. For example, if you want to hide the host name of your {project_name} "
+"server inside your private network."
 msgstr ""
-"通常、経路名はバックエンド・ホストと同じ名前ですが、必要ではありません。たとえば、プライベート・ネットワーク内の{project_name}サーバーのホスト名を隠す場合などに、別の経路名を使用できます。"
+"通常、プロダクション環境では経路名はバックエンド・ホストと同じ名前を使うべきですが、必要ではありません。たとえば、プライベート・ネットワーク内の{project_name}サーバーのホスト名を隠す場合などに、別の経路名を使用できます。"
 
 #. type: Title ====
 #, no-wrap
@@ -216,251 +224,3 @@ msgstr ""
 #, no-wrap
 msgid "</subsystem>\n"
 msgstr "</subsystem>\n"
-
-#. type: Title ====
-#, no-wrap
-msgid "Example cluster setup with mod_cluster"
-msgstr "mod_clusterでのクラスター設定のサンプル"
-
-#. type: Plain text
-msgid ""
-"In the example, we will use link:http://mod-cluster.jboss.org/[Mod Cluster] "
-"as load balancer. One of the key features of mod cluster is, that there is "
-"not much configuration on the load balancer side. Instead it requires "
-"support on the backend node side. Backend nodes communicate with the load "
-"balancer through the dedicated protocol called MCMP and they notify "
-"loadbalancer about various events (eg. node joined or left cluster, new "
-"application was deployed etc)."
-msgstr ""
-"サンプルとして、link:http://mod-cluster.jboss.org/[Mod Cluster]をロードバランサーとして使用します。mod"
-" "
-"clusterの重要な特徴の1つは、ロードバランサー側の設定が少ないことです。その代わりに、バックエンド・ノード側でのサポートが必要です。バックエンド・ノードは、MCMPと呼ばれる専用プロトコルを通じてロードバランサーと通信し、さまざまなイベント（たとえばノードの参加、またはクラスターの置換、新しいアプリケーションのデプロイなど）についてロードバランサーに通知します。"
-
-#. type: Plain text
-msgid ""
-"Example setup will consist of the one {appserver_name} {appserver_version} "
-"load balancer node and two {project_name} nodes."
-msgstr ""
-"サンプルの設定は、{appserver_name} "
-"{appserver_version}ロードバランサー・ノードと2つの{project_name}ノードで構成されます。"
-
-#. type: Plain text
-msgid ""
-"Clustering example require MULTICAST to be enabled on machine's loopback "
-"network interface. This can be done by running the following commands under "
-"root privileges (on Linux):"
-msgstr ""
-"クラスタリングのサンプルでは、MULTICASTをマシンのループバック・ネットワーク・インターフェイスで有効にすることを要求されます。これは、root特権（Linux上）で以下のコマンドを実行して行うことができます。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"route add -net 224.0.0.0 netmask 240.0.0.0 dev lo\n"
-"ifconfig lo multicast\n"
-msgstr ""
-"route add -net 224.0.0.0 netmask 240.0.0.0 dev lo\n"
-"ifconfig lo multicast\n"
-
-#. type: Title =====
-#, no-wrap
-msgid "Load Balancer Configuration"
-msgstr "ロードバランサー設定"
-
-#. type: Plain text
-msgid ""
-"Unzip the {appserver_name} {appserver_version} server somewhere. Assumption "
-"is location `EAP_LB`"
-msgstr ""
-"{appserver_name} {appserver_version}サーバーをどこかに解凍します。サンプルの場所は `EAP_LB` です。"
-
-#. type: Plain text
-msgid ""
-"Edit `EAP_LB/standalone/configuration/standalone.xml` file. In the undertow "
-"subsystem add the mod_cluster configuration under filters like this:"
-msgstr ""
-"`EAP_LB/standalone/configuration/standalone.xml` "
-"ファイルを編集します。undertowサブシステム内で以下のように、filtersの下にmod_cluster設定を追加します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
-" ...\n"
-" <filters>\n"
-"  ...\n"
-"  <mod-cluster name=\"modcluster\" advertise-socket-binding=\"modcluster\"\n"
-"      advertise-frequency=\"${modcluster.advertise-frequency:2000}\"\n"
-"      management-socket-binding=\"http\" enable-http2=\"true\"/>\n"
-" </filters>\n"
-msgstr ""
-"<subsystem xmlns=\"{subsystem_undertow_xml_urn}\">\n"
-" ...\n"
-" <filters>\n"
-"  ...\n"
-"  <mod-cluster name=\"modcluster\" advertise-socket-binding=\"modcluster\"\n"
-"      advertise-frequency=\"${modcluster.advertise-frequency:2000}\"\n"
-"      management-socket-binding=\"http\" enable-http2=\"true\"/>\n"
-" </filters>\n"
-
-#. type: Plain text
-msgid "and `filter-ref` under `default-host` like this:"
-msgstr "次に、以下のように `default-host` の下に `filter-ref` を追加します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<host name=\"default-host\" alias=\"localhost\">\n"
-"    ...\n"
-"    <filter-ref name=\"modcluster\"/>\n"
-"</host>\n"
-msgstr ""
-"<host name=\"default-host\" alias=\"localhost\">\n"
-"    ...\n"
-"    <filter-ref name=\"modcluster\"/>\n"
-"</host>\n"
-
-#. type: Plain text
-msgid "Then under `socket-binding-group` add this group:"
-msgstr "`socket-binding-group` の下に以下のグループを追加します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<socket-binding name=\"modcluster\" port=\"0\"\n"
-"    multicast-address=\"${jboss.modcluster.multicast.address:224.0.1.105}\"\n"
-"    multicast-port=\"23364\"/>\n"
-msgstr ""
-"<socket-binding name=\"modcluster\" port=\"0\"\n"
-"    multicast-address=\"${jboss.modcluster.multicast.address:224.0.1.105}\"\n"
-"    multicast-port=\"23364\"/>\n"
-
-#. type: Plain text
-msgid "Save the file and run the server:"
-msgstr "ファイルを保存して以下のようにサーバーを実行します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"cd $WILDFLY_LB/bin\n"
-"./standalone.sh\n"
-msgstr ""
-"cd $WILDFLY_LB/bin\n"
-"./standalone.sh\n"
-
-#. type: Title =====
-#, no-wrap
-msgid "Backend node configuration"
-msgstr "バックエンド・ノードの設定"
-
-#. type: Plain text
-msgid ""
-"Unzip the {project_name} server distribution to some location. Assuming "
-"location is `RHSSO_NODE1` ."
-msgstr "{project_name}サーバー配布物をどこかに解凍します。サンプルの場所は `RHSSO_NODE1` です。"
-
-#. type: Plain text
-msgid ""
-"Edit `RHSSO_NODE1/standalone/configuration/standalone-ha.xml` and configure "
-"datasource against the shared database.  See <<_rdbms-setup-checklist, "
-"Database chapter >> for more details."
-msgstr ""
-"共有データベースに対して `RHSSO_NODE1/standalone/configuration/standalone-ha.xml` "
-"を編集してデータソースを設定します。詳しくは、<<_rdbms-setup-checklist, データベースの章>>を参照してください。"
-
-#. type: Plain text
-msgid ""
-"In the undertow subsystem, add the `session-config` under the `servlet-"
-"container` element:"
-msgstr "undertowサブシステム内で、 `servlet-container` 要素の下に `session-config` を追加します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<servlet-container name=\"default\">\n"
-"    <session-cookie name=\"AUTH_SESSION_ID\" http-only=\"true\" />\n"
-"    ...\n"
-"</servlet-container>\n"
-msgstr ""
-"<servlet-container name=\"default\">\n"
-"    <session-cookie name=\"AUTH_SESSION_ID\" http-only=\"true\" />\n"
-"    ...\n"
-"</servlet-container>\n"
-
-#. type: Plain text
-msgid ""
-"Use the `session-config` only with the mod_cluster load balancer. In other "
-"cases, configure sticky session over the `AUTH_SESSION_ID` cookie directly "
-"in a load balancer."
-msgstr ""
-"`session-config` は、mod_clusterロードバランサーでのみ使用してください。それ以外の場合は、 "
-"`AUTH_SESSION_ID` Cookieによるスティッキー・セッションをロードバランサーで直接設定してください。"
-
-#. type: Plain text
-msgid ""
-"Then you can configure `proxy-address-forwarding` as described in the "
-"chapter <<_setting-up-a-load-balancer-or-proxy, Load Balancer >> .  Note "
-"that mod_cluster uses AJP connector by default, so you need to configure "
-"that one."
-msgstr ""
-"これで次に、<<_setting-up-a-load-balancer-or-proxy, ロードバランサー>>の章で説明したとおり、 `proxy-"
-"address-forwarding` "
-"を設定することができます。この設定は、mod_clusterがデフォルトでAJP接続を使用するため必要だということに注意してください。"
-
-#. type: Plain text
-msgid "That's all as mod_cluster is already configured."
-msgstr "mod_clusterはすでに設定済みなので、以上です。"
-
-#. type: Plain text
-msgid ""
-"The node name of the {project_name} can be detected automatically based on "
-"the hostname of current server. However for more fine grained control, it is"
-" recommended to use system property `jboss.node.name` to specify the node "
-"name directly. It is especially useful in case that you test with 2 backend "
-"nodes on same physical server etc. So you can run the startup command like "
-"this:"
-msgstr ""
-"{project_name}のノード名は、現在のサーバーのホスト名に基づき自動的に検出されます。しかし、より細かく制御するには、システム・プロパティー "
-"`jboss.node.name` "
-"を使用してノード名を直接指定することをお勧めします。これは、同じ物理サーバー上で2つのバックエンド・ノードをテストする場合などに特に便利です。以下のようにstartupコマンドを実行することができます。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"cd $RHSSO_NODE1\n"
-"./standalone.sh -c standalone-ha.xml -Djboss.socket.binding.port-offset=100 -Djboss.node.name=node1\n"
-msgstr ""
-"cd $RHSSO_NODE1\n"
-"./standalone.sh -c standalone-ha.xml -Djboss.socket.binding.port-offset=100 -Djboss.node.name=node1\n"
-
-#. type: Plain text
-msgid ""
-"Configure the second backend server in same way and run with different port "
-"offset and node name."
-msgstr "2番目のバックエンド・サーバーを同じ方法で設定し、異なるポート・オフセットとノード名で実行します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"cd $RHSSO_NODE2\n"
-"./standalone.sh -c standalone-ha.xml -Djboss.socket.binding.port-offset=200 -Djboss.node.name=node2\n"
-msgstr ""
-"cd $RHSSO_NODE2\n"
-"./standalone.sh -c standalone-ha.xml -Djboss.socket.binding.port-offset=200 -Djboss.node.name=node2\n"
-
-#. type: Plain text
-msgid ""
-"Access the server on `http://localhost:8080/auth` . Creation of admin user "
-"is possible just from local address and without load balancer (proxy) "
-"access, so you first need to access backend node directly on "
-"`http://localhost:8180/auth` to create admin user."
-msgstr ""
-"`http://localhost:8080/auth` "
-"でサーバーにアクセスします。管理者ユーザーの作成は、ロードバランサー（プロキシー）へアクセスせずに、ローカルアドレスからのみ可能です。そのため、最初に "
-"`http://localhost:8180/auth` のバックエンド・ノードに直接アクセスし、管理ユーザーを作成する必要があります。"
-
-#. type: Plain text
-msgid ""
-"When using mod_cluster you should always access the cluster through the load"
-" balancer and not directly through the backend node."
-msgstr ""
-"mod_clusterを使用する場合は、バックエンド・ノードを直接経由するのではなく、ロードバランサーを経由して常にクラスターにアクセスする必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__sticky-sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
