### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -77,7 +82,7 @@ msgid ""
 "if your provider can validate one or more different credential types (for "
 "example, if your provider can validate a password)."
 msgstr ""
-"`org.keycloak.credential.CredentialInputValidator`|プロバイダーが1つまたは複数の異なるクレデンシャル・タイプを検証する（たとえば、プロバイダーがパスワード検証をする）場合はこのインターフェイスを実装します。"
+"`org.keycloak.credential.CredentialInputValidator`|プロバイダーが1つ以上の異なるクレデンシャル・タイプを検証する（たとえば、プロバイダーがパスワード検証をする）場合はこのインターフェイスを実装します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/provider-capability-interfaces.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__provider-capability-interfaces
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
