### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -89,12 +89,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The only supported versions of Fuse 7 is {fuse7Version}. If you use earlier "
-"versions of Fuse 7, it is possible that some functions will not work "
-"correctly. In particular, integration will not work at all for earlier "
-"versions of Fuse 7 than 7.0.1."
+"The only supported version of Fuse 7 is the latest release. If you use "
+"earlier versions of Fuse 7, it is possible that some functions will not work"
+" correctly. In particular, integration will not work at all for versions of "
+"Fuse 7 lower than 7.0.1."
 msgstr ""
-"サポートされているFuse 7のバージョンは{fuse7Version}のみです。以前のバージョンのFuse "
+"サポートされているFuse 7のバージョンは最新リリースのみです。以前のバージョンのFuse "
 "7を使用している場合、一部の機能が正しく動作しない可能性があります。特に、7.0.1より前のバージョンのFuse 7では、統合はまったく機能しません。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
