### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,7 +53,7 @@ msgid ""
 "user."
 msgstr ""
 "ここでは管理者が `john` "
-"を検索したことがわかります。Johnのアカウントの横に代理ログインのボタンが表示されます。ボタンをクリックすると、そのユーザーで代理ログインできます。"
+"を検索したことがわかります。Johnのアカウントの横にimpersonateボタンが表示されます。ボタンをクリックすると、そのユーザーで代理ログインできます。"
 
 #. type: Plain text
 msgid "Also, you can impersonate the user from the user `Details` tab."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/impersonation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__impersonation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
