### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/migration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/migration.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/migration.ja_JP.po
@@ -3,6 +3,12 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# n.watanabe <nwatanabe.ase@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -14,20 +20,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-msgid ""
-"There are some obvious disadvantages though to using an import strategy:"
-msgstr "インポート・ストラテジーの使用には明らかな欠点がいくつかあります。"
-
-#. type: Plain text
-msgid ""
-"With the import approach, you have to keep local keycloak storage and "
-"external storage in sync. The User Storage SPI has capability interfaces "
-"that you can implement to support synchronization, but this can quickly "
-"become painful and messy."
-msgstr ""
-"インポートのアプローチでは、ローカルのkeycloakストレージと外部ストレージを同期させておく必要があります。ユーザー・ストレージSPIには、同期をサポートできるために実装できるケーパビリティー・インターフェイスがありますが、これはすぐにやっかいで面倒なものになります。"
 
 #. type: Title ===
 #, no-wrap
@@ -94,6 +86,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"There are some obvious disadvantages though to using an import strategy:"
+msgstr "インポート・ストラテジーの使用には明らかな欠点がいくつかあります。"
+
+#. type: Plain text
+msgid ""
 "Looking up a user for the first time will require multiple updates to "
 "{project_name} database. This can be a big performance loss under load and "
 "put a lot of strain on the {project_name} database. The user federated "
@@ -102,6 +99,15 @@ msgid ""
 msgstr ""
 "初めてユーザーを検索するには、{project_name}データベースを複数回更新する必要があります。これは、負荷がかかった状態でパフォーマンスが大きく低下する可能性があり、{project_name}データベースに多くの負担をかけることになります。ユーザー・フェデレーティッド・ストレージ・アプローチでは、必要以上のデータを保持し、外部ストアの機能に応じて使用されるということがありません。"
 " "
+
+#. type: Plain text
+msgid ""
+"With the import approach, you have to keep local keycloak storage and "
+"external storage in sync. The User Storage SPI has capability interfaces "
+"that you can implement to support synchronization, but this can quickly "
+"become painful and messy."
+msgstr ""
+"インポートのアプローチでは、ローカルのkeycloakストレージと外部ストレージを同期させておく必要があります。ユーザー・ストレージSPIには、同期をサポートできるために実装できるケーパビリティー・インターフェイスがありますが、これはすぐにやっかいで面倒なものになります。"
 
 #. type: Title ====
 #, no-wrap
@@ -191,8 +197,8 @@ msgstr ""
 " `CredentialInputUpdater` "
 "インターフェイスにカプセル化されました。この実装は任意で、クレデンシャルの検証や更新をサポートするかどうかによって異なります。クレデンシャル管理は "
 "`UserModel` メソッドに存在しましたが、これらも `CredentialInputValidator` と "
-"`CredentialInputUpdater` インターフェイスに移行されました。 "
-"`CredentialInputUpdater`インターフェイスを実装しないと、プロバイダーが提供するクレデンシャルは{project_name}ストレージ内でローカルにオーバーライドされる可能性があることに注意してください。したがって、クレデンシャルを読み取り専用にする場合は、"
+"`CredentialInputUpdater` インターフェイスに移行されました。 `CredentialInputUpdater` "
+"インターフェイスを実装しないと、プロバイダーが提供するクレデンシャルは{project_name}ストレージ内でローカルにオーバーライドされる可能性があることに注意してください。したがって、クレデンシャルを読み取り専用にする場合は、"
 " `CredentialInputUpdater.updateCredential()` メソッドを実装し、 `ReadOnlyException` "
 "を返します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/migration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__migration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
