### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -3,21 +3,22 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-msgid "Possible configuration options are:"
-msgstr "設定可能なオプションは、以下のとおりです。"
 
 #. type: Title ===
 #, no-wrap
@@ -60,6 +61,10 @@ msgstr ""
 "        </properties>\n"
 "    </provider>\n"
 "</spi>\n"
+
+#. type: Plain text
+msgid "Possible configuration options are:"
+msgstr "設定可能なオプションは、以下のとおりです。"
 
 #. type: Labeled list
 #, no-wrap
@@ -120,8 +125,8 @@ msgid ""
 "client.  Set to -`1` to disable this checking and the background thread."
 msgstr ""
 "接続プール内でアイドル状態を維持する最大時間です（デフォルトでは900秒）。Apache "
-"HTTPクライアントのバックグラウンドクリーナースレッドを開始します。- `1` "
-"にセットすると、このチェックとバックグラウンドスレッドは無効になります。"
+"HTTPクライアントのバックグラウンド・クリーナー・スレッドを開始します。- `1` "
+"にセットすると、このチェックとバックグラウンド・スレッドは無効になります。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -125,7 +125,7 @@ msgid ""
 "client.  Set to -`1` to disable this checking and the background thread."
 msgstr ""
 "接続プール内でアイドル状態を維持する最大時間です（デフォルトでは900秒）。Apache "
-"HTTPクライアントのバックグラウンド・クリーナー・スレッドを開始します。- `1` "
+"HTTPクライアントのバックグラウンド・クリーナー・スレッドを開始します。　`-1` "
 "にセットすると、このチェックとバックグラウンド・スレッドは無効になります。"
 
 #. type: Labeled list


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__outgoing
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
