### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -68,6 +68,14 @@ msgstr ""
 "$ unzip keycloak-saml-eap6-adapter-dist.zip\n"
 
 #. type: Plain text
+msgid ""
+"These zip files create new JBoss Modules specific to the WildFly/JBoss EAP "
+"SAML Adapter within your WildFly or JBoss EAP distro."
+msgstr ""
+"これらのzipファイルは、WildFlyまたはJBoss EAP用の配布物内のWildFly/JBoss EAP "
+"SAMLアダプターに固有の新しいJBossモジュールを作成します。"
+
+#. type: Plain text
 msgid "Install on JBoss EAP 7.x:"
 msgstr "JBoss EAP 7.xへのインストールは次のとおりです。"
 
@@ -91,11 +99,10 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"These zip files create new JBoss Modules specific to the WildFly/JBoss EAP "
-"SAML Adapter within your WildFly or JBoss EAP distro."
+"These zip files create new JBoss Modules specific to the JBoss EAP SAML "
+"Adapter within your JBoss EAP distro."
 msgstr ""
-"これらのzipファイルは、WildFlyまたはJBoss EAP用の配布物内のWildFly/JBoss EAP "
-"SAMLアダプターに固有の新しいJBossモジュールを作成します。"
+"これらのzipファイルは、JBoss EAP用の配布物内のJBoss EAP SAMLアダプターに固有の新しいJBossモジュールを作成します。"
 
 #. type: Plain text
 msgid ""
@@ -156,8 +163,8 @@ msgstr "JBoss EAP 7.1以上"
 
 #. type: Block title
 #, no-wrap
-msgid "JBoss EAP 7.0 and EAP 6"
-msgstr "JBoss EAP 7.0とEAP 6"
+msgid "JBoss EAP 7.0 and EAP 6.4"
+msgstr "JBoss EAP 7.0とEAP 6.4"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
