### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -38,7 +38,7 @@ msgstr "GitLab"
 msgid ""
 "There are a number of steps you have to complete to be able to enable login "
 "with GitLab."
-msgstr "GitLabにログインできるようにするには、いくつかのステップを完了しなければなりません。"
+msgstr "GitLabでログインできるようにするには、いくつかのステップを完了しなければなりません。"
 
 #. type: Plain text
 msgid ""
@@ -72,7 +72,7 @@ msgid ""
 "https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab as OAuth2 "
 "authentication service provider]."
 msgstr ""
-"GitHubでログインを可能にするには、まずアプリケーションを "
+"GitLabでログインできるようにするには、まずアプリケーションを "
 "https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab as OAuth2 "
 "authentication service provider] に登録する必要があります。"
 

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,8 +36,8 @@ msgstr "GitLab"
 
 #. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to login to "
-"GitLab."
+"There are a number of steps you have to complete to be able to enable login "
+"with GitLab."
 msgstr "GitLabにログインできるようにするには、いくつかのステップを完了しなければなりません。"
 
 #. type: Plain text
@@ -57,18 +61,18 @@ msgstr "`Save` をクリックする前に、GitLabから `Client ID` と `Clien
 
 #. type: Plain text
 msgid ""
-"You will the `Redirect URI` from this page in a later step, which you will "
-"provide to GitLab when you register {project_name} as a client there."
+"You will the use `Redirect URI` from this page in a later step, which you "
+"will provide to GitLab when you register {project_name} as a client there."
 msgstr ""
 "後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をGitLabに提供します。"
 
 #. type: Plain text
 msgid ""
-"To enable login with GitLab you first have to register an application "
-"project in https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab"
-" as OAuth2 authentication service provider]."
+"To enable login with GitLab you first have to register an application in "
+"https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab as OAuth2 "
+"authentication service provider]."
 msgstr ""
-"GitHubでログインを可能にするには、まずアプリケーション・プロジェクトを "
+"GitHubでログインを可能にするには、まずアプリケーションを "
 "https://docs.gitlab.com/ee/integration/oauth_provider.html[GitLab as OAuth2 "
 "authentication service provider] に登録する必要があります。"
 
@@ -87,12 +91,11 @@ msgstr "image:images/gitlab-developer-applications.png[]"
 #. type: Plain text
 msgid ""
 "Copy the `Redirect URI` from the {project_name} `Add Identity Provider` page"
-" and enter it into the `Authorization callback URL` field on the GitLab "
-"`Register a new OAuth application` page."
+" and enter it into the Redirect URI field on the GitLab Add new application "
+"page."
 msgstr ""
-"{project_name}の `Add Identity Provider` ページから `Redirect URI` をコピーし、GitLabの "
-"`Register a new OAuth application` ページの `Authorization callback URL` "
-"フィールドに入力します。"
+"{project_name}の `Add Identity Provider` ページから取得した `Redirect URI` "
+"をコピーし、GitLabのAdd new applicationページのRedirect URIフィールドに入力します。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__gitlab
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
