### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/4_1_0_final.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/4_1_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_1_0_final.ja_JP.po
@@ -1,0 +1,33 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Making Spring Boot 2 the default starter"
+msgstr "Spring Boot 2をデフォルトのスターターにしました"
+
+#. type: Plain text
+msgid ""
+"Starting with release 4.1, the Spring Boot starter will be based on the "
+"Spring Boot 2 adapter. If you are using an older Spring Boot version, the "
+"keycloak-legacy-spring-boot-starter is available."
+msgstr ""
+"リリース4.1以降、Spring BootスターターはSpring Boot 2アダプターをベースにしています。以前のバージョンのSpring "
+"Bootを使用している場合は、keycloak-legacy-spring-boot-starterが利用可能です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/4_1_0_final.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__4_1_0_final
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
