### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -128,77 +128,76 @@ msgstr "image:images/google-dashboard.png[]"
 
 #. type: Plain text
 msgid ""
-"To be able to retrieve the profiles of Google users, you need to turn on the"
-" Google+ APIs.  Select the `Enable and manage APIs` and click the `Google+ "
-"API` link."
+"Then navigate to the `APIs & Services` section in the Google Developer "
+"Console. On that screen, navigate to `Credentials` administration."
 msgstr ""
-"Googleユーザーのプロファイルを取得するには、Google+ APIsを有効にする必要があります。 `Enable and manage APIs`"
-" を選択し、 `Google+ API` リンクをクリックします。"
-
-#. type: Block title
-#, no-wrap
-msgid "APIs"
-msgstr "API"
-
-#. type: Plain text
-msgid "image:images/google-api-list.png[]"
-msgstr "image:images/google-api-list.png[]"
+"次に、Googleデベロッパーコンソールの `APIs & Services` セクションに移動します。その画面で、 `Credentials` "
+"管理に移動します。"
 
 #. type: Plain text
 msgid ""
-"Click the `Enable` button on this page.  You will get a message that you "
-"must create the credentials of your project.  So click the `Go to "
-"Credentials` button."
+"When users log into Google from {project_name} they will see a consent "
+"screen from Google which will ask the user if {project_name} is allowed to "
+"view information about their user profile. Thus Google requires some basic "
+"information about the product before creating any secrets for it. For a new "
+"project, you have first to configure `OAuth consent screen`."
 msgstr ""
-"このページの `Enable` ボタンをクリックします。プロジェクトのクレデンシャルを作成する必要があるというメッセージが表示されます。そこで、 `Go"
-" to Credentials` ボタンをクリックします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Go To Credentials"
-msgstr "クレデンシャルへ移動"
-
-#. type: Plain text
-msgid "image:images/google-go-to-credentials.png[]"
-msgstr "image:images/google-go-to-credentials.png[]"
-
-#. type: Plain text
-msgid "You will then be brought to the credentials page."
-msgstr "これで、クレデンシャルのページが表示されます。"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"If you logout in the middle of this, there is a menu in the top left hand corner.  Select `API Manager` and it\n"
-"       will bring you to your desired screen.\n"
-msgstr "この間にログアウトすると、左上隅にメニューが表示されます。 `API Manager` を選択すると、目的の画面が表示されます。\n"
+"ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。そのため、Googleはプロダクトのシークレットを作成する前に、プロダクトに関するいくつかの基本情報を必要とします。新しいプロジェクトのために、あなたは最初に"
+" `OAuth同意画面` を設定しなければなりません。"
 
 #. type: Plain text
 msgid ""
-"You will then be asked to specify what credentials you need and what type of"
-" data you will be accessing."
-msgstr "次に、必要なクレデンシャルとアクセスするデータの種類を指定するよう求められます。"
-
-#. type: Block title
-#, no-wrap
-msgid "Add Credentials"
-msgstr "クレデンシャルの追加"
-
-#. type: Plain text
-msgid "image:images/google-add-credentials.png[]"
-msgstr "image:images/google-add-credentials.png[]"
-
-#. type: Plain text
-msgid ""
-"Select `Web server` and `User data` and click the `What credentials do I "
-"need?` button."
+"For the very basic setup, filling in the Application name is sufficient. You"
+" can also set additional details like scopes for Google APIs in this page."
 msgstr ""
-"`Web server` と `User data` を選択し、 `What credentials do I need?` ボタンをクリックします。"
+"非常に基本的な設定では、アプリケーション名を入力するだけで十分です。このページでは、Google "
+"APIのスコープなど、追加の詳細を設定することもできます。"
 
 #. type: Block title
 #, no-wrap
-msgid "Create OAuth ID"
-msgstr "OAuth IDの作成"
+msgid "Fill in OAuth consent screen details"
+msgstr "OAuth同意画面の詳細を入力"
+
+#. type: Plain text
+msgid "image:images/google-oauth-consent-screen.png[]"
+msgstr "image:images/google-oauth-consent-screen.png[]"
+
+#. type: Plain text
+msgid ""
+"The next step is to create OAuth client ID and client secret. Back in "
+"`Credentials` administration, navigate to `Credentials` tab and select "
+"`OAuth client ID` under the `Create credentials` button."
+msgstr ""
+"次のステップは、OAuthクライアントIDとクライアント・シークレットを作成することです。 `Credentials` "
+"管理に戻り、`Credentials` タブに行き、 `Create credentials` ボタンの下の `OAuth client ID` "
+"を選択してください。"
+
+#. type: Block title
+#, no-wrap
+msgid "Create credentials"
+msgstr "クレデンシャルの作成"
+
+#. type: Plain text
+msgid "image:images/google-create-credentials.png[]"
+msgstr "image:images/google-create-credentials.png[]"
+
+#. type: Plain text
+msgid ""
+"You will then be brought to the `Create OAuth client ID` page. Select `Web "
+"application` as the application type. Specify the name you want for your "
+"client.  You'll also need to copy and paste the `Redirect URI` from the "
+"{project_name} `Add Identity Provider` page into the `Authorized redirect "
+"URIs` field.  After you do this, click the `Create` button."
+msgstr ""
+"そうすると `Create OAuth client ID` ページが表示されます。アプリケーション・タイプとして `Web application` "
+"を選択します。また、{project_name}の `Add Identity Provider` ページから `Redirect URI` "
+"をコピーし、 `Authorized redirect URIs` フィールドに貼り付ける必要があります。これを済ませたら、 `Create` "
+"ボタンをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Create OAuth client ID"
+msgstr "OAuthクライアントIDの作成"
 
 #. type: Plain text
 msgid "image:images/google-create-oauth-id.png[]"
@@ -206,32 +205,11 @@ msgstr "image:images/google-create-oauth-id.png[]"
 
 #. type: Plain text
 msgid ""
-"Next you'll need to create an OAuth 2.0 client ID.  Specify the name you "
-"want for your client.  You'll also need to copy and paste the `Redirect URI`"
-" from the {project_name} `Add Identity Provider` page into the `Authorized "
-"redirect URIs` field.  After you do this, click the `Create client ID` "
-"button."
+"After you click `Create` you will be brought to the `Credentials` page. "
+"Click on your new OAuth 2.0 Client ID to view the settings of your new "
+"Google Client."
 msgstr ""
-"次に、OAuth 2.0クライアントIDを作成する必要があります。クライアントに必要な名前を指定します。また、{project_name}の `Add "
-"Identity Provider` ページから `Redirect URI` をコピーし、 `Authorized redirect URIs` "
-"フィールドに貼り付ける必要があります。これを済ませたら、 `Create client ID` ボタンをクリックします。"
-
-#. type: Plain text
-msgid ""
-"When users log into Google from {project_name} they will see a consent "
-"screen from Google which will ask the user if {project_name} is allowed to "
-"view information about their user profile.  The next Google config screen "
-"asks you for information about this screen."
-msgstr ""
-"ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。次のGoogleの設定画面に、この画面に関する情報が表示されます。"
-
-#. type: Plain text
-msgid ""
-"Once you click `Done` you will be brought to the `Credentials` page.  Click "
-"on your new OAuth 2.0 Client ID to view the settings of your new Google "
-"Client."
-msgstr ""
-"`Done` をクリックすると、 `Credentials` ページが表示されます。 新しいOAuth "
+"`Create` をクリックすると、 `Credentials` ページが表示されます。新しいOAuth "
 "2.0クライアントのIDをクリックすると、新しいGoogleクライアントの設定が表示されます。"
 
 #. type: Block title


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
