### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -420,7 +420,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Register a provider using Modules"
-msgstr "モジュールを使用したプロバイダーの登録"
+msgstr "Modulesを使用したプロバイダーの登録"
 
 #. type: Plain text
 msgid ""
@@ -430,8 +430,8 @@ msgid ""
 " add the event listener sysout example provider using the `jboss-cli` script"
 " execute:"
 msgstr ""
-"たとえばモジュールを使用するプロバイダーを登録すると、まずモジュールが作成されます。これを実行するには、jboss-cliスクリプトを使用するか、手動で"
-" `KEYCLOAK_HOME/modules` 内にフォルダーを作成して、jarと `module.xml` を追加します。たとえば、 `jboss-"
+"Modulesを使用してプロバイダーを登録するには、まずモジュールを作成します。これを実行するには、jboss-cliスクリプトを使用するか、手動で "
+"`KEYCLOAK_HOME/modules` 内にフォルダーを作成して、jarと `module.xml` を追加します。たとえば、 `jboss-"
 "cli` スクリプトを使用してイベントリスナーのsysoutサンプル・プロバイダーを追加するには、以下を実行します。"
 
 #. type: delimited block -

--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -521,7 +521,7 @@ msgid ""
 "example to disable the Infinispan user cache provider add:"
 msgstr ""
 "`standalone.xml` 、 `standalone-ha.xml` 、または `domain.xml` "
-"内で、プロバイダーの有効な属性をfalseに設定することによって、プロバイダーを無効にすることができます。たとえば、Infinispanユーザー・キャッシュ・プロバイダーを無効にするには、以下を追加します。"
+"内で、プロバイダーのenabled属性をfalseに設定することによって、プロバイダーを無効にすることができます。たとえば、Infinispanユーザー・キャッシュ・プロバイダーを無効にするには、以下を追加します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -5,7 +5,7 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -44,7 +44,7 @@ msgid ""
 "To implement an SPI you need to implement its ProviderFactory and Provider "
 "interfaces. You also need to create a service configuration file."
 msgstr ""
-"SPIを実装するには、SPIのProviderFactoryとプロバイダー・インターフェイスを実装する必要があります。また、サービス設定ファイルを作成する必要があります。"
+"SPIを実装するには、SPIのProviderFactoryとProviderインターフェイスを実装する必要があります。また、サービス設定ファイルを作成する必要があります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -259,7 +259,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Your provider can also lookup other providers if needed. For example:"
-msgstr "また、プロバイダーも必要に応じて他のプロバイダーを参照することができます。たとえば、"
+msgstr "また、プロバイダーも必要に応じて他のプロバイダーを参照することができます。以下が例です。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -488,9 +488,9 @@ msgid ""
 "section of `standalone.xml`, `standalone-ha.xml`, or `domain.xml`, and "
 "adding it to the providers:"
 msgstr ""
-"モジュールを作成すると、{project_name}でこのモジュールを登録する必要があります。 これは `standalone.xml` 、 "
+"モジュールを作成したら、{project_name}にこのモジュールを登録する必要があります。登録は、 `standalone.xml` 、 "
 "`standalone-ha.xml` 、または `domain.xml` のkeycloak-"
-"serverサブシステムセクションを編集し、それをプロバイダーに追加することにより行われます。"
+"serverサブシステムのセクションを編集し、それをプロバイダーに追加することにより行われます。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -453,8 +453,8 @@ msgid ""
 "`KEYCLOAK_HOME/modules/org/acme/provider/main`.  Then copy `provider.jar` to"
 " this folder and create `module.xml` with the following content:"
 msgstr ""
-"または、それを手動で作成するには、 `KEYCLOAK_HOME/modules/org/acme/provider/main` "
-"フォルダーを作成して起動します。次に `provider.jar` をこのフォルダーにコピーし、以下の内容で `module.xml` を作成します。"
+"または、それを手動で作成するには、まずは `KEYCLOAK_HOME/modules/org/acme/provider/main` "
+"フォルダーを作成します。次に `provider.jar` をこのフォルダーにコピーし、以下の内容で `module.xml` を作成します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
