### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
@@ -414,21 +414,59 @@ msgid ""
 "Defines a set of one or more claims that must be resolved and pushed to the "
 "{project_name} server in order to make these claims available to policies. "
 "See <<_enforcer_claim_information_point, Claim Information Point>> for more "
-"details.  ** *lazy-load-paths*"
+"details."
 msgstr ""
-"これらのクレームをポリシーで利用できるようにするために解決され、{project_name}サーバーにプッシュされなければならない1つ以上のクレームのセットを定義します。詳細については、<<_enforcer_claim_information_point, 請求情報ポイント>>を参照してください。\n"
-"** *lazy-load-paths*"
+"これらのクレームをポリシーで利用できるようにするために解決され、{project_name}サーバーにプッシュされなければならない1つ以上のクレームのセットを定義します。詳細については、<<_enforcer_claim_information_point,"
+" Claim Information Point>>を参照してください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "** *lazy-load-paths*\n"
+msgstr "** *lazy-load-paths*\n"
 
 #. type: Plain text
 msgid ""
 "Specifies how the adapter should fetch the server for resources associated "
-"with paths in your application. If true, the policy enforcer is going to "
+"with paths in your application. If *true*, the policy enforcer is going to "
 "fetch resources on-demand accordingly with the path being requested. This "
 "configuration is specially useful when you don't want to fetch all resources"
 " from the server during deployment (in case you have provided no `paths`) or"
 " in case you have defined only a sub set of `paths` and want to fetch others"
 " on-demand."
 msgstr ""
-"アプリケーションのパスに関連付けられたリソースに対して、アダプターがサーバーをフェッチする方法を指定します。trueの場合、ポリシー・エンフォーサーは、要求されているパスに従ってオンデマンド・リソースをフェッチします。配備中にサーバーからすべてのリソースを取得したくない場合（"
+"アプリケーションのパスに関連付けられたリソースに対して、アダプターがサーバーをフェッチする方法を指定します。 *true* "
+"の場合、ポリシー・エンフォーサーは、要求されているパスに従ってオンデマンド・リソースをフェッチします。配備中にサーバーからすべてのリソースを取得したくない場合（"
 " `paths` を指定しなかった場合）や、 `paths` "
 "のサブセットしか定義せず、要求に応じて他のものをフェッチしたい場合に、この設定は特に便利です。"
+
+#. type: Plain text
+#, no-wrap
+msgid "** *http-method-as-scope*\n"
+msgstr "** *http-method-as-scope*\n"
+
+#. type: Plain text
+msgid ""
+"Specifies how scopes should be mapped to HTTP methods. If set to *true*, the"
+" policy enforcer will use the HTTP method from the current request to check "
+"whether or not access should be granted. When enabled, make sure your "
+"resources in {project_name} are associated with scopes representing each "
+"HTTP method you are protecting."
+msgstr ""
+"スコープをHTTPメソッドにマッピングする方法を指定します。 *true* "
+"に設定されている場合、ポリシー・エンフォーサーは現在のリクエストからのHTTPメソッドを使用して、アクセスを許可する必要があるかどうかをチェックします。有効になっている場合は、{project_name}のリソースが保護している各HTTPメソッドを表すスコープに関連付けられていることを確認してください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "** *claim-information-point*\n"
+msgstr "** *claim-information-point*\n"
+
+#. type: Plain text
+msgid ""
+"Defines a set of one or more *global* claims that must be resolved and "
+"pushed to the {project_name} server in order to make these claims available "
+"to policies. See <<_enforcer_claim_information_point, Claim Information "
+"Point>> for more details."
+msgstr ""
+"これらのクレームをポリシーで利用できるようにするために解決され、{project_name}サーバーにプッシュされなければならない1つ以上の "
+"*global* クレームのセットを定義します。詳細については、<<_enforcer_claim_information_point, Claim "
+"Information Point>>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-keycloak-enforcement-filter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
