### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -441,8 +441,8 @@ msgid ""
 "        return false;\n"
 "    }\n"
 msgstr ""
-"return false;\n"
-" }\n"
+"        return false;\n"
+"    }\n"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -638,7 +638,7 @@ msgid ""
 msgstr ""
 "`Config.Scope` パラメーターは、 `standalone.xml` 、 `standalone-ha.xml` 、または "
 "`domain.xml` "
-"内で設定することができるファクトリー設定です。これらのファイルがある場所について、詳しくはlink:{installguide_link}[{installguide_name}]を参照してください。"
+"内で設定することができるファクトリー設定です。これらのファイルがある場所についての詳細は、link:{installguide_link}[{installguide_name}]を参照してください。"
 
 #. type: Plain text
 msgid "For example, by adding the following to `standalone.xml`:"

--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -531,7 +531,7 @@ msgid ""
 "         to determine the _capability interfaces_ that the provider implements.\n"
 msgstr ""
 "テンプレート・パラメーターを指定しないと、プロバイダーは機能しません。ランタイムは、クラスのイントロスペクションが実行し、プロバイダーが実装する "
-"_capability interfaces_ を定義します。\n"
+"_ケイパビリティー･インターフェース_ を定義します。\n"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -7,14 +7,14 @@
 # Shinsuke UEDA, 2017
 # Hiroshi Aida <daian183@gmail.com>, 2018
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -626,8 +626,8 @@ msgid ""
 "field with the username and password combinations stored there."
 msgstr ""
 "`init()` "
-"メソッドの実装では、クラスパスからユーザー宣言を含むプロパティー・ファイルを見つけます。次に、そこに格納されているユーザー名とパスワードの組み合わせを`properties`"
-" フィールドにロードします。"
+"メソッドの実装では、クラスパスからユーザー宣言を含むプロパティー・ファイルを見つけます。次に、そこに格納されているユーザー名とパスワードの組み合わせを "
+"`properties` フィールドにロードします。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -7,7 +7,7 @@
 # Shinsuke UEDA, 2017
 # Hiroshi Aida <daian183@gmail.com>, 2018
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -521,7 +521,7 @@ msgid ""
 "class we defined before: `PropertyFileUserStorageProvider`."
 msgstr ""
 "まず最初に注意すべき点は、 `UserStorageProviderFactory` "
-"クラスを実装する際、テンプレート・パラメーターとして具体的なプロバイダー・クラス・実装を渡す必要があるということです。ここでは、以前に定義したプロバイダー・クラス"
+"クラスを実装する際、テンプレート・パラメーターとして具体的なプロバイダー・クラスの実装を渡す必要があるということです。ここでは、以前に定義したプロバイダー・クラス"
 " `PropertyFileUserStorageProvider` を指定します。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po
@@ -626,8 +626,8 @@ msgid ""
 "field with the username and password combinations stored there."
 msgstr ""
 "`init()` "
-"メソッドの実装では、クラスパスからのユーザー宣言を含むプロパティー・ファイルが見つかります。次に、そこに格納されているユーザー名とパスワードの組み合わせを、"
-" `properties` フィールドをロードします。"
+"メソッドの実装では、クラスパスからユーザー宣言を含むプロパティー・ファイルを見つけます。次に、そこに格納されているユーザー名とパスワードの組み合わせを`properties`"
+" フィールドにロードします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/simple-example.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__simple-example
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
