### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,12 +37,12 @@ msgstr ""
 msgid ""
 "The Client Registration Service provides built-in support for {project_name}"
 " Client Representations, OpenID Connect Client Meta Data and SAML Entity "
-"Descriptors.  The Client Registration Service endpoint is `/realms/<realm"
-">/clients-registrations/<provider>`."
+"Descriptors.  The Client Registration Service endpoint is "
+"`/auth/realms/<realm>/clients-registrations/<provider>`."
 msgstr ""
 "クライアント登録サービスには、{project_name} Client Representations、OpenID Connect Client "
 "Meta DataおよびSAML Entity Descriptorsのビルトインサポートが用意されています。クライアント登録サービスのエンドポイントは"
-" `/realms/<realm>/clients-registrations/<provider>` です。"
+" `/auth/realms/<realm>/clients-registrations/<provider>` です。"
 
 #. type: Plain text
 msgid "The built-in supported `providers` are:"
@@ -224,10 +228,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "To create a client create a Client Representation (JSON) then perform an "
-"HTTP POST request to `/realms/<realm>/clients-registrations/default`."
+"HTTP POST request to `/auth/realms/<realm>/clients-registrations/default`."
 msgstr ""
 "クライアントを作成するには、Client Representation（JSON）を作成し、次にHTTP POSTリクエストを "
-"`/realms/<realm>/clients-registrations/default` に送信します。"
+"`/auth/realms/<realm>/clients-registrations/default` に送信します。"
 
 #. type: Plain text
 msgid ""
@@ -241,9 +245,9 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "To retrieve the Client Representation perform an HTTP GET request to "
-"`/realms/<realm>/clients-registrations/default/<client id>`."
+"`/auth/realms/<realm>/clients-registrations/default/<client id>`."
 msgstr ""
-"Client Representationを取得するには、HTTP GETリクエストを `/realms/<realm>/clients-"
+"Client Representationを取得するには、HTTP GETリクエストを `/auth/realms/<realm>/clients-"
 "registrations/default/<client id>` に送信します。"
 
 #. type: Plain text
@@ -253,19 +257,19 @@ msgstr "新しい登録アクセストークンも返します。"
 #. type: Plain text
 msgid ""
 "To update the Client Representation perform an HTTP PUT request with the "
-"updated Client Representation to: `/realms/<realm>/clients-"
+"updated Client Representation to: `/auth/realms/<realm>/clients-"
 "registrations/default/<client id>`."
 msgstr ""
-"Client Representationを更新するには、更新したClient Representationを次のURLにHTTP PUTします：  "
-"`/realms/<realm>/clients-registrations/default/<client id>` 。"
+"Client Representationを更新するには、更新したClient Representationを次のURLにHTTP PUTします： "
+"`/auth/realms/<realm>/clients-registrations/default/<client id>` 。"
 
 #. type: Plain text
 msgid ""
 "To delete the Client Representation perform an HTTP DELETE request to: "
-"`/realms/<realm>/clients-registrations/default/<client id>`"
+"`/auth/realms/<realm>/clients-registrations/default/<client id>`"
 msgstr ""
-"Client Representationを削除するには、HTTP DELETEリクエストを `/realms/<realm>/clients-"
-"registrations/default/<client id>` に送信します。"
+"Client Representationを削除するには、次のURLにHTTP DELETEします： `/auth/realms/<realm"
+">/clients-registrations/default/<client id>` 。"
 
 #. type: Title ===
 #, no-wrap
@@ -290,9 +294,9 @@ msgstr "Authorization: basic BASE64(client-id + ':' + client-secret)\n"
 #. type: Plain text
 msgid ""
 "To retrieve the Adapter Configuration then perform an HTTP GET request to "
-"`/realms/<realm>/clients-registrations/install/<client id>`."
+"`/auth/realms/<realm>/clients-registrations/install/<client id>`."
 msgstr ""
-"アダプター設定を取得するには、HTTP GETリクエストを `/realms/<realm>/clients-"
+"アダプター設定を取得するには、HTTP GETリクエストを `/auth/realms/<realm>/clients-"
 "registrations/install/<client id>` に送信します。"
 
 #. type: Plain text
@@ -325,19 +329,19 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The endpoint to use these specifications to register clients in "
-"{project_name} is `/realms/<realm>/clients-registrations/openid-"
+"{project_name} is `/auth/realms/<realm>/clients-registrations/openid-"
 "connect[/<client id>]`."
 msgstr ""
-"これらの仕様を使用した、{project_name}にクライアントを登録するエンドポイントは、 `/realms/<realm>/clients-"
-"registrations/openid-connect[/<client id>]` です。"
+"これらの仕様を使用した、{project_name}にクライアントを登録するエンドポイントは、 `/auth/realms/<realm"
+">/clients-registrations/openid-connect[/<client id>]` です。"
 
 #. type: Plain text
 msgid ""
 "This endpoints can also be found in the OpenID Connect Discovery endpoint "
-"for the realm, `/realms/<realm>/.well-known/openid-configuration`."
+"for the realm, `/auth/realms/<realm>/.well-known/openid-configuration`."
 msgstr ""
-"このエンドポイントは、そのレルムのOpenID Connect Discoveryエンドポイント（ `/realms/<realm>/.well-"
-"known/openid-configuration` ）でも見つかります。"
+"このエンドポイントは、そのレルムのOpenID Connect Discoveryエンドポイント（ `/auth/realms/<realm"
+">/.well-known/openid-configuration` ）でも見つかります。"
 
 #. type: Title ====
 #, no-wrap
@@ -362,10 +366,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "To create a client perform an HTTP POST request with the SAML Entity "
-"Descriptor to `/realms/<realm>/clients-registrations/saml2-entity-"
+"Descriptor to `/auth/realms/<realm>/clients-registrations/saml2-entity-"
 "descriptor`."
 msgstr ""
-"クライアントを作成するには、SAMLエンティティー記述子を使用して `/realms/<realm>/clients-"
+"クライアントを作成するには、SAMLエンティティー記述子を使用して `/auth/realms/<realm>/clients-"
 "registrations/saml2-entity-descriptor` にHTTP POSTリクエストを送信します。"
 
 #. type: Title ===


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
