### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,7 +103,7 @@ msgid ""
 "declare metadata that is needed to render and store each configuration "
 "variable of the provider."
 msgstr ""
-" `ComponentFactory.getConfigProperties()` メソッドは、 "
+"`ComponentFactory.getConfigProperties()` メソッドは、 "
 "`org.keycloak.provider.ProviderConfigProperty` "
 "インスタンスのリストを返します。これらのインスタンスは、プロバイダーの設定変数をそれぞれレンダリングして格納するのに必要なメタデータを宣言します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
