### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/augmenting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/augmenting.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/augmenting.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -170,5 +175,5 @@ msgid ""
 "`AbstractUserAdapterFederatedStorage`.  The `setUsername()` method makes "
 "changes to the properties file and saves it."
 msgstr ""
-"代わりに`AbstractUserAdapterFederatedStorage` の匿名クラスの実装を定義します。 `setUsername()` "
+"代わりに `AbstractUserAdapterFederatedStorage` の匿名クラスの実装を定義します。 `setUsername()` "
 "メソッドはプロパティー・ファイルを変更して保存します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/augmenting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__augmenting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
