### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +31,7 @@ msgid ""
 "connect to external user databases and credential stores. The built-in LDAP "
 "and ActiveDirectory support is an implementation of this SPI in action. Out "
 "of the box, {project_name} uses its local database to create, update, and "
-"look up users and validation credentials. Often though, organizations have "
+"look up users and validate credentials. Often though, organizations have "
 "existing external proprietary user databases that they cannot migrate to "
 "{project_name}'s data model. For those situations, application developers "
 "can write implementations of the User Storage SPI to bridge the external "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
