### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,6 +32,7 @@ msgid ""
 " you to delegate authentication to a semi-trusted and respected entity where"
 " the user probably already has an account.  {project_name} provides built-in"
 " support for the most common social networks out there, such as Google, "
-"Facebook, Twitter, GitHub, LinkedIn, Microsoft and StackOverflow."
+"Facebook, Twitter, GitHub, LinkedIn, Microsoft and Stack Overflow."
 msgstr ""
-"インターネット上のアプリケーションでは、ユーザーはアクセスするためにサイトに登録する必要があります。さらに別のユーザー名とパスワードの組み合わせを覚えておく必要があります。ソーシャル・アイデンティティー・プロバイダーを使用すると、ユーザーはすでにアカウントを持っている可能性のある、ある程度信頼性があり評判のよい事業者に認証を委譲することができます。{project_name}は、Google、Facebook、Twitter、GitHub、LinkedIn、Microsoft、StackOverflowなど、最も一般的なソーシャル・ネットワークのビルトイン・サポートを提供しています。"
+"インターネット上のアプリケーションでは、ユーザーはアクセスするためにサイトに登録する必要があります。さらに別のユーザー名とパスワードの組み合わせを覚えておく必要があります。ソーシャル・アイデンティティー・プロバイダーを使用すると、ユーザーはすでにアカウントを持っている可能性のある、ある程度信頼性があり評判のよい事業者に認証を委譲することができます。{project_name}は、Google、Facebook、Twitter、GitHub、LinkedIn、Microsoft、Stack"
+" Overflowなど、最も一般的なソーシャル・ネットワークのビルトイン・サポートを提供しています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social-login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
