### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
@@ -3,6 +3,12 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -148,7 +154,7 @@ msgid ""
 "interface.  This is the instance that is cached locally in local storage."
 msgstr ""
 "このコールバックが必要な場合、プロバイダー・クラスはこのインターフェイスを実装する必要があります。 `UserModel` "
-"デリゲート・パラメーターはプロバイダーから返された ` UserModel` インスタンスです。 `CachedUserModel` は拡張された "
+"デリゲート・パラメーターはプロバイダーから返された `UserModel` インスタンスです。 `CachedUserModel` は拡張された "
 "`UserModel` インターフェイスです。これは、ローカル・ストレージにローカルでキャッシュされるインスタンスです。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
