### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -428,7 +428,7 @@ msgstr "{project_name}アイデンティティー・プロバイダーにMellon�
 msgid ""
 "Assumption: The {project_name} IdP has already been installed on the "
 "$idp_host."
-msgstr "仮定: project_name}のIdPはすでに$idp_hostにインストールされています。"
+msgstr "仮定: {project_name}のIdPはすでに$idp_hostにインストールされています。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -90,7 +90,7 @@ msgstr "Apache HTTPDモジュールの設定を生成するには、以下のス
 msgid ""
 "Go to the Installation page of your SAML client and select the Mod Auth "
 "Mellon files option."
-msgstr "SAMLクライアントのインストール・ページに移動し、Mod Auth Mellonファイル・オプションを選択します。"
+msgstr "SAMLクライアントのインストール・ページに移動し、Mod Auth Mellon filesオプションを選択します。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__mod-auth-mellon
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
