### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,15 +69,15 @@ msgstr ""
 msgid ""
 "\tauth:\n"
 "\t  token:\n"
-"\t    realm: http://localhost:8080/auth/auth/realms/master/protocol/docker-v2/auth\n"
+"\t    realm: http://localhost:8080/auth/realms/master/protocol/docker-v2/auth\n"
 "\t    service: docker-test\n"
-"\t    issuer: http://localhost:8080/auth/auth/realms/master\n"
+"\t    issuer: http://localhost:8080/auth/realms/master\n"
 msgstr ""
 "\tauth:\n"
 "\t  token:\n"
-"\t    realm: http://localhost:8080/auth/auth/realms/master/protocol/docker-v2/auth\n"
+"\t    realm: http://localhost:8080/auth/realms/master/protocol/docker-v2/auth\n"
 "\t    service: docker-test\n"
-"\t    issuer: http://localhost:8080/auth/auth/realms/master\n"
+"\t    issuer: http://localhost:8080/auth/realms/master\n"
 
 #. type: Plain text
 msgid ""
@@ -116,13 +120,13 @@ msgstr ""
 #. type: Plain text
 #, no-wrap
 msgid ""
-"    REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080/auth/auth/realms/master/protocol/docker-v2/auth\n"
+"    REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080/auth/realms/master/protocol/docker-v2/auth\n"
 "    REGISTRY_AUTH_TOKEN_SERVICE: docker-test\n"
-"    REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080/auth/auth/realms/master\n"
+"    REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080/auth/realms/master\n"
 msgstr ""
-"    REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080/auth/auth/realms/master/protocol/docker-v2/auth\n"
+"    REGISTRY_AUTH_TOKEN_REALM: http://localhost:8080/auth/realms/master/protocol/docker-v2/auth\n"
 "    REGISTRY_AUTH_TOKEN_SERVICE: docker-test\n"
-"    REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080/auth/auth/realms/master\n"
+"    REGISTRY_AUTH_TOKEN_ISSUER: http://localhost:8080/auth/realms/master\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
