### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po
@@ -51,7 +51,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Installing JBoss EAP Adapter from an RPM"
-msgstr "RPMからJBoss EAPアダプターをインストールします。"
+msgstr "RPMからのJBoss EAPアダプターのインストール"
 
 #. type: Plain text
 msgid "Install the EAP 7 Adapters from an RPM:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
