### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Shinsuke UEDA, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Shinsuke UEDA, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,14 +20,10 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
-#, no-wrap
-msgid "Event Configuration"
-msgstr "イベント設定"
-
 #. type: Plain text
-msgid "image:{project_images}/login-events-config.png[]"
-msgstr "image:{project_images}/login-events-config.png[]"
+#, no-wrap
+msgid "Update Password"
+msgstr "Update Password"
 
 #. type: Block title
 #, no-wrap
@@ -41,6 +42,15 @@ msgid ""
 msgstr ""
 "ログインイベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、イベントは保存されず、管理コンソールに表示されることもありません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
 " `Events` メニュー項目に行き、 `Config` タブを選択してください。"
+
+#. type: Block title
+#, no-wrap
+msgid "Event Configuration"
+msgstr "イベント設定"
+
+#. type: Plain text
+msgid "image:{project_images}/login-events-config.png[]"
+msgstr "image:{project_images}/login-events-config.png[]"
 
 #. type: Plain text
 msgid ""
@@ -248,11 +258,6 @@ msgstr ""
 msgid "Login Error"
 msgstr "Login Error"
 
-#. type: Labeled list
-#, no-wrap
-msgid "Update Password"
-msgstr "Update Password"
-
 #. type: Plain text
 msgid "Update TOTP"
 msgstr "Update TOTP"
@@ -276,7 +281,7 @@ msgid ""
 "`standalone-ha.xml`, or `domain.xml` that comes with your distribution and "
 "adding for example:"
 msgstr ""
-"1つまたは複数のイベントを除外するには、配布物に付属している `standalone.xml` 、` standalone-ha.xml` 、 "
+"1つまたは複数のイベントを除外するには、配布物に付属している `standalone.xml` 、`standalone-ha.xml` 、 "
 "`domain.xml` を編集して、次のように追加します。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
