### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -94,7 +98,7 @@ msgid ""
 "also used to configure non-infrastructure level things that are specific to "
 "{project_name} components."
 msgstr ""
-"このガイドの大半は、{project_name}の基盤レベルの設定について説明します。このレベルの設定は、{project_name}が構築されたアプリケーション・サーバーに特化した設定ファイル内で実行されます。スタンドアローン動作モードでは、このファイルは"
+"このガイドの大半は、{project_name}の基盤レベルの設定について説明します。このレベルの設定は、{project_name}が構築されたアプリケーション・サーバーに特化した設定ファイル内に定義されます。スタンドアローン動作モードでは、このファイルは"
 " _.../standalone/configuration/standalone.xml_ "
 "にあります。また、このファイルは{project_name}のコンポーネントに特化した非基盤レベルの設定にも使用されます。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
