### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -658,7 +658,7 @@ msgstr "起動スクリプトの実行"
 msgid ""
 "Since we're simulating a two node cluster on one development machine, you'll"
 " run the boot script twice:"
-msgstr "1つの開発マシンで2つのノードクラスターをシミュレートしますので、以下のとおり、起動スクリプトを2回実行します。"
+msgstr "1つの開発マシンで2つのノードクラスターをシミュレートするので、以下のとおり、起動スクリプトを2回実行します。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -141,7 +146,7 @@ msgid ""
 "_.../domain/configuration/domain.xml_ configuration file.  This is where the"
 " domain profile and server group for the {project_name} server are defined."
 msgstr ""
-"このガイドの各章では、データベース、HTTPネットワーク接続、キャッシュ、およびその他の基盤関連のさまざまな設定について、説明します。これらを設定するために、スタンドアローン・モードでは"
+"このガイドの各章では、データベース、HTTPネットワーク接続、キャッシュ、およびその他の基盤関連のさまざまな設定について説明します。これらを設定するために、スタンドアローン・モードでは"
 "  _standalone.xml_ ファイルを使用するのに対して、ドメインモードでは "
 "_.../domain/configuration/domain.xml_ "
 "を使用します。Keycloakサーバーのドメイン・プロファイルとサーバーグループは、以下で定義されます。"

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -178,7 +178,7 @@ msgid ""
 "connections."
 msgstr ""
 "この _domain.xml_ ファイルの特徴を確認していきましょう。 `auth-server-standalone` と `auth-server-"
-"clustered` `profile` "
+"clustered` の `profile` "
 "のXMLブロックでは、どのような設定にするかの大半を定義します。そして、ネットワーク接続、キャッシュ、データベース接続などを設定します。"
 
 #. type: Block title


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
