### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -7,13 +7,13 @@
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,9 +54,9 @@ msgstr "SSL/TLSハンドシェイク中に、サーバーとクライアント�
 
 #. type: Plain text
 msgid ""
-"The container (WildFly) validates the certificate PKIX path and the "
-"certificate expiration"
-msgstr "コンテナ（WildFly）は、証明書のPKIXパスと有効期限を検証します。"
+"The container ({appserver_name}) validates the certificate PKIX path and the"
+" certificate expiration"
+msgstr "コンテナ（{appserver_name}）は、証明書のPKIXパスと有効期限を検証します。"
 
 #. type: Plain text
 msgid ""
@@ -249,24 +249,25 @@ msgstr "X.509クライアント証明書のユーザー認証を有効にする"
 
 #. type: Plain text
 msgid ""
-"The following sections describe how to configure WildFly/Undertow and the "
-"{project_name} Server to enable X.509 client certificate authentication."
+"The following sections describe how to configure {appserver_name}/Undertow "
+"and the {project_name} Server to enable X.509 client certificate "
+"authentication."
 msgstr ""
-"以下のセクションでは、X.509クライアント証明書認証を有効にするためにWildFly/Undertowと{project_name}サーバーを設定する方法について説明します。"
+"以下のセクションでは、X.509クライアント証明書認証を有効にするために{appserver_name}/Undertowと{project_name}サーバーを設定する方法について説明します。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "Enable mutual SSL in WildFly"
-msgstr "WildFlyで相互SSLを有効にする"
+msgid "Enable mutual SSL in {appserver_name}"
+msgstr "{appserver_name}で相互SSLを有効にする"
 
 #. type: Plain text
 msgid ""
 "See link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
 "#AdminGuide-EnableSSL[Enable SSL] and "
 "link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide#AdminGuide-%7B%7B%3Cssl%2F%3E%7D%7D[SSL]"
-" for the instructions how to enable SSL in WildFly."
+" for the instructions how to enable SSL in {appserver_name}."
 msgstr ""
-"WildFlyでSSLを有効にする方法については、link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
+"{appserver_name}でSSLを有効にする方法については、link:https://docs.jboss.org/author/display/WFLY10/Admin+Guide"
 "#AdminGuide-EnableSSL[Enable "
 "SSL]とlink:https://docs.jboss.org/author/display/WFLY10/Admin+Guide#AdminGuide-%7B%7B%3Cssl%2F%3E%7D%7D[SSL]を参照してください。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
