### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -155,7 +155,7 @@ msgstr "**claim_token_format**\n"
 
 #. type: Plain text
 msgid ""
-"This parameter is *optional. A string indicating the format of the token "
+"This parameter is *optional*. A string indicating the format of the token "
 "specified in the `claim_token` parameter. {project_name} supports two token "
 "formats: `urn:ietf:params:oauth:token-type:jwt` and "
 "`https://openid.net/specs/openid-connect-core-1_0.html#IDToken`. The "
@@ -179,7 +179,7 @@ msgstr "**rpt**\n"
 
 #. type: Plain text
 msgid ""
-"This parameter is *optional. A previously issued RPT which permissions "
+"This parameter is *optional*. A previously issued RPT which permissions "
 "should also be evaluated and added in a new one. This parameter allows "
 "clients in possession of an RPT to perform incremental authorization where "
 "permissions are added on demand."
@@ -194,7 +194,7 @@ msgstr "**permission**\n"
 
 #. type: Plain text
 msgid ""
-"This parameter is *optional. A string representing a set of one or more "
+"This parameter is *optional*. A string representing a set of one or more "
 "resources and scopes the client is seeking access. This parameter can be "
 "defined multiple times in order to request permission for multiple resource "
 "and scopes. This parameter is an extension to `urn:ietf:params:oauth:grant-"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
