### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/identity-broker/mappers.adoc:2
 #, no-wrap
 msgid "Mapping Claims and Assertions"
 msgstr "クレームとアサーションのマッピング"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:7
 msgid ""
 "You can import the SAML and OpenID Connect metadata provided by the external"
 " IDP you are authenticating with into the environment of the realm.  This "
@@ -33,34 +35,29 @@ msgstr ""
 "Connectのメタデータを、レルムの環境にインポートすることができます。これにより、ユーザー・プロファイルのメタデータおよびその他の情報を抽出して、アプリケーションで使用できるようにすることができます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:11
 msgid ""
 "Each new user that logs into your realm via an external identity provider "
-"will have an entry for it created in the local {project_name} database.  The"
-" act of importing metadata from the SAML or OIDC assertions and claims will "
-"create this data with the local realm database."
+"will have an entry for them created in the local {project_name} database, "
+"based on the metadata from the SAML or OIDC assertions and claims."
 msgstr ""
-"外部アイデンティティー・プロバイダーを使用してレルムにログインする新規ユーザーは、ローカルの{project_name}データベースにエントリーが作成されます。SAMLまたはOIDCのアサーションおよびクレームからメタデータをインポートすると、ローカルのレルム・データベースにこのデータが作成されます。"
+"外部アイデンティティー・プロバイダーを使用してレルムにログインする新規ユーザーは、ローカルの{project_name}データベースにエントリーが作成されます（SAMLまたはOIDCのアサーションおよびクレームから取得したメタデータをベースに）。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:14
 msgid ""
 "If you click on an identity provider listed in the `Identity Providers` page"
 " for your realm, you will be brought to the IDPs `Settings` tab.  On this "
-"page is also a `Mappers` tab.  Click on that tab to start mapping your "
-"incoming IDP metadata."
+"page there is also a `Mappers` tab.  Click on that tab to start mapping your"
+" incoming IDP metadata."
 msgstr ""
 "レルムの `Identity Providers` ページにリストされているアイデンティティー・プロバイダーをクリックすると、IDPの "
 "`Settings` タブが表示されます。このページには、 `Mappers` "
 "タブもあります。そのタブをクリックして、受信するIDPメタデータのマッピングを開始します。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:16
 msgid "image:{project_images}/identity-provider-mappers.png[]"
 msgstr "image:{project_images}/identity-provider-mappers.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:20
 msgid ""
 "There is a `Create` button on this page.  Clicking on this create button "
 "allows you to create a broker mapper.  Broker mappers can import SAML "
@@ -71,12 +68,10 @@ msgstr ""
 "ブローカー・マッパーは、SAML属性またはOIDCのID/アクセストークンのクレームをユーザー属性およびユーザーロールのマッピングにインポートできます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:22
 msgid "image:{project_images}/identity-provider-mapper.png[]"
 msgstr "image:{project_images}/identity-provider-mapper.png[]"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:25
 msgid ""
 "Select a mapper from the `Mapper Type` list.  Hover over the tooltip to see "
 "a description of what the mapper does.  The tooltips also describe what "
@@ -88,7 +83,6 @@ msgstr ""
 " `Save` ボタンをクリックすると、新しいマッパーが追加されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:28
 msgid ""
 "For JSON based claims, you can use dot notation for nesting and square "
 "brackets to access array fields by index.  For example "
@@ -97,7 +91,6 @@ msgstr ""
 "JSONベースのクレームでは、ネストと角括弧にドット表記を使用して、インデックスで配列フィールドにアクセスできます。たとえば、'contact.address[0].country'です。"
 
 #. type: Plain text
-#: source/server_admin/topics/identity-broker/mappers.adoc:30
 msgid ""
 "To investigate the structure of user profile JSON data provided by social "
 "providers you can enable the `DEBUG` level logger "

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -5,6 +5,7 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -40,7 +41,7 @@ msgid ""
 "will have an entry for them created in the local {project_name} database, "
 "based on the metadata from the SAML or OIDC assertions and claims."
 msgstr ""
-"外部アイデンティティー・プロバイダーを使用してレルムにログインする新規ユーザーは、ローカルの{project_name}データベースにエントリーが作成されます（SAMLまたはOIDCのアサーションおよびクレームから取得したメタデータをベースに）。"
+"外部アイデンティティー・プロバイダーを使用してレルムにログインする新規ユーザーは、SAMLまたはOIDCのアサーションおよびクレームから取得したメタデータをもとにして、ローカルの{project_name}データベースにエントリーが作成されます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
