### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,10 +32,10 @@ msgstr "LinkedIn"
 
 #. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to login to "
-"LinkedIn.  First, go to the `Identity Providers` left menu item and select "
-"`LinkedIn` from the `Add provider` drop down list.  This will bring you to "
-"the `Add identity provider` page."
+"There are a number of steps you have to complete to be able to enable login "
+"with LinkedIn.  First, go to the `Identity Providers` left menu item and "
+"select `LinkedIn` from the `Add provider` drop down list.  This will bring "
+"you to the `Add identity provider` page."
 msgstr ""
 "LinkedInにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
 "に移動し、 `Add provider` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 `Add identity "

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,9 +37,9 @@ msgid ""
 "select `LinkedIn` from the `Add provider` drop down list.  This will bring "
 "you to the `Add identity provider` page."
 msgstr ""
-"LinkedInにログインするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity Providers` "
-"に移動し、 `Add provider` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 `Add identity "
-"provider` ページが表示されます。"
+"LinkedInでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
+"Providers` に移動し、 `Add provider` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 "
+"`Add identity provider` ページが表示されます。"
 
 #. type: Plain text
 msgid "image:{project_images}/linked-in-add-identity-provider.png[]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__linked-in
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
