### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +23,7 @@ msgstr ""
 #: source/securing_apps/topics/saml/java/general-config/sp-keys.adoc:3
 #, no-wrap
 msgid "Service Provider Keys and Key Elements"
-msgstr "サービス・プロバイダーの鍵とキー要素"
+msgstr "サービス・プロバイダーのKeysとKey要素"
 
 #. type: Plain text
 #: source/securing_apps/topics/saml/java/general-config/sp-keys.adoc:8


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp-keys.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp-keys
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
