### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,10 +191,10 @@ msgid ""
 "token provides access to retrieve the client configuration later, but also "
 "to update or delete the client.  The registration access token is included "
 "with the request in the same way as a bearer token or initial access token."
-"  Registration access tokens are only valid once when it's used the response"
-" will include a new token."
+"  Registration access tokens are only valid once, when it's used the "
+"response will include a new token."
 msgstr ""
-"クライアント登録サービスを介してクライアントを作成する際には、レスポンスには登録アクセストークンが含まれます。登録アクセストークンは、クライアント設定を取得するだけでなく、クライアントの更新や削除のためのアクセス権を提供します。登録アクセストークンは、ベアラートークンや初期アクセストークンと同じ方法でリクエストに含まれます。登録アクセストークンの使用は一度だけ有効であり、新しいトークンがレスポンスに含まれます。"
+"クライアント登録サービスを介してクライアントを作成する際には、レスポンスには登録アクセストークンが含まれます。登録アクセストークンは、クライアント設定を取得するだけでなく、クライアントの更新や削除のためのアクセス権を提供します。登録アクセストークンは、ベアラートークンや初期アクセストークンと同じ方法でリクエストに含まれます。登録アクセストークンは一度だけ有効であり、それを使用すると新しいトークンがレスポンスに含まれます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
