### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -814,7 +814,7 @@ msgid ""
 msgstr ""
 "{project_name}がリバース・プロキシーの背後にある場合、通常は{project_dirref}/standalone/configuration/standalone.xmlに"
 " `x509cert-lookup` SPIの代替プロバイダーを設定する必要があります。HTTPヘッダーから証明書を検索する `default` "
-"プロバイダーに加えて、次に説明する `haproxy` と `apache`という2つの組み込みプロバイダーも追加されています。"
+"プロバイダーに加えて、次に説明する `haproxy` と `apache` という2つの組み込みプロバイダーも追加されています。"
 
 #. type: Title =====
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -863,7 +863,7 @@ msgid ""
 "be `CERT_CHAIN_9` ."
 msgstr ""
 "この設定例では、クライアント証明書はHTTPヘッダー `SSL_CLIENT_CERT` から検索され、チェーンの他の証明書は "
-"`CERT_CHAIN_0` 、 `CERT_CHAIN_1` 、…、` CERT_CHAIN_9` のようなHTTPヘッダーから検索されます。属性 "
+"`CERT_CHAIN_0` 、 `CERT_CHAIN_1` 、…、 `CERT_CHAIN_9` のようなHTTPヘッダーから検索されます。属性 "
 "`certificateChainLength` はチェーンの最大長です。最後に試行された属性は `CERT_CHAIN_9` です。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
