### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-73.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-73.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-73.ja_JP.po
@@ -1,0 +1,236 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "**Templates**\n"
+msgstr "**テンプレート**\n"
+
+#. type: Plain text
+msgid "Account: account.ftl"
+msgstr "Account: account.ftl"
+
+#. type: Plain text
+msgid "Account: totp.ftl"
+msgstr "Account: totp.ftl"
+
+#. type: Plain text
+msgid "Login: info.ftl"
+msgstr "Login: info.ftl"
+
+#. type: Plain text
+msgid "Login: login-config-totp.ftl"
+msgstr "Login: login-config-totp.ftl"
+
+#. type: Plain text
+msgid "Login: login-reset-password.ftl"
+msgstr "Login: login-reset-password.ftl"
+
+#. type: Plain text
+msgid "Login: login.ftl"
+msgstr "Login: login.ftl"
+
+#. type: Plain text
+#, no-wrap
+msgid "**Messages**\n"
+msgstr "**メッセージ**\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "**Styles**\n"
+msgstr "**スタイル**\n"
+
+#. type: Plain text
+msgid "Account: applications.ftl"
+msgstr "Account: applications.ftl"
+
+#. type: Plain text
+msgid "Account: template.ftl"
+msgstr "Account: template.ftl"
+
+#. type: Plain text
+msgid "Login: error.ftl"
+msgstr "Login: error.ftl"
+
+#. type: Plain text
+msgid "Login: login-idp-link-email.ftl"
+msgstr "Login: login-idp-link-email.ftl"
+
+#. type: Plain text
+msgid "Login: login-oauth-grant.ftl"
+msgstr "Login: login-oauth-grant.ftl"
+
+#. type: Plain text
+msgid "Login: login-totp.ftl"
+msgstr "Login: login-totp.ftl"
+
+#. type: Plain text
+msgid "Login: login-update-password.ftl"
+msgstr "Login: login-update-password.ftl"
+
+#. type: Plain text
+msgid "Login: login-update-profile.ftl"
+msgstr "Login: login-update-profile.ftl"
+
+#. type: Plain text
+msgid "Login: login-verify-email.ftl"
+msgstr "Login: login-verify-email.ftl"
+
+#. type: Plain text
+msgid "Account: messages_en.properties"
+msgstr "Account: messages_en.properties"
+
+#. type: Plain text
+msgid "Admin: admin-messages_en.properties"
+msgstr "Admin: admin-messages_en.properties"
+
+#. type: Plain text
+msgid "Email: messages_en.properties"
+msgstr "Email: messages_en.properties"
+
+#. type: Plain text
+msgid "Login: messages_en.properties"
+msgstr "Login: messages_en.properties"
+
+#. type: Title =====
+#, no-wrap
+msgid "Theme changes RH-SSO 7.3"
+msgstr "RH-SSO 7.3でのテーマの変更"
+
+#. type: Plain text
+msgid "Account: resource-detail.ftl (new)"
+msgstr "Account: resource-detail.ftl（新規）"
+
+#. type: Plain text
+msgid "Account: resources.ftl (new)"
+msgstr "Account: resources.ftl（新規）"
+
+#. type: Plain text
+msgid "Email-html: email-test.ftl"
+msgstr "Email-html: email-test.ftl"
+
+#. type: Plain text
+msgid "Email-html: email-verification-with-code.ftl (new)"
+msgstr "Email-html: email-verification-with-code.ftl（新規）"
+
+#. type: Plain text
+msgid "Email-html: email-verification.ftl"
+msgstr "Email-html: email-verification.ftl"
+
+#. type: Plain text
+msgid "Email-html: event-login_error.ftl"
+msgstr "Email-html: event-login_error.ftl"
+
+#. type: Plain text
+msgid "Email-html: event-removed_totp.ftl"
+msgstr "Email-html: event-removed_totp.ftl"
+
+#. type: Plain text
+msgid "Email-html: event-update_password.ftl"
+msgstr "Email-html: event-update_password.ftl"
+
+#. type: Plain text
+msgid "Email-html: event-update_totp.ftl"
+msgstr "Email-html: event-update_totp.ftl"
+
+#. type: Plain text
+msgid "Email-html: executeActions.ftl"
+msgstr "Email-html: executeActions.ftl"
+
+#. type: Plain text
+msgid "Email-html: identity-provider-link.ftl"
+msgstr "Email-html: identity-provider-link.ftl"
+
+#. type: Plain text
+msgid "Email-html: password-reset.ftl"
+msgstr "Email-html: password-reset.ftl"
+
+#. type: Plain text
+msgid "Email-text: email-verification-with-code.ftl (new)"
+msgstr "Email-text: email-verification-with-code.ftl（新規）"
+
+#. type: Plain text
+msgid "Email-text: email-verification.ftl"
+msgstr "Email-text: email-verification.ftl"
+
+#. type: Plain text
+msgid "Email-text: executeActions.ftl"
+msgstr "Email-text: executeActions.ftl"
+
+#. type: Plain text
+msgid "Email-text: identity-provider-link.ftl"
+msgstr "Email-text: identity-provider-link.ftl"
+
+#. type: Plain text
+msgid "Email-text: password-reset.ftl"
+msgstr "Email-text: password-reset.ftl"
+
+#. type: Plain text
+msgid "Login: cli_splash.ftl (new)"
+msgstr "Login: cli_splash.ftl（新規）"
+
+#. type: Plain text
+msgid "Login: code.ftl"
+msgstr "Login: code.ftl"
+
+#. type: Plain text
+msgid "Login: login-config-totp-text.ftl (new)"
+msgstr "Login: login-config-totp-text.ftl（新規）"
+
+#. type: Plain text
+msgid "Login: login-idp-link-confirm.ftl"
+msgstr "Login: login-idp-link-confirm.ftl"
+
+#. type: Plain text
+msgid "Login: login-page-expired.ftl"
+msgstr "Login: login-page-expired.ftl"
+
+#. type: Plain text
+msgid "Login: login-verify-email-code-text.ftl (new)"
+msgstr "Login: login-verify-email-code-text.ftl（新規）"
+
+#. type: Plain text
+msgid "Login: login-x509-info.ftl"
+msgstr "Login: login-x509-info.ftl"
+
+#. type: Plain text
+msgid "Login: register.ftl"
+msgstr "Login: register.ftl"
+
+#. type: Plain text
+msgid "Login: template.ftl"
+msgstr "Login: template.ftl"
+
+#. type: Plain text
+msgid "Login: terms.ftl"
+msgstr "Login: terms.ftl"
+
+#. type: Plain text
+msgid "Welcome: index.ftl (new)"
+msgstr "Welcome: index.ftl（新規）"
+
+#. type: Plain text
+msgid "Login: login-rhsso.css (new)"
+msgstr "Login: login-rhsso.css（新規）"
+
+#. type: Plain text
+msgid "Welcome: welcome-rhsso.css"
+msgstr "Welcome: welcome-rhsso.css"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/rhsso/migrate_themes-changes-73.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__rhsso__migrate_themes-changes-73
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
