### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,61 +19,25 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
-msgstr ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
-msgstr ""
-"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
-"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
-"      version=\"3.0\">\n"
-
 #. type: Plain text
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr ""
-"このセクションでは、直接WARパッケージ内にconfigファイルを追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
+"このセクションでは、直接WARパッケージ内に設定ファイルを追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
 
-#. type: Plain text
+#. type: delimited block -
+#, no-wrap
 msgid ""
-"The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your"
-" WAR package.  This is a Jetty specific config file and you must define a "
-"Keycloak specific authenticator within it."
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 msgstr ""
-"まず、WARパッケージに `WEB-INF/jetty-web.xml` "
-"ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のAuthenticatorを定義する必要があります。"
-
-#. type: Plain text
-msgid ""
-"Finally you must specify both a `login-config` and use standard servlet "
-"security to specify role-base constraints on your URLs.  Here's an example:"
-msgstr ""
-"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
-"と標準のサーブレット・セキュリティーの両方を指定する必要があります。例を次に示します。"
+"<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n"
+"      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"      xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n"
+"      version=\"3.0\">\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -79,31 +47,39 @@ msgstr "\t<module-name>customer-portal</module-name>\n"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    <security-constraint>\n"
-"        <web-resource-collection>\n"
-"            <web-resource-name>Customers</web-resource-name>\n"
-"            <url-pattern>/*</url-pattern>\n"
-"        </web-resource-collection>\n"
-"        <auth-constraint>\n"
-"            <role-name>user</role-name>\n"
-"        </auth-constraint>\n"
-"        <user-data-constraint>\n"
-"            <transport-guarantee>CONFIDENTIAL</transport-guarantee>\n"
-"        </user-data-constraint>\n"
-"    </security-constraint>\n"
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 msgstr ""
-"    <security-constraint>\n"
-"        <web-resource-collection>\n"
-"            <web-resource-name>Customers</web-resource-name>\n"
-"            <url-pattern>/*</url-pattern>\n"
-"        </web-resource-collection>\n"
-"        <auth-constraint>\n"
-"            <role-name>user</role-name>\n"
-"        </auth-constraint>\n"
-"        <user-data-constraint>\n"
-"            <transport-guarantee>CONFIDENTIAL</transport-guarantee>\n"
-"        </user-data-constraint>\n"
-"    </security-constraint>\n"
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
+
+#. type: Plain text
+msgid ""
+"Next you must create a `keycloak-saml.xml` adapter config file within the "
+"`WEB-INF` directory of your WAR.  The format of this config file is "
+"described in the <<_saml-general-config,General Adapter Config>> section."
+msgstr ""
+"次に、WARの `WEB-INF` ディレクトリーに `keycloak-saml.xml` "
+"アダプター設定ファイルを作成する必要があります。この設定ファイルの形式は、<<_saml-general-"
+"config,共通アダプター設定>>のセクションで説明しています。"
+
+#. type: Plain text
+msgid ""
+"Finally you must specify both a `login-config` and use standard servlet "
+"security to specify role-base constraints on your URLs.  Here's an example:"
+msgstr ""
+"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
+"と標準のサーブレット・セキュリティーの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -123,6 +99,15 @@ msgstr ""
 msgid "Jetty 9 Per WAR Configuration"
 msgstr "WARごとのJetty 9の設定"
 
+#. type: Plain text
+msgid ""
+"The first thing you must do is create a `WEB-INF/jetty-web.xml` file in your"
+" WAR package.  This is a Jetty specific config file and you must define a "
+"Keycloak specific authenticator within it."
+msgstr ""
+"まず、WARパッケージに `WEB-INF/jetty-web.xml` "
+"ファイルを作成します。これはJetty固有の設定ファイルで、その中にKeycloak固有のAuthenticatorを定義する必要があります。"
+
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -148,12 +133,31 @@ msgstr ""
 "    </Get>\n"
 "</Configure>\n"
 
-#. type: Plain text
+#. type: delimited block -
+#, no-wrap
 msgid ""
-"Next you must create a `keycloak-saml.xml` adapter config file within the "
-"`WEB-INF` directory of your WAR.  The format of this config file is "
-"described in the <<_saml-general-config,General Adapter Config>> section."
+"    <security-constraint>\n"
+"        <web-resource-collection>\n"
+"            <web-resource-name>Customers</web-resource-name>\n"
+"            <url-pattern>/*</url-pattern>\n"
+"        </web-resource-collection>\n"
+"        <auth-constraint>\n"
+"            <role-name>user</role-name>\n"
+"        </auth-constraint>\n"
+"        <user-data-constraint>\n"
+"            <transport-guarantee>CONFIDENTIAL</transport-guarantee>\n"
+"        </user-data-constraint>\n"
+"    </security-constraint>\n"
 msgstr ""
-"次に、WARの `WEB-INF` ディレクトリーに `keycloak-saml.xml` "
-"アダプター設定ファイルを作成する必要があります。この設定ファイルの形式は、<<_saml-general-"
-"config,共通アダプター設定>>のセクションで説明しています。"
+"    <security-constraint>\n"
+"        <web-resource-collection>\n"
+"            <web-resource-name>Customers</web-resource-name>\n"
+"            <url-pattern>/*</url-pattern>\n"
+"        </web-resource-collection>\n"
+"        <auth-constraint>\n"
+"            <role-name>user</role-name>\n"
+"        </auth-constraint>\n"
+"        <user-data-constraint>\n"
+"            <transport-guarantee>CONFIDENTIAL</transport-guarantee>\n"
+"        </user-data-constraint>\n"
+"    </security-constraint>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jetty-adapter/jetty9_per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jetty-adapter__jetty9_per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
