### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -5,7 +5,7 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -226,7 +226,7 @@ msgid ""
 "metadata about the IDP."
 msgstr ""
 "外部IDPのSAML "
-"IDPエンティティー記述子を指すURLまたはファイルを指定することによって、この設定データをすべてインポートすることもできます。{project_name}の外部IDPに接続している場合は、"
+"IDPエンティティー記述子を指すURLまたはファイルを指定することによって、この設定データをすべてインポートすることもできます。{project_name}の外部IDPに接続している場合は、URL"
 " `<root>/auth/realms/{realm-name}/protocol/saml/descriptor` "
 "からIDP設定をインポートできます。このリンクは、IDPに関するメタデータを記述したXML文書です。"
 

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -3,27 +3,22 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#, no-wrap
-msgid "Signature Algorithm"
-msgstr "Signature Algorithm"
-
-#. type: Plain text
-#, no-wrap
-msgid "SAML Signature Key Name"
-msgstr "SAML Signature Key Name"
 
 #. type: Block title
 #, no-wrap
@@ -105,7 +100,7 @@ msgstr ""
 "IDPがIDPエンティティー記述子を表記する場合、このフィールドの値がそこに指定されます。\n"
 
 #. type: Plain text
-msgid "Enable if your SAML IDP supports backchannel logout"
+msgid "Enable if your SAML IDP supports backchannel logout."
 msgstr "SAML IDPがバックチャネル・ログアウトをサポートしている場合に有効にします。"
 
 #. type: Plain text
@@ -115,10 +110,10 @@ msgstr "NameID Policy Format"
 #. type: Plain text
 msgid ""
 "Specifies the URI reference corresponding to a name identifier format. "
-"Defaults to urn:oasis:names:tc:SAML:2.0:nameid-format:persistent."
+"Defaults to `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`."
 msgstr ""
-"名前識別子の形式に対応するURI参照を指定します。デフォルトはurn:oasis:names:tc:SAML:2.0:nameid-"
-"format:persistentです。"
+"名前識別子の形式に対応するURI参照を指定します。デフォルトは `urn:oasis:names:tc:SAML:2.0:nameid-"
+"format:persistent` です。"
 
 #. type: Plain text
 msgid "HTTP-POST Binding Response"
@@ -153,14 +148,24 @@ msgstr "Want AuthnRequests Signed"
 #. type: Plain text
 msgid ""
 "If true, it will use the realm's keypair to sign requests sent to the "
-"external SAML IDP"
+"external SAML IDP."
 msgstr "trueの場合、レルムの鍵ペアを使用して、外部SAML IDPに送信されたリクエストに署名します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Signature Algorithm"
+msgstr "Signature Algorithm"
 
 #. type: Plain text
 msgid ""
 "If `Want AuthnRequests Signed` is on, then you can also pick the signature "
 "algorithm to use."
 msgstr "`Want AuthnRequests Signed` がonの場合、使用する署名アルゴリズムを選択することもできます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "SAML Signature Key Name"
+msgstr "SAML Signature Key Name"
 
 #. type: Plain text
 #, no-wrap
@@ -185,9 +190,9 @@ msgstr "Force Authentication"
 
 #. type: Plain text
 msgid ""
-"Indicates that the user will be forced to enter in their credentials at the "
+"Indicates that the user will be forced to enter their credentials at the "
 "external IDP even if they are already logged in."
-msgstr "すでにログインしている場合でも、ユーザーが外部IDPでクレデンシャルを入力するよう強制されることを指定します。"
+msgstr "すでにログインしている場合でも、ユーザーが外部IDPでクレデンシャルを入力するよう強制されることを示します。"
 
 #. type: Plain text
 msgid "Validate Signature"
@@ -196,8 +201,8 @@ msgstr "Validate Signature"
 #. type: Plain text
 msgid ""
 "Whether or not the realm should expect that SAML requests and responses from"
-" the external IDP be digitally signed.  It is highly recommended you turn "
-"this on!"
+" the external IDP to be digitally signed.  It is highly recommended you turn"
+" this on!"
 msgstr ""
 "外部IDPからのSAMLリクエストとレスポンスがデジタル署名されることを、レルムが期待するかどうかを指定します。これをonにすることを強くお勧めします。"
 
@@ -216,7 +221,7 @@ msgid ""
 "You can also import all this configuration data by providing a URL or file "
 "that points to the SAML IDP entity descriptor of the external IDP.  If you "
 "are connecting to a {project_name} external IDP, you can import the IDP "
-"settings from the url `<root>/auth/realms/{realm-"
+"settings from the URL `<root>/auth/realms/{realm-"
 "name}/protocol/saml/descriptor`.  This link is an XML document describing "
 "metadata about the IDP."
 msgstr ""
@@ -249,7 +254,7 @@ msgstr ""
 "ボタンも表示されます。このボタンをクリックすると、外部SPにインポートするために使用できるSAML SPエンティティー記述子がエクスポートされます。"
 
 #. type: Plain text
-msgid "This metadata is also available publicly by going to the URL"
+msgid "This metadata is also available publicly by going to the URL."
 msgstr "このメタデータは、このURLにアクセスすることで一般公開されています。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
