### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -37,9 +37,9 @@ msgid ""
 "select `Twitter` from the `Add provider` drop down list.  This will bring "
 "you to the `Add identity provider` page."
 msgstr ""
-"Twitterにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
-"に移動し、 `Add identity provider` のドロップダウン・リストから `Twitter` を選択します。 これにより、 `Add "
-"identity provider` ページが表示されます。"
+"Twitterでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
+"Providers` に移動し、 `Add identity provider` のドロップダウン・リストから `Twitter` "
+"を選択します。これにより、 `Add identity provider` ページが表示されます。"
 
 #. type: Plain text
 msgid "image:{project_images}/twitter-add-identity-provider.png[]"
@@ -99,7 +99,7 @@ msgid ""
 "You cannot use `localhost` in the `Callback URL`.  Instead replace it with "
 "`127.0.0.1` if you are trying to test drive Twitter login on your laptop."
 msgstr ""
-"`Callback URL` に `localhost` を使うことはできません。ラップトップでTwitterのログインを試してみる場合は、 "
+"`Callback URL` に `localhost` を使うことはできません。ラップトップでTwitterのログインをテストしてみる場合は、 "
 "`127.0.0.1` に置き換えてください。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,10 +32,10 @@ msgstr "Twitter"
 
 #. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to login to "
-"Twitter.  First, go to the `Identity Providers` left menu item and select "
-"`Twitter` from the `Add provider` drop down list.  This will bring you to "
-"the `Add identity provider` page."
+"There are a number of steps you have to complete to be able to enable login "
+"with Twitter.  First, go to the `Identity Providers` left menu item and "
+"select `Twitter` from the `Add provider` drop down list.  This will bring "
+"you to the `Add identity provider` page."
 msgstr ""
 "Twitterにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
 "に移動し、 `Add identity provider` のドロップダウン・リストから `Twitter` を選択します。 これにより、 `Add "
@@ -95,13 +95,12 @@ msgstr ""
 "URI` をコピーする必要があります。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"You cannot use `localhost` in the `Callback URL`.  Instead replace it with `127.0.0.1` if you are trying to\n"
-"         testdrive Twitter login on your laptop.\n"
+"You cannot use `localhost` in the `Callback URL`.  Instead replace it with "
+"`127.0.0.1` if you are trying to test drive Twitter login on your laptop."
 msgstr ""
 "`Callback URL` に `localhost` を使うことはできません。ラップトップでTwitterのログインを試してみる場合は、 "
-"`127.0.0.1` に置き換えてください。\n"
+"`127.0.0.1` に置き換えてください。"
 
 #. type: Plain text
 msgid "After clicking save you will be brought to the `Details` page."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__twitter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
