### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,12 +44,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The only supported version of Fuse 6 is {fuseVersion}. If you use earlier "
-"versions of Fuse 6, it is possible that some functions will not work "
-"correctly. In particular, the https://hawt.io/[Hawtio] integration will not "
-"work with earlier versions of Fuse 6."
+"The only supported version of Fuse 6 is the latest release. If you use "
+"earlier versions of Fuse 6, it is possible that some functions will not work"
+" correctly. In particular, the https://hawt.io/[Hawtio] integration will not"
+" work with earlier versions of Fuse 6."
 msgstr ""
-"サポートされているFuse 6のバージョンは{fuseVersion}のみです。以前のバージョンのFuse "
+"サポートされているFuse 6のバージョンは最新リリースのみです。以前のバージョンのFuse "
 "6を使用している場合、一部の機能が正しく動作しない可能性があります。特に、 https://hawt.io/[Hawtio] との統合は、Fuse "
 "6の以前のバージョンでは機能しません。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
