### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po
@@ -121,7 +121,7 @@ msgstr "provider"
 msgid ""
 "This is the provider alias of the external IDP that you defined in the "
 "`Identity Provider` section of the admin console."
-msgstr "管理コンソールの `アイデンティティ・プロバイダー` のセクションで定義した外部IDPのプロバイダー・エイリアスです。"
+msgstr "管理コンソールの `アイデンティティー・プロバイダー` のセクションで定義した外部IDPのプロバイダー・エイリアスです。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/identity-brokering/account-linking.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__identity-brokering__account-linking
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
