### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po
@@ -1,0 +1,413 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Audience Support"
+msgstr "Audienceのサポート"
+
+#. type: Plain text
+msgid ""
+"The typical environment where the {project_name} is deployed generally "
+"consists of a set of _confidential_ or _public_ client applications "
+"(frontend client applications) which use {project_name} for authentication."
+msgstr ""
+"{project_name}がデプロイされる典型的な環境は、一般に、認証に{project_name}を使用する _confidential_ または "
+"_public_ なクライアント・アプリケーション（フロントエンド・クライアント・アプリケーション）のセットで構成されています。"
+
+#. type: Plain text
+msgid ""
+"There are also _services_ (called _Resource Servers_ in the OAuth 2 "
+"specification), which serve requests from frontend client applications and "
+"provide resources. These services typically require an _Access token_ "
+"(Bearer token) to be sent to them to authenticate for a particular request. "
+"This token was previously obtained by the frontend application when it tries"
+" to log in against {project_name}."
+msgstr ""
+"フロントエンドのクライアント・アプリケーションからのリクエストを処理し、リソースを提供する _サービス_（OAuth 2の仕様では _リソースサーバー_"
+" と呼ばれます）もあります。これらのサービスは通常、特定のリクエストに対して認証するためにサービスに送信される _アクセストークン_ "
+"（ベアラートークン）を必要とします。このトークンは、フロントエンド・アプリケーションが{project_name}に対してログインを試行したときに取得されたものです。"
+
+#. type: Plain text
+msgid ""
+"In the environment where the trust among services is low, you may encounter "
+"this scenario:"
+msgstr "サービス間の信頼性が低い環境では、次のシナリオが発生する可能性があります。"
+
+#. type: Plain text
+msgid ""
+"A frontend client called `my-app` is required to be authenticated against "
+"{project_name}."
+msgstr "`my-app` というフロントエンド・クライアントは{project_name}によって認証される必要があります。"
+
+#. type: Plain text
+msgid ""
+"A user is authenticated in {project_name}. {project_name} then issued tokens"
+" to the `my-app` application."
+msgstr ""
+"ユーザーは{project_name}で認証されています。そして{project_name}は `my-app` "
+"アプリケーションにトークンを発行しました。"
+
+#. type: Plain text
+msgid ""
+"The application `my-app` used the token to invoke the service `evil-"
+"service`. The application needs to invoke `evil-service` as the service is "
+"able to serve some very useful data."
+msgstr ""
+"アプリケーション `my-app` はトークンを使ってサービス `evil-service` "
+"を呼び出しました。サービスは非常に有用なデータを提供することができるので、アプリケーションは `evil-service` を呼び出す必要があります。"
+
+#. type: Plain text
+msgid ""
+"The `evil-service` application returned the response to `my-app`. However, "
+"at the same time, it kept the token previously sent to it."
+msgstr ""
+"`evil-service` アプリケーションは `my-app` にレスポンスを返しました。ただし、同時に、以前に送信されたトークンが保持されました。"
+
+#. type: Plain text
+msgid ""
+"The `evil-service` application then invoked another service called `good-"
+"service` with the previously kept token. The invocation was successful and "
+"`good-service` returned the data. This results in broken security as the "
+"`evil-service` misused the token to access other services on behalf of the "
+"client `my-app`."
+msgstr ""
+"そして `evil-service` アプリケーションは以前に保持したトークンを使って `good-service` "
+"と呼ばれる別のサービスを呼び出しました。呼び出しは成功し、 `good-service` はデータを返しました。 `evil-service` "
+"がクライアント `my-app` に代わって他のサービスにアクセスするためにトークンを悪用したため、セキュリティーが破綻します。"
+
+#. type: Plain text
+msgid ""
+"This flow may not be an issue in many environments with the high level of "
+"trust among services. However in other environments, where the trust among "
+"services is lower, this can be problematic."
+msgstr ""
+"このフローは、サービス間の信頼性が高い多くの環境では問題にならないかもしれません。しかし、サービス間の信頼性が低い他の環境では、これが問題になる可能性があります。"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"In some environments, this example work flow may be even requested behavior as the `evil-service` may need to retrieve\n"
+"      additional data from `good-service` to be able to properly return the requested data to the original caller (my-app client).\n"
+"      You may notice similarities with the Kerberos Credential Delegation. As with the Kerberos Credential Delegation, an unlimited\n"
+"      audience is a mixed blessing as it is only useful when a high level of trust exists among services. Otherwise, it is\n"
+"      recommended to limit audience as described next. You can limit audience and at the same time allow the `evil-service` to\n"
+"      retrieve required data from the `good-service`. In this case, you need to ensure that both the `evil-service` and `good-service`\n"
+"      are added as audiences to the token.\n"
+msgstr ""
+"環境によっては、リクエストされたデータを元の呼び出し元（my-appクライアント）に正しく返せるように、 `evil-service` が `good-"
+"service` "
+"から追加のデータを取得する必要があるかもしれないため、このワークフロー例は要求された動作でさえあるかもしれません。あなたは、Kerberos "
+"Credential Delegationとの類似点に気付くかもしれません。Kerberos Credential "
+"Delegationと同様に、サービス間に高い信頼レベルがある場合にのみ有用なため、無制限のAudienceは必ずしもいい事ずくめではないです。それ以外の場合は、次に説明するようにAudienceを制限することをお勧めします。Audienceを制限し、同時に"
+" `evil-service` が `good-service` から必要なデータを取得することを許可することができます。この場合、トークンに "
+"`evil-service` と `good-service` の両方がAudienceとして追加されていることを確認する必要があります。\n"
+
+#. type: Plain text
+msgid ""
+"To prevent any misuse of the access token as in the example above, it is "
+"recommended to limit _Audience_ on the token and configure your services to "
+"verify the audience on the token. If this is done, the flow above will "
+"change, like this:"
+msgstr ""
+"上記の例のようにアクセストークンの誤用を防ぐために、トークンの _Audience_ "
+"を制限し、トークンのAudienceを検証するようにサービスを設定することをお勧めします。これが行われると、上記のフローは次のように変わります。"
+
+#. type: Plain text
+msgid ""
+"A user is authenticated in {project_name}. {project_name} then issued tokens"
+" to the `my-app` application. The client application already knows that it "
+"will need to invoke service `evil-service`, so it used `scope=evil-service` "
+"in the authentication request sent to the {project_name} server. See "
+"<<_client_scopes, Client Scopes section>> for more details about the _scope_"
+" parameter.  The token issued to the `my-app` client contains the audience, "
+"as in `\"audience\": [ \"evil-service\" ]`, which declares that the client "
+"wants to use this access token to invoke just the service `evil-service`."
+msgstr ""
+"ユーザーは{project_name}で認証されています。そして{project_name}は `my-app` "
+"アプリケーションにトークンを発行しました。クライアント・アプリケーションはすでにサービス `evil-service` "
+"を呼び出す必要があることを知っているので、{project_name}サーバーに送信される認証リクエストで `scope = evil-service`"
+" を使いました。 _scope_ パラメータの詳細については、<<_client_scopes, "
+"クライアント・スコープのセクション>>を参照してください。 `my-app` クライアントに発行されたトークンは `\"audience\": [ "
+"\"evil-service\" ]` のようにAudienceを含んでいます。これはクライアントがこのアクセストークンを使って `evil-"
+"service` サービスだけを呼び出すことを望んでいることを宣言します。"
+
+#. type: Plain text
+msgid ""
+"The `evil-service` application served the request to the `my-app`. At the "
+"same time, it kept the token previously sent to it."
+msgstr ""
+"`evil-service` アプリケーションは `my-app` にリクエストを送信しました。同時に、以前に送信されたトークンが保持されました。"
+
+#. type: Plain text
+msgid ""
+"The `evil-service` application then invoked the `good-service` with the "
+"previously kept token. Invocation was not successful because `good-service` "
+"checks the audience on the token and it sees that audience is only `evil-"
+"service`. This is expected behavior and security is not broken."
+msgstr ""
+"それから `evil-service` アプリケーションは以前に保持されたトークンで `good-service` "
+"を呼び出しました。呼び出しは成功しませんでした。なぜなら、 `good-service` "
+"はトークン上のAudienceをチェックし、Audienceは単に `evil-service` "
+"であると見なしたためです。これは予想される動作であり、セキュリティーは破られていません。"
+
+#. type: Plain text
+msgid ""
+"If the client wants to invoke the `good-service` later, it will need to "
+"obtain another token by issuing the SSO login with the `scope=good-service`."
+" The returned token will then contain `good-service` as an audience:"
+msgstr ""
+"クライアントが後で `good-service` を呼び出したい場合は、 `scope = good-service` "
+"を指定してSSOログインを発行し、別のトークンを取得する必要があります。返されたトークンはAudienceとして `good-service` "
+"を含みます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "\"audience\": [ \"good-service\" ]\n"
+msgstr "\"audience\": [ \"good-service\" ]\n"
+
+#. type: Plain text
+msgid "and can be used to invoke `good-service`."
+msgstr "そして `good-service` を呼び出すために使うことができます。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Setup"
+msgstr "セットアップ"
+
+#. type: Plain text
+msgid "To properly set up audience checking:"
+msgstr "Audienceチェックを正しく設定するには、次のようにします。"
+
+#. type: Plain text
+msgid ""
+"Ensure that services are configured to check audience on the access token "
+"sent to them by adding the flag _verify-token-audience_ in the adapter "
+"configuration. See link:{adapterguide_link}#_java_adapter_config[Adapter "
+"configuration] for details."
+msgstr ""
+"アダプター設定にフラグ _verify-token-audience_ "
+"を追加して、サービスがそれらに送信されたアクセストークンでAudienceをチェックするように設定されていることを確認します。詳しくは、 "
+"link:{adapterguide_link}#_java_adapter_config[アダプター構成] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Ensure that when an access token is issued by {project_name}, it contains "
+"all requested audiences and does not contain any audiences that are not "
+"needed. The audience can be either automatically added due the client roles "
+"as described in the <<_audience_resolve, next section>> or it can be "
+"hardcoded as described <<_audience_hardcoded, below>>."
+msgstr ""
+"アクセストークンが{project_name}によって発行されたときに、要求されたすべてのAudienceが含まれ、不要なAudienceが含まれていないことを確認してください。Audienceは、"
+" <<_audience_resolve, 次のセクション>> で説明されているようにクライアントロールによって自動的に追加されるか、または "
+"<<_audience_hardcoded, 以下>> のようにハードコーディングされます。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Automatically add audience"
+msgstr "Audienceを自動的に追加"
+
+#. type: Plain text
+msgid ""
+"In the default client scope _roles_, there is an _Audience Resolve_ protocol"
+" mapper defined. This protocol mapper will check all the clients for which "
+"current token has at least one client role available. Then the client ID of "
+"each of those clients will be added as an audience automatically. This is "
+"especially useful if your service (usually bearer-only) clients rely on "
+"client roles."
+msgstr ""
+"デフォルトのクライアント・スコープ _roles_ には、 _Audience Resolve_ "
+"プロトコル・マッパーが定義されています。このプロトコルマッパーは、現在のトークンに使用可能なクライアントロールが少なくとも1つあるか、すべてのクライアントに対してチェックします。その後、それらの各クライアントのクライアントIDがAudienceとして自動的に追加されます。これは、サービス（通常はベアラーのみ）クライアントがクライアントロールに依存している場合に特に便利です。"
+
+#. type: Plain text
+msgid ""
+"As an example, let us assume that you have a bearer-only client `good-"
+"service` and the confidential client `my-app`, which you want to "
+"authenticate and then use the access token issued for the `my-app` to invoke"
+" the `good-service` REST service. If the following are true:"
+msgstr ""
+"例として、認証したいベアラー専用クライアント `good-service` とコンフィデンシャル・クライアント `my-app` があり、 `good-"
+"service` RESTサービスを呼び出すために、 `my-app` に対して発行されたアクセストークンを使用するとしましょう。以下が当てはまる場合、"
+
+#. type: Plain text
+msgid "The `good-service` client has any client roles defined on itself"
+msgstr "`good-service` クライアントはそれ自身に定義された任意のクライアントロールを持つ"
+
+#. type: Plain text
+msgid "Target user has at least one of those client roles assigned"
+msgstr "ターゲット・ユーザーに、これらのクライアントロールの少なくとも1つが割り当てられている"
+
+#. type: Plain text
+msgid "Client `my-app` has the role scope mappings for the assigned role"
+msgstr "クライアント `my-app` は、割り当てられたロールに対してロール・スコープ・マッピングを持っている"
+
+#. type: Plain text
+msgid ""
+"then the `good-service` will be automatically added as an audience to the "
+"access token issued for the `my-app`."
+msgstr "`good-service` が ` my-app` に対して発行されたアクセストークンにAudienceとして自動的に追加されます。"
+
+#. type: Plain text
+msgid ""
+"If you want to ensure that audience is not added automatically, do not "
+"configure role scope mappings directly on the `my-app` client, but instead "
+"create a dedicated client scope, for example called `good-service`, which "
+"will contain the role scope mappings for the client roles of the `good-"
+"service` client. Assuming that this client scope will be added as an "
+"optional client scope to the `my-app` client, the client roles and audience "
+"will be added to the token just if explicitly requested by the `scope=good-"
+"service` parameter."
+msgstr ""
+"Audienceが自動的に追加されないようにするには、ロール・スコープ・マッピングを直接 `my-app` "
+"クライアントに設定しないでください。代わりに、 `good-service` "
+"クライアントのクライアントロールのロール・スコープ・マッピングを含む専用のクライアント・スコープ（たとえば、 `good-service` "
+"）を作成してください。このクライアント・スコープがオプションのクライアント・スコープとして `my-app` "
+"クライアントに追加されると仮定すると、クライアントロールとAudienceは `scope=good-service` "
+"パラメーターによって明示的に要求された場合にのみトークンに追加されます。"
+
+#. type: Plain text
+msgid ""
+"The frontend client itself is not automatically added to the access token "
+"audience. This allows for easy differentiation between the access token and "
+"the ID token, because the access token will not contain the client for which"
+" the token was issued as an audience. So in he example above, the `my-app` "
+"won't be added as an audience. If you need the client itself as an audience,"
+" see the <<_audience_hardcoded, hardcoded audience>> option. However, using "
+"the same client as both frontend and REST service is not recommended."
+msgstr ""
+"フロントエンド・クライアント自体は、アクセストークンのAudienceに自動的に追加されません。アクセストークンには、トークンがAudienceとして発行されたクライアントが含まれないため、これによりアクセストークンとIDトークンを簡単に区別できます。したがって、上記の例では、"
+" `my-app` "
+"はAudienceとして追加されません。クライアント自体をAudienceとして必要とする場合は、<<_audience_hardcoded, "
+"ハードコードされたAudience>>のオプションを見てください。ただし、フロントエンドとRESTサービスの両方に同じクライアントを使用することはお勧めできません。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Hardcoded audience"
+msgstr "ハードコードされたAudience"
+
+#. type: Plain text
+msgid ""
+"For the case when your service relies on realm roles or does not rely on the"
+" roles in the token at all, it can be useful to use hardcoded audience. This"
+" is a protocol mapper, which will add client ID of the specified service "
+"client as an audience to the token.  You can even use any custom value, for "
+"example some URL, if you want different audience than client ID."
+msgstr ""
+"サービスがレルムロールに依存している場合、またはトークン内のロールにまったく依存していない場合は、ハードコードされたAudienceを使用すると便利です。これはプロトコル・マッパーであり、指定されたサービス・クライアントのクライアントIDをAudienceとしてトークンに追加します。クライアントIDとは異なるユーザー層が必要な場合は、任意のカスタム値（たとえば、URL）を使用することもできます。"
+
+#. type: Plain text
+msgid ""
+"You can add protocol mapper directly to the frontend client, however than "
+"the audience will be always added. If you want more fine-grain control, you "
+"can create protocol mapper on the dedicated client scope, which will be "
+"called for example `good-service`."
+msgstr ""
+"プロトコル・マッパーをフロントエンド・クライアントに直接追加できますが、Audienceは常に追加されます。よりきめ細かい制御が必要な場合は、専用のクライアント・スコープで、たとえば"
+" `good-service` と呼ばれるようなプロトコル・マッパーを作成できます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Audience Protocol Mapper"
+msgstr "Audience Protocol Mapper"
+
+#. type: Plain text
+msgid "image:{project_images}/audience_mapper.png[]"
+msgstr "image:{project_images}/audience_mapper.png[]"
+
+#. type: Plain text
+msgid ""
+"From the <<_client_installation, Installation tab>> of the `good-service` "
+"client, you can generate the adapter configuration and you can confirm that "
+"_verify-token-audience_ option will be set to true. This indicates that the "
+"adapter will require verifying the audience if you use this generated "
+"configuration."
+msgstr ""
+"`good-service` クライアントの<<_client_installation, "
+"Installationタブ>>から、アダプター設定を生成でき、 _verify-token-audience_ "
+"オプションがtrueに設定されることを確認できます。この生成された設定を使用する場合、アダプターがAudienceの検証を必要とすることを示しています。"
+
+#. type: Plain text
+msgid ""
+"Finally, you need to ensure that the `my-app` frontend client is able to "
+"request `good-service` as an audience in its tokens.  On the `my-app` "
+"client, click the _Client Scopes_ tab. Then assign `good-service` as an "
+"optional (or default) client scope. See <<_client_scopes_linking, Client "
+"Scopes Linking section>> for more details."
+msgstr ""
+"最後に、 `my-app` フロントエンド・クライアントがそのトークンの中のAudienceとして `good-service` "
+"をリクエストできることを確認する必要があります。 `my-app` クライアントで、 _Client Scopes_ "
+"タブをクリックしてください。それからオプションの（またはデフォルトの）クライアント・スコープとして `good-service` "
+"を割り当てます。詳しくは<<_client_scopes_linking, クライアント・スコープ・リンキングのセクション>>を参照してください。"
+
+#. type: Plain text
+msgid ""
+"You can optionally <<_client_scopes_evaluate, Evaluate Client Scopes>> and "
+"generate an example access token. If you do, notice that `good-service` will"
+" be added to the audience of the generated access token only if `good-"
+"service` is included in the _scope_ parameter in the case you assigned it as"
+" an optional client scope."
+msgstr ""
+"オプションで<<_client_scopes_evaluate, "
+"クライアント・スコープの評価>>を実行してアクセストークンのサンプルを生成することもできます。その場合、 `good-service` が "
+"_scope_ パラメーターに含まれている場合にのみ、生成されたアクセストークンのAudienceに `good-service` "
+"が追加されることに注意してください。"
+
+#. type: Plain text
+msgid ""
+"In your `my-app` application, you must ensure that _scope_ parameter is used"
+" with the value `good-service` always included when you want to issue the "
+"token for accessing the `good-service`.  See the "
+"link:{adapterguide_link}#_params_forwarding[parameters forwarding section], "
+"if your application uses the servlet adapter, or the "
+"link:{adapterguide_link}#_javascript_adapter[javascript adapter section], if"
+" your application uses the javascript adapter."
+msgstr ""
+"`my-app` アプリケーションで、 `good-service` にアクセスするためのトークンを発行したいときには、 _scope_ "
+"パラメーターが必ず `good-service` "
+"の値とともに使われるようにしなければなりません。アプリケーションがサーブレット・アダプターを使用している場合は "
+"link:{adapterguide_link}#_params_forwarding[パラメーター転送のセクション] "
+"を、アプリケーションがJavaScriptアダプターを使用している場合は "
+"link:{adapterguide_link}#_javascript_adapter[JavaScriptアダプターのセクション] "
+"を参照してください。"
+
+#. type: Plain text
+msgid ""
+"If you are unsure what the correct audience and roles in the token will be, "
+"it is always a good idea to <<_client_scopes_evaluate, Evaluate Client "
+"Scopes>> in the admin console and do some testing around it."
+msgstr ""
+"トークン内の正しいAudienceとロールがどのようなものになるのかわからない場合は、管理コンソールで<<_client_scopes_evaluate,"
+" クライアント・スコープの評価>>を実行し、それをテストすることをお勧めします。"
+
+#. type: Plain text
+msgid ""
+"Both the _Audience_ and _Audience Resolve_ protocol mappers add the "
+"audiences just to the access token by default. The ID Token typically "
+"contains only single audience, which is the client ID of the client for "
+"which the token was issued. This is a requirement of the OpenID Connect "
+"specification. On the other hand, the access token does not necessarily have"
+" the client ID of the client, which was the token issued for, unless any of "
+"the audience mappers added it."
+msgstr ""
+"_Audience_ と _Audience Resolve_ "
+"の両方のプロトコル・マッパーは、デフォルトでAudienceをアクセストークンだけに追加します。IDトークンには通常、単一のAudience（トークンが発行されたクライアントのクライアントID）しか含まれていません。これはOpenID"
+" "
+"Connectの仕様における要件です。一方、アクセストークンは、Audienceマッパーがそれを追加しない限り、必ずしもクライアントID（発行されたトークンであるクライアントのクライアントID）を持つ必要はありません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__audience
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
