### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -194,7 +194,7 @@ msgid ""
 "<<_clear-cache, Clearing the cache>> section for more details.\n"
 msgstr ""
 "オプションの項目。{project_name}がこのアイデンティティー・プロバイダーによって署名された外部IDトークンの署名を検証するかどうかを指定します。これがonの場合、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵を知る必要があります。セットアップ方法は以下を参照してください。\n"
-"警告: パフォーマンスのために、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵をキャッシュします。アイデンティティー・プロバイダーの秘密鍵が侵害されたと思われる場合は、鍵を更新するのは明らか良い方法ですが、鍵キャッシュをクリアするのも良い方法です。詳細については、<<_clear-cache, キャッシュのクリア>>のセクションを参照してください。\n"
+"警告：パフォーマンスのために、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵をキャッシュします。アイデンティティー・プロバイダーの秘密鍵が侵害されたと思われる場合は、鍵を更新するのは明らか良い方法ですが、鍵キャッシュをクリアするのも良い方法です。詳細については、<<_clear-cache, キャッシュのクリア>>のセクションを参照してください。\n"
 
 #. type: Plain text
 msgid "Use JWKS URL"
@@ -221,7 +221,7 @@ msgid ""
 " If you use an external {project_name} as an identity provider, then you can use URL like http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs assuming your brokered\n"
 " {project_name} is running on http://broker-keycloak:8180 and it's realm is `test`.\n"
 msgstr ""
-"アイデンティティー・プロバイダーのJWK鍵が保存されているURL。 詳細については、 https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK仕様] を参照してください。\n"
+"アイデンティティー・プロバイダーのJWK鍵が保存されているURL。詳細については、 https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK仕様] を参照してください。\n"
 "外部の{project_name}アイデンティティー・プロバイダーを使用している場合、{project_name}は http://broker-keycloak:8180 上で実行されており、そのレルムは `test` であると仮定すると、 http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs のようなURLを使用することができます。\n"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,11 +24,6 @@ msgstr ""
 #, no-wrap
 msgid "Prompt"
 msgstr "Prompt"
-
-#. type: Plain text
-#, no-wrap
-msgid "Client ID"
-msgstr "Client ID"
 
 #. type: Block title
 #, no-wrap
@@ -84,16 +84,16 @@ msgid "Authorization URL"
 msgstr "Authorization URL"
 
 #. type: Plain text
-msgid "Authorization URL endpoint required by the OIDC protocol"
-msgstr "OIDCプロトコルで必要な認可URLエンドポイント"
+msgid "Authorization URL endpoint required by the OIDC protocol."
+msgstr "OIDCプロトコルで必要な認可URLエンドポイント。"
 
 #. type: Plain text
 msgid "Token URL"
 msgstr "Token URL"
 
 #. type: Plain text
-msgid "Token URL endpoint required by the OIDC protocol"
-msgstr "OIDCプロトコルで必要なトークンURLエンドポイント"
+msgid "Token URL endpoint required by the OIDC protocol."
+msgstr "OIDCプロトコルで必要なトークンURLエンドポイント。"
 
 #. type: Plain text
 msgid "Logout URL"
@@ -127,13 +127,18 @@ msgid ""
 msgstr ""
 "OIDCプロトコルで定義されたUserInfo URLエンドポイント。これは、ユーザー・プロファイル情報をダウンロードできるエンドポイントです。"
 
+#. type: Labeled list
+#, no-wrap
+msgid "Client ID"
+msgstr "Client ID"
+
 #. type: Plain text
 #, no-wrap
 msgid ""
-"This realm will act as an OIDC client to the external federation IDP you are configuring here.  Your realm will need a OIDC client ID when using the Authorization Code Flow\n"
-" to interact with the external IDP\n"
+"This realm will act as an OIDC client to the external IDP.  Your realm will need an OIDC client ID when using the Authorization Code Flow\n"
+" to interact with the external IDP.\n"
 msgstr ""
-"このレルムは、ここで設定している外部フェデレーションIDPへのOIDCクライアントとして機能します。認可コードフローを使用して外部IDPと対話するときに、レルムにはOIDCのクライアントIDが必要になります。\n"
+"このレルムは、外部IDPへのOIDCクライアントとして機能します。認可コードフローを使用して外部IDPと対話するときに、レルムにはOIDCのクライアントIDが必要になります。\n"
 
 #. type: Plain text
 msgid "Client Secret"
@@ -164,14 +169,14 @@ msgstr "Default Scopes"
 #. type: Plain text
 msgid ""
 "Space-separated list of OIDC scopes to send with the authentication request."
-"  The default is `openid`"
+"  The default is `openid`."
 msgstr "認証リクエストとともに送信される、OIDCスコープのスペース区切りのリスト。デフォルトは `openid` です。"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "Another optional switch.  This is the prompt parameter defined by the OIDC specification. Through it you can force re-authentication and other options.  See the specification for\n"
-" more details\n"
+" more details.\n"
 msgstr ""
 "オプションの項目。これは、OIDC仕様で定義されたプロンプト・パラメーターです。これにより、再認証やその他のオプションを強制することができます。詳細は、仕様を参照してください。\n"
 
@@ -182,14 +187,14 @@ msgstr "Validate Signatures"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"Another optional switch. This is to specify if {project_name} will verify the signatures on the external ID Token signed by this Identity provider. If this is on,\n"
-"the {project_name} will need to know the public key of the external OIDC identity provider. See below for how to setup it.\n"
-"WARNING: For the performance purposes, {project_name} caches the public key of the external OIDC identity provider. If you think that private key of your Identity provider\n"
+"Another optional switch. This is to specify if {project_name} will verify the signatures on the external ID Token signed by this identity provider. If this is on,\n"
+"the {project_name} will need to know the public key of the external OIDC identity provider. See below for how to set it up.\n"
+"WARNING: For the performance purposes, {project_name} caches the public key of the external OIDC identity provider. If you think that private key of your identity provider\n"
 "was compromised, it is obviously good to update your keys, but it's also good to clear the keys cache. See\n"
 "<<_clear-cache, Clearing the cache>> section for more details.\n"
 msgstr ""
 "オプションの項目。{project_name}がこのアイデンティティー・プロバイダーによって署名された外部IDトークンの署名を検証するかどうかを指定します。これがonの場合、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵を知る必要があります。セットアップ方法は以下を参照してください。\n"
-"警告：パフォーマンスのために、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵をキャッシュします。アイデンティティー・プロバイダーの秘密鍵が侵害されたと思われる場合は、鍵を更新するのは明らか良い方法ですが、鍵キャッシュをクリアするのも良い方法です。詳細については、<<_clear-cache, キャッシュのクリア>>のセクションを参照してください。\n"
+"警告: パフォーマンスのために、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵をキャッシュします。アイデンティティー・プロバイダーの秘密鍵が侵害されたと思われる場合は、鍵を更新するのは明らか良い方法ですが、鍵キャッシュをクリアするのも良い方法です。詳細については、<<_clear-cache, キャッシュのクリア>>のセクションを参照してください。\n"
 
 #. type: Plain text
 msgid "Use JWKS URL"
@@ -198,12 +203,12 @@ msgstr "Use JWKS URL"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"Applicable if `Validate Signatures` is on. If the switch is on, then identity provider public keys  will be downloaded from given JWKS URL.\n"
-" This allows great flexibility because new keys will be always re-downloaded again when identity provider generates new keypair. If the switch is off,\n"
-" then public key (or certificate) from the {project_name} DB is used, so when identity provider keypair changes, you always need to import new key to the {project_name} DB as well.\n"
+"Applicable if `Validate Signatures` is on. If the switch is on, then identity provider public keys will be downloaded from given JWKS URL.\n"
+" This allows great flexibility because new keys will be always re-downloaded when the identity provider generates new keypair. If the switch is off,\n"
+" then public key (or certificate) from the {project_name} DB is used, so whenever the identity provider keypair changes, you will always need to import the new key to the {project_name} DB as well.\n"
 msgstr ""
 "`Validate Signatures` がonの場合に適用されます。スイッチがonの場合、特定のJWKS URLからアイデンティティー・プロバイダーの公開鍵がダウンロードされます。\n"
-"これにより、アイデンティティー・プロバイダーが新しい鍵ペアを生成するときに、新しい鍵が常に再ダウンロードされるため、柔軟性が向上します。スイッチがoffの場合、{project_name}のDBからの公開鍵（または証明書）が使用されるため、アイデンティティー・プロバイダーの鍵ペアが変更されたときは、常に新しい鍵を{project_name}のDBにインポートする必要があります。\n"
+"これにより、アイデンティティー・プロバイダーが新しい鍵ペアを生成するときに、新しい鍵が常に再ダウンロードされるため、柔軟性が向上します。スイッチがoffの場合、{project_name}のDBからの公開鍵（または証明書）が使用されるため、アイデンティティー・プロバイダーの鍵ペアが変更されるたびに、常に新しい鍵を{project_name}のDBにインポートする必要があります。\n"
 
 #. type: Plain text
 msgid "JWKS URL"
@@ -212,11 +217,11 @@ msgstr "JWKS URL"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"URL where identity provider keys in JWK format are stored. See https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK specification] for more details.\n"
-" If you use external {project_name} identity provider, then you can use URL like http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs assuming your brokered\n"
-" {project_name} is running on http://broker-keycloak:8180 and it's realm is `test` .\n"
+"URL where the identity provider JWK keys are stored. See the https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK specification] for more details.\n"
+" If you use an external {project_name} as an identity provider, then you can use URL like http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs assuming your brokered\n"
+" {project_name} is running on http://broker-keycloak:8180 and it's realm is `test`.\n"
 msgstr ""
-"JWK形式のアイデンティティー・プロバイダーの鍵が保存されているURL。 詳細については、 https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK仕様] を参照してください。\n"
+"アイデンティティー・プロバイダーのJWK鍵が保存されているURL。 詳細については、 https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK仕様] を参照してください。\n"
 "外部の{project_name}アイデンティティー・プロバイダーを使用している場合、{project_name}は http://broker-keycloak:8180 上で実行されており、そのレルムは `test` であると仮定すると、 http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs のようなURLを使用することができます。\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
