### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -582,6 +582,21 @@ msgstr ""
 "設定可能な値は _session_ と _cookie_ です。デフォルトは _session_ "
 "です。つまり、アダプターがアカウント情報をHTTPセッションに保管します。一方、 _cookie_ "
 "は情報をクッキーに格納することを意味します。詳細は<<_applicationclustering,アプリケーション・クラスタリング>>を参照してください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "token-cookie-path"
+msgstr "token-cookie-path"
+
+#. type: Plain text
+msgid ""
+"When using a cookie store, this option sets the path of the cookie used to "
+"store account info. If it's a relative path, then it is assumed that the "
+"application is running in a context root, and is interpreted relative to "
+"that context root.  If it's an absolute path, then the absolute path is used"
+" to set the cookie path. Defaults to use paths relative to the context root."
+msgstr ""
+"Cookieストアを使用する場合、このオプションにはアカウント情報を保存するために使用されるCookieのパスを設定します。相対パスの場合、アプリケーションはコンテキスト・ルートで実行されていると見なされ、そのコンテキスト・ルートに対して相対的に解釈されます。絶対パスの場合は、絶対パスを使用してCookieのパスを設定します。デフォルトではコンテキスト・ルートからの相対パスを使用します。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__java-adapter-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
