### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,15 +20,13 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/session-data.adoc:2
 #, no-wrap
 msgid "Available User Session Data"
 msgstr "利用可能なユーザー・セッション・ データ"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/session-data.adoc:6
 msgid ""
-"After a user logs in from the external IDP, there's some additional user "
+"After a user logs in from the external IDP, there is some additional user "
 "session note data that {project_name} stores that you can access.  This data"
 " can be propagated to the client requesting a login via the token or SAML "
 "assertion being passed back to it by using an appropriate client mapper."
@@ -32,37 +34,32 @@ msgstr ""
 "ユーザーが外部IDPからログインすると、アクセス可能なユーザー・セッション・ノート・データが{project_name}に追加で保存されます。このデータは、適切なクライアント・マッパーを使用して戻されるトークンまたはSAMLアサーションを介して、ログインを要求するクライアントに伝播できます。"
 
 #. type: Labeled list
-#: source/server_admin/topics/identity-broker/session-data.adoc:7
 #, no-wrap
 msgid "identity_provider"
 msgstr "identity_provider"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/session-data.adoc:9
 msgid "This is the IDP alias of the broker used to perform the login."
 msgstr "ログインを実行するために使用されるブローカーのIDPエイリアスです。"
 
 #. type: Labeled list
-#: source/server_admin/topics/identity-broker/session-data.adoc:10
 #, no-wrap
 msgid "identity_provider_identity"
 msgstr "identity_provider_identity"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/session-data.adoc:13
 msgid ""
 "This is the IDP username of the currently authenticated user. This is often "
-"same like the {project_name} username, but doesn't necessarily needs to be."
-"  For example {project_name} user `john` can be linked to the Facebook user "
-"`john123@gmail.com`, so in that case value of user session note will be "
-"`john123@gmail.com` ."
+"the same as the {project_name} username, but doesn't necessarily needs to "
+"be.  For example {project_name} user `john` can be linked to the Facebook "
+"user `john123@gmail.com`, so in that case value of user session note will be"
+" `john123@gmail.com` ."
 msgstr ""
 "現在認証されているユーザーのIDPユーザー名です。これは{project_name}ユーザー名と同じことが多いですが、必ずしもそうである必要はありません。たとえば、{project_name}のユーザー"
 " `john` は、Facebookのユーザー `john123@gmail.com` にリンクできます。その場合、ユーザー・セッション・ノートの値は "
 "`john123@gmail.com` になります。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/session-data.adoc:15
 msgid ""
 "You can use a <<_protocol-mappers, Protocol Mapper>> of type `User Session "
 "Note` to propagate this information to your clients."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__session-data
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
