### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -297,8 +297,8 @@ msgid ""
 "`StorageId.getExternalId()` method is invoked to obtain the username embeded"
 " in the `id` parameter. The method then delegates to `getUserByUsername()`."
 msgstr ""
-"`getUserById()` メソッドは、 `org.keycloak.storage.StorageId` ヘルパークラスを使って "
-"`id`パラメーターを解析します。 `StorageId.getExternalId()` メソッドは、 `id` "
+"`getUserById()` メソッドは、 `org.keycloak.storage.StorageId` ヘルパークラスを使って `id` "
+"パラメーターを解析します。 `StorageId.getExternalId()` メソッドは、 `id` "
 "パラメーターに埋め込まれたユーザー名を取得するために呼び出されます。そして、このメソッドは `getUserByUsername()` に委譲します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__simple-example
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
