### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -99,31 +104,30 @@ msgid ""
 "examples.  There is a very simple example in the example distribution in "
 "`providers/rest` and there is a more advanced example in `providers/domain-"
 "extension`, which shows how to add an authenticated REST endpoint and other "
-"functionalities like <<extensions.adoc#_extensions_spi,Adding your own SPI>>"
-" or <<extensions.adoc#_extensions_jpa,Extending datamodel with your own JPA "
-"entities>>."
+"functionalities like <<_extensions_spi, Adding your own SPI>> or "
+"<<_extensions_jpa,Extending datamodel with your own JPA entities>>."
 msgstr ""
 "これによって、オブジェクトを返却し、 https://github.com/jax-rs[JAX-RSリソース] "
 "として機能することができます。詳しくは、Javadocとサンプルを参照してください。 `providers/rest` "
 "のサンプル配布物には非常に簡単なサンプルがあり、 `providers/domain-extension` "
-"にはさらに高度なサンプルがあります。この高度なサンプルによって、認証済みのRESTエンドポイントと、<<extensions.adoc#_extensions_spi,独自のSPIを追加する>>や<<extensions.adoc#_extensions_jpa,独自のJPAエンティティーでデータモデルを拡張する>>のような、その他の機能を追加する方法が示されます。"
+"にはさらに高度なサンプルがあります。この高度なサンプルによって、認証済みのRESTエンドポイントと、<<_extensions_spi,独自のSPIを追加する>>や<<_extensions_jpa,独自のJPAエンティティーでデータモデルを拡張する>>のような、その他の機能を追加する方法が示されます。"
 
 #. type: Plain text
 msgid ""
 "For details on how to package and deploy a custom provider, refer to the "
-"<<providers.adoc#_providers,Service Provider Interfaces>> chapter."
+"<<_providers,Service Provider Interfaces>> chapter."
 msgstr ""
-"カスタム・プロバイダーをパッケージングしてデプロイする方法についての詳細は、<<providers.adoc#_providers,サービス・プロバイダー・インターフェイス>>の章を参照してください。"
+"カスタム・プロバイダーをパッケージングしてデプロイする方法についての詳細は、<<_providers,サービス・プロバイダー・インターフェイス>>の章を参照してください。"
 
 #. type: Plain text
 msgid ""
-"This is useful especially with the <<extensions.adoc#_extensions_rest,Custom"
-" REST endpoints>>. To add your own kind of SPI, you need to implement the "
+"This is useful especially with the <<_extensions_rest,Custom REST "
+"endpoints>>. To add your own kind of SPI, you need to implement the "
 "interface `org.keycloak.provider.Spi` and define the ID of your SPI and the "
 "`ProviderFactory` and `Provider` classes. That looks like this:"
 msgstr ""
-"これは特に<<extensions.adoc#_extensions_rest,カスタムRESTエンドポイント>>を使用する際に便利です。独自のSPIを追加するには、"
-" `org.keycloak.provider.Spi` インターフェイスを実装して、SPIのIDと `ProviderFactory` および "
+"これは特に<<_extensions_rest,カスタムRESTエンドポイント>>を使用する際に便利です。独自のSPIを追加するには、 "
+"`org.keycloak.provider.Spi` インターフェイスを実装して、SPIのIDと `ProviderFactory` および "
 "`Provider` のクラスを定義する必要があります。以下のようになります。"
 
 #. type: delimited block -
@@ -223,9 +227,9 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Finally you need to implement your providers in the same manner as described"
-" in the <<providers.adoc#_providers,Service Provider Interfaces>> chapter."
+" in the <<_providers,Service Provider Interfaces>> chapter."
 msgstr ""
-"最後に、<<providers.adoc#_providers,サービス・プロバイダー・インタフェース>>の章で説明したのと同じ方法で、プロバイダーを実装する必要があります。"
+"最後に、<<_providers,サービス・プロバイダー・インタフェース>>の章で説明したのと同じ方法で、プロバイダーを実装する必要があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
