### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -987,7 +987,7 @@ msgid ""
 "logged as `DEBUG`.)"
 msgstr ""
 "ここでは、すべてのイベントを受け取り、jboss-loggingを通じてそれらを記録する組み込みのイベント・リスナーを設定する例を示します。 "
-"`org.keycloak.events` というロガーを使うと、エラー・イベントは `WARN` として記録され、他は`DEBUG` "
+"`org.keycloak.events` というロガーを使うと、エラー・イベントは `WARN` として記録され、他は `DEBUG` "
 "として記録されます。"
 
 #. type: delimited block -

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -3,11 +3,17 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# katakura__pro <h.katakura@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: katakura__pro <h.katakura@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -860,7 +866,7 @@ msgid ""
 "Make sure to change the attribute values for `keystore`, `keystorePassword`,"
 " `keyPassword`, and `alias` to match your specific keystore."
 msgstr ""
-"特定のキーストアに一致するように、 `keystore` 、 ` keystorePassword` 、`keyPassword` 、および "
+"特定のキーストアに一致するように、 `keystore` 、 `keystorePassword` 、`keyPassword` 、および "
 "`alias` の属性値を変更してください。"
 
 #. type: Title ====

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -1310,7 +1310,10 @@ msgid ""
 "[command]`--roleid`) to identify a specific client role."
 msgstr ""
 "専用の[command]`get-roles` "
-"コマンドを使用します。クライアントを識別するためにclientId属性（[command]`--cclientid`オプションで）またはID（[command]`--cid`オプションで）を渡し、クライアントロールを識別するためにロール名（[command]`--rolename`オプションで）またはID（[command]`--roleid`で）を渡します。"
+"コマンドを使用します。クライアントを識別するためにclientId属性（[command]`--cclientid` "
+"オプションで）またはID（[command]`--cid` "
+"オプションで）を渡し、クライアントロールを識別するためにロール名（[command]`--rolename` "
+"オプションで）またはID（[command]`--roleid` で）を渡します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -1128,7 +1128,7 @@ msgstr "`ifResourceExists` を `FAIL` 、 `SKIP` 、 `OVERWRITE` のいずれか
 
 #. type: Plain text
 msgid "Use `-f` to submit the exported realm `.json` file"
-msgstr "エクスポートされたレルム `.json` ファイルを送信するには、 ` -f` を使います。"
+msgstr "エクスポートされたレルム `.json` ファイルを送信するには、 `-f` を使います。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
