### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -37,19 +37,19 @@ msgstr "設定"
 
 #. type: Title ====
 #, no-wrap
-msgid "StackOverflow"
-msgstr "StackOverflow"
+msgid "Stack Overflow"
+msgstr "Stack Overflow"
 
 #. type: Plain text
 msgid ""
 "There are a number of steps you have to complete to be able to enable login "
-"with StackOverflow.  First, go to the `Identity Providers` left menu item "
-"and select `StackOverflow` from the `Add provider` drop down list.  This "
+"with Stack Overflow.  First, go to the `Identity Providers` left menu item "
+"and select `Stack Overflow` from the `Add provider` drop down list.  This "
 "will bring you to the `Add identity provider` page."
 msgstr ""
-"StackOverflowでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `StackOverflow` を選択します。これにより、"
-" `Add identity provider` ページが表示されます。"
+"Stack Overflowでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
+"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Stack Overflow` "
+"を選択します。これにより、 `Add identity provider` ページが表示されます。"
 
 #. type: Plain text
 msgid "image:{project_images}/stack-overflow-add-identity-provider.png[]"
@@ -57,12 +57,12 @@ msgstr "image:{project_images}/stack-overflow-add-identity-provider.png[]"
 
 #. type: Plain text
 msgid ""
-"To enable login with StackOverflow you first have to register an OAuth "
+"To enable login with Stack Overflow you first have to register an OAuth "
 "application on https://stackapps.com/[StackApps].  Go to "
 "https://stackapps.com/apps/oauth/register[registering your application on "
 "Stack Apps] URL and login."
 msgstr ""
-"StackOverflowでログインを可能にするには、まず https://stackapps.com/[Stack Apps] "
+"Stack Overflowでログインを可能にするには、まず https://stackapps.com/[Stack Apps] "
 "にOAuthアプリケーションを登録する必要があります。 "
 "https://stackapps.com/apps/oauth/register[registering your application on "
 "Stack Apps] のURLにアクセスしてログインします。"
@@ -70,10 +70,11 @@ msgstr ""
 #. type: Plain text
 #, no-wrap
 msgid ""
-"StackOverflow often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
+"Stack Overflow often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
 "      configuration steps might be slightly different.\n"
 msgstr ""
-"StackOverflowはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
+"Stack "
+"Overflowはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
 
 #. type: Plain text
 msgid "image:images/stack-overflow-app-register.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po
@@ -5,7 +5,7 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__stack-overflow
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
