### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -253,7 +253,8 @@ msgid ""
 " to enable the provider for a specific realm."
 msgstr ""
 "`getId()` "
-"メソッドはユーザー・ストレージ・プロバイダーの名前を返します。特定のレルムのプロバイダーを有効にしたい場合、このidは管理コンソールのユーザー・フェデレーション・ページ内に表示されます。"
+"メソッドはユーザー・ストレージ・プロバイダーの名前を返します。特定のレルムのプロバイダーを有効にしたい場合、このidは管理コンソールのUser "
+"Federationページ内に表示されます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,13 +22,13 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "}\n"
-msgstr "}\n"
+msgid "    }\n"
+msgstr "    }\n"
 
 #. type: delimited block -
 #, no-wrap
-msgid "    }\n"
-msgstr "    }\n"
+msgid "}\n"
+msgstr "}\n"
 
 #. type: Title ===
 #, no-wrap
@@ -163,7 +168,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "    /**\n"
-"     * This is the name of the provider and will be showed in the admin console as an option.\n"
+"     * This is the name of the provider and will be shown in the admin console as an option.\n"
 "     *\n"
 "     * @return\n"
 "     */\n"
@@ -171,7 +176,7 @@ msgid ""
 "    String getId();\n"
 msgstr ""
 "    /**\n"
-"     * This is the name of the provider and will be showed in the admin console as an option.\n"
+"     * This is the name of the provider and will be shown in the admin console as an option.\n"
 "     *\n"
 "     * @return\n"
 "     */\n"
@@ -244,18 +249,17 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The `getId()` method returns the name of the User Storage provider.  This id"
-" will be displayed in the admin console's `UserFederation` page when you "
-"want to enable the provider for a specific realm."
+" will be displayed in the admin console's User Federation page when you want"
+" to enable the provider for a specific realm."
 msgstr ""
 "`getId()` "
-"メソッドはユーザー・ストレージ・プロバイダーの名前を返します。特定のレルムのプロバイダーを有効にしたい場合、このidは管理コンソールの "
-"`UserFederation` ページ内に表示されます。"
+"メソッドはユーザー・ストレージ・プロバイダーの名前を返します。特定のレルムのプロバイダーを有効にしたい場合、このidは管理コンソールのユーザー・フェデレーション・ページ内に表示されます。"
 
 #. type: Plain text
 msgid ""
 "The `create()` method is responsible for allocating an instance of the "
 "provider class.  It takes a `org.keycloak.models.KeycloakSession` parameter."
-"  This object can be used to lookup other information and metadata as well "
+"  This object can be used to look up other information and metadata as well "
 "as provide access to various other components within the runtime.  The "
 "`ComponentModel` parameter represents how the provider was enabled and "
 "configured within a specific realm.  It contains the instance id of the "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__provider-interfaces
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
