### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -323,10 +327,8 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ ./bin/jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+msgid "$ ./bin/jboss-cli.sh --file=bin/adapter-elytron-install-offline.cli\n"
+msgstr "$ ./bin/jboss-cli.sh --file=bin/adapter-elytron-install-offline.cli\n"
 
 #. type: Block title
 #, no-wrap
@@ -335,10 +337,8 @@ msgstr "WildFly 10以上"
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ ./bin/jboss-cli.sh --file=adapter-install-offline.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
+msgid "$ ./bin/jboss-cli.sh --file=bin/adapter-install-offline.cli\n"
+msgstr "$ ./bin/jboss-cli.sh --file=bin/adapter-install-offline.cli\n"
 
 #. type: Plain text
 msgid ""
@@ -373,17 +373,13 @@ msgstr "あるいは、サーバーが起動している場合は、次のよう
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ ./bin/jboss-cli.sh --file=adapter-elytron-install.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+msgid "$ ./bin/jboss-cli.sh -c --file=bin/adapter-elytron-install.cli\n"
+msgstr "$ ./bin/jboss-cli.sh -c --file=bin/adapter-elytron-install.cli\n"
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ ./bin/jboss-cli.sh --file=adapter-install.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
+msgid "$ ./bin/jboss-cli.sh -c --file=bin/adapter-install.cli\n"
+msgstr "$ ./bin/jboss-cli.sh -c --file=bin/adapter-install.cli\n"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
