### PR TITLE
Translations for i18n/po/ja_JP/topics/templates/techpreview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/topics/templates/techpreview.ja_JP.po
+++ b/i18n/po/ja_JP/topics/templates/techpreview.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,14 +27,17 @@ msgstr ""
 "であり、完全にはサポートされていません。この機能はデフォルトで無効になっています。"
 
 #. type: delimited block =
-msgid ""
-"To enable start the server with `-Dkeycloak.profile=preview`. For more "
-"details see link:{installguide_profile_link}[{installguide_profile_name}]."
-msgstr ""
-"有効にするには、 `-Dkeycloak.profile=preview` "
-"でサーバーを起動します。詳細はlink:{installguide_profile_link}[{installguide_profile_name}]を参照してください。"
+msgid "To enable start the server with `-Dkeycloak.profile=preview`"
+msgstr "有効にするには、 `-Dkeycloak.profile=preview` を使用してサーバーを起動します。"
+
+#. type: delimited block =
+msgid "or `{tech_feature_setting}`"
+msgstr "または、 `{tech_feature_setting}` を使用してサーバーを起動します。"
 
 #. type: delimited block =
 msgid ""
-"{tech_feature_name} is *Technology Preview* and is not fully supported."
-msgstr "{tech_feature_name}は、 *テクノロジー・プレビュー* であり、完全にはサポートされていません。"
+"For more details see "
+"link:{installguide_profile_link}[{installguide_profile_name}]."
+msgstr ""
+"詳しくは、 link:{installguide_profile_link}[{installguide_profile_name}] "
+"を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/topics/templates/techpreview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/topics__templates__techpreview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
