### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -3,11 +3,18 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Shinsuke UEDA, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,51 +46,25 @@ msgstr "Name"
 msgid "Description"
 msgstr "Description"
 
-#. type: Plain text
-msgid "This will bring you to the `Add Client` page."
-msgstr "これにより、 `Add Client` ページが表示されます。"
-
-#. type: Block title
+#. type: Labeled list
 #, no-wrap
-msgid "Client Settings"
-msgstr "クライアントの設定"
+msgid "Enabled"
+msgstr "Enabled"
 
-#. type: Plain text
-msgid ""
-"This is the display name for the client whenever it is displayed in a "
-"{project_name} UI screen.  You can localize the value of this field by "
-"setting up a replacement string value i.e. $\\{myapp}.  See the "
-"link:{developerguide_link}[{developerguide_name}] for more information."
-msgstr ""
-"これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+#. type: Labeled list
+#, no-wrap
+msgid "Client ID"
+msgstr "Client ID"
 
-#. type: Plain text
-msgid ""
-"This specifies the description of the client.  This can also be localized."
-msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
+#. type: Labeled list
+#, no-wrap
+msgid "Signature Algorithm"
+msgstr "Signature Algorithm"
 
-#. type: Plain text
-msgid ""
-"If this is turned off, the client will not be allowed to request "
-"authentication."
-msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
-
-#. type: Plain text
-msgid ""
-"If this is on, then users will get a consent page which asks the user if "
-"they grant access to that application.  It will also display the metadata "
-"that the client is interested in so that the user knows exactly what "
-"information the client is getting access to.  If you've ever done a social "
-"login to Google, you'll often see a similar page.  {project_name} provides "
-"the same functionality."
-msgstr ""
-"これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
-
-#. type: Plain text
-msgid ""
-"If {project_name} uses any configured relative URLs, this value is prepended"
-" to them."
-msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
+#. type: Labeled list
+#, no-wrap
+msgid "SAML Signature Key Name"
+msgstr "SAML Signature Key Name"
 
 #. type: Title ===
 #, no-wrap
@@ -108,6 +89,10 @@ msgstr ""
 "SAMLクライアントを作成するには、左側メニューの項目 `Clients` に移動します。このページには右側に `Create` ボタンがあります。"
 
 #. type: Plain text
+msgid "This will bring you to the `Add Client` page."
+msgstr "これにより、 `Add Client` ページが表示されます。"
+
+#. type: Plain text
 msgid "image:{project_images}/add-client-saml.png[]"
 msgstr "image:{project_images}/add-client-saml.png[]"
 
@@ -130,14 +115,14 @@ msgstr ""
 " `Settings` タブでこれを修正できます。 `Save` をクリックすると、クライアントが作成され、クライアントの `Settings` "
 "タブに移動します。"
 
+#. type: Block title
+#, no-wrap
+msgid "Client Settings"
+msgstr "クライアントの設定"
+
 #. type: Plain text
 msgid "image:{project_images}/client-settings-saml.png[]"
 msgstr "image:{project_images}/client-settings-saml.png[]"
-
-#. type: Plain text
-#, no-wrap
-msgid "Client ID"
-msgstr "Client ID"
 
 #. type: Plain text
 msgid ""
@@ -149,14 +134,40 @@ msgstr ""
 "SAMLリクエストから引き出し、この値でクライアントに照合します。"
 
 #. type: Plain text
-#, no-wrap
-msgid "Enabled"
-msgstr "Enabled"
+msgid ""
+"This is the display name for the client whenever it is displayed in a "
+"{project_name} UI screen.  You can localize the value of this field by "
+"setting up a replacement string value i.e. $\\{myapp}.  See the "
+"link:{developerguide_link}[{developerguide_name}] for more information."
+msgstr ""
+"これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+
+#. type: Plain text
+msgid ""
+"This specifies the description of the client.  This can also be localized."
+msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
+
+#. type: Plain text
+msgid ""
+"If this is turned off, the client will not be allowed to request "
+"authentication."
+msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
 
 #. type: Labeled list
 #, no-wrap
 msgid "Consent Required"
 msgstr "Consent Required"
+
+#. type: Plain text
+msgid ""
+"If this is on, then users will get a consent page which asks the user if "
+"they grant access to that application.  It will also display the metadata "
+"that the client is interested in so that the user knows exactly what "
+"information the client is getting access to.  If you've ever done a social "
+"login to Google, you'll often see a similar page.  {project_name} provides "
+"the same functionality."
+msgstr ""
+"これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -218,18 +229,8 @@ msgstr ""
 "Authレスポンスに埋め込まれます。"
 
 #. type: Plain text
-#, no-wrap
-msgid "Signature Algorithm"
-msgstr "Signature Algorithm"
-
-#. type: Plain text
 msgid "Choose between a variety of algorithms for signing SAML documents."
 msgstr "SAMLドキュメントに署名するためのアルゴリズムを選択します。"
-
-#. type: Plain text
-#, no-wrap
-msgid "SAML Signature Key Name"
-msgstr "SAML Signature Key Name"
 
 #. type: Plain text
 msgid ""
@@ -344,6 +345,12 @@ msgstr ""
 msgid "Root URL"
 msgstr "Root URL"
 
+#. type: Plain text
+msgid ""
+"If {project_name} uses any configured relative URLs, this value is prepended"
+" to them."
+msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
+
 #. type: Labeled list
 #, no-wrap
 msgid "Valid Redirect URIs"
@@ -355,13 +362,13 @@ msgid ""
 "add.  Click the - sign next to URLs you want to remove.  Remember that you "
 "still have to click the `Save` button! Wildcards (\\*) are only allowed at "
 "the end of of a URI, i.e. $$http://host.com/*$$.  This field is used when "
-"the exact SAML endpoints are not registered and {project_name} is pull the "
-"Assertion Consumer URL from the request."
+"the exact SAML endpoints are not registered and {project_name} is pulling "
+"the Assertion Consumer URL from the request."
 msgstr ""
-"これはオプションのフィールドです。URLパターンを入力し、+ 記号をクリックして追加します。削除するにはURLの横にある - "
+"これはオプションのフィールドです。 URLパターンを入力し、+ 記号をクリックして追加します。削除するにはURLの横にある - "
 "記号をクリックします。反映には `Save` ボタンをクリックする必要があることに留意してください。ワイルドカード（\\*）は "
-"$$http://host.com/*$$ "
-"のように、URIの最後にのみ使用できます。このフィールドは、正確なSAMLエンドポイントが登録されておらず、{project_name}がリクエストからアサーション・コンシューマURLを取得している場合に使用されます。"
+"$$http://host.com/*$$ のように、URIの最後にのみ使用できます。 "
+"このフィールドは、正確なSAMLエンドポイントが登録されておらず、{project_name}がリクエストからアサーション・コンシューマURLを取得している場合に使用されます。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -5,9 +5,9 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
 # Shinsuke UEDA, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
