### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -3,6 +3,10 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -14,40 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-msgid ""
-"If the {project_name} server requires HTTPS and this config option is set to"
-" `true` you do not have to specify a truststore.  This setting should only "
-"be used during development and *never* in production as it will disable "
-"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
-" `false`."
-msgstr ""
-"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
-"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、プロダクション環境では"
-" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "truststore"
-msgstr "truststore"
-
-#. type: Plain text
-msgid ""
-"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
-" set and the truststore requires a password."
-msgstr ""
-"トラストストアのキーストアのパスワードです。これは _REQUIRED_ で、 `truststore` "
-"を設定すると、トラストストアはパスワードを必要とします。"
-
-#. type: Plain text
-msgid ""
-"This is the file path to a keystore file.  This keystore contains client "
-"certificate for two-way SSL when the adapter makes HTTPS requests to the "
-"{project_name} server.  This is _OPTIONAL_."
-msgstr ""
-"キーストア・ファイルへのファイルパスです。このキーストアには、アダプターが{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライアント証明書を含めます。これは"
-" _OPTIONAL_ です。"
 
 #. type: Title =====
 #, no-wrap
@@ -105,6 +75,18 @@ msgstr ""
 msgid "disableTrustManager"
 msgstr "disableTrustManager"
 
+#. type: Plain text
+msgid ""
+"If the {project_name} server requires HTTPS and this config option is set to"
+" `true` you do not have to specify a truststore.  This setting should only "
+"be used during development and *never* in production as it will disable "
+"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
+" `false`."
+msgstr ""
+"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、プロダクション環境では"
+" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
+
 #. type: Labeled list
 #, no-wrap
 msgid "allowAnyHostname"
@@ -123,6 +105,11 @@ msgstr ""
 "に設定する場合、トラストストア経由で{project_name}サーバーの証明書は検証されますが、ホスト名の検証は行われません。 "
 "SSL証明書の検証が一部無効となるため、この設定は開発時にのみ使用すべきで、プロダクション環境では *決して使用してはいけません* 。これは "
 "_OPTIONAL_ です。デフォルトは `false` です。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "truststore"
+msgstr "truststore"
 
 #. type: Plain text
 msgid ""
@@ -145,10 +132,27 @@ msgstr ""
 msgid "truststorePassword"
 msgstr "truststorePassword"
 
+#. type: Plain text
+msgid ""
+"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
+" set and the truststore requires a password."
+msgstr ""
+"トラストストアのキーストアのパスワードです。これは _REQUIRED_ で、 `truststore` "
+"を設定すると、トラストストアはパスワードを必要とします。"
+
 #. type: Labeled list
 #, no-wrap
 msgid "clientKeystore"
 msgstr "clientKeystore"
+
+#. type: Plain text
+msgid ""
+"This is the file path to a keystore file.  This keystore contains client "
+"certificate for two-way SSL when the adapter makes HTTPS requests to the "
+"{project_name} server.  This is _OPTIONAL_."
+msgstr ""
+"キーストア・ファイルへのファイルパスです。このキーストアには、アダプターが{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライアント証明書を含めます。これは"
+" _OPTIONAL_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -169,4 +173,4 @@ msgstr "proxyUrl"
 
 #. type: Plain text
 msgid "URL to HTTP proxy to use for HTTP connections.  This is _OPTIONAL_."
-msgstr "HTTP接続に使用するHTTPプロキシのURLです。これは _OPTIONAL_ です。"
+msgstr "HTTP接続に使用するHTTPプロキシーのURLです。これは _OPTIONAL_ です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_httpclient_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
