### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -113,17 +113,17 @@ msgstr "truststore"
 
 #. type: Plain text
 msgid ""
-"The value is the file path to a keystore file.  If you prefix the path with "
-"`classpath:`, then the truststore will be obtained from the deployment's "
-"classpath instead.  Used for outgoing HTTPS communications to the "
-"{project_name} server.  Client making HTTPS requests need a way to verify "
-"the host of the server they are talking to.  This is what the trustore does."
-"  The keystore contains one or more trusted host certificates or certificate"
-" authorities.  You can create this truststore by extracting the public "
-"certificate of the {project_name} server's SSL keystore.  This is _REQUIRED_"
-" unless `disableTrustManager` is `true`."
+"The value is the file path to a truststore file.  If you prefix the path "
+"with `classpath:`, then the truststore will be obtained from the "
+"deployment's classpath instead.  Used for outgoing HTTPS communications to "
+"the {project_name} server.  Client making HTTPS requests need a way to "
+"verify the host of the server they are talking to.  This is what the "
+"trustore does.  The keystore contains one or more trusted host certificates "
+"or certificate authorities.  You can create this truststore by extracting "
+"the public certificate of the {project_name} server's SSL keystore.  This is"
+" _REQUIRED_ unless `disableTrustManager` is `true`."
 msgstr ""
-"キーストア・ファイルへのファイルパスです。パスに `classpath:` "
+"トラストストア・ファイルへのファイルパスです。パスに `classpath:` "
 "を付けると、トラストストアはデプロイメントのクラスパスから取得されます。これは{project_name}サーバーへのHTTPS通信に使用されます。HTTPSリクエストを行うクライアントは、通信を行うサーバーのホストを検証する必要があります。これがトラストストアの役割です。キーストアには、1つ以上の信頼されたホストの証明書または認証局が含まれています。このトラストストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。これは、"
 " `disableTrustManager` が `true` でない限り、 _REQUIRED_ です。"
 
@@ -134,11 +134,10 @@ msgstr "truststorePassword"
 
 #. type: Plain text
 msgid ""
-"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
-" set and the truststore requires a password."
+"Password for the truststore.  This is _REQUIRED_ if `truststore` is set and "
+"the truststore requires a password."
 msgstr ""
-"トラストストアのキーストアのパスワードです。これは _REQUIRED_ で、 `truststore` "
-"を設定すると、トラストストアはパスワードを必要とします。"
+"トラストストアのパスワードです。これは _REQUIRED_ で、 `truststore` を設定すると、トラストストアはパスワードを必要とします。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -67,8 +67,8 @@ msgid ""
 "many connections to the {project_name} server should be pooled.  This is "
 "_OPTIONAL_.  The default value is `10`."
 msgstr ""
-"アダプターは、アクセス・コードをアクセス・トークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。"
-" これは _OPTIONAL_ です。デフォルトは `10` です。"
+"アダプターは、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。これは"
+" _OPTIONAL_ です。デフォルトは `10` です。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,7 +67,7 @@ msgid ""
 "many connections to the {project_name} server should be pooled.  This is "
 "_OPTIONAL_.  The default value is `10`."
 msgstr ""
-"アダプターは、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。これは"
+"アダプターは、アクセスコードをアクセストークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。これは"
 " _OPTIONAL_ です。デフォルトは `10` です。"
 
 #. type: Labeled list


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/idp_httpclient_subelement.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__idp_httpclient_subelement
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
