### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Shinsuke UEDA, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -431,7 +436,7 @@ msgid ""
 msgstr ""
 "このマッパーは、Microsoft Active Directory（MSAD）固有のものです。 "
 "MSADユーザー・アカウントの状態を{project_name}アカウントの状態（アカウントが有効、パスワードが期限切れなど）に緊密に統合できます。 "
-"`userAccountControl` と ` pwdLastSet` "
+"`userAccountControl` と `pwdLastSet` "
 "LDAP属性を使っています（どちらもMSAD固有のものであり、LDAP標準ではありません）。たとえば `pwdLastSet` が `0` "
 "の場合、{project_name}ユーザーはパスワードを更新する必要があり、UPDATE_PASSWORD必須アクションがユーザーに追加されます。 "
 "`userAccountControl` が `514` （無効なアカウント）の場合、{project_name}ユーザーも無効になります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__user-federation__ldap
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
