### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/4_8_0_final.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/4_8_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_8_0_final.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,7 +51,7 @@ msgstr "これは現在はテクノロジー・プレビュー機能です。"
 #. type: Title =
 #, no-wrap
 msgid "Rules/Drools Policy Marked as a Technology Preview Feature"
-msgstr "テクノロジー・プレビュー機能としてマークされたRules/Droolsポリシー"
+msgstr "Rules/Droolsポリシーをテクノロジー・プレビュー機能としてマーク"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/release_notes/topics/4_8_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_8_0_final.ja_JP.po
@@ -51,7 +51,7 @@ msgstr "これは現在はテクノロジー・プレビュー機能です。"
 #. type: Title =
 #, no-wrap
 msgid "Rules/Drools Policy Marked as a Technology Preview Feature"
-msgstr "Rules/Droolsポリシーをテクノロジー・プレビュー機能としてマーク"
+msgstr "Rules/Droolsポリシーはテクノロジー・プレビュー機能としてマークされました"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/4_8_0_final.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__4_8_0_final
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
