### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr ""
 msgid "Example"
 msgstr "例"
 
-#. type: Title ===
+#. type: Title ==
 #, no-wrap
 msgid "Client Scopes"
 msgstr "クライアント・スコープ"
@@ -142,7 +142,7 @@ msgid ""
 "mappers defined, and these mappers correspond to the claims defined in the "
 "OpenID Connect specification."
 msgstr ""
-"クライアント・スコープの `profile` 、 ` email` 、 `address` および `phone` も "
+"クライアント・スコープの `profile` 、 `email` 、 `address` および `phone` も "
 "https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims[OpenID "
 "Connect仕様] "
 "で定義されています。これらのクライアント・スコープには、ロール・スコープ・マッピングは定義されていませんが、いくつかのプロトコル・マッパーが定義されています。これらのマッパーは、OpenID"
@@ -154,7 +154,7 @@ msgid ""
 "`Mappers` tab, you will see the protocol mappers, which correspond to the "
 "claims defined in the specification for the scope `phone`."
 msgstr ""
-"たとえば、 `phone` のクライアント・スコープを開き、` Mappers` タブを開くためにクリックすると、 `phone` "
+"たとえば、 `phone` のクライアント・スコープを開き、`Mappers` タブを開くためにクリックすると、 `phone` "
 "スコープの仕様で定義されているクレームに対応するプロトコル・マッパーが表示されます。"
 
 #. type: Block title
@@ -204,7 +204,7 @@ msgid ""
 "specification and not added to the `scope` claim. This is used to add "
 "allowed web origins to the access token `allowed-origins` claim."
 msgstr ""
-"クライアント・スコープ `web-origins` もOpenID Connect仕様で定義されておらず、` scope` "
+"クライアント・スコープ `web-origins` もOpenID Connect仕様で定義されておらず、`scope` "
 "クレームに追加されていません。これは、許可されたWebオリジンをアクセストークンの `allowed-origins` "
 "クレームに追加するために使用されます。"
 
@@ -334,8 +334,8 @@ msgid ""
 msgstr ""
 "scopeパラメーターには、スコープの値をスペースで区切った文字列が含まれます（これが、クライアント・スコープ名にスペース文字を含めることができない理由です）。値"
 " `openid` はすべてのOpenID "
-"Connectリクエストに使用されるメタ値なので、この例では無視します。トークンには、クライアント・スコープの `profile` 、 ` email`"
-" （デフォルト・スコープ）、 `phone` "
+"Connectリクエストに使用されるメタ値なので、この例では無視します。トークンには、クライアント・スコープの `profile` 、 `email` "
+"（デフォルト・スコープ）、 `phone` "
 "（スコープ・パラメーターによって要求されるオプションのクライアント・スコープ）のマッパーとロールスコープのマッピングが含まれます。"
 
 #. type: Block title


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
