### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/4_3_0_final.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/4_3_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_3_0_final.ja_JP.po
@@ -162,7 +162,7 @@ msgid ""
 "identity provider any login from a different domain is rejected."
 msgstr ""
 "Googleでのログインは、GoogleログインをGoogleの特定のホストドメインに制限するための `hd` "
-"パラメータをサポートします。これがアイデンティティー・プロバイダーで指定されている場合は、異なるドメインからのログインは拒否されます。"
+"パラメーターをサポートします。これがアイデンティティー・プロバイダーで指定されている場合は、異なるドメインからのログインは拒否されます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/release_notes/topics/4_3_0_final.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/4_3_0_final.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,9 +96,9 @@ msgid ""
 "server should respond to an authorization request. This parameter accepts "
 "two values:"
 msgstr ""
-"以前のバージョンでは、アクセストークンとリフレッシュトークンを含む標準のOAuth2レスポンスを使用して、アクセス許可は常にサーバーから返されていました。このリリースでは、クライアントは"
+"以前のバージョンでは、アクセストークンとリフレッシュトークンを含む標準のOAuth2レスポンスを使用して、パーミッションは常にサーバーから返されていました。このリリースでは、クライアントは"
 " `response_mode` "
-"パラメータを使用してサーバーが認可リクエストにどのように応答するべきかを指定することができます。このパラメーターは次の2つの値を受け入れます。"
+"パラメーターを使用してサーバーが認可リクエストにどのように応答するべきかを指定することができます。このパラメーターは次の2つの値を受け入れます。"
 
 #. type: Plain text
 msgid "`decision`"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/4_3_0_final.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__4_3_0_final
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
