### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,8 +40,8 @@ msgid ""
 "OpenID Connect (OIDC) that supports both access tokens in a browser cookie "
 "or bearer tokens."
 msgstr ""
-"{project_name}は、ブラウザーCookie内のアクセストークンまたはベアラートークンの両方をサポートするOpenID "
-"Connect（OIDC）で使用するGoプログラミング言語のアダプターを提供します。"
+"{project_name}は、ブラウザーCookie内のアクセストークンとベアラートークンの両方をサポートし、OpenID "
+"Connect（OIDC）を使用するGoプログラミング言語のアダプターを提供します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__keycloak-gatekeeper
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
