### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -4,7 +4,6 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
@@ -54,7 +53,7 @@ msgid ""
 "queries the external user store for the user and maps the external data "
 "representation of the user to {project_name}'s user metamodel."
 msgstr ""
-"{project_name}ランタイムは、ユーザーがログインしているときなど、ユーザーを検索する必要があるときに、ユーザーを特定するためにいくつかの手順を実行します。まず、ユーザーがユーザー・キャッシュに入っているかどうかを調べます。ユーザーが見つかった場合は、そのメモリー内表現を使用します。次に、{project_name}ローカル・データベース内のユーザーを探します。ユーザーが見つからない場合は、ユーザー・ストレージSPIプロバイダの実装をループして、そのうちの1つがランタイムが探しているユーザーを返すまでユーザークエリーを実行します。プロバイダーは外部ユーザーストアにユーザーを照会し、ユーザーの外部データ表現を{project_name}のユーザー・メタモデルにマップします。"
+"{project_name}ランタイムは、ユーザーがログインしているときなどの、ユーザーを検索する必要があるときに、ユーザーを特定するためいくつかの手順を実行します。まず、ユーザーがユーザー・キャッシュに入っているかどうかを調べます。ユーザーが見つかった場合は、そのメモリー内表現を使用します。次に、{project_name}ローカル・データベース内のユーザーを探します。ユーザーが見つからない場合は、ユーザー・ストレージSPIプロバイダーの実装をループして、そのうちの1つがランタイムが探しているユーザーを返すまでユーザークエリーを実行します。プロバイダーは外部ユーザーストアにユーザーを照会し、ユーザーの外部データ表現を{project_name}のユーザー・メタモデルにマップします。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -38,7 +38,9 @@ msgid ""
 "user store and the internal user object model that {project_name} uses to "
 "log in users and manage them."
 msgstr ""
-"ユーザー・ストレージSPIを使用して、外部ユーザー・データベースとクレデンシャル・ストアに接続するように、{project_name}の拡張機能を実装できます。組み込みのLDAPとActiveDirectoryのサポートは、このSPIを実際に実装したものです。設定などの作業をせず、すぐに{project_name}はローカル・データベースを使用して、ユーザーの作成、更新、検索とクレデンシャルの検証をします。しかし、多くの場合、組織は{project_name}のデータモデルに移行できない既存の外部独自のユーザー・データベースを持っています。このような状況では、アプリケーション開発者は、ユーザー・ストレージSPIの実装を記述して、外部ユーザーストアと、{project_name}がユーザーのログインおよび管理に使用する内部ユーザー・オブジェクト・モデルをブリッジすることができます。"
+"ユーザー・ストレージSPIを使用して、外部ユーザー・データベースとクレデンシャル・ストアに接続するように、{project_name}の拡張機能を実装できます。組み込みのLDAPとActive"
+" "
+"Directoryのサポートは、このSPIを実際に実装したものです。設定などの作業をせず、すぐに{project_name}はローカル・データベースを使用して、ユーザーの作成、更新、検索とクレデンシャルの検証をします。しかし、多くの場合、組織は{project_name}のデータモデルに移行できない外部の独自ユーザー・データベースをすでに持っています。このような状況では、アプリケーション開発者は、ユーザー・ストレージSPIの実装をコーディングして、外部ユーザーストアと、{project_name}がユーザーのログインおよび管理に使用する内部ユーザー・オブジェクト・モデルをブリッジすることができます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
