### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -43,7 +43,7 @@ msgstr "Bitbucket"
 msgid ""
 "There are a number of steps you have to complete to be able to enable login "
 "with Bitbucket."
-msgstr "Bitbucketにログインできるようにするには、いくつかのステップを完了しなければなりません。"
+msgstr "Bitbucketでログインできるようにするには、いくつかのステップを完了しなければなりません。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,6 +24,16 @@ msgstr ""
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
+#. type: Block title
+#, no-wrap
+msgid "Add a New App"
+msgstr "新しいアプリケーションの追加"
+
+#. type: Block title
+#, no-wrap
+msgid "Register App"
+msgstr "アプリケーションの登録"
+
 #. type: Title ====
 #, no-wrap
 msgid "Bitbucket"
@@ -27,8 +41,8 @@ msgstr "Bitbucket"
 
 #. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to login to "
-"Bitbucket."
+"There are a number of steps you have to complete to be able to enable login "
+"with Bitbucket."
 msgstr "Bitbucketにログインできるようにするには、いくつかのステップを完了しなければなりません。"
 
 #. type: Plain text
@@ -53,15 +67,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"You will the `Redirect URI` from this page in a later step, which you will "
-"provide to Bitbucket when you register {project_name} as a client there."
+"You will use the `Redirect URI` from this page in a later step, which you "
+"will provide to Bitbucket when you register {project_name} as a client "
+"there."
 msgstr ""
 "後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をBitbucketに提供します。"
-
-#. type: Block title
-#, no-wrap
-msgid "Add a New App"
-msgstr "新しいアプリケーションの追加"
 
 #. type: Plain text
 msgid ""
@@ -89,11 +99,6 @@ msgstr "image:images/bitbucket-developer-applications.png[]"
 msgid "Click the `Add consumer` button."
 msgstr "`Add consumer` ボタンをクリックします。"
 
-#. type: Block title
-#, no-wrap
-msgid "Register App"
-msgstr "アプリケーションの登録"
-
 #. type: Plain text
 msgid "image:images/bitbucket-register-app.png[]"
 msgstr "image:images/bitbucket-register-app.png[]"
@@ -101,12 +106,11 @@ msgstr "image:images/bitbucket-register-app.png[]"
 #. type: Plain text
 msgid ""
 "Copy the `Redirect URI` from the {project_name} `Add Identity Provider` page"
-" and enter it into the `Authorization callback URL` field on the Bitbucket "
-"`Register a new OAuth application` page."
+" and enter it into the Callback URL field on the Bitbucket Add OAuth "
+"Consumer page."
 msgstr ""
 "{project_name}の `Add Identity Provider` ページから `Redirect URI` "
-"をコピーし、Bitbucketの `Register a new OAuth application` ページの `Authorization "
-"callback URL` フィールドに入力します。"
+"をコピーし、BitbucketのAdd OAuth ConsumerページのCallback URLフィールドに入力します。"
 
 #. type: Plain text
 msgid ""
@@ -136,5 +140,9 @@ msgstr ""
 " `Add identity provider` ページに入力する必要があります。"
 
 #. type: Plain text
-msgid "+To finish, return to {project_name} and enter them. Click `Save`."
-msgstr "終了するには、{project_name}に戻り、それらを入力してください。 `Save` をクリックします。"
+msgid ""
+"+Find the values of `client ID` and `secret` on this page and enter them "
+"into the {project_name} Add Identity Provider page. Click `Save`."
+msgstr ""
+"クライアントIDとシークレットをコピーして、{project_name}の `Add identity provider` "
+"ページに貼り付けることができます。 "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__bitbucket
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
