### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -8,7 +8,7 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # naoto watanabe <nabenao11@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -2460,9 +2460,8 @@ msgid ""
 "{project_name} server (Property `jboss.node.name`) contains the correct name"
 " used by the load balancer server to identify the current server."
 msgstr ""
-"おそらく、ロードバランサーを "
-"スティッキー・セッションをサポートするように設定する必要があることを意味します。{project_name}サーバー（プロパティー "
-"`jboss.node.name` ）の起動時に使用される指定されたルート名に、 "
+"おそらく、ロードバランサーをスティッキー・セッションをサポートするように設定する必要があることを意味します。{project_name}サーバー起動中に使用される指定されたルート名（プロパティー"
+" `jboss.node.name` ）に、 "
 "ロードバランサー・サーバーが現在のサーバーを識別するために使用する正しい名前が含まれていることを確認してください。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -2460,7 +2460,7 @@ msgid ""
 "{project_name} server (Property `jboss.node.name`) contains the correct name"
 " used by the load balancer server to identify the current server."
 msgstr ""
-"おそらく、ロードバランサーをスティッキー・セッションをサポートするように設定する必要があることを意味します。{project_name}サーバー起動中に使用される指定されたルート名（プロパティー"
+"おそらく、スティッキー・セッションをサポートするようにロードバランサーを設定する必要があることを意味します。{project_name}サーバー起動中に使用される指定されたルート名（プロパティー"
 " `jboss.node.name` ）に、 "
 "ロードバランサー・サーバーが現在のサーバーを識別するために使用する正しい名前が含まれていることを確認してください。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
