### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,39 +21,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
-#. type: Block title
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:20
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:16
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:16
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:22
-#, no-wrap
-msgid "Register Application"
-msgstr "アプリケーションの登録"
-
 #. type: Title ====
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:2
 #, no-wrap
 msgid "Twitter"
 msgstr "Twitter"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:6
 msgid ""
 "There are a number of steps you have to complete to be able to login to "
 "Twitter.  First, go to the `Identity Providers` left menu item and select "
@@ -60,12 +42,10 @@ msgstr ""
 "identity provider` ページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:9
 msgid "image:{project_images}/twitter-add-identity-provider.png[]"
 msgstr "image:{project_images}/twitter-add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:13
 msgid ""
 "You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
 " Secret` from Twitter.  One piece of data you'll need from this page is the "
@@ -77,21 +57,23 @@ msgstr ""
 "です。Twitterに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:15
 msgid ""
 "To enable login with Twtter you first have to create an application in the "
-"https://apps.twitter.com[Twitter Application Management]."
+"https://developer.twitter.com/apps/[Twitter Application Management]."
 msgstr ""
-"Twtterでログインを可能にするには、まず https://apps.twitter.com[Twitter Application "
-"Management] でアプリケーションを作成する必要があります。"
+"Twtterでログインを可能にするには、まず https://developer.twitter.com/apps/[Twitter "
+"Application Management] でアプリケーションを作成する必要があります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Register Application"
+msgstr "アプリケーションの登録"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:18
 msgid "image:images/twitter-app-register.png[]"
 msgstr "image:images/twitter-app-register.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:21
 msgid ""
 "Click on the `Create New App` button.  This will bring you to the `Create an"
 " Application` page."
@@ -99,12 +81,10 @@ msgstr ""
 "`Create New App` ボタンをクリックします。これにより、 `Create an Application` ページが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:24
 msgid "image:images/twitter-app-create.png[]"
 msgstr "image:images/twitter-app-create.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:28
 msgid ""
 "Enter in a Name and Description.  The Website can be anything, but cannot "
 "have a `localhost` address.  For the `Callback URL` you must copy the "
@@ -115,7 +95,6 @@ msgstr ""
 "URI` をコピーする必要があります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:31
 #, no-wrap
 msgid ""
 "You cannot use `localhost` in the `Callback URL`.  Instead replace it with `127.0.0.1` if you are trying to\n"
@@ -125,39 +104,32 @@ msgstr ""
 "`127.0.0.1` に置き換えてください。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:33
 msgid "After clicking save you will be brought to the `Details` page."
 msgstr "保存をクリックすると、 `Details` ページに移動します。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:34
 #, no-wrap
 msgid "App Details"
 msgstr "App Details"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:36
 msgid "image:images/twitter-details.png[]"
 msgstr "image:images/twitter-details.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:39
 msgid "Next go to the `Keys and Access Tokens` tab."
 msgstr "次に、 `Keys and Access Tokens` タブをクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:40
 #, no-wrap
 msgid "Keys and Access Tokens"
 msgstr "Keys and Access Tokens"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:42
 msgid "image:images/twitter-keys.png[]"
 msgstr "image:images/twitter-keys.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:44
 msgid ""
 "Finally, you will need to obtain the API Key and secret from this page and "
 "copy them back into the `Client ID` and `Client Secret` fields on the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__twitter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
