### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,16 +28,17 @@ msgstr "ユーザー・キャッシュ"
 
 #. type: Plain text
 msgid ""
-"When a user is loaded by ID, username, or email queries it is cached. When a"
-" user is cached, it iterates through the entire `UserModel` interface and "
-"pulls this information to a local in-memory-only cache. In a cluster, this "
-"cache is still local, but it becomes an invalidation cache. When a user is "
-"modified, it is evicted. This eviction event is propagated to the entire "
-"cluster so that the other nodes' user cache is also invalidated."
+"When a user object is loaded by ID, username, or email queries it is cached."
+" When a user object is bing cached, it iterates through the entire "
+"`UserModel` interface and pulls this information to a local in-memory-only "
+"cache. In a cluster, this cache is still local, but it becomes an "
+"invalidation cache. When a user object is modified, it is evicted. This "
+"eviction event is propagated to the entire cluster so that the other nodes' "
+"user cache is also invalidated."
 msgstr ""
-"ID、ユーザー名、または電子メールのクエリーによってユーザーが読み込まれると、キャッシュされます。ユーザーがキャッシュされると、それは "
-"`UserModel` インタフェース全体を反復し、この情報をローカルのメモリー内専用キャッシュに保持します。 "
-"クラスターでは、このキャッシュはまだローカルですが、無効化キャッシュになります。ユーザーが変更されると、キャッシュは削除されます。このエビクション・イベントはクラスター全体に伝播され、他のノードのユーザー・キャッシュも無効になります。"
+"ID、ユーザー名、または電子メールのクエリーによってユーザー・オブジェクトが読み込まれると、キャッシュされます。ユーザー・オブジェクトがキャッシュされると、それは"
+" `UserModel` インタフェース全体を反復し、この情報をローカルのメモリー内専用キャッシュに保持します。 "
+"クラスターでは、このキャッシュはまだローカルですが、無効化キャッシュになります。ユーザー・オブジェクトが変更されると、キャッシュは削除されます。このエビクション・イベントはクラスター全体に伝播され、他のノードのユーザー・キャッシュも無効になります。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
