### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po
@@ -4,8 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -31,8 +30,8 @@ msgid ""
 "authentication process with the external IDP.  For that, you can use the "
 "`Store Token` configuration option on the IDP's settings page."
 msgstr ""
-"{project_name}では、外部IDPを使用して認証プロセスからのトークンとレスポンスを保存できます。そのために、IDPの設定ページで "
-"`Store Token` の設定オプションを使用できます。"
+"{project_name}は、外部IDPとの認証プロセスから取得したトークンとレスポンスを保存できます。そのために、IDPの設定ページで `Store"
+" Token` の設定オプションを使用できます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__tokens
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
