### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,4 +35,4 @@ msgid ""
 "Admins can logout a user or set of users from the Admin Console. They can "
 "revoke tokens and set up all the token and session timeouts there too."
 msgstr ""
-"ユーザーがレルムにログインすると、{project_name}はユーザー・セッションを維持し、セッション内で訪問したすべてのクライアントを記憶します。これらのユーザー・セッションに対してレルム管理者が実行できる多くの管理機能があります。レルム全体のログイン統計を表示し、各クライアントに誰がどこからログインしているのかを確認できます。管理者は、管理コンソールからユーザーまたはユーザーのセットをログアウトできます。トークンを取り消したり、すべてのトークンとセッションのタイムアウトを設定することも可能です。"
+"ユーザーがレルムにログインすると、{project_name}はユーザー・セッションを維持し、セッション内でアクセスしたすべてのクライアントを記憶します。これらのユーザー・セッションに対してレルム管理者が実行できる多くの管理機能があります。レルム全体のログイン統計を表示し、各クライアントに誰がどこからログインしているのかを確認できます。管理者は、管理コンソールからユーザーまたはユーザーのセットをログアウトできます。トークンを取り消したり、すべてのトークンとセッションのタイムアウトを設定することも可能です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
