### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -6,7 +6,7 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy

--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3124,8 +3124,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Configuring a StackOverflow identity provider"
-msgstr "StackOverflowアイデンティティー・プロバイダーの設定"
+msgid "Configuring a Stack Overflow identity provider"
+msgstr "Stack Overflowアイデンティティー・プロバイダーの設定"
 
 #. type: Plain text
 msgid "Use `stackoverflow` command as the [command]`providerId`."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
