### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,5 +35,5 @@ msgid ""
 "perform some action.  Built-in listeners include a simple log file and the "
 "ability to send an email if an event occurs."
 msgstr ""
-"{project_name}は豊富な監査機能を提供します。すべてのログイン・アクションの記録をデータベースに格納し、管理コンソールで確認することができます。すべての管理アクションを記録してレビューすることもできます。プラグインがこれらのイベントを待ち受けて何らかのアクションを実行できるListener"
+"{project_name}は豊富な監査機能を提供します。すべてのログイン・アクションの記録をデータベースに格納し、管理コンソールで確認することができます。すべての管理アクションを記録して見直すこともできます。プラグインがこれらのイベントを待ち受けて何らかのアクションを実行できるListener"
 " SPIもあります。ビルトインのリスナーには、単純なログファイルと、イベントが発生した場合に電子メールを送信する機能が含まれています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
