### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,9 +59,9 @@ msgstr "次のように、RPMからEAP 7アダプターをインストールし�
 
 #. type: Plain text
 msgid ""
-"You must subscribe to the JBoss EAP 7.0 repository before you can install "
-"the EAP 7 adapters from an RPM."
-msgstr "RPMからEAP 7アダプターをインストールする前に、JBoss EAP 7.0リポジトリーにサブスクライブする必要があります。"
+"You must subscribe to the JBoss EAP 7 repository before you can install the "
+"EAP 7 adapters from an RPM."
+msgstr "RPMからEAP 7アダプターをインストールする前に、JBoss EAP 7リポジトリーにサブスクライブする必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -71,13 +71,12 @@ msgstr "すでに別のJBoss EAPリポジトリーに登録している場合は
 
 #. type: Plain text
 msgid ""
-"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 7.0 "
-"repository using the following command. Replace <RHEL_VERSION> with either 6"
-" or 7 depending on your Red Hat Enterprise Linux version."
+"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 7 repository "
+"using the following command. Replace <RHEL_VERSION> with either 6 or 7 "
+"depending on your Red Hat Enterprise Linux version."
 msgstr ""
-"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
-"7.0リポジトリーをサブスクライブします。Red Hat Enterprise "
-"Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
+"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP 7リポジトリーを登録します。Red Hat"
+" Enterprise Linuxのバージョンに応じて、 <RHEL_VERSION> を6または7のいずれかに置き換えてください。"
 
 #. type: delimited block -
 #, no-wrap
@@ -130,18 +129,18 @@ msgstr "次のように、RPMからEAP 6アダプターをインストールし�
 
 #. type: Plain text
 msgid ""
-"You must subscribe to the JBoss EAP 6.0 repository before you can install "
-"the EAP 6 adapters from an RPM."
-msgstr "RPMからEAP 6アダプターをインストールする前に、JBoss EAP 6.0リポジトリーにサブスクライブする必要があります。"
+"You must subscribe to the JBoss EAP 6 repository before you can install the "
+"EAP 6 adapters from an RPM."
+msgstr "RPMからEAP 6アダプターをインストールする前に、JBoss EAP 6リポジトリーにサブスクライブする必要があります。"
 
 #. type: Plain text
 msgid ""
-"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 6.0 "
-"repository using the following command. Replace <RHEL_VERSION> with either 6"
-" or 7 depending on your Red Hat Enterprise Linux version."
+"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 6 repository "
+"using the following command. Replace <RHEL_VERSION> with either 6 or 7 "
+"depending on your Red Hat Enterprise Linux version."
 msgstr ""
 "Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
-"6.0リポジトリーにサブスクライブします。Red Hat Enterprise "
+"6リポジトリーにサブスクライブします。Red Hat Enterprise "
 "Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
