### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -3,6 +3,11 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -138,7 +143,7 @@ msgid ""
 "The following example exposes `/auth/admin` on port `8444` while not "
 "permitting access with the default port `8443`."
 msgstr ""
-"次の例では、 `/auth/admin` をポート` 8444` で公開しますが、デフォルトポート `8443` ではアクセスを許可しません。"
+"次の例では、 `/auth/admin` をポート `8444` で公開しますが、デフォルトポート `8443` ではアクセスを許可しません。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
