### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Shinsuke UEDA, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Shinsuke UEDA, 2017\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -76,7 +81,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Application Drilldown"
-msgstr "アプリケーション・ドリルダウン"
+msgstr "アプリケーションのドリルダウン"
 
 #. type: Plain text
 msgid ""
@@ -100,7 +105,7 @@ msgstr "image:{project_images}/application-sessions.png[]"
 #. type: Title ====
 #, no-wrap
 msgid "User Drilldown"
-msgstr "ユーザー・ドリルダウン"
+msgstr "ユーザーのドリルダウン"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__administering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
