### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,7 +36,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Implementing a SPI"
+msgid "Implementing an SPI"
 msgstr "SPIの実装"
 
 #. type: Plain text
@@ -48,7 +48,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For example, to implement the Theme Selector Spi you need to implement "
+"For example, to implement the Theme Selector SPI you need to implement "
 "ThemeSelectorProviderFactory and ThemeSelectorProvider and also provide the "
 "file `META-INF/services/org.keycloak.theme.ThemeSelectorProviderFactory`."
 msgstr ""
@@ -145,8 +145,8 @@ msgstr ""
 msgid ""
 "Keycloak creates a single instance of provider factories which makes it "
 "possible to store state for multiple requests.  Provider instances are "
-"created by calling create on the factory for each requests so these should "
-"be light-weight object."
+"created by calling create on the factory for each request so these should be"
+" light-weight object."
 msgstr ""
 "Keycloakは、複数のリクエストの状態を格納することを可能にするプロバイダー・ファクトリーの単一のインスタンスを作成します。プロバイダー・インスタンスは、それぞれのリクエストに対してファクトリーでcreateを呼び出すことによって作成されるため、軽量オブジェクトである必要があります。"
 
@@ -213,13 +213,11 @@ msgstr "org.acme.provider.MyThemeSelectorProviderFactory\n"
 msgid ""
 "You can configure your provider through `standalone.xml`, `standalone-"
 "ha.xml`, or `domain.xml`.  See the "
-"link:{installguide_link}[{installguide_name}] for more details on where the "
-"`standalone.xml`, `standalone-ha.xml`, or `domain.xml` file lives."
+"link:{installguide_link}[{installguide_name}] for more details on where to "
+"find these files."
 msgstr ""
 "`standalone.xml` 、 `standalone-ha.xml` 、または `domain.xml` "
-"を介してプロバイダーを設定することができます。 `standalone.xml` 、 `standalone-ha.xml` 、または "
-"`domain.xml` "
-"ファイルがある場所についての詳細は、link:{installguide_link}[{installguide_name}]を参照してください。"
+"を介してプロバイダーを設定することができます。これらのファイルがある場所についての詳細は、link:{installguide_link}[{installguide_name}]を参照してください。"
 
 #. type: Plain text
 msgid "For example by adding the following to `standalone.xml`:"
@@ -309,7 +307,7 @@ msgstr "管理コンソールでのSPI実装の情報表示"
 #. type: Plain text
 msgid ""
 "Sometimes it is useful to show additional info about your Provider to a "
-"{project_name} administrator. You can show provider build time informations "
+"{project_name} administrator. You can show provider build time information "
 "(eg. version of custom provider currently installed), current configuration "
 "of the provider (eg. url of remote system your provider talks to) or some "
 "operational info (average time of response from remote system your provider "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
