### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/upgrade_adapters.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/upgrade_adapters.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/upgrade_adapters.ja_JP.po
@@ -3,6 +3,11 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
@@ -137,7 +142,7 @@ msgstr "{appserver_name}アダプターをアップグレードするには、�
 #. type: Title ==
 #, no-wrap
 msgid "Upgrading the JavaScript Adapter"
-msgstr "Javaスクリプト・アダプターのアップグレード"
+msgstr "JavaScriptアダプターのアップグレード"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/upgrading/topics/upgrade_adapters.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/upgrade_adapters.ja_JP.po
@@ -148,7 +148,7 @@ msgstr "JavaScriptアダプターのアップグレード"
 msgid ""
 "To upgrade a JavaScript adapter that has been copied to your web "
 "application, complete the following steps:"
-msgstr "webアプリケーションにコピーされたJavaスクリプト・アダプターをアップグレードするには、以下の手順に沿って行います。"
+msgstr "webアプリケーションにコピーされたJavaScriptアダプターをアップグレードするには、以下の手順に沿って行います。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/upgrade_adapters.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__upgrade_adapters
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
