### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,9 +54,9 @@ msgstr "Dockerレジストリーの設定ファイルのインストール"
 
 #. type: Plain text
 msgid ""
-"For users with more advanced docker registry configurations, it is generally"
+"For users with more advanced Docker registry configurations, it is generally"
 " recommended to provide your own registry configuration file.  The "
-"{project_name} docker provider supports this mechanism via the _Registry "
+"{project_name} Docker provider supports this mechanism via the _Registry "
 "Config File_ Format Option.  Choosing this option will generate output "
 "similar to the following:"
 msgstr ""
@@ -145,25 +145,25 @@ msgstr "Docker Compose YAMLファイル"
 #. type: Plain text
 msgid ""
 "This installation method is meant to be an easy way to get a docker registry"
-" authenticating against a keycloak server.  It is intended for development "
-"purposes only and should never be used in a production or production-like "
-"environment."
+" authenticating against a {project_name} server.  It is intended for "
+"development purposes only and should never be used in a production or "
+"production-like environment."
 msgstr ""
-"このインストール方法は、Keycloakサーバーで認証するDockerレジストリーを構築する簡易的な方法です。これは開発目的のみを対象としており、プロダクション環境やそれと同等の環境には使用しないでください。"
+"このインストール方法は、{project_name}サーバーで認証するDockerレジストリーを構築する簡易的な方法です。これは開発目的のみを対象としており、プロダクション環境やそれと同等の環境には使用しないでください。"
 
 #. type: Plain text
 msgid ""
 "The zip file installation mechanism provides a quickstart for developers who"
-" want to understand how the keycloak server can interact with the docker "
-"registry.  In order to configure:"
+" want to understand how the {project_name} server can interact with the "
+"Docker registry.  In order to configure:"
 msgstr ""
-"zipファイルのインストール・メカニズムは、KeycloakサーバーがDockerレジストリーとどのようにやりとりができるかを理解したい開発者のために、クイックスタートを提供します。"
+"zipファイルのインストール・メカニズムは、{project_name}サーバーがDockerレジストリーとどのようにやりとりができるかを理解したい開発者のために、クイックスタートを提供します。"
 " 下記のとおりに設定します。"
 
 #. type: Plain text
 msgid ""
 "From the desired realm, create a client configuration.  At this point you "
-"won't have a docker registry - the quickstart will take care of that part."
+"won't have a Docker registry - the quickstart will take care of that part."
 msgstr "目的のレルムから、クライアント設定を作成します。この時点で、Dockerレジストリーはありません。クイックスタートがその部分を担当します。"
 
 #. type: Plain text
@@ -177,22 +177,21 @@ msgid "Unzip the archive to the desired location, and open the directory."
 msgstr "アーカイブを目的の場所に解凍し、ディレクトリーを開きます。"
 
 #. type: Plain text
-msgid "Start the docker registry with `docker-compose up`"
+msgid "Start the Docker registry with `docker-compose up`"
 msgstr "Dockerレジストリーを `docker-compose up` で起動します。"
 
 #. type: Plain text
 msgid ""
-"INFO: it is recommended that you configure the docker registry client in a "
-"realm other than 'master', since the HTTP Basic auth flow will not present "
-"forms."
+"it is recommended that you configure the Docker registry client in a realm "
+"other than 'master', since the HTTP Basic auth flow will not present forms."
 msgstr ""
-"情報：HTTP "
+"HTTP "
 "BASIC認証のフローはフォームを提示しないので、Dockerレジストリー・クライアントを'master'以外のレルムに設定することをお勧めします。"
 
 #. type: Plain text
 msgid ""
 "Once the above configuration has taken place, and the keycloak server and "
-"docker registry are running, docker authentication should be successful:"
+"Docker registry are running, docker authentication should be successful:"
 msgstr "上記の設定が完了し、KeycloakサーバーとDockerレジストリーが実行されたら、Docker認証が成功するはずです。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
