### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Shinsuke UEDA, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -450,3 +450,29 @@ msgid ""
 "should help with configuring the corresponding mappers."
 msgstr ""
 "デフォルトでは、ユーザー名、姓、名、電子メールなどの基本的な{project_name}ユーザー属性を対応するLDAP属性にマップする、ユーザー属性マッパーがあります。これらを拡張し、追加の属性マッピングを自由に与えることができます。管理コンソールにはツールチップが用意されており、対応するマッパーの設定に役立ちます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Password Hashing"
+msgstr "パスワード・ハッシング"
+
+#. type: Plain text
+msgid ""
+"When the password of user is updated from {project_name} and sent to LDAP, "
+"it is always sent in plain-text. This is different from updating the "
+"password to built-in {project_name} database, when the hashing and salting "
+"is applied to the password before it is sent to DB.  In the case of LDAP, "
+"the {project_name} relies on the LDAP server to provide hashing and salting "
+"of passwords."
+msgstr ""
+"ユーザーのパスワードは、{project_name}から更新されてLDAPに送信される際に、常にプレーンテキストで送信されます。これは、ハッシュ化とソルト付与がDBに送信される前のパスワードに適用される、組み込み{project_name}データベースへのパスワード更新とは異なります。LDAPの場合、{project_name}は、パスワードのハッシュ化とソルト付与をLDAPサーバーに任せています。"
+
+#. type: Plain text
+msgid ""
+"Most of LDAP servers (Microsoft Active Directory, RHDS, FreeIPA) provide "
+"this by default. Some others (OpenLDAP, ApacheDS) may store the passwords in"
+" plain-text by default and you may need to explicitly enable password "
+"hashing for them. See the documentation of your LDAP server more details."
+msgstr ""
+"ほとんどのLDAPサーバー（Microsoft Active "
+"Directory、RHDS、FreeIPA）はデフォルトでこれを提供します。それ以外（OpenLDAP、ApacheDS）はデフォルトで平文でパスワードを保存するかもしれません（そしてそれらに対してパスワードのハッシュ化を明示的に有効にする必要があるかもしれません）。詳しくは、ご使用のLDAPサーバーのドキュメントを参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/user-federation/ldap.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__user-federation__ldap
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
