### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
@@ -3,25 +3,21 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-msgid "image:{project_images}/standalone-boot-files.png[]"
-msgstr "image:{project_images}/standalone-boot-files.png[]"
-
-#. type: Plain text
-msgid "To boot the server:"
-msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Block title
 #, no-wrap
@@ -32,6 +28,23 @@ msgstr "Linux/Unix"
 #, no-wrap
 msgid "Windows"
 msgstr "Windows"
+
+#. type: Plain text
+msgid "To boot the server:"
+msgstr "サーバーを起動するには下記を実行します"
+
+#. type: Plain text
+msgid "image:{project_images}/standalone-boot-files.png[]"
+msgstr "image:{project_images}/standalone-boot-files.png[]"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
+"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
+"      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
+msgstr ""
+"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"
 
 #. type: Title ===
 #, no-wrap
@@ -62,8 +75,8 @@ msgid ""
 "settings for networking, databases, caches, and discovery.  This file "
 "resides in _.../standalone/configuration/standalone-ha.xml_.  There's a few "
 "things missing from this configuration.  You can't run {project_name} in a "
-"cluster without a configuring a shared database connection.  You also need "
-"to deploy some type of load balancer in front of the cluster.  The "
+"cluster without configuring a shared database connection.  You also need to "
+"deploy some type of load balancer in front of the cluster.  The "
 "<<_clustering,clustering>> and <<_database,database>> sections of this guide"
 " walk you though these things."
 msgstr ""
@@ -79,15 +92,6 @@ msgstr "スタンドアローンHA設定"
 #. type: Plain text
 msgid "image:{project_images}/standalone-ha-config-file.png[]"
 msgstr "image:{project_images}/standalone-ha-config-file.png[]"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
-"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
-"      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
-msgstr ""
-"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone-ha
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
