### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/classic-war.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/classic-war.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/classic-war.ja_JP.po
@@ -243,7 +243,7 @@ msgid ""
 msgstr ""
 "このリゾルバーは、 `keycloak.config` システム・プロパティーで指定されたフォルダーの中で "
 "`<your_web_context>-keycloak.json` というファイルを探します。 `keycloak.config` "
-"が設定されていなければ、代わりに ` karaf.etc` システム・プロパティーが使われます。"
+"が設定されていなければ、代わりに `karaf.etc` システム・プロパティーが使われます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/classic-war.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__classic-war
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
