### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,7 +24,7 @@ msgid ""
 "Follow the steps in <<_providers,Service Provider Interfaces>> for more "
 "details on how to create and deploy a custom provider."
 msgstr ""
-"カスタムプロバイダーを作成してデプロイする方法の詳細については、<<_providers,サービス・プロバイダー・インターフェイス>>の手順に従ってください。"
+"カスタム・プロバイダーを作成してデプロイする方法の詳細については、<<_providers,サービス・プロバイダー・インターフェイス>>の手順に従ってください。"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/themes-selector.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__themes-selector
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
