### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,8 +99,8 @@ msgid ""
 "This contains configuration files and working directory when running "
 "{project_name} in <<_standalone-mode,standalone mode>>."
 msgstr ""
-"<<_standalone-mode,standalone "
-"mode>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリーは含まれません。"
+"<<_standalone-"
+"mode,スタンドアローン・モード>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリーは含まれません。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__installation__directory-structure
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
