### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -38,8 +38,8 @@ msgid ""
 "applications from WildFly to the JBoss EAP, as the JBoss EAP adapter is "
 "supported for much longer period."
 msgstr ""
-"今回のリリースでは、WildFlyの最新バージョンでアダプターのテストとメンテナンスを行っています。WildFlyの新しいバージョンがリリースされると、現在のアダプターは非推奨になり、WildFlyの次のリリース後にサポートが削除されます。もう一つの選択肢は、JBoss"
-" EAPアダプターがより長期間サポートされるように、アプリケーションをWildFlyからJBoss EAPに切り替えることです。"
+"今回のリリースでは、WildFlyの最新バージョンでのみアダプターのテストとメンテナンスを行っています。WildFlyの新しいバージョンがリリースされると、現在のアダプターは非推奨になり、WildFlyの次のリリース後にサポートが削除されます。もう一つの選択肢は、JBoss"
+" EAPアダプターの場合はより長期間サポートされますので、アプリケーションをWildFlyからJBoss EAPに切り替えることです。"
 
 #. type: Plain text
 msgid "Install on WildFly 9 or newer or on JBoss EAP 7:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
