### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,7 +73,7 @@ msgstr ""
 "このセクションには、ユーザーが所有するすべてのリソースのリストが含まれています。ユーザーはリソースをクリックして詳細を表示したり、リソースを他のユーザーと共有することができます。"
 
 #. type: Plain text
-msgid "Managed *Resources shared with me*"
+msgid "Manage *Resources shared with me*"
 msgstr "*Resources shared with me* の管理"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-account-my-resources
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
