### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -115,10 +115,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "For the OpenID Connect protocol, there are client scopes `profile`, `email`,"
-" `address`, `phone` and `offline_access` ."
+" `address`, `phone`, `offline_access`, `roles` and `web-origins`."
 msgstr ""
 "OpenID Connectプロトコルには、 `profile` 、 `email` 、 `address` 、 `phone` 、 "
-"`offline_access` のクライアント・スコープがあります。"
+"`offline_access` 、 `roles` 、 `web-origins` のクライアント・スコープがあります。"
 
 #. type: Plain text
 msgid ""
@@ -184,6 +184,29 @@ msgid ""
 "create/update/remove any protocol mappers (or role scope mappings)."
 msgstr ""
 "ビルトインのクライアント・スコープには、仕様に従って定義されたプロトコル・マッパーが完全に含まれていますが、クライアント・スコープの編集やプロトコル・マッパー（またはロール・スコープ・マッピング）の作成/更新/削除は自由にでできます。"
+
+#. type: Plain text
+msgid ""
+"The client scope `roles` is not defined in the OpenID Connect specification "
+"and it is also not added automatically to the `scope` claim in the access "
+"token. This client scope has some mappers, which are used to add roles of "
+"the user to the access token and possibly add some audiences for the clients"
+" with at least one client role as described in the <<_audience_resolve, "
+"Audience section>>."
+msgstr ""
+"クライアント・スコープの `roles` はOpenID Connectの仕様では定義されておらず、アクセストークンの `scope` "
+"のクレームにも自動的に追加されません。このクライアント・スコープにはいくつかのマッパーがあります。マッパーは、ユーザーのロールをアクセストークンに追加し、<<_audience_resolve,"
+" オーディエンスのセクション>>で説明されているように少なくとも1つのクライアントロールを持つクライアントにオーディエンスを追加するために使用されます。"
+
+#. type: Plain text
+msgid ""
+"The client scope `web-origins` is also not defined in the OpenID Connect "
+"specification and not added to the `scope` claim. This is used to add "
+"allowed web origins to the access token `allowed-origins` claim."
+msgstr ""
+"クライアント・スコープ `web-origins` もOpenID Connect仕様で定義されておらず、` scope` "
+"クレームに追加されていません。これは、許可されたWebオリジンをアクセストークンの `allowed-origins` "
+"クレームに追加するために使用されます。"
 
 #. type: Title ====
 #, no-wrap
@@ -380,6 +403,33 @@ msgstr ""
 "特定のユーザーに対して生成され、特定のクライアントに対して発行された `scope` "
 "パラメーターの指定された値を持つ実際のアクセストークンのサンプルを見るには、 `Evaluate` "
 "画面からユーザーを選択してください。これにより、使用されているすべてのクレームおよびロールマッピングが含まれているトークンのサンプルが生成されます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Client Scopes Permissions"
+msgstr "クライアント・スコープ・パーミッション"
+
+#. type: Plain text
+msgid ""
+"When issuing tokens for a particular user, the client scope is applied only "
+"if the user is permitted to use it. In the case that a client scope does not"
+" have any role scope mappings defined on itself, then each user is "
+"automatically permitted to use this client scope. However, when a client "
+"scope has any role scope mappings defined on itself, then the user must be a"
+" member of at least one of the roles. In other words, there must be an "
+"intersection between the user roles and the roles of the client scope. "
+"Composite roles are taken into account when evaluating this intersection."
+msgstr ""
+"特定のユーザーに対してトークンを発行する場合、そのユーザーがそのトークンの使用を許可されている場合にのみクライアント・スコープが適用されます。クライアント・スコープにロール・スコープ・マッピングが定義されていない場合、各ユーザーはこのクライアント・スコープの使用を自動的に許可されます。ただし、クライアント・スコープにそれ自体で定義されているロール・スコープ・マッピングがある場合、そのユーザーは少なくとも1つのロールのメンバーである必要があります。つまり、ユーザーロールとクライアント・スコープのロールの間には共通部分がなければなりません。この共通部分を評価するときには、複合ロールが考慮されます。"
+
+#. type: Plain text
+msgid ""
+"If a user is not permitted to use the client scope, then no protocol mappers"
+" or role scope mappings will be used when generating tokens and the client "
+"scope will not appear in the _scope_ value in the token."
+msgstr ""
+"ユーザーがクライアント・スコープの使用を許可されていない場合、トークンの生成時にプロトコル・マッパーまたはロール・スコープ・マッピングは使用されず、クライアント・スコープはトークンの"
+" _scope_ 値に表示されません。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
