### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -46,9 +46,9 @@ msgid ""
 "select `Google` from the `Add provider` drop down list.  This will bring you"
 " to the `Add identity provider` page."
 msgstr ""
-"Googleにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
-"に移動し、 `Add provider` のドロップダウン・リストから `Google` を選択します。これにより、 `Add identity "
-"provider` ページが表示されます。"
+"Googleでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
+"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Google` を選択します。これにより、 `Add "
+"identity provider` ページが表示されます。"
 
 #. type: Plain text
 msgid "image:{project_images}/google-add-identity-provider.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,10 +41,10 @@ msgstr "Google"
 
 #. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to login to "
-"Google.  First, go to the `Identity Providers` left menu item and select "
-"`Google` from the `Add provider` drop down list.  This will bring you to the"
-" `Add identity provider` page."
+"There are a number of steps you have to complete to be able to enable login "
+"with Google.  First, go to the `Identity Providers` left menu item and "
+"select `Google` from the `Add provider` drop down list.  This will bring you"
+" to the `Add identity provider` page."
 msgstr ""
 "Googleにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
 "に移動し、 `Add provider` のドロップダウン・リストから `Google` を選択します。これにより、 `Add identity "
@@ -69,7 +69,7 @@ msgstr ""
 msgid ""
 "To enable login with Google you first have to create a project and a client "
 "in the https://console.cloud.google.com/project[Google Developer Console].  "
-"Then you need to copy the client id and secret into the {project_name} Admin"
+"Then you need to copy the client ID and secret into the {project_name} Admin"
 " Console."
 msgstr ""
 "Googleでのログインを可能にするには、まず https://console.cloud.google.com/project[Google "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
