### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -45,13 +45,14 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"There is one caveat: Even though {appserver_name} is bundled with keycloak, "
-"you cannot use this as an application container.  Instead, you must run a "
-"separate {appserver_name} instance on the same machine as the {project_name}"
-" server to run your Java servlet application. Run the {project_name} using a"
-" different port than the {appserver_name}, to avoid port conflicts."
+"There is one caveat: Even though {appserver_name} is bundled with "
+"{project_name}, you cannot use this as an application container.  Instead, "
+"you must run a separate {appserver_name} instance on the same machine as the"
+" {project_name} server to run your Java servlet application. Run the "
+"{project_name} using a different port than the {appserver_name}, to avoid "
+"port conflicts."
 msgstr ""
-"1つの注意点があります。{appserver_name}はkeycloakにバンドルされていますが、これをアプリケーション・コンテナーとして使用することはできません。代わりに、Javaサーブレット・アプリケーションを実行するには、{project_name}サーバーと同じマシン上で別の{appserver_name}インスタンスを実行する必要があります。ポートの競合を避けるため、{appserver_name}とは異なるポートを使用して{project_name}を実行します。"
+"1つの注意点があります。{appserver_name}は{project_name}にバンドルされていますが、これをアプリケーション・コンテナーとして使用することはできません。代わりに、Javaサーブレット・アプリケーションを実行するには、{project_name}サーバーと同じマシン上で別の{appserver_name}インスタンスを実行する必要があります。ポートの競合を避けるため、{appserver_name}とは異なるポートを使用して{project_name}を実行します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
