### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po
@@ -263,7 +263,7 @@ msgstr "クライアント `my-app` は、割り当てられたロールに対�
 msgid ""
 "then the `good-service` will be automatically added as an audience to the "
 "access token issued for the `my-app`."
-msgstr "`good-service` が ` my-app` に対して発行されたアクセストークンにAudienceとして自動的に追加されます。"
+msgstr "`good-service` が `my-app` に対して発行されたアクセストークンにAudienceとして自動的に追加されます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__audience
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
