### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +33,7 @@ msgid ""
 " secured either by browser login and/or bearer token authentication.  You "
 "can also define role constraints for URL patterns within your applications."
 msgstr ""
-"{project_name}には、{project_name}アダプターをインストールすることができないwebアプリケーションとサービスのフロントに置くことができる、HTTP(S)プロキシがあります。ブラウザー・ログインとベアラー・トークン認証の両方、またはそのいずれかによって特定のURLが保護されるように、URLフィルターを設定することができます。また、アプリケーション内のURLパターンのためのロール制約を定義することもできます。"
+"{project_name}には、{project_name}アダプターをインストールすることができないwebアプリケーションとサービスのフロントに置くことができる、HTTP(S)プロキシーがあります。ブラウザー・ログインとベアラー・トークン認証の両方、またはそのいずれかによって特定のURLが保護されるように、URLフィルターを設定することができます。また、アプリケーション内のURLパターンのためのロール制約を定義することもできます。"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/proxy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__proxy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
