### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
@@ -103,7 +103,7 @@ msgid ""
 " ."
 msgstr ""
 "{project_name}は `<session-id>.<owner-node-id>` のような形式のCookie "
-"`AUTH_SESSION_ID` を作成します。サンプルでは `123.node2` となります。"
+"`AUTH_SESSION_ID` を作成します。この例では `123.node2` となります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
@@ -103,7 +103,7 @@ msgid ""
 " ."
 msgstr ""
 "{project_name}は `<session-id>.<owner-node-id>` のような形式のCookie "
-"`AUTH_SESSION_ID` を作成します．サンプルとしては、 `123.node2` となります。"
+"`AUTH_SESSION_ID` を作成します。サンプルでは `123.node2` となります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__sticky-sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
