### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -119,10 +119,12 @@ msgstr "WildFly 11以上"
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ ./bin/jboss-cli.sh --file=adapter-elytron-install-saml.cli\n"
+msgid ""
+"$ cd $JBOSS_HOME\n"
+"$ ./bin/jboss-cli.sh -c --file=bin/adapter-elytron-install-saml.cli\n"
 msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+"$ cd $JBOSS_HOME\n"
+"$ ./bin/jboss-cli.sh -c --file=bin/adapter-elytron-install-saml.cli\n"
 
 #. type: Block title
 #, no-wrap
@@ -132,11 +134,11 @@ msgstr "WildFly 10以上"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"$ cd $JBOSS_HOME/bin\n"
-"$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
+"$ cd $JBOSS_HOME\n"
+"$ /bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
 msgstr ""
-"$ cd $JBOSS_HOME/bin\n"
-"$ jboss-cli.sh -c --file=adapter-install-saml.cli\n"
+"$ cd $JBOSS_HOME\n"
+"$ /bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
 
 #. type: Plain text
 msgid ""
@@ -156,6 +158,15 @@ msgstr "JBoss EAP 7.1以上"
 #, no-wrap
 msgid "JBoss EAP 7.0 and EAP 6"
 msgstr "JBoss EAP 7.0とEAP 6"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd $JBOSS_HOME\n"
+"$ ./bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
+msgstr ""
+"$ cd $JBOSS_HOME\n"
+"$ ./bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
