### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po
@@ -3,11 +3,17 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,13 +23,13 @@ msgstr ""
 
 #. type: Plain text
 #, no-wrap
-msgid "Permissions"
-msgstr "パーミッション"
+msgid "Policies"
+msgstr "ポリシー"
 
 #. type: Plain text
 #, no-wrap
-msgid "Policies"
-msgstr "ポリシー"
+msgid "Permissions"
+msgstr "パーミッション"
 
 #. type: Title =
 #, no-wrap
@@ -91,6 +97,10 @@ msgstr ""
 #, no-wrap
 msgid "Importing a Configuration File"
 msgstr "設定ファイルのインポート"
+
+#. type: Plain text
+msgid "To import a configuration file, complete the following steps:"
+msgstr "設定ファイルをインポートするには、以下の手順を実行します。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-import-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-import-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
