### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -93,8 +93,8 @@ msgstr "truststore"
 
 #. type: Plain text
 msgid ""
-"Password for the truststore keystore.  This is _REQUIRED_ if `truststore` is"
-" set and the truststore requires a password."
+"Password for the truststore.  This is _REQUIRED_ if `truststore` is set and "
+"the truststore requires a password."
 msgstr ""
 "トラストストアのパスワードです。これは _REQUIRED_ で、 `truststore` を設定すると、トラストストアはパスワードを必要とします。"
 
@@ -510,15 +510,16 @@ msgstr "HTTPプロキシーを使用する場合はそのURLを設定します�
 
 #. type: Plain text
 msgid ""
-"The value is the file path to a keystore file.  If you prefix the path with "
-"`classpath:`, then the truststore will be obtained from the deployment's "
-"classpath instead.  Used for outgoing HTTPS communications to the "
-"{project_name} server.  Client making HTTPS requests need a way to verify "
-"the host of the server they are talking to.  This is what the trustore does."
-"  The keystore contains one or more trusted host certificates or certificate"
-" authorities.  You can create this truststore by extracting the public "
-"certificate of the {project_name} server's SSL keystore.  This is _REQUIRED_"
-" unless `ssl-required` is `none` or `disable-trust-manager` is `true`."
+"The value is the file path to a truststore file.  If you prefix the path "
+"with `classpath:`, then the truststore will be obtained from the "
+"deployment's classpath instead.  Used for outgoing HTTPS communications to "
+"the {project_name} server.  Client making HTTPS requests need a way to "
+"verify the host of the server they are talking to.  This is what the "
+"trustore does.  The keystore contains one or more trusted host certificates "
+"or certificate authorities.  You can create this truststore by extracting "
+"the public certificate of the {project_name} server's SSL keystore.  This is"
+" _REQUIRED_ unless `ssl-required` is `none` or `disable-trust-manager` is "
+"`true`."
 msgstr ""
 "トラストストア・ファイルへのファイルパスです。パスに `classpath:` "
 "を付けると、トラストストアはデプロイメントのクラスパスから取得されます。これは{project_name}サーバーへのHTTPS通信に使用されます。HTTPSリクエストを行うクライアントは、通信を行うサーバーのホストを検証する必要があります。これがトラストストアの役割です。キーストアには、1つ以上の信頼されたホストの証明書または認証局が含まれています。このトラストストアは、{project_name}サーバーのSSLキーストアのパブリック証明書を抽出することで作成できます。これは、"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__java-adapter-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
