### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po
@@ -1,0 +1,101 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Locale Selector"
+msgstr "ロケール・セレクター"
+
+#. type: Plain text
+msgid ""
+"By default, the locale is selected using the `DefaultLocaleSelectorProvider`"
+" which implements the `LocaleSelectorProvider` interface. English is the "
+"default language when internationalization is disabled. With "
+"internationalization enabled, the locale is resolved in the following "
+"priority:"
+msgstr ""
+"デフォルトでは、ロケールは `LocaleSelectorProvider` インターフェイスを実装する "
+"`DefaultLocaleSelectorProvider` "
+"を使用して選択されます。国際化が無効の場合は、英語がデフォルトの言語です。国際化が有効になっている場合は、ロケールは次の優先順位で解決されます。"
+
+#. type: Plain text
+msgid "`kc_locale` query parameter"
+msgstr "`kc_locale` クエリー・パラメーター"
+
+#. type: Plain text
+msgid "`KEYCLOAK_LOCALE` cookie value"
+msgstr "`KEYCLOAK_LOCALE` Cookie値"
+
+#. type: Plain text
+msgid "User's preferred locale if a user instance is available"
+msgstr "ユーザー・インスタンスが利用可能な場合はユーザーの優先ロケール"
+
+#. type: Plain text
+msgid "`ui_locales` query parameter"
+msgstr "`ui_locales` クエリー・パラメーター"
+
+#. type: Plain text
+msgid "`Accept-Language` request header"
+msgstr "`Accept-Language` リクエスト・ヘッダー"
+
+#. type: Plain text
+msgid "Realm's default language"
+msgstr "レルムのデフォルトの言語"
+
+#. type: Plain text
+msgid ""
+"This behaviour can be changed through the `LocaleSelectorSPI` by "
+"implementing the `LocaleSelectorProvider` and "
+"`LocaleSelectorProviderFactory`."
+msgstr ""
+"この動作は `LocaleSelectorProvider` と `LocaleSelectorProviderFactory` を実装することで "
+"`LocaleSelectorSPI` を通して変更することができます。"
+
+#. type: Plain text
+msgid ""
+"The `LocaleSelectorProvider` interface has a single method, `resolveLocale`,"
+" which must return a locale given a `RealmModel` and a nullable `UserModel`."
+" The actual request is available from the `KeycloakSession#getContext` "
+"method."
+msgstr ""
+"`LocaleSelectorProvider` インターフェースは `resolveLocale` という単一のメソッドを持ちます。これは "
+"`RealmModel` とnull許容の `UserModel` を与えられたロケールを返さなければなりません。実際のリクエストは "
+"`KeycloakSession#getContext` メソッドから利用できます。"
+
+#. type: Plain text
+msgid ""
+"Custom implementations can extend the `DefaultLocaleSelectorProvider` in "
+"order to reuse parts of the default behaviour. For example to ignore the "
+"`Accept-Language` request header, a custom implementation could extend the "
+"default provider, override it's `getAcceptLanguageHeaderLocale`, and return "
+"a null value. As a result the locale selection will fall back on the "
+"realms's default language."
+msgstr ""
+"カスタム実装ではデフォルトの振る舞いの一部を再利用するために `DefaultLocaleSelectorProvider` "
+"を継承することができます。例えば `Accept-Language` リクエストヘッダを無視するために、カスタム実装はデフォルト・プロバイダーを継承し、"
+" `getAcceptLanguageHeaderLocale` "
+"をオーバーライドし、そしてnull値を返すことができます。結果として、ロケールの選択はレルムのデフォルト言語に戻ります。"
+
+#. type: Plain text
+msgid ""
+"Follow the steps in <<_providers,Service Provider Interfaces>> for more "
+"details on how to create and deploy a custom provider."
+msgstr ""
+"カスタムプロバイダーを作成してデプロイする方法の詳細については、<<_providers,サービス・プロバイダー・インターフェイス>>の手順に従ってください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__locale-selector
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
