### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/mod-auth-openidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/mod-auth-openidc.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/mod-auth-openidc.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,7 +34,7 @@ msgid ""
 "_mod_auth_openidc_ GitHub repo for more details on configuration."
 msgstr ""
 "https://github.com/zmartzone/mod_auth_openidc[mod_auth_openidc]は、OpenID "
-"Connect用のApache HTTPプラグインです。現在利用している言語/環境でApache HTTPDをプロキシとして使用できる場合は、 "
+"Connect用のApache HTTPプラグインです。現在利用している言語/環境でApache HTTPDをプロキシーとして使用できる場合は、 "
 "_mod_auth_openidc_ を使用してOpenID "
 "ConnectでWebアプリケーションを保護することができます。このモジュールの設定は、このドキュメントの範囲を超えています。設定の詳細については、 "
 "_mod_auth_openidc_ のGitHubリポジトリーを参照ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/mod-auth-openidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__mod-auth-openidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
