### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
@@ -80,10 +80,10 @@ msgid ""
 "use the parameter `grant_type=client_credentials` as per the OAuth2 "
 "specification."
 msgstr ""
-"起動するREST URLは `/auth/realms/{realm-name}/protocol/openid-connect/token` "
+"呼び出すREST URLは `/auth/realms/{realm-name}/protocol/openid-connect/token` "
 "です。このURLを呼び出すのはPOSTリクエストで、クライアントのクレデンシャルを送信する必要があります。デフォルトでは、クライアントのクレデンシャルはクライアントのclientIdとclientSecretによって"
 " `Authorization: Basic` "
-"ヘッダーで表されますが、署名されたJWTアサーションまたはクライアント認証のためのその他のカスタム・メカニズムでクライアントを認証することもできます。また、OAuth2仕様に従ってパラメータ"
+"ヘッダーで表されますが、署名されたJWTアサーションまたはクライアント認証のためのその他のカスタム・メカニズムでクライアントを認証することもできます。また、OAuth2仕様に従ってパラメーター"
 " `grant_type=client_credentials` を使う必要があります。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,7 +20,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Title ====
 #, no-wrap
 msgid "Service Accounts"
 msgstr "サービス・アカウント"
@@ -30,11 +35,10 @@ msgid ""
 "will appear.  You need to turn on this switch.  Also make sure that you have"
 " configured your <<_client-credentials, client credentials>>."
 msgstr ""
-"各OIDCクライアントには、 _サービス・アカウント_ "
-"が組み込まれており、アクセストークンを取得できます。これは、<<<_client_credentials_grant,クライアント・クレデンシャル・グラント>>のOAuth"
-" 2.0仕様で説明されています。この機能を使用するには、クライアントの<<_access-type, アクセスタイプ>>を `confidential`"
-" に設定する必要があります。これを行うと、 `Service Accounts Enabled` "
-"スイッチが現れます。このスイッチをオンにする必要があります。また、<<_client-credentials, "
+"各OIDCクライアントには、 _サービス・アカウント_ が組み込まれており、アクセストークンを取得できます。これは、OAuth "
+"2.0仕様の<<_client_credentials_grant,クライアント・クレデンシャル・グラント>>で説明されています。この機能を使用するには、クライアントの"
+"<<_access-type, アクセスタイプ>>を `confidential` に設定する必要があります。これを行うと、 `Service "
+"Accounts Enabled` スイッチが現れます。このスイッチをオンにする必要があります。また、<<_client-credentials, "
 "クライアント・クレデンシャル>>を設定していることを確認してください。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__service-accounts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
