### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
@@ -333,7 +333,7 @@ msgstr "$ ./bin/jboss-cli.sh --file=bin/adapter-elytron-install-offline.cli\n"
 #. type: Block title
 #, no-wrap
 msgid "WildFly 10 or older"
-msgstr "WildFly 10以上"
+msgstr "WildFly 10以前"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po
@@ -114,7 +114,7 @@ msgid ""
 "supported for much longer period."
 msgstr ""
 "今回のリリースでは、WildFlyの最新バージョンでのみアダプターのテストとメンテナンスを行っています。WildFlyの新しいバージョンがリリースされると、現在のアダプターは非推奨になり、WildFlyの次のリリース後にサポートが削除されます。もう一つの選択肢は、JBoss"
-" EAPアダプターの場合はより長期間サポートされますので、アプリケーションをWildFlyからJBoss EAPに切り替えることです。"
+" EAPアダプターの場合はより長期間サポートされるので、アプリケーションをWildFlyからJBoss EAPに切り替えることです。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
