### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,34 +20,31 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/default-provider.adoc:3
 #, no-wrap
 msgid "Default Identity Provider"
 msgstr "デフォルトのアイデンティティー・プロバイダー"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/default-provider.adoc:6
 msgid ""
-"It's possible to automatically redirect to a identity provider instead of "
-"displaying the login form. To enable this go to `Authentication` select the "
-"`Browser` flow. Then click on config for the `Identity Provider Redirector` "
-"authenticator. Set `Default Identity Provider` to the alias of the identity "
-"provider you want to automatically redirect users to."
+"It is possible to automatically redirect to a identity provider instead of "
+"displaying the login form. To enable this go to the `Authentication` page in"
+" the administration console and select the `Browser` flow. Then click on "
+"config for the `Identity Provider Redirector` authenticator. Set `Default "
+"Identity Provider` to the alias of the identity provider you want to "
+"automatically redirect users to."
 msgstr ""
-"ログイン・フォームを表示する代わりに、アイデンティティー・プロバイダーに自動的にリダイレクトすることが可能です。これを有効にするには "
-"`Authentication` に行き、 `Browser` フローを選択してください。次に、 `Identity Provider "
+"ログイン・フォームを表示する代わりに、アイデンティティー・プロバイダーに自動的にリダイレクトすることが可能です。これを有効にするには、管理コンソールの "
+"`Authentication` のページを開き、 `Browser` フローを選択してください。次に、 `Identity Provider "
 "Redirector` オーセンティケーターの設定をクリックします。 `Default Identity Provider` "
 "を、自動的にユーザーをリダイレクトするアイデンティティー・プロバイダーのエイリアスに設定します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/default-provider.adoc:8
 msgid ""
 "If the configured default identity provider is not found the login form will"
 " be displayed instead."
 msgstr "設定されたデフォルトのアイデンティティー・プロバイダーが見つからない場合は、代わりにログイン・フォームが表示されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/default-provider.adoc:9
 msgid ""
 "This authenticator is also responsible for dealing with the `kc_idp_hint` "
 "query parameter. See <<_client_suggested_idp, client suggested identity "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__default-provider
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
