### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po
@@ -3,6 +3,10 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -39,7 +43,7 @@ msgid ""
 "configuration file you are using, configuration of the _keycloak-server_ "
 "subsystem is the same."
 msgstr ""
-"ここで設定可能なセッティングは無限にありますが、このセクションでは  _keycloak-server_ "
+"ここで設定可能な設定は無限にありますが、このセクションでは  _keycloak-server_ "
 "サブシステムの設定について説明します。どの設定ファイルを使用していても、 _keycloak-server_ サブシステムの設定は同じです。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
