### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,23 +34,25 @@ msgid ""
 "Some applications want to integrate with social providers like Facebook, but"
 " do not want to provide an option to login via these social providers.  "
 "{project_name} offers a browser-based API that applications can use to link "
-"an existing user account to a specific external IDP.  This is called client "
-"initiated account linking."
+"an existing user account to a specific external IDP.  This is called client-"
+"initiated account linking. Account linking can only be initiated by OIDC "
+"applications."
 msgstr ""
-"アプリケーションの中には、Facebookなどのソーシャル・プロバイダーと統合したいが、これらのソーシャル・プロバイダーを介してログインするオプションを提供したくないものもあります。{project_name}は、既存のユーザー・アカウントを特定の外部IDPにリンクするためにアプリケーションが使用できる、ブラウザー・ベースのAPIを提供しています。これは、Client"
-" Initiated Account Linkingと呼ばれます。"
+"アプリケーションの中には、Facebookなどのソーシャル・プロバイダーと統合したいが、これらのソーシャル・プロバイダーを介してログインするオプションを提供したくないものもあります。{project_name}は、既存のユーザー・アカウントを特定の外部IDPにリンクするためにアプリケーションが使用できる、ブラウザー・ベースのAPIを提供しています。これは"
+"、Client-Initiated Account "
+"Linkingと呼ばれます。アカウント・リンキングは、OIDCアプリケーションによってのみ開始できます。"
 
 #. type: Plain text
 msgid ""
-"The way it works is that the application forward's the user's browser to a "
+"The way it works is that the application forwards the user's browser to a "
 "URL on the {project_name} server requesting that it wants to link the user's"
 " account to a specific external provider (i.e. Facebook).  The server "
 "initiates a login with the external provider.  The browser logs in at the "
-"external provider and is redirected back to the auth server.  The auth "
-"server establishes the link and redirects back to the application with a "
+"external provider and is redirected back to the server.  The server "
+"establishes the link and redirects back to the application with a "
 "confirmation."
 msgstr ""
-"これを動作させるには、アプリケーションがユーザーのブラウザーを{project_name}サーバー上のURLに転送して、ユーザーのアカウントを特定の外部プロバイダー（Facebookなど）にリンクすることを要求します。サーバーは、外部プロバイダーとのログインを開始します。ブラウザーは外部プロバイダーにログインし、認証サーバーにリダイレクトされます。認証サーバーはリンクを確立し、確認のためにアプリケーションにリダイレクトします。"
+"これを動作させるには、アプリケーションがユーザーのブラウザーを{project_name}サーバー上のURLに転送して、ユーザーのアカウントを特定の外部プロバイダー（Facebookなど）にリンクすることを要求します。サーバーは、外部プロバイダーとのログインを開始します。ブラウザーは外部プロバイダーにログインし、サーバーにリダイレクトされます。サーバーはリンクを確立し、確認のためにアプリケーションにリダイレクトします。"
 
 #. type: Plain text
 msgid ""
@@ -62,9 +68,9 @@ msgstr "管理コンソールで、必要なアイデンティティー・プロ
 
 #. type: Plain text
 msgid ""
-"The application must already be logged in as an existing user via the OIDC "
+"The user account must already be logged in as an existing user via the OIDC "
 "protocol"
-msgstr "アプリケーションは、OIDCプロトコルを介して既存のユーザーとしてログインしている必要がある。"
+msgstr "ユーザー・アカウントは、OIDCプロトコルを介して既存のユーザーとしてログインしている必要がある。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__identity-brokering__account-linking
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
