### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -132,7 +132,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "To use this filter, include this maven artifact in your WAR poms:"
-msgstr "このフィルタを使用するには、WARのpomに次のmavenアーティファクトを含めます。"
+msgstr "このフィルターを使用するには、WARのpomに次のmavenアーティファクトを含めます。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/servlet-filter-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__servlet-filter-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
