### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -337,8 +337,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"This endpoints can also be found in the OpenID Connect Discovery endpoint "
-"for the realm, `/auth/realms/<realm>/.well-known/openid-configuration`."
+"This endpoint can also be found in the OpenID Connect Discovery endpoint for"
+" the realm, `/auth/realms/<realm>/.well-known/openid-configuration`."
 msgstr ""
 "このエンドポイントは、そのレルムのOpenID Connect Discoveryエンドポイント（ `/auth/realms/<realm"
 ">/.well-known/openid-configuration` ）でも見つかります。"

--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -46,7 +46,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "The built-in supported `providers` are:"
-msgstr "サポートされている組み込みの `providers` は以下のとおりです。"
+msgstr "サポートされている組み込みの `provider` は以下のとおりです。"
 
 #. type: Plain text
 msgid "default - {project_name} Client Representation (JSON)"
@@ -526,8 +526,8 @@ msgid ""
 msgstr ""
 "匿名リクエスト（トークンの無いリクエスト）は、新しいクライアントを作成（登録）することだけが許可されています。したがって、匿名リクエストを使用して新しいクライアントを登録すると、レスポンスにはそのクライアントの読み取り、更新、削除リクエストに使用する登録アクセストークンが含まれます。ただし、匿名登録レスポンスから取得した登録アクセストークンを使用すると、匿名ポリシーの対象にもなります！これは、たとえば、"
 " `Trusted Hosts` "
-"ポリシーがあるならば、クライアント更新リクエストも信頼されたホストから来る必要があることを意味します。また、たとえば、クライアントの更新時に "
-"`Consent Required` ポリシーが存在する場合に、 `Consent Required` を無効にするなどはできません。"
+"ポリシーがあるならば、クライアント更新リクエストも信頼されたホストから送信される必要があることを意味します。また、たとえば、クライアントの更新時に "
+"`Consent Required` ポリシーが存在する場合に、 `Consent Required` を無効にするようなことはできません。"
 
 #. type: Plain text
 msgid "Currently we have these policy implementations:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
