### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -3,11 +3,17 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -119,3 +125,34 @@ msgid ""
 msgstr ""
 "リストボックスから `Mapper Type` "
 "を選びます。ツールチップにカーソルを合わせると、そのマッパータイプが何をするのかの説明が表示されます。さまざまなマッパータイプに対して異なる設定パラメーターが表示されます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Priority order"
+msgstr "優先順位"
+
+#. type: Plain text
+msgid ""
+"Mapper implementations have _priority order_. This priority order is not the"
+" configuration property of the mapper; rather, it is the property of the "
+"concrete implementation of the mapper."
+msgstr ""
+"マッパーの実装には _優先順位_ があります。この優先順位はマッパーの設定プロパティーではなく、むしろそれはマッパーの具体的な実装のプロパティーです。"
+
+#. type: Plain text
+msgid ""
+"Mappers are sorted in the admin console by the order in the list of mappers "
+"and the changes in the token or assertion will be applied using that order "
+"with the lowest being applied first. This means that implementations which "
+"are dependent on other implementations are processed in the needed order."
+msgstr ""
+"マッパーは、管理コンソールにおけるマッパーのリストの順序に従ってソートされ、トークンまたはアサーションの変更はその順序で最も低いものが最初に適用されます。これは、他の実装に依存している実装が必要な順序で処理されることを意味します。"
+
+#. type: Plain text
+msgid ""
+"For example, when we first want to compute the roles which will be included "
+"with a token, we first resolve audiences based on those roles. Then, we "
+"process a JavaScript script that uses the roles and audiences already "
+"available in the token."
+msgstr ""
+"たとえば、最初にトークンに含まれるロールを割り出したい場合は、まずそれらのロールに基づいてオーディエンスを解決します。次に、トークンですでに利用可能なロールとオーディエンスを使用するJavaScriptのスクリプトを処理します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
