### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/events.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/events.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/events.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_development/topics/events.adoc:2
 #, no-wrap
 msgid "Event Listener SPI"
 msgstr "イベントリスナーSPI"
 
 #. type: Plain text
-#: source/server_development/topics/events.adoc:6
 msgid ""
 "Writing a Event Listener Provider starts by implementing the "
 "`EventListenerProvider` and `EventListenerProviderFactory` interfaces. "
@@ -33,11 +35,8 @@ msgstr ""
 "インタフェースを実装することから始まります。これを行う方法の詳細については、Javadocとサンプルを参照してください。"
 
 #. type: Plain text
-#: source/server_development/topics/events.adoc:8
-#: source/server_development/topics/user-federation-mapper.adoc:15
-#: source/server_development/topics/user-federation.adoc:15
 msgid ""
 "For details on how to package and deploy a custom provider refer to the "
-"<<providers.adoc#providers,Service Provider Interfaces>> chapter."
+"<<_providers,Service Provider Interfaces>> chapter."
 msgstr ""
-"カスタム・プロバイダーをパッケージ化してデプロイする方法の詳細については、<<providers.adoc#providers,サービス・プロバイダー・インタフェース>>の章を参照してください。"
+"カスタム・プロバイダーをパッケージングしてデプロイする方法についての詳細は、<<_providers,サービス・プロバイダー・インターフェイス>>の章を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/events.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__events
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
