### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -1569,7 +1569,7 @@ msgid ""
 "between `site1` and `site2` is broken."
 msgstr ""
 "サイト `site2` は、 `site1` の観点から完全にオフラインです。これは、`site2` "
-"のすべての{jdgserver_name}サーバーがオフである。 *または* 、 ` site1` と `site2` "
+"のすべての{jdgserver_name}サーバーがオフである、 *または* 、 `site1` と `site2` "
 "の間のネットワークが切断されていることを意味します。"
 
 #. type: Plain text
@@ -1588,7 +1588,7 @@ msgid ""
 "remote cache on `jdg1` server, which is supposed to backup data to the "
 "`jdg2` server in the `site2`. See <<communication>> for more information."
 msgstr ""
-"`site1` の{project_name}サーバーは、` site2` の `jdg2` サーバーにデータをバックアップすることを想定し、 "
+"`site1` の{project_name}サーバーは、`site2` の `jdg2` サーバーにデータをバックアップすることを想定し、 "
 "`jdg1` サーバー上のリモート・キャッシュにセッションを書き込もうとします。 詳細については、<<communication>>を参照してください。"
 
 #. type: Plain text
@@ -1596,7 +1596,7 @@ msgid ""
 "Server `jdg2` is offline or unreachable from `jdg1`. So the backup from "
 "`jdg1` to `jdg2` will fail."
 msgstr ""
-"`jdg2` サーバーがオフラインであるか、 ` jdg1` から到達できない状態なので、 `jdg1` から `jdg2` "
+"`jdg2` サーバーがオフラインであるか、 `jdg1` から到達できない状態なので、 `jdg1` から `jdg2` "
 "へのバックアップは失敗します。"
 
 #. type: Plain text
@@ -1740,9 +1740,8 @@ msgid ""
 "to be done bidirectionally between both sites or just unidirectionally, as "
 "in only from `site1` to `site2`, but not from `site2` to `site1`."
 msgstr ""
-"状態の転送は、手動で行う必要があります。 {jdgserver_name}サーバーはこれを自動的には行いません。たとえばsplit-"
-"brainの場合は、管理者だけがどちらのサイトに優先権があるのかを判断できるので、両方のサイト間で双方向に、または単方向で状態転送を行う必要がある場合、"
-" site2`から `site2`へは移動しません。"
+"ステート・トランスファーは、手動で行う必要があります。{jdgserver_name}サーバーはこれを自動的には行いません。たとえば、スプリット・ブレイン中は、管理者のみが誰がどのサイトを優先するかを決定することができます。したがって、ステート・トランスファーが両方のサイト間で双方向に、または"
+" `site1` から `site2` へのみ単方向で行われる必要がありますが、`site2` から `site1` への単方向は行われません。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
