### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,8 +78,8 @@ msgstr "次のように、使用しているプラットフォームに適した
 
 #. type: Block title
 #, no-wrap
-msgid "WildFly 10 and Linux/Unix"
-msgstr "WildFly 10・Linux/Unix"
+msgid "EAP 6.3 and Linux/Unix"
+msgstr "EAP 6.3 and Linux/Unix"
 
 #. type: delimited block -
 #, no-wrap
@@ -85,48 +89,68 @@ msgid ""
 msgstr ""
 "$ cd bin\n"
 "$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "EAP 6.3 and Windows"
+msgstr "EAP 6.3 and Windows"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"> cd bin\n"
+"> jboss-cli.bat --file=adapter-install-offline.cli\n"
+msgstr ""
+"> cd bin\n"
+"> jboss-cli.bat --file=adapter-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "EAP 7.2.5 and Linux/Unix"
+msgstr "EAP 7.2.5 and Linux/Unix"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd bin\n"
+"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+msgstr ""
+"$ cd bin\n"
+"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "EAP 7.2.5 and Windows"
+msgstr "EAP 7.2.5 and Windows"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"> cd bin\n"
+"> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
+msgstr ""
+"> cd bin\n"
+"> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "WildFly 10 and Linux/Unix"
+msgstr "WildFly 10・Linux/Unix"
 
 #. type: Block title
 #, no-wrap
 msgid "WildFly 10 and Windows"
 msgstr "WildFly 10・Windows"
 
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-install-offline.cli\n"
-msgstr ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-install-offline.cli\n"
-
 #. type: Block title
 #, no-wrap
 msgid "Wildfly 11 and Linux/Unix"
 msgstr "WildFly 11・Linux/Unix"
 
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
-
 #. type: Block title
 #, no-wrap
 msgid "Wildfly 11 and Windows"
 msgstr "WildFly 11・Windows"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
-msgstr ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__install-client-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
