### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,7 +33,7 @@ msgid ""
 " required to implement this interface. It provides a mapping between the "
 "external user store and the user metamodel that {project_name} uses."
 msgstr ""
-"_capability_ _interfaces_ で定義されたメソッドのほとんどは、ユーザーの表現が返されるか、または渡されます。これらの表現は、 "
+"_ケイパビリティー・インターフェイス_ で定義されたメソッドのほとんどは、ユーザーの表現が返されるか、または渡されます。これらの表現は、 "
 "`org.keycloak.models.UserModel` "
 "インターフェイスによって定義されます。アプリ開発者はこのインターフェイスを実装する必要があります。これは、外部ユーザーストアと{project_name}が使用するユーザー・メタモデルとの間のマッピングを提供します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/model-interfaces.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__model-interfaces
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
