### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po
@@ -61,7 +61,7 @@ msgstr "`Save` をクリックする前に、GitLabから `Client ID` と `Clien
 
 #. type: Plain text
 msgid ""
-"You will the use `Redirect URI` from this page in a later step, which you "
+"You will use the `Redirect URI` from this page in a later step, which you "
 "will provide to GitLab when you register {project_name} as a client there."
 msgstr ""
 "後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をGitLabに提供します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/gitlab.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__gitlab
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
