### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -39,7 +39,7 @@ msgstr ""
 msgid ""
 "This can be achieve either directly in {project_name} or with a proxy such "
 "as Apache or nginx."
-msgstr "これは、{project_name}で直接行うことも、Apacheやnginxなどのプロキシで行うこともできます。"
+msgstr "これは、{project_name}で直接行うことも、Apacheやnginxなどのプロキシーで行うこともできます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -46,7 +46,8 @@ msgid ""
 "For the proxy option please follow the documentation for the proxy. You need"
 " to control access to any requests to `/auth/admin`."
 msgstr ""
-"プロキシ・オプションについては、プロキシのマニュアルを参照してください。 `/auth/admin` へのリクエストのアクセスを制御する必要があります。"
+"プロキシー・オプションについては、プロキシーのマニュアルを参照してください。 `/auth/admin` "
+"へのリクエストのアクセスを制御する必要があります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -126,7 +126,7 @@ msgid ""
 "correctly to make sure {project_name} receives the client IP address and not"
 " the proxy IP address"
 msgstr ""
-"IP制限において、プロキシを使用している場合は、プロキシのIPアドレスではなく、クライアントのIPアドレスで{project_name}が受け取るようにIPを正しく設定することが重要です。"
+"IP制限において、プロキシーを使用している場合は、プロキシーのIPアドレスではなく、クライアントのIPアドレスで{project_name}が受け取るようにIPを正しく設定することが重要です。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
