### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -3,17 +3,30 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# KojiNose <knose.dev@gmail.com>, 2017
+# n.watanabe <nwatanabe.ase@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Configuration"
+msgstr "設定"
 
 #. type: Plain text
 #, no-wrap
@@ -25,15 +38,6 @@ msgstr "*Name*\n"
 msgid "*Description*\n"
 msgstr "*Description*\n"
 
-#. type: Title ==
-#, no-wrap
-msgid "Configuration"
-msgstr "設定"
-
-#. type: Plain text
-msgid "A string with more details about this policy."
-msgstr "このポリシーの詳細を示す文字列。"
-
 #. type: Plain text
 #, no-wrap
 msgid "*Logic*\n"
@@ -44,6 +48,10 @@ msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
 msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
+
+#. type: Plain text
+msgid "A string with more details about this policy."
+msgstr "このポリシーの詳細を示す文字列。"
 
 #. type: Title =
 #, no-wrap
@@ -206,7 +214,7 @@ msgid ""
 "You can even use another variant of ABAC to obtain attributes from the "
 "identity and define a condition accordingly:"
 msgstr ""
-"アイデンティティから属性を取得し、それに応じて条件を定義するために、ABAC（属性ベースのアクセス・コントロール）の別のバリアントを使用することもできます。"
+"アイデンティティーから属性を取得し、それに応じて条件を定義するために、ABAC（属性ベースのアクセス・コントロール）の別のバリアントを使用することもできます。"
 
 #. type: Code block
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-drools-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
