### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -3,22 +3,22 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "import ...\n"
-msgstr "import ...\n"
 
 #. type: Title ==
 #, no-wrap
@@ -65,6 +65,11 @@ msgstr "ThemeSelectorProviderFactoryのサンプルを次に示します。"
 #, no-wrap
 msgid "package org.acme.provider;\n"
 msgstr "package org.acme.provider;\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "import ...\n"
+msgstr "import ...\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -665,7 +670,7 @@ msgid ""
 "  Your factory class would perform a JNDI lookup of the Stateful EJB in its "
 "create() method."
 msgstr ""
-" `ProviderFactory` の実装はプレーンなJavaオブジェクトである必要があります。ファクトリー・クラスは、その create() "
+"`ProviderFactory` の実装はプレーンなJavaオブジェクトである必要があります。ファクトリー・クラスは、その create() "
 "メソッド内でステートフルEJBのJNDIルックアップを実行します。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
