### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po
@@ -1,0 +1,99 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Pushing Claims"
+msgstr "クレームのプッシュ"
+
+#. type: Plain text
+msgid ""
+"When obtaining permissions from the server you can push arbitrary claims in "
+"order to have these claims available to your policies when evaluating "
+"permissions."
+msgstr ""
+"サーバーからパーミッションを取得する際に、パーミッションの評価においてクレームをポリシーで利用できるようにするために、任意のクレームをプッシュできます。"
+
+#. type: Plain text
+msgid ""
+"If you are obtaining permissions from the server *without* using a "
+"permission ticket (UMA flow), you can send an authorization request to the "
+"token endpoint as follows:"
+msgstr ""
+"パーミッション・チケットを使用 *せずに* "
+"サーバーからパーミッションを取得している場合（UMAフロー）、次のようにトークン・エンドポイントに認可リクエストを送信できます。"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\" \\\n"
+"  --data \"claim_token=ewogICAib3JnYW5pemF0aW9uIjogWyJhY21lIl0KfQ==\" \\\n"
+"  --data \"claim_token_format=urn:ietf:params:oauth:token-type:jwt\" \\\n"
+"  --data \"client_id={resource_server_client_id}\" \\\n"
+"  --data \"client_secret={resource_server_client_secret}\" \\\n"
+"  --data \"audience={resource_server_client_id}\"\n"
+msgstr ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\" \\\n"
+"  --data \"claim_token=ewogICAib3JnYW5pemF0aW9uIjogWyJhY21lIl0KfQ==\" \\\n"
+"  --data \"claim_token_format=urn:ietf:params:oauth:token-type:jwt\" \\\n"
+"  --data \"client_id={resource_server_client_id}\" \\\n"
+"  --data \"client_secret={resource_server_client_secret}\" \\\n"
+"  --data \"audience={resource_server_client_id}\"\n"
+
+#. type: Plain text
+msgid ""
+"The `claim_token` parameter expects a BASE64 encoded JSON with a format "
+"similar to the example below:"
+msgstr "`claim_token` パラメーターは、以下の例のようなフォーマットのBASE64でエンコードされたJSONを期待します。"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"{\n"
+"    \"organization\" : [\"acme\"]\n"
+"}\n"
+msgstr ""
+"{\n"
+"    \"organization\" : [\"acme\"]\n"
+"}\n"
+
+#. type: Plain text
+msgid ""
+"The format expects one or more claims where the value for each claim must be"
+" an array of strings."
+msgstr "このフォーマットでは、1つまたは複数のクレームを想定しており、各クレームの値は文字列型の配列である必要があります。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Pushing Claims Using UMA"
+msgstr "UMAを使用したクレームのプッシュ"
+
+#. type: Plain text
+msgid ""
+"For more details about how to push claims when using UMA and permission "
+"tickets, please take a look at <<_service_protection_permission_api_papi, "
+"Permission API>>"
+msgstr ""
+"UMAとパーミッション・チケットを使用してクレームをプッシュする方法の詳細については、<<_service_protection_permission_api_papi,"
+" Permission API>>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-pushing-claims
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
