### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: TAMURA Kohei <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,7 +34,7 @@ msgid ""
 "the PEM key format.  You usually use this option if you are generating keys "
 "using `openssl` or similar command line tool."
 msgstr ""
-"`Key` 要素の中では、 `PrivateKeyPem` 、 `PublicKeyPem` 、 ` CertificatePem` "
+"`Key` 要素の中では、 `PrivateKeyPem` 、 `PublicKeyPem` 、 `CertificatePem` "
 "というサブ要素を使って、鍵と証明書を直接宣言します。これらの要素に含まれる値は、PEM鍵形式に準拠している必要があります。 `openssl` "
 "などのコマンドライン・ツールを使用して鍵を生成する場合は、通常このオプションを使用します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys/key_pems.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp-keys__key_pems
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
