### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/multi-tenancy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/multi-tenancy.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +31,7 @@ msgid ""
 "with multiple {project_name} realms. The realms can be located on the same "
 "{project_name} instance or on different instances."
 msgstr ""
-"SAMLは、<<_multi_tenancy,マルチテナンシー>のOIDCと同じ機能を提供します。つまり、単一のターゲットアプリケーション（WAR）を複数の{project_name}レルムで保護できます。レルムは、同じ{project_name}インスタンスまたは異なるインスタンスに配置できます。"
+"SAMLは、<<_multi_tenancy,マルチテナンシー>に対してOIDCと同じ機能を提供します。つまり、単一のターゲット・アプリケーション（WAR）を複数の{project_name}レルムで保護できます。レルムは、同じ{project_name}インスタンスまたは異なるインスタンスに配置できます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/multi-tenancy.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/multi-tenancy.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +31,8 @@ msgid ""
 "with multiple {project_name} realms. The realms can be located on the same "
 "{project_name} instance or on different instances."
 msgstr ""
-"SAMLは、<<_multi_tenancy,マルチテナンシー>に対してOIDCと同じ機能を提供します。つまり、単一のターゲット・アプリケーション（WAR）を複数の{project_name}レルムで保護できます。レルムは、同じ{project_name}インスタンスまたは異なるインスタンスに配置できます。"
+"SAMLは、<<_multi_tenancy,マルチテナンシー>> "
+"についてOIDCと同じ機能を提供します。つまり、単一のターゲット・アプリケーション（WAR）を複数の{project_name}レルムで保護できます。レルムは、同じ{project_name}インスタンスまたは異なるインスタンスに配置できます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/multi-tenancy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__multi-tenancy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
