### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -1978,7 +1978,7 @@ msgid ""
 "the retry will usually be successful and the entity will have applied "
 "updates from both concurrent transactions."
 msgstr ""
-"タイムアウト0の場合、トランザクションは直ちに失敗し、値 `FAIL`のバックアップ `failure-policy` "
+"タイムアウト0の場合、トランザクションは直ちに失敗し、値 `FAIL` のバックアップ `failure-policy` "
 "が設定されていれば、{project_name}から再試行されます。2番目の同時トランザクションが終了するまで、通常は再試行が成功し、エンティティーは両方の同時トランザクションから更新を適用します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
