### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -73,7 +73,7 @@ msgid ""
 " in front of the {project_name} server.  See the "
 "link:{installguide_link}[{installguide_name}]."
 msgstr ""
-"{project_name}は、初回実行時に自己署名証明書を生成します。自己署名証明書は安全ではないため、テスト目的でのみ使用してください。CA署名付き証明書を{project_name}サーバー自体、または{project_name}サーバーの前にあるリバースプロキシーにインストールすることを強くお勧めします。{installguide_link}"
+"{project_name}は、初回実行時に自己署名証明書を生成します。自己署名証明書は安全ではないため、テスト目的でのみ使用してください。CA署名付き証明書を{project_name}サーバー自体、または{project_name}サーバーの前にあるリバース・プロキシーにインストールすることを強くお勧めします。{installguide_link}"
 " [{installguide_name}]のリンクを参照してください。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -3,25 +3,23 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"{project_name} is not set up by default to handle SSL/HTTPS.\n"
-"          It is highly recommended that you either enable SSL on the {project_name} server itself or on a reverse proxy in front of the {project_name} server.\n"
-msgstr ""
-"{project_name}は、デフォルトではSSL/HTTPSを処理するように設定されていません。{project_name}サーバー上、または{project_name}サーバーのフロントにあるリバース・プロキシー上のいずれかでSSLを有効にすることを強くお勧めします。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -68,6 +66,18 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"{project_name} generates a self-signed certificate the first time it runs.  "
+"Please note that self-signed certificates are not secure, and should only be"
+" used for testing purposes.  It is highly recommended that you install a CA-"
+"signed certificate on the {project_name} server itself or on a reverse proxy"
+" in front of the {project_name} server.  See the "
+"link:{installguide_link}[{installguide_name}]."
+msgstr ""
+"{project_name}は、初回実行時に自己署名証明書を生成します。自己署名証明書は安全ではないため、テスト目的でのみ使用してください。CA署名付き証明書を{project_name}サーバー自体、または{project_name}サーバーの前にあるリバースプロキシーにインストールすることを強くお勧めします。{installguide_link}"
+" [{installguide_name}]のリンクを参照してください。"
+
+#. type: Plain text
+msgid ""
 "To configure the SSL Mode of your realm, you need to click on the `Realm "
 "Settings` left menu item and go to the `Login` tab."
 msgstr ""
@@ -81,13 +91,13 @@ msgstr "`Require SSL` オプションにより、SSLモードが選択できま�
 
 #. type: Plain text
 msgid ""
-"Users can interact with {project_name} so long as they stick to private IP "
-"addresses like `localhost`, `127.0.0.1`, `10.0.x.x`, `192.168.x.x`, and "
-"`172.16.x.x`.  If you try to access {project_name} from a non-private IP "
-"address you will get an error."
+"Users can interact with {project_name} without SSL so long as they stick to "
+"private IP addresses like `localhost`, `127.0.0.1`, `10.0.x.x`, "
+"`192.168.x.x`, and `172.16.x.x`.  If you try to access {project_name} "
+"without SSL from a non-private IP address you will get an error."
 msgstr ""
 "`localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 `172.16.x.x` "
-"のようなプライベートIPアドレスに固定する限り、ユーザーは{project_name}と対話できます。非プライベートIPアドレスから{project_name}にアクセスしようとすると、エラーが発生します。"
+"のようなプライベートIPアドレスに固定する限り、ユーザーはSSL無しで{project_name}と対話できます。非プライベートIPアドレスからSSL無しで{project_name}にアクセスしようとすると、エラーが発生します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
