### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,15 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/tokens.adoc:2
-#: source/server_development/topics/identity-brokering/tokens.adoc:2
 #, no-wrap
 msgid "Retrieving External IDP Tokens"
 msgstr "外部IDPトークンの取得"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/tokens.adoc:6
-#: source/server_development/topics/identity-brokering/tokens.adoc:6
 msgid ""
 "{project_name} allows you to store tokens and responses from the "
 "authentication process with the external IDP.  For that, you can use the "
@@ -34,8 +35,6 @@ msgstr ""
 "`Store Token` の設定オプションを使用できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/tokens.adoc:10
-#: source/server_development/topics/identity-brokering/tokens.adoc:10
 msgid ""
 "Application code can retrieve these tokens and responses to pull in extra "
 "user information, or to securely invoke requests on the external IDP.  For "
@@ -47,8 +46,6 @@ msgstr ""
 " APIを呼び出すことができます。特定のアイデンティティー・プロバイダーのトークンを取得するには、次のようにリクエストを送信する必要があります。"
 
 #. type: delimited block -
-#: source/server_admin/topics/identity-broker/tokens.adoc:16
-#: source/server_development/topics/identity-brokering/tokens.adoc:16
 #, no-wrap
 msgid ""
 "GET /auth/realms/{realm}/broker/{provider_alias}/token HTTP/1.1\n"
@@ -60,8 +57,6 @@ msgstr ""
 "Authorization: Bearer <KEYCLOAK ACCESS TOKEN>\n"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/tokens.adoc:23
-#: source/server_development/topics/identity-brokering/tokens.adoc:23
 msgid ""
 "An application must have authenticated with {project_name} and have received"
 " an access token.  This access token will need to have the `broker` client-"
@@ -80,11 +75,9 @@ msgstr ""
 "のスイッチをオンにすることで、新しくインポートされたユーザーにこのロールを自動的に割り当てることができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/tokens.adoc:25
-#: source/server_development/topics/identity-brokering/tokens.adoc:25
 msgid ""
 "These external tokens can be re-established by either logging in again "
-"through the provider, or using the client initiated account linking API."
+"through the provider, or using the client-initiated account linking API."
 msgstr ""
-"これらの外部トークンは、プロバイダーを介して再度ログインするか、Client Initiated Account Linking "
+"これらの外部トークンは、プロバイダーを介して再度ログインするか、Client-Initiated Account Linking "
 "APIを使用して再確立できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__tokens
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
