### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po
@@ -8,13 +8,13 @@
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -413,14 +413,14 @@ msgid ""
 "http://directory.apache.org/apacheds/[ApacheDS] Kerberos server.  You need "
 "to build {project_name} from sources and then run the Kerberos server with "
 "maven-exec-plugin from our testsuite.  See details "
-"https://github.com/keycloak/keycloak/blob/master/misc/Testsuite.md#user-"
-"content-kerberos-server[here] ."
+"https://github.com/keycloak/keycloak/blob/master/docs/tests.md#kerberos-"
+"server[here] ."
 msgstr ""
 "迅速なテストとユニットテストのために、非常にシンプルな http://directory.apache.org/apacheds/[ApacheDS] "
 "Kerberosサーバーを使用します。ソースから{project_name}をビルドし、テストスイートからmaven-exec-"
 "pluginを使ってKerberosサーバーを実行する必要があります。詳細は "
-"https://github.com/keycloak/keycloak/blob/master/misc/Testsuite.md#user-"
-"content-kerberos-server[こちら] を参照してください。"
+"https://github.com/keycloak/keycloak/blob/master/docs/tests.md#kerberos-"
+"server[こちら] を参照してください。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__kerberos
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
