### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -168,16 +172,14 @@ msgid ""
 "<<_saml_logout_in_cluster,above>> needs to be replicated not only within "
 "individual clusters but across all the data centers e.g.  "
 "https://access.redhat.com/documentation/en-"
-"us/red_hat_jboss_data_grid/6.6/html/administration_and_configuration_guide"
-"/chap-"
+"us/red_hat_data_grid/6.6/html/administration_and_configuration_guide/chap-"
 "externalize_sessions#Externalize_HTTP_Session_from_JBoss_EAP_6.x_to_JBoss_Data_Grid[via"
 " standalone Infinispan/JDG server]:"
 msgstr ""
 "このケースをカバーするために、<<_saml_logout_in_cluster,上記>>で記述されたSAMLセッション・キャッシュは、個々のクラスター内だけでなく、すべてのデータセンターにわたってレプリケーションする必要があります。例："
 " https://access.redhat.com/documentation/en-"
-"us/red_hat_jboss_data_grid/6.6/html/administration_and_configuration_guide"
-"/chap-"
-"externalize_sessions#Externalize_HTTP_Session_from_JBoss_EAP_6.x_to_JBoss_Data_Grid[スタンド・アロンInfinispan/JDGサーバー経由]："
+"us/red_hat_data_grid/6.6/html/administration_and_configuration_guide/chap-"
+"externalize_sessions#Externalize_HTTP_Session_from_JBoss_EAP_6.x_to_JBoss_Data_Grid[スタンドアローンInfinispan/JDGサーバー経由]："
 
 #. type: Plain text
 msgid "A cache has to be added to the standalone Infinispan/JDG server."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__logout
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
