### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -425,7 +425,7 @@ msgstr "ハイブリッド・アプリとCordova"
 
 #. type: Plain text
 msgid ""
-"Keycloak support hybird mobile apps developed with "
+"Keycloak support hybrid mobile apps developed with "
 "https://cordova.apache.org/[Apache Cordova]. The Javascript adapter has two "
 "modes for this: `cordova` and `cordova-native`:"
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
