### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +35,7 @@ msgid ""
 " should be evicted from local caches. This greatly reduces network traffic, makes things efficient, and avoids transmitting sensitive\n"
 "metadata over the wire.\n"
 msgstr ""
-"{project_name}には、2タイプのキャッシュがあります。1つ目は、データベースの前に置かれていて、DBの負荷を減らし、データをメモリーに保持することで全体の応答時間を短縮します。レルム、クライアント、ロール、およびユーザー・メタデータは、この1つ目のタイプのキャッシュに保持されます。このキャッシュはローカル・キャッシュです。クラスターにより多くの{project_name}サーバーがある場合でも、ローカル・キャッシュはレプリケーションを使用しません。その代わり、ローカル・キャッシュはローカルにのみコピーを保持し、エントリーが更新された場合は無効化メッセージが残りのクラスターに送られてエントリーは追い出されます。別途レプリケーションされたキャッシュ"
+"{project_name}には、2つのタイプのキャッシュがあります。1つ目のキャッシュは、データベースの前に置かれていて、DBの負荷を減らし、データをメモリーに保持することで全体の応答時間を短縮します。レルム、クライアント、ロール、およびユーザー・メタデータは、このタイプのキャッシュに保持されます。このキャッシュはローカル・キャッシュです。クラスターにより多くの{project_name}サーバーがある場合でも、ローカル・キャッシュはレプリケーションを使用しません。その代わり、ローカル・キャッシュはローカルにのみコピーを保持し、エントリーが更新された場合は無効化メッセージが残りのクラスターに送られてエントリーは追い出されます。別途レプリケーションされたキャッシュ"
 " `work` "
 "がありますが、このタスクは、何のエントリーがローカル・キャッシュから取り除かれるかについて、クラスター全体に無効化メッセージを送信するタスクになります。これによって、ネットワーク・トラフィックがかなり減り、効率化され、機密性の高いメタデータ通信の送信が回避されます。\n"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
