### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -8,14 +8,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # naoto watanabe <nabenao11@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -79,17 +79,11 @@ msgstr ""
 msgid ""
 "link:{jdgserver_crossdcdocs_link}[JBoss Data Grid Cross-Datacenter "
 "Replication] {project_name} uses JBoss Data Grid (JDG) for the replication "
-"of Infinispan data between the data centers. We use the `Remote Client-"
-"Server Mode` described in the JDG documentation in "
-"link:{jdgserver_crossdcdocs_link}#configure_cross_datacenter_replication_remote_client_server_mode[Configure"
-" Cross-Datacenter Replication]."
+"of Infinispan data between the data centers."
 msgstr ""
 "link:{jdgserver_crossdcdocs_link}[JBoss Data Grid Cross-Datacenter "
 "Replication] {project_name}では、JBoss Data "
-"Grid（JDG）を使用して、データセンター間でInfinispanデータをレプリケーションします。 "
-"link:{jdgserver_crossdcdocs_link}#configure_cross_datacenter_replication_remote_client_server_mode[Configure"
-" Cross-Datacenter Replication] のJDGドキュメントで記載されている `Remote Client-Server "
-"Mode` を使用します。"
+"Grid（JDG）を使用して、データセンター間でInfinispanデータをレプリケーションします。"
 
 #. type: Title ====
 #, no-wrap
@@ -511,14 +505,12 @@ msgstr ""
 msgid ""
 "{jdgserver_name} servers `jdg1` and `jdg2` are connected to each other "
 "through the RELAY2 protocol and `backup` based {jdgserver_name} caches in a "
-"similar way as described in the "
-"link:{jdgserver_crossdcdocs_link}#configure_cross_datacenter_replication_remote_client_server_mode[JDG"
-" documentation]."
+"similar way as described in the link:{jdgserver_crossdcdocs_link}[JDG "
+"documentation]."
 msgstr ""
 "{jdgserver_name}サーバーである `jdg1` と `jdg2` は、 "
-"link:{jdgserver_crossdcdocs_link}#configure_cross_datacenter_replication_remote_client_server_mode[JDGのドキュメント]"
-" で記載されているのと同様の方法で、RELAY2プロトコルと `backup` "
-"ベースの{jdgserver_name}キャッシュを介して相互に接続されています。"
+"link:{jdgserver_crossdcdocs_link}[JDGのドキュメント] で記載されているのと同様の方法で、RELAY2プロトコルと "
+"`backup` ベースの{jdgserver_name}キャッシュを介して相互に接続されています。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
