### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -299,7 +299,7 @@ msgstr ""
 " _standalone.xml_ 、 _standalone-ha.xml_ 、または _host.xml_ "
 "の各ファイルを編集する必要があります。その後、キーストア・ファイルをデプロイメントの _configuration/_ "
 "ディレクトリーに移動するか、または任意の場所に配置して絶対パスを指定します。絶対パスを使用している場合は、設定からオプションの `relative-"
-"to` パラメータを削除してください（<<_operating-mode, 動作モード>>を参照）。"
+"to` パラメーターを削除してください（<<_operating-mode, 動作モード>>を参照）。"
 
 #. type: Plain text
 msgid "Add the new `security-realm` element using the CLI:"

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
@@ -298,8 +298,8 @@ msgstr ""
 "適切な証明書を含むJavaキーストアができたため、それを使用するように{project_name}のインストールを設定する必要があります。まず、キーストアを使用してHTTPSを有効にするために、"
 " _standalone.xml_ 、 _standalone-ha.xml_ 、または _host.xml_ "
 "の各ファイルを編集する必要があります。その後、キーストア・ファイルをデプロイメントの _configuration/_ "
-"ディレクトリに移動するか、または任意の場所に配置して絶対パスを指定します。絶対パスを使用している場合は、設定からオプションの `relative-to`"
-" パラメータを削除してください（<<_operating-mode, 動作モード>>を参照）。"
+"ディレクトリーに移動するか、または任意の場所に配置して絶対パスを指定します。絶対パスを使用している場合は、設定からオプションの `relative-"
+"to` パラメータを削除してください（<<_operating-mode, 動作モード>>を参照）。"
 
 #. type: Plain text
 msgid "Add the new `security-realm` element using the CLI:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
