### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -282,22 +287,65 @@ msgstr "キーストアを使用するための{project_name}設定"
 #. type: Plain text
 msgid ""
 "Now that you have a Java keystore with the appropriate certificates, you "
-"need to configure your {project_name} installation to use it.  First step is"
-" to move the keystore file to the _configuration/_ directory of your "
-"deployment and to edit the _standalone.xml_, _standalone-ha.xml_ or "
-"_domain.xml_ file to use the keystore and enable HTTPS.  (See <<_operating-"
-"mode, operating mode>>)."
+"need to configure your {project_name} installation to use it.  First, you "
+"must edit the _standalone.xml_, _standalone-ha.xml_, or _host.xml_ file to "
+"use the keystore and enable HTTPS. You may then either move the keystore "
+"file to the _configuration/_ directory of your deployment or the file in a "
+"location you choose and provide an absolute path to it. If you are using "
+"absolute paths, remove the optional `relative-to` parameter from your "
+"configuration (See <<_operating-mode, operating mode>>)."
 msgstr ""
-"適切な証明書を持つJavaキーストアが用意できたので、このキーストアを使用できるように{project_name}を設定する必要があります。まず、キーストア・ファイルを"
-" _configuration/_ ディレクトリー構成に移動し、キーストアを使用するように _standalone.xml_ 、 "
-"_standalone-ha.xml_ または _domain.xml_ ファイルを編集し、HTTPSを有効にします（<<_operating-"
-"mode, 動作モード>>を参照してください）。"
+"適切な証明書を含むJavaキーストアができたため、それを使用するように{project_name}のインストールを設定する必要があります。まず、キーストアを使用してHTTPSを有効にするために、"
+" _standalone.xml_ 、 _standalone-ha.xml_ 、または _host.xml_ "
+"の各ファイルを編集する必要があります。その後、キーストア・ファイルをデプロイメントの _configuration/_ "
+"ディレクトリに移動するか、または任意の場所に配置して絶対パスを指定します。絶対パスを使用している場合は、設定からオプションの `relative-to`"
+" パラメータを削除してください（<<_operating-mode, 動作モード>>を参照）。"
+
+#. type: Plain text
+msgid "Add the new `security-realm` element using the CLI:"
+msgstr "次のようにCLIを使用して、新しい `security-realm` 要素を追加します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ /core-service=management/security-realm=UndertowRealm:add()\n"
+msgstr "$ /core-service=management/security-realm=UndertowRealm:add()\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ /core-service=management/security-realm=UndertowRealm/server-"
+"identity=ssl:add(keystore-path=keycloak.jks, keystore-relative-"
+"to=jboss.server.config.dir, keystore-password=secret)\n"
+msgstr ""
+"$ /core-service=management/security-realm=UndertowRealm/server-"
+"identity=ssl:add(keystore-path=keycloak.jks, keystore-relative-"
+"to=jboss.server.config.dir, keystore-password=secret)\n"
 
 #. type: Plain text
 msgid ""
-"In the standalone or domain configuration file, search for the `security-"
-"realms` element and add:"
-msgstr "スタンドアローンまたはドメイン設定ファイル内で、 `security-realms` 要素を検索して以下を追加します。"
+"If using domain mode, the commands should be executed in every host using "
+"the `/host=<host_name>/` prefix (in order to create the `security-realm` in "
+"all of them), like this, which you would repeat for each host:"
+msgstr ""
+"ドメインモードを使用している場合は、コマンドはすべてのホストで `/host=<host_name>/` "
+"プレフィックスを使用して実行します（すべてのホストで `security-realm` を作成するために）。次のように、各ホスト分繰り返します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ /host=<host_name>/core-service=management/security-realm=UndertowRealm"
+"/server-identity=ssl:add(keystore-path=keycloak.jks, keystore-relative-"
+"to=jboss.server.config.dir, keystore-password=secret)\n"
+msgstr ""
+"$ /host=<host_name>/core-service=management/security-realm=UndertowRealm"
+"/server-identity=ssl:add(keystore-path=keycloak.jks, keystore-relative-"
+"to=jboss.server.config.dir, keystore-password=secret)\n"
+
+#. type: Plain text
+msgid ""
+"In the standalone or host configuration file, the `security-realms` element "
+"should look like this:"
+msgstr "スタンドアローンまたはホスト設定ファイルでは、 `security-realms` 要素は次のようになります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -320,11 +368,38 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Find the element `server name=\"default-server\"` (it's a child element of "
-"`subsystem xmlns=\"{subsystem_undertow_xml_urn}\"`) and add:"
+"Next, in the standalone or each domain configuration file, search for any "
+"instances of `security-realm`. Modify the `https-listener` to use the "
+"created realm:"
 msgstr ""
-"`server name=\"default-server\"` 要素（ `subsystem "
-"xmlns=\"{subsystem_undertow_xml_urn}\"` の子要素）を検索して以下を追加します。"
+"次に、スタンドアローンまたは各ドメイン設定ファイルで、 `security-realm` "
+"のインスタンスを検索します。作成したレルムを使用するように、次のように `https-listener` を修正します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ /subsystem=undertow/server=default-server/https-listener=https:write-"
+"attribute(name=security-realm, value=UndertowRealm)\n"
+msgstr ""
+"$ /subsystem=undertow/server=default-server/https-listener=https:write-"
+"attribute(name=security-realm, value=UndertowRealm)\n"
+
+#. type: Plain text
+msgid ""
+"If using domain mode, prefix the command with the profile that is being used"
+" with: `/profile=<profile_name>/`."
+msgstr ""
+"ドメインモードを使用している場合は、使用されているプロファイルをコマンドの先頭に `/profile=<profile_name>/` "
+"のように付けます。"
+
+#. type: Plain text
+msgid ""
+"The resulting element, `server name=\"default-server\"`, which is a child "
+"element of `subsystem xmlns=\"{subsystem_undertow_xml_urn}\"`, should "
+"contain the following stanza:"
+msgstr ""
+"結果として得られる要素 `server name=\"default-server\"` は、これは `subsystem "
+"xmlns=\"{subsystem_undertow_xml_urn}\"` の子要素であり、次のような内容を含みます。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
