### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -5,15 +5,15 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -174,15 +174,15 @@ msgstr ""
 
 #. type: Plain text
 msgid "Impersonated user sessions provide the following details:"
-msgstr "偽装されたユーザー・セッションは、次の詳細を提供します。"
+msgstr "代理ユーザー・セッションは、次の詳細を提供します。"
 
 #. type: Plain text
 msgid "`IMPERSONATOR_ID`: The ID of an impersonating user"
-msgstr "`IMPERSONATOR_ID`: 偽装しているユーザーのID"
+msgstr "`IMPERSONATOR_ID`: 代理ユーザーのID"
 
 #. type: Plain text
 msgid "`IMPERSONATOR_USERNAME`: The username of an impersonating user"
-msgstr "`IMPERSONATOR_USERNAME`: 偽装しているユーザーのユーザー名"
+msgstr "`IMPERSONATOR_USERNAME`: 代理ユーザーのユーザー名"
 
 #. type: Plain text
 msgid "Service account sessions provide the following details:"
@@ -190,16 +190,16 @@ msgstr "サービス・アカウント・セッションは、次の詳細を提
 
 #. type: Plain text
 msgid "`clientId`: The client ID of the service account"
-msgstr "`clientId`: サービス・アカウントのクライアントID"
+msgstr "`clientId` ：サービス・アカウントのクライアントID"
 
 #. type: Plain text
 msgid ""
 "`clientAddress`: The remote host IP of the service account authenticated "
 "device"
-msgstr "`clientAddress`: サービス・アカウント認証済みデバイスのリモートホストIP"
+msgstr "`clientAddress` ：サービス・アカウント認証済みデバイスのリモートホストIP"
 
 #. type: Plain text
 msgid ""
 "`clientHost`: The remote host name of the service account authenticated "
 "device"
-msgstr "`clientHost`: サービス・アカウント認証済みデバイスのリモートホスト名"
+msgstr "`clientHost` ：サービス・アカウント認証済みデバイスのリモートホスト名"

--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -7,13 +7,13 @@
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -156,3 +156,50 @@ msgid ""
 "available in the token."
 msgstr ""
 "たとえば、最初にトークンに含まれるロールを割り出したい場合は、まずそれらのロールに基づいてオーディエンスを解決します。次に、トークンですでに利用可能なロールとオーディエンスを使用するJavaScriptのスクリプトを処理します。"
+
+#. type: Title ====
+#, no-wrap
+msgid "OIDC User Session Note Mappers"
+msgstr "OIDCユーザー・セッション・ノート・マッパー"
+
+#. type: Plain text
+msgid ""
+"User session details are via mappers and depend on various criteria. User "
+"session details are automatically included when you use or enable a feature "
+"on a client. You can also click the `Add builtin` button to include session "
+"details."
+msgstr ""
+"ユーザー・セッションの詳細は、マッパーを介し、さまざまな基準に依存します。クライアントである機能を使用または有効にすると、ユーザー・セッションの詳細が自動的に含まれます。セッションの詳細を含めるために、"
+" `Add builtin` ボタンをクリックすることもできます。"
+
+#. type: Plain text
+msgid "Impersonated user sessions provide the following details:"
+msgstr "偽装されたユーザー・セッションは、次の詳細を提供します。"
+
+#. type: Plain text
+msgid "`IMPERSONATOR_ID`: The ID of an impersonating user"
+msgstr "`IMPERSONATOR_ID`: 偽装しているユーザーのID"
+
+#. type: Plain text
+msgid "`IMPERSONATOR_USERNAME`: The username of an impersonating user"
+msgstr "`IMPERSONATOR_USERNAME`: 偽装しているユーザーのユーザー名"
+
+#. type: Plain text
+msgid "Service account sessions provide the following details:"
+msgstr "サービス・アカウント・セッションは、次の詳細を提供します。"
+
+#. type: Plain text
+msgid "`clientId`: The client ID of the service account"
+msgstr "`clientId`: サービス・アカウントのクライアントID"
+
+#. type: Plain text
+msgid ""
+"`clientAddress`: The remote host IP of the service account authenticated "
+"device"
+msgstr "`clientAddress`: サービス・アカウント認証済みデバイスのリモートホストIP"
+
+#. type: Plain text
+msgid ""
+"`clientHost`: The remote host name of the service account authenticated "
+"device"
+msgstr "`clientHost`: サービス・アカウント認証済みデバイスのリモートホスト名"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
