### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po
@@ -3,11 +3,18 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# n.watanabe <nwatanabe.ase@gmail.com>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: n.watanabe <nwatanabe.ase@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,45 +23,32 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/saml/java/assertion-api.adoc:57
-#: source/server_development/topics/user-storage/configuration.adoc:18
-#: source/server_development/topics/user-storage/configuration.adoc:23
-#: source/server_development/topics/user-storage/configuration.adoc:28
-#: source/server_development/topics/user-storage/provider-interfaces.adoc:26
-#: source/server_development/topics/user-storage/provider-interfaces.adoc:38
-#: source/server_development/topics/user-storage/provider-interfaces.adoc:50
-#: source/server_development/topics/user-storage/registration-query.adoc:109
-#: source/server_development/topics/user-storage/simple-example.adoc:146
-#: source/server_development/topics/auth-spi.adoc:460
-#: source/server_development/topics/providers.adoc:75
 #, no-wrap
 msgid "    }\n"
 msgstr "    }\n"
 
 #. type: Block title
-#: source/server_development/topics/user-storage/augmenting.adoc:45
-#: source/server_development/topics/user-storage/import.adoc:29
-#: source/server_development/topics/user-storage/registration-query.adoc:13
-#: source/server_development/topics/user-storage/registration-query.adoc:31
-#: source/server_development/topics/user-storage/registration-query.adoc:63
-#: source/server_development/topics/user-storage/registration-query.adoc:79
-#: source/server_development/topics/user-storage/registration-query.adoc:97
-#: source/server_development/topics/user-storage/registration-query.adoc:130
-#: source/server_development/topics/user-storage/registration-query.adoc:161
-#: source/server_development/topics/user-storage/registration-query.adoc:189
-#: source/server_development/topics/user-storage/registration-query.adoc:210
 #, no-wrap
 msgid "PropertyFileUserStorageProvider"
 msgstr "PropertyFileUserStorageProvider"
 
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    @Override\n"
+"    public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {\n"
+"        if (!supportsCredentialType(input.getType()) || !(input instanceof UserCredentialModel)) return false;\n"
+msgstr ""
+"@Override\n"
+" public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {\n"
+" if (!supportsCredentialType(input.getType()) || !(input instanceof UserCredentialModel)) return false;\n"
+
 #. type: Title ===
-#: source/server_development/topics/user-storage/registration-query.adoc:2
 #, no-wrap
 msgid "Add/Remove User and Query Capability interfaces"
 msgstr "ユーザーおよびクエリー機能の追加/削除インターフェイス"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:7
 msgid ""
 "One thing we have not done with our example is allow it to add and remove "
 "users or change passwords. Users defined in our example are also not "
@@ -66,20 +60,17 @@ msgstr ""
 " `UserQueryProvider` と `UserRegistrationProvider` インタフェースを実装する必要があります。"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/registration-query.adoc:8
 #, no-wrap
 msgid "Implementing UserRegistrationProvider"
 msgstr "UserRegistrationProviderの実装"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:12
 msgid ""
 "To implement adding and removing users from this particular store, we first "
 "have to be able to save our properties file to disk."
 msgstr "特定のストアにユーザーを追加または削除するために、プロパティー・ファイルをディスクに保存する必要があります。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:27
 #, no-wrap
 msgid ""
 "    public void save() {\n"
@@ -107,20 +98,17 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:30
 msgid ""
 "Then, the implementation of the `addUser()` and `removeUser()` methods "
 "becomes simple."
 msgstr "このとき、 `addUser()` メソッドと `removeUser()` メソッドの実装は単純になります。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:35
 #, no-wrap
 msgid "    public static final String UNSET_PASSWORD=\"#$!-UNSET-PASSWORD\";\n"
 msgstr "    public static final String UNSET_PASSWORD=\"#$!-UNSET-PASSWORD\";\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:44
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -142,7 +130,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:53
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -164,7 +151,6 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:58
 msgid ""
 "Notice that when adding a user we set the password value of the property map"
 " to be `UNSET_PASSWORD`.  We do this as we can't have null values for a "
@@ -176,32 +162,17 @@ msgstr ""
 "`CredentialInputValidator` メソッドを変更する必要もあります。"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:62
 msgid ""
-"`addUser()` will be called if the provider implements the "
+"The `addUser()` method will be called if the provider implements the "
 "`UserRegistrationProvider` interface. If your provider has a configuration "
 "switch to turn of adding a user, returning `null` from this method will skip"
 " the provider and call the next one."
 msgstr ""
 "プロバイダーが `UserRegistrationProvider` インターフェイスを実装している場合、 `addUser()` "
-"が呼び出されます。プロバイダーがユーザーを追加するための設定スイッチを持っている場合、このメソッドから  `null` "
+"メソッドが呼び出されます。プロバイダーがユーザーを追加するための設定スイッチを持っている場合、このメソッドから  `null` "
 "を返すとプロバイダーをスキップして、次のメソッドを呼び出します。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:69
-#: source/server_development/topics/user-storage/simple-example.adoc:115
-#, no-wrap
-msgid ""
-"    @Override\n"
-"    public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {\n"
-"        if (!supportsCredentialType(input.getType()) || !(input instanceof UserCredentialModel)) return false;\n"
-msgstr ""
-"@Override\n"
-" public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {\n"
-" if (!supportsCredentialType(input.getType()) || !(input instanceof UserCredentialModel)) return false;\n"
-
-#. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:75
 #, no-wrap
 msgid ""
 "        UserCredentialModel cred = (UserCredentialModel)input;\n"
@@ -217,14 +188,12 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:78
 msgid ""
 "Since we can now save our property file, it also makes sense to allow "
 "password updates."
 msgstr "プロパティー・ファイルを保存できるようになったので、パスワードの更新を許可するのも理にかなっています。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:93
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -252,12 +221,10 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:96
-msgid "We can now also implement disabling a password too."
+msgid "We can now also implement disabling a password."
 msgstr "また、パスワードを無効にすることもできます。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:107
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -277,7 +244,6 @@ msgstr ""
 "        }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:111
 #, no-wrap
 msgid ""
 "    private static final Set<String> disableableTypes = new HashSet<>();\n"
@@ -285,7 +251,6 @@ msgstr ""
 "    private static final Set<String> disableableTypes = new HashSet<>();\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:115
 #, no-wrap
 msgid ""
 "    static {\n"
@@ -297,7 +262,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:118
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -307,7 +271,6 @@ msgstr ""
 "    public Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:121
 #, no-wrap
 msgid ""
 "        return disableableTypes;\n"
@@ -317,20 +280,17 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:124
 msgid ""
 "With these methods implemented, you'll now be able to change and disable the"
 " password for the user in the administration console."
 msgstr "これらのメソッドを実装すると、管理コンソールでユーザーのパスワードを変更および無効にできるようになります。"
 
 #. type: Title ====
-#: source/server_development/topics/user-storage/registration-query.adoc:125
 #, no-wrap
 msgid "Implementing UserQueryProvider"
 msgstr "UserQueryProviderの実装"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:129
 msgid ""
 "Without implementing `UserQueryProvider` the administration console would "
 "not be able to view and manage users that were loaded by our example "
@@ -340,7 +300,6 @@ msgstr ""
 "を実装しなければ、管理コンソールはサンプル・プロバイダーによってロードされたユーザーを表示および管理できません。このインターフェイスの実装を見てみましょう。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:137
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -354,7 +313,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:142
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -368,7 +326,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:156
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -400,7 +357,6 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:160
 msgid ""
 "The `getUser()` method iterates over the key set of the property file, "
 "delegating to `getUserByUsername()` to load a user.  Notice that we are "
@@ -413,7 +369,6 @@ msgstr ""
 "パラメーターに基づいてこの呼び出しにインデックスを付けることに注目してください。外部ストアがページネーションをサポートしていない場合は、同様のロジックを実行する必要があります。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:168
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -427,7 +382,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:183
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -461,7 +415,6 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:188
 msgid ""
 "The first declaration of `searchForUser()` takes a string parameter. This is"
 " supposed to be a string that you use to search username and email "
@@ -473,7 +426,6 @@ msgstr ""
 " `String.contains()` メソッドを使用しています。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:196
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -487,7 +439,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:204
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -507,7 +458,6 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:208
 msgid ""
 "The `searchForUser()` method that takes a `Map` parameter can search for a "
 "user based on first, last name, username, and email.  We only store "
@@ -519,7 +469,6 @@ msgstr ""
 " に処理を委譲しています。"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:217
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -533,7 +482,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:222
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -547,7 +495,6 @@ msgstr ""
 "    }\n"
 
 #. type: delimited block -
-#: source/server_development/topics/user-storage/registration-query.adoc:227
 #, no-wrap
 msgid ""
 "    @Override\n"
@@ -561,7 +508,6 @@ msgstr ""
 "    }\n"
 
 #. type: Plain text
-#: source/server_development/topics/user-storage/registration-query.adoc:230
 msgid ""
 "We do not store groups or attributes, so the other methods return an empty "
 "list."

--- a/i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po
@@ -222,7 +222,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "We can now also implement disabling a password."
-msgstr "また、パスワードを無効にすることもできます。"
+msgstr "また、パスワードを無効にすることができます。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__registration-query
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
