### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po
@@ -3,17 +3,26 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "keycloak.json"
+msgstr "keycloak.json"
 
 #. type: Title =
 #, no-wrap
@@ -31,7 +40,7 @@ msgstr ""
 "クレーム情報ポイント（CIP）は、クレームを解決し、それらのクレームを{project_name}サーバーにプッシュすることにより、ポリシーへのアクセス・コンテキストに関する詳細情報を提供します。さまざまなソースからの要求を解決するために、次のようなポリシー・エンフォーサーの設定オプションとして定義できます。"
 
 #. type: Plain text
-msgid "HTTP Request (parameters, headers, body, headers, etc)"
+msgid "HTTP Request (parameters, headers, body, etc)"
 msgstr "HTTPリクエスト（パラメーター、ヘッダー、ボディーなど）"
 
 #. type: Plain text
@@ -67,11 +76,6 @@ msgid ""
 "Here are several examples showing how you can extract claims from an HTTP "
 "request:"
 msgstr "HTTPリクエストからクレームを抽出する方法を示すいくつかの例を以下に示します。"
-
-#. type: Block title
-#, no-wrap
-msgid "keycloak.json"
-msgstr "keycloak.json"
 
 #. type: Code block
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-claim-information-point
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
