### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,11 +165,11 @@ msgstr "Enabled"
 
 #. type: Plain text
 msgid "Turn the provider on/off."
-msgstr "プロバイダーのオン/オフ。"
+msgstr "プロバイダーのオン/オフの設定です。"
 
 #. type: Plain text
 msgid "Hide on Login Page"
-msgstr "Hide On Login Page"
+msgstr "Hide on Login Page"
 
 #. type: Plain text
 msgid ""
@@ -182,7 +182,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Account Linking Only"
-msgstr "アカウント・リンキングのみ"
+msgstr "Account Linking Only"
 
 #. type: Plain text
 msgid ""
@@ -233,7 +233,7 @@ msgstr "GUI Order"
 msgid ""
 "The order number that sorts how the available IDPs are listed on the login "
 "page."
-msgstr "利用可能なIDPがログイン・ページにどのように表示されるかを並べ替えるオーダー番号。"
+msgstr "利用可能なIDPがログインページにどのように表示されるかを並べ替える順番設定です。"
 
 #. type: Title ===
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,29 +19,12 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-#: source/server_admin/topics/clients/client-saml.adoc:46
-#: source/server_admin/topics/identity-broker/configuration.adoc:53
-#, no-wrap
-msgid "Enabled"
-msgstr "Enabled"
-
-#. type: Plain text
-#: source/server_admin/topics/sessions/timeouts.adoc:15
-#: source/server_admin/topics/identity-broker/configuration.adoc:45
-#: source/server_admin/topics/identity-broker/oidc.adoc:19
-#: source/server_admin/topics/identity-broker/saml.adoc:18
-msgid "Configuration|Description"
-msgstr "設定|説明"
-
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/configuration.adoc:3
 #, no-wrap
 msgid "General Configuration"
 msgstr "共通設定"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:8
 msgid ""
 "The identity broker configuration is all based on identity providers.  "
 "Identity providers are created for each realm and by default they are "
@@ -48,25 +35,21 @@ msgstr ""
 "アイデンティティー・ブローカーの設定は、すべてアイデンティティー・プロバイダーに基づいています。アイデンティティー・プロバイダーは各レルムに対して作成され、デフォルトでは単一アプリケーションごとに有効化されます。つまり、レルムのユーザーは、アプリケーションにサインインするときに、登録されているアイデンティティー・プロバイダーのいずれかを使用することができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:10
 msgid ""
 "In order to create an identity provider click the `Identity Providers` left "
 "menu item."
 msgstr "アイデンティティー・プロバイダーを作成するには、左側の `Identity Providers` をクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:11
 #, no-wrap
 msgid "Identity Providers"
-msgstr "Identity Providers"
+msgstr "アイデンティティー・プロバイダー"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:13
 msgid "image:{project_images}/identity-providers.png[]"
 msgstr "image:{project_images}/identity-providers.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:16
 msgid ""
 "In the drop down list box, choose the identity provider you want to add.  "
 "This will bring you to the configuration page for that identity provider "
@@ -76,29 +59,15 @@ msgstr ""
 "これにより、そのアイデンティティー・プロバイダー・タイプの設定ページが表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:17
-#: source/server_admin/topics/identity-broker/oidc.adoc:10
-#: source/server_admin/topics/identity-broker/saml.adoc:9
-#: source/server_admin/topics/identity-broker/social/facebook.adoc:7
-#: source/server_admin/topics/identity-broker/social/github.adoc:7
-#: source/server_admin/topics/identity-broker/social/google.adoc:6
-#: source/server_admin/topics/identity-broker/social/linked-in.adoc:7
-#: source/server_admin/topics/identity-broker/social/microsoft.adoc:7
-#: source/server_admin/topics/identity-broker/social/openshift.adoc:9
-#: source/server_admin/topics/identity-broker/social/paypal.adoc:7
-#: source/server_admin/topics/identity-broker/social/stack-overflow.adoc:7
-#: source/server_admin/topics/identity-broker/social/twitter.adoc:7
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:19
 msgid "image:{project_images}/add-identity-provider.png[]"
 msgstr "image:{project_images}/add-identity-provider.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:22
 msgid ""
 "Above is an example of configuring a Google social login provider.  Once you"
 " configure an IDP, it will appear on the {project_name} login page as an "
@@ -107,41 +76,36 @@ msgstr ""
 "上記は、Googleのソーシャル・ログイン・プロバイダーを設定する例です。IDPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:23
 #, no-wrap
 msgid "IDP login page"
 msgstr "IDPログイン・ページ"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:25
 msgid "image:{project_images}/identity-provider-login-page.png[]"
 msgstr "image:{project_images}/identity-provider-login-page.png[]"
 
 #. type: Labeled list
-#: source/server_admin/topics/identity-broker/configuration.adoc:27
 #, no-wrap
 msgid "Social"
 msgstr "ソーシャル"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:31
 msgid ""
 "Social providers allow you to enable social authentication in your realm.  "
 "{project_name} makes it easy to let users log in to your application using "
-"an existing account with a social network.  Currently Facebook, Google, "
-"Twitter, GitHub, LinkedIn, Microsoft, and StackOverflow are supported with "
-"more planned for the future."
+"an existing account with a social network.  Currently supported providers "
+"include: Twitter, Facebook, Google, LinkedIn, Instagram, Microsoft, PayPal, "
+"Openshift v3, GitHub, GitLab, Bitbucket, and Stack Overflow."
 msgstr ""
-"ソーシャル・プロバイダーは、レルムでソーシャル認証を有効にすることができます。{project_name}は、ユーザーがソーシャル・ネットワークの既存アカウントを使用して、アプリケーションに簡単にログインできるようにします。現在、Facebook、Google、Twitter、GitHub、LinkedIn、Microsoft、StackOverflowがサポートされており、将来的にはさらなる追加が計画されています。"
+"ソーシャル・プロバイダーは、レルムでソーシャル認証を有効にすることができます。{project_name}は、ユーザーがソーシャル・ネットワークの既存アカウントを使用して、アプリケーションに簡単にログインできるようにします。現在、Twitter、Facebook、Google、LinkedIn、Instagram、Microsoft、PayPal、Openshift"
+" v3、GitHub、GitLab、Bitbucket、Stack Overflowがサポートされています。"
 
 #. type: Labeled list
-#: source/server_admin/topics/identity-broker/configuration.adoc:32
 #, no-wrap
 msgid "Protocol-based"
 msgstr "プロトコル・ ベース"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:37
 msgid ""
 "Protocol-based providers are those that rely on a specific protocol in order"
 " to authenticate and authorize users.  They allow you to connect to any "
@@ -155,58 +119,59 @@ msgstr ""
 "v1.0プロトコルをサポートしています。これにより、これらのオープンスタンダードに基づいた任意のアイデンティティー・プロバイダーを簡単に設定および仲介できるようになります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:40
 msgid ""
 "Although each type of identity provider has its own configuration options, "
-"all of them share some very common configuration.  Regardless the identity "
-"provider you are creating, you'll see the following configuration options "
-"available:"
+"all of them share some very common configuration.  Regardless of which "
+"identity provider you are creating, you'll see the following configuration "
+"options available:"
 msgstr ""
-"各タイプのアイデンティティー・プロバイダーには独自の設定オプションがありますが、すべて共通の設定を共有しています。作成しているアイデンティティー・プロバイダに関係なく、次の設定オプションが使用できます。"
+"各タイプのアイデンティティー・プロバイダーには独自の設定オプションがありますが、すべて共通の設定を共有しています。作成しているアイデンティティー・プロバイダーに関係なく、次の設定オプションが使用できます。"
 
 #. type: Block title
-#: source/server_admin/topics/identity-broker/configuration.adoc:41
 #, no-wrap
 msgid "Common Configuration"
 msgstr "共通の設定"
 
 #. type: Named 'cols' AttributeList argument for style 'cols'
-#: source/server_admin/topics/identity-broker/configuration.adoc:42
 #, no-wrap
 msgid "1,1"
 msgstr "1,1"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:47
+msgid "Configuration|Description"
+msgstr "設定|説明"
+
+#. type: Plain text
 msgid "Alias"
 msgstr "Alias"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:51
 #, no-wrap
 msgid ""
-"The alias is an unique identifier for an identity provider. It is used to reference an identity provider internally.\n"
+"The alias is a unique identifier for an identity provider. It is used to reference an identity provider internally.\n"
 " Some protocols such as OpenID Connect require a redirect URI or callback url in order to communicate with an identity provider.\n"
 " In this case, the alias is used to build the redirect URI.\n"
-" Every single identity provider must have an alias. Examples are facebook, google, idp.acme.com, etc.\n"
+" Every single identity provider must have an alias. Examples are `facebook`, `google`, `idp.acme.com`, etc.\n"
 msgstr ""
-"エイリアスは、アイデンティティー・プロバイダの一意な識別子です。アイデンティティー・プロバイダーを内部的に参照するために使用されます。\n"
+"エイリアスは、アイデンティティー・プロバイダーの一意な識別子です。アイデンティティー・プロバイダーを内部的に参照するために使用されます。\n"
 "OpenID Connectなどの一部のプロトコルでは、アイデンティティー・プロバイダーと通信するために、リダイレクトURIまたはコールバックURLが必要です。\n"
 "この場合、エイリアスはリダイレクトURIを構築するために使用されます。\n"
-"すべてのアイデンティティー・プロバイダーにエイリアスが必要です。例としては、facebook、google、idp.acme.comなどです。\n"
+"すべてのアイデンティティー・プロバイダーにエイリアスが必要です。例としては、 `facebook` 、 `google` 、 `idp.acme.com` などです。\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Enabled"
+msgstr "Enabled"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:54
-msgid "Turn the provider on/off"
-msgstr "プロバイダーのオン/オフ"
+msgid "Turn the provider on/off."
+msgstr "プロバイダーのオン/オフ。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:56
-msgid "Hide On Login Page"
+msgid "Hide on Login Page"
 msgstr "Hide On Login Page"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:57
 msgid ""
 "When this switch is on, this provider will not be shown as a login option on"
 " the login page.  Clients can still request to use this provider by using "
@@ -216,12 +181,10 @@ msgstr ""
 " 'kc_idp_hint' パラメーターを使用して、このプロバイダーの使用を引き続き依頼できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:59
-msgid "Link Only"
-msgstr "Link Only"
+msgid "Account Linking Only"
+msgstr "アカウント・リンキングのみ"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:60
 msgid ""
 "When this switch is on, this provider cannot be used to login users and will"
 " not be shown as an option on the login page.  Existing accounts can still "
@@ -230,37 +193,31 @@ msgstr ""
 "このスイッチをオンにすると、このプロバイダーはユーザーのログインでは使用することができず、ログイン・ページにはオプションとして表示されません。しかし、既存のアカウントはこのプロバイダーとリンクできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:63
 msgid "Store Tokens"
 msgstr "Store Tokens"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:64
 msgid "Whether or not to store the token received from the identity provider."
 msgstr "アイデンティティー・プロバイダーから受け取ったトークンを保存するかどうか。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:66
 msgid "Stored Tokens Readable"
 msgstr "Stored Tokens Readable"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:68
 #, no-wrap
 msgid ""
 "Whether or not users are allowed to retrieve the stored identity provider token.  This also applies to the _broker_ client-level\n"
-" role _read token_\n"
+" role _read token_.\n"
 msgstr ""
 "ユーザーは保存されたアイデンティティー・プロバイダー・トークンを取得できるかどうか。 _broker_ クライアント・レベルのロール _read "
 "token_ にも適用されます。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:70
-msgid "Trust email"
-msgstr "Trust email"
+msgid "Trust Email"
+msgstr "Trust Email"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:72
 #, no-wrap
 msgid ""
 "If the identity provider supplies an email address this email address will be trusted.  If the realm required email validation,\n"
@@ -269,26 +226,21 @@ msgstr ""
 "アイデンティティー・プロバイダーがメールアドレスを提供する場合、このメールアドレスは信頼されます。レルムに電子メールの検証が必要な場合、このIDPからログインしたユーザーは電子メールの検証プロセスを経る必要はありません。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:74
-msgid "GUI order"
-msgstr "GUI order"
+msgid "GUI Order"
+msgstr "GUI Order"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:75
 msgid ""
-"The order number that sorts how the available IDPs are listed on the "
-"{project_name} login page."
-msgstr "利用可能なIDPが{project_name}ログイン・ページにどのように表示されるかを並べ替えるオーダー番号。"
+"The order number that sorts how the available IDPs are listed on the login "
+"page."
+msgstr "利用可能なIDPがログイン・ページにどのように表示されるかを並べ替えるオーダー番号。"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/configuration.adoc:77
-#: source/server_admin/topics/identity-broker/first-login-flow.adoc:3
 #, no-wrap
 msgid "First Login Flow"
 msgstr "First Login Flow"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:79
 #, no-wrap
 msgid ""
 "This is the authentication flow that will be triggered for users that log into {project_name} through this IDP\n"
@@ -296,12 +248,10 @@ msgid ""
 msgstr "このIDPを通じて、初めて{project_name}にログインするユーザーのためにトリガーされる認証フローです。\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:81
 msgid "Post Login Flow"
 msgstr "Post Login Flow"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/configuration.adoc:82
 msgid ""
 "Authentication flow that is triggered after the user finishes logging in "
 "with the external identity provider."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
