### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -22,7 +22,7 @@ msgstr ""
 #. type: Title ==
 #, no-wrap
 msgid "Token Exchange"
-msgstr "トークンの交換"
+msgstr "Token Exchange"
 
 #. type: Plain text
 msgid ""
@@ -35,7 +35,9 @@ msgid ""
 " A client may have a need to impersonate a user.  Here's a short summary of "
 "the current capabilities of {project_name} around token exchange."
 msgstr ""
-"{project_name}において、トークンの交換とはクレデンシャルまたはトークンのセットを使用して、全く異なるトークンを取得するプロセスです。クライアントは信頼性の低いアプリケーションを呼び出すかもしれず、現在のトークンをダウングレードしたい場合があります。クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために保存されたトークンを、{project_name}トークンに交換したいことがあります。他の{project_name}のレルムや外部IDPによって作成された外部トークンを信頼することができます。クライアントはあるユーザーに成り代わる必要があるかもしれません。トークンの交換に関する{project_name}の現在の機能の概要を簡単に説明します。"
+"{project_name}において、Token "
+"Exchangeとはクレデンシャルまたはトークンのセットを使用して、全く異なるトークンを取得するプロセスです。クライアントは信頼性の低いアプリケーションを呼び出すかもしれず、現在のトークンをダウングレードしたい場合があります。クライアントは、リンクされたソーシャル・プロバイダー・アカウントのために保存されたトークンを、{project_name}トークンに交換したいことがあります。他の{project_name}のレルムや外部IDPによって作成された外部トークンを信頼することができます。クライアントはあるユーザーに成り代わる必要があるかもしれません。Token"
+" Exchangeに関する{project_name}の現在の機能の概要を簡単に説明します。"
 
 #. type: Plain text
 msgid ""
@@ -67,8 +69,8 @@ msgid ""
 "specification.  It is a simple grant type invocation on a realm's OpenID "
 "Connect token endpoint."
 msgstr ""
-"{project_name}のトークンの交換は、 link:https://tools.ietf.org/html/draft-ietf-oauth-"
-"token-exchange-16[OAuth Token Exchange] "
+"{project_name}のToken Exchangeは、 link:https://tools.ietf.org/html/draft-ietf-"
+"oauth-token-exchange-16[OAuth Token Exchange] "
 "の仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
 " Connectトークン・エンドポイントでの単純なグラントタイプの呼び出しです。"
 
@@ -89,7 +91,8 @@ msgid ""
 " list of form parameters"
 msgstr ""
 "フォーム・パラメーター（ `application/x-www-form-urlencoded` "
-"）を入力として受け取り、出力は交換をリクエストしたトークンのタイプに依存します。トークンの交換はクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。パブリック・クライアントは、クライアント識別子をフォーム・パラメーターとして指定します。コンフィデンシャルクライアントは、フォーム・パラメーターを使用してクライアントIDとシークレット、BASIC認証を渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。"
+"）を入力として受け取り、出力は交換をリクエストしたトークンのタイプに依存します。Token "
+"Exchangeはクライアント・エンドポイントであるため、リクエストは呼び出し元のクライアントに認証情報を提供する必要があります。パブリック・クライアントは、クライアント識別子をフォーム・パラメーターとして指定します。コンフィデンシャルクライアントは、フォーム・パラメーターを使用してクライアントIDとシークレット、BASIC認証を渡すこともできますが、管理者はレルム内でクライアント認証フローを設定することもできます。"
 " フォーム・パラメーターのリストは次のとおりです"
 
 #. type: Labeled list
@@ -351,7 +354,8 @@ msgid ""
 "Token exchange setup requires knowledge of fine grain admin permissions (See the link:{adminguide_link}[{adminguide_name}] for more information).  You will need to grant clients\n"
 "      permission to exchange.  This is discussed more later in this chapter.\n"
 msgstr ""
-"トークン交換のセットアップには細かい粒度の管理権限が必要です（詳細はlink:{adminguide_link}[{adminguide_name}]のリンクを参照してください）。クライアントに交換の権限を付与する必要があります。これについては、この章の後半で説明します。\n"
+"Token "
+"Exchangeのセットアップには細かい粒度の管理権限が必要です（詳細はlink:{adminguide_link}[{adminguide_name}]のリンクを参照してください）。クライアントに交換の権限を付与する必要があります。これについては、この章の後半で説明します。\n"
 
 #. type: Plain text
 msgid ""
@@ -1093,7 +1097,7 @@ msgstr "交換の脆弱性"
 msgid ""
 "When you start allowing token exchanges, there's various things you have to "
 "both be aware of and careful of."
-msgstr "トークン交換の許可を行う上で、意識して気をつけなければならないさまざまなことがあります。"
+msgstr "Token Exchangeの許可を行う上で、意識して気をつけなければならないさまざまなことがあります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
