### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po
@@ -3,6 +3,9 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -15,23 +18,41 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Labeled list
+#, no-wrap
+msgid "signRequest"
+msgstr "signRequest"
+
+#. type: Labeled list
+#, no-wrap
+msgid "validateResponseSignature"
+msgstr "validateResponseSignature"
+
+#. type: Labeled list
+#, no-wrap
+msgid "requestBinding"
+msgstr "requestBinding"
+
+#. type: Labeled list
+#, no-wrap
+msgid "responseBinding"
+msgstr "responseBinding"
+
 #. type: Title =====
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:2
 #, no-wrap
 msgid "IDP SingleLogoutService sub element"
 msgstr "IDP SingleLogoutServiceサブ要素"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:6
 #, no-wrap
 msgid ""
 "The `SingleLogoutService` sub element defines the logout SAML endpoint of the IDP.   The client adapter will send requests\n"
 "to the IDP formatted via the settings within this element when it wants to logout.\n"
 msgstr ""
-"`SingleLogoutService`サブ要素は、IDPのログアウトSAMLエンドポイントを定義します。クライアント・アダプターは、ログアウトしたいときに、この要素内の設定によって書式設定されたIDPにリクエストを送信します。\n"
+"`SingleLogoutService` "
+"サブ要素は、IDPのログアウトSAMLエンドポイントを定義します。クライアント・アダプターは、ログアウトしたいときに、この要素内の設定によって書式設定されたIDPにリクエストを送信します。\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:17
 #, no-wrap
 msgid ""
 "<SingleLogoutService validateRequestSignature=\"true\"\n"
@@ -52,15 +73,7 @@ msgstr ""
 "                     postBindingUrl=\"posturl\"\n"
 "                     redirectBindingUrl=\"redirecturl\">\n"
 
-#. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:19
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:20
-#, no-wrap
-msgid "signRequest"
-msgstr "signRequest"
-
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:22
 msgid ""
 "Should the client sign logout requests it makes to the IDP? This setting is "
 "_OPTIONAL_.  Defaults to whatever the IDP `signaturesRequired` element value"
@@ -70,13 +83,11 @@ msgstr ""
 "`signaturesRequired` 要素の値です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:23
 #, no-wrap
 msgid "signResponse"
 msgstr "signResponse"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:26
 msgid ""
 "Should the client sign logout responses it sends to the IDP requests? This "
 "setting is _OPTIONAL_.  Defaults to whatever the IDP `signaturesRequired` "
@@ -86,13 +97,11 @@ msgstr ""
 "`signaturesRequired` 要素の値です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:27
 #, no-wrap
 msgid "validateRequestSignature"
 msgstr "validateRequestSignature"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:29
 msgid ""
 "Should the client expect signed logout request documents from the IDP? This "
 "setting is _OPTIONAL_. Defaults to whatever the IDP `signaturesRequired` "
@@ -101,15 +110,7 @@ msgstr ""
 "IDPからのログアウト・リクエストのドキュメントが署名されていることをクライアントが期待するかどうかの設定です。この設定は _OPTIONAL_ "
 "です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
 
-#. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:30
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:24
-#, no-wrap
-msgid "validateResponseSignature"
-msgstr "validateResponseSignature"
-
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:32
 msgid ""
 "Should the client expect signed logout response documents from the IDP? This"
 " setting is _OPTIONAL_. Defaults to whatever the IDP `signaturesRequired` "
@@ -118,15 +119,7 @@ msgstr ""
 "IDPからのログアウト・レスポンスのドキュメントが署名されていることをクライアントが期待するかどうかの設定です。この設定は _OPTIONAL_ "
 "です。デフォルトはIDPの `signaturesRequired` 要素の値です。"
 
-#. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:33
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:28
-#, no-wrap
-msgid "requestBinding"
-msgstr "requestBinding"
-
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:36
 msgid ""
 "This is the SAML binding type used for communicating SAML requests to the "
 "IDP. This setting is _OPTIONAL_.  The default value is `POST`, but you can "
@@ -135,15 +128,7 @@ msgstr ""
 "IDPとのSAMLリクエストでの通信に使用するSAMLバインディング・タイプです。この設定は _OPTIONAL_ です。デフォルト値は `POST` "
 "ですが、 `REDIRECT` に設定することもできます。"
 
-#. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:37
-#: source/securing_apps/topics/saml/java/general-config/idp_singlesignonservice_subelement.adoc:32
-#, no-wrap
-msgid "responseBinding"
-msgstr "responseBinding"
-
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:40
 msgid ""
 "This is the SAML binding type used for communicating SAML responses to the "
 "IDP. The values of this can be `POST` or `REDIRECT`.  This setting is "
@@ -154,13 +139,11 @@ msgstr ""
 "にできます。この設定は _OPTIONAL_ です。デフォルト値は `POST` ですが、 `REDIRECT` に設定することもできます。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:41
 #, no-wrap
 msgid "postBindingUrl"
 msgstr "postBindingUrl"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:43
 msgid ""
 "This is the URL for the IDP's logout service when using the POST binding. "
 "This setting is _REQUIRED_ if using the `POST` binding."
@@ -169,13 +152,11 @@ msgstr ""
 "_REQUIRED_ です。"
 
 #. type: Labeled list
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:44
 #, no-wrap
 msgid "redirectBindingUrl"
 msgstr "redirectBindingUrl"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.adoc:46
 msgid ""
 "This is the URL for the IDP's logout service when using the REDIRECT "
 "binding. This setting is _REQUIRED_ if using the REDIRECT binding."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_singlelogoutservice_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_singlelogoutservice_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
