### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,7 +21,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Registering with an Identity Provider"
-msgstr "アイデンティティ・プロバイダーでの登録"
+msgstr "アイデンティティー・プロバイダーでの登録"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/idp-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__idp-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
