### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -349,20 +349,6 @@ msgstr ""
 "WildFly 11以上でもレガシーな非Elytronアダプターが使用できます。つまり、それらのバージョンでも `adapter-install-"
 "offline.cli` を使用することができます。ただし、新しいElytronアダプターを使用することをお勧めします。"
 
-#. type: Block title
-#, no-wrap
-msgid "JBoss EAP 7.0"
-msgstr "JBoss EAP 7.0"
-
-#. type: Plain text
-msgid ""
-"It is possible to use the legacy non-Elytron adapter on JBoss EAP 7.1 or "
-"newer as well, meaning you can use `adapter-install-offline.cli` even on "
-"those versions. However, we recommend to use the newer Elytron adapter."
-msgstr ""
-"JBoss EAP 7.1以上でもレガシーな非Elytronアダプターが使用できます。つまり、それらのバージョンでも `adapter-install-"
-"offline.cli` を使用することができます。ただし、新しいElytronアダプターを使用することをお勧めします。"
-
 #. type: Plain text
 msgid "The offline script is not available for JBoss EAP 6.4"
 msgstr "オフライン・スクリプトはJBoss EAP 6.4では使用できません"
@@ -381,10 +367,18 @@ msgstr "$ ./bin/jboss-cli.sh -c --file=bin/adapter-elytron-install.cli\n"
 msgid "$ ./bin/jboss-cli.sh -c --file=bin/adapter-install.cli\n"
 msgstr "$ ./bin/jboss-cli.sh -c --file=bin/adapter-install.cli\n"
 
-#. type: Block title
+#. type: Plain text
+msgid ""
+"It is possible to use the legacy non-Elytron adapter on JBoss EAP 7.1 or "
+"newer as well, meaning you can use `adapter-install-offline.cli`"
+msgstr ""
+"JBoss EAP 7.1以上でもレガシーな非Elytronアダプターが使用できます。つまり、 `adapter-install-"
+"offline.cli` を使用することができます。"
+
+#. type: Attribute :fuseHawtioEAPVersion:
 #, no-wrap
-msgid "JBoss EAP 7.0 and 6.4"
-msgstr "JBoss EAP 7.0と6.4"
+msgid "JBoss EAP 6.4"
+msgstr "JBoss EAP 6.4"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
