### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,11 +27,11 @@ msgstr "プロファイル"
 
 #. type: Plain text
 msgid ""
-"{project_name} has a single profile, community, that enables most features "
-"by default, including features that are considered less mature. It is "
-"however possible to disable individual features."
+"There are features in {project_name} that are not enabled by default, these "
+"include features that are not fully supported. In addition there are some "
+"features that are enabled by default, but that can be disabled."
 msgstr ""
-"{project_name}には、成熟度が低いと考えられる機能を含め、デフォルトですべての機能を有効にするcommunityプロファイルがあります。ただし、個々の機能を無効にすることは可能です。"
+"{project_name}には、デフォルトでは有効とされていない機能があり、完全にはサポートされていないものがあります。さらに、デフォルトで有効とされている機能を無効にすることもできます。"
 
 #. type: Plain text
 msgid "The features that can be enabled and disabled are:"
@@ -34,8 +39,8 @@ msgstr "有効および無効にできる機能は、以下のとおりです。
 
 #. type: Named 'cols' AttributeList argument for style 'cols'
 #, no-wrap
-msgid "3*"
-msgstr "3*"
+msgid "4*"
+msgstr "4*"
 
 #. type: Labeled list
 #, no-wrap
@@ -51,19 +56,62 @@ msgstr "説明"
 msgid "Enabled by default"
 msgstr "デフォルトで有効"
 
-#. type: Labeled list
-#, no-wrap
-msgid "authorization"
-msgstr "authorization"
-
-#. type: Title =
-#, no-wrap
-msgid "Authorization Services"
-msgstr "認可サービス"
+#. type: Plain text
+msgid "Support level"
+msgstr "サポートレベル"
 
 #. type: Plain text
-msgid "Yes"
-msgstr "Yes"
+msgid "ifeval::[{project_community}==true]"
+msgstr "ifeval::[{project_community}==true]"
+
+#. type: Plain text
+msgid "account2"
+msgstr "account2"
+
+#. type: Plain text
+msgid "New Account Management Console"
+msgstr "新しいアカウント管理コンソール"
+
+#. type: Plain text
+msgid "No"
+msgstr "No"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Experimental\n"
+"endif::[]\n"
+msgstr ""
+"Experimental\n"
+"endif::[]\n"
+
+#. type: Plain text
+msgid "account_api"
+msgstr "account_api"
+
+#. type: Plain text
+msgid "Account Management REST API"
+msgstr "アカウント管理REST API"
+
+#. type: Plain text
+msgid "Preview"
+msgstr "Preview"
+
+#. type: Plain text
+msgid "admin_fine_grained_authz"
+msgstr "admin_fine_grained_authz"
+
+#. type: Plain text
+msgid "Fine-Grained Admin Permissions"
+msgstr "きめ細かい管理権限"
+
+#. type: Plain text
+msgid "authz_drools_policy"
+msgstr "authz_drools_policy"
+
+#. type: Plain text
+msgid "Drools Policy for Authorization Services"
+msgstr "認可サービス用のDroolsポリシー"
 
 #. type: Plain text
 msgid "docker"
@@ -74,8 +122,8 @@ msgid "Docker Registry protocol"
 msgstr "Dockerレジストリーのプロトコル"
 
 #. type: Plain text
-msgid "No"
-msgstr "No"
+msgid "Supported"
+msgstr "Supported"
 
 #. type: Plain text
 msgid "impersonation"
@@ -86,6 +134,18 @@ msgid "Ability for admins to impersonate users"
 msgstr "管理者がユーザーに成り代わる機能"
 
 #. type: Plain text
+msgid "Yes"
+msgstr "Yes"
+
+#. type: Plain text
+msgid "openshift_integration"
+msgstr "openshift_integration"
+
+#. type: Plain text
+msgid "Extension to enable securing OpenShift"
+msgstr "OpenShiftを保護するための拡張"
+
+#. type: Plain text
 msgid "script"
 msgstr "script"
 
@@ -94,17 +154,16 @@ msgid "Write custom authenticators using JavaScript"
 msgstr "Javaスクリプトを使用したカスタム認証の記述"
 
 #. type: Plain text
-msgid ""
-"{project_name} has two profiles, product and preview. The product profile is"
-" enabled by default, which disables some tech preview features. To enable "
-"the features you can either switch to the preview profile or enable "
-"individual features."
-msgstr ""
-"{project_name}には、productとpreviewの2プロファイルがあります。productプロファイルはデフォルトで有効になっていて、テクニカル・プレビュー機能を無効にします。この機能を有効にするには、previewプロファイルに切り替えるか、個別機能を有効にします。"
+msgid "token_exchange"
+msgstr "token_exchange"
 
 #. type: Plain text
-msgid "To enable the preview profile start the server with:"
-msgstr "previewプロファイルを有効にするには、以下のようにサーバーを起動します。"
+msgid "Token Exchange Service"
+msgstr "Token Exchangサービス"
+
+#. type: Plain text
+msgid "To enable all preview features start the server with:"
+msgstr "すべてのプレビュー機能を有効にするには、次のようにサーバーを起動します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -146,6 +205,16 @@ msgstr ""
 "サンプルとして、Dockerを有効にするには `-Dkeycloak.profile.feature.docker=enabled` を使用します。"
 
 #. type: Plain text
+msgid ""
+"You can set this permanently in the `profile.properties` file by adding:"
+msgstr "`profile.properties` ファイルに以下を追加することにより、永続的に設定することができます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "feature.docker=enabled\n"
+msgstr "feature.docker=enabled\n"
+
+#. type: Plain text
 msgid "To disable a specific feature start the server with:"
 msgstr "特定の機能を無効にするには、以下のようにサーバーを起動します。"
 
@@ -164,38 +233,7 @@ msgstr ""
 "サンプルとして、代理ログイン機能を無効にするには `-Dkeycloak.profile.feature.impersonation=disabled`"
 " を使用します。"
 
-#. type: Plain text
-msgid ""
-"You can set this permanently in the `profile.properties` file by adding:"
-msgstr "`profile.properties` ファイルに以下を追加することにより、永続的に設定することができます。"
-
 #. type: delimited block -
 #, no-wrap
 msgid "feature.impersonation=disabled\n"
 msgstr "feature.impersonation=disabled\n"
-
-#. type: Plain text
-msgid ""
-"To enable a specific feature without enabling the full preview profile you "
-"can start the server with:"
-msgstr "previewプロファイルを有効にするのではなく、特定の機能のみ有効にするには、以下のようにサーバーを起動します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
-msgstr ""
-"bin/standalone.sh|bat -Dkeycloak.profile.feature.<feature name>=enabled`\n"
-
-#. type: Plain text
-msgid ""
-"For example to enable Authorization Services use "
-"`-Dkeycloak.profile.feature.authorization=enabled`."
-msgstr ""
-"サンプルとして、認可サービスを有効にするには、 `-Dkeycloak.profile.feature.authorization=enabled` "
-"を使用します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid "feature.authorization=enabled\n"
-msgstr "feature.authorization=enabled\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
