### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -5,7 +5,7 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
@@ -79,8 +79,8 @@ msgid ""
 "If the password policy is updated, an Update Password action must be set for"
 " every user. An automatic trigger is scheduled as a future enhancement."
 msgstr ""
-"パスワード・ポリシーが更新されている場合は、すべてのユーザーに対してUpdate "
-"Passwordアクションが設定されている必要があります。自動トリガーは将来の拡張として予定されています。"
+"パスワード・ポリシーを更新する場合は、すべてのユーザーに対してUpdate "
+"Passwordアクションを設定する必要があります。自動トリガーは将来の拡張として予定されています。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__password-policies
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
