### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/fuse-admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/fuse-admin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/fuse-admin.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -105,6 +109,23 @@ msgstr ""
 "JAASレルムから使用するクライアント・アプリケーションの設定を指定します。"
 
 #. type: Plain text
+msgid ""
+"Start Fuse and install the `keycloak` JAAS realm. The easiest way is to "
+"install the `keycloak-jaas` feature, which has the JAAS realm predefined. "
+"You can override the feature's predefined realm by using your own `keycloak`"
+" JAAS realm with higher ranking. For details see the "
+"https://access.redhat.com/documentation/en-us/red_hat_fuse/7.2/html-"
+"single/apache_karaf_security_guide/index#ESBSecureContainer[JBoss Fuse "
+"documentation]."
+msgstr ""
+"Fuseを起動し、 `keycloak` のJAASレルムをインストールしてください。最も簡単な方法は、JAASレルムがあらかじめ定義された "
+"`keycloak-jaas` 機能をインストールすることです。独自の `keycloak` "
+"JAASレルムを使用して、より高いランクでその機能の定義済みレルムを上書きすることができます。詳細については、 "
+"https://access.redhat.com/documentation/en-us/red_hat_fuse/7.2/html-"
+"single/apache_karaf_security_guide/index#ESBSecureContainer[JBoss Fuse "
+"documentation] を参照してください。"
+
+#. type: Plain text
 msgid "Use these commands in the Fuse terminal:"
 msgstr "Fuseターミナルで次のコマンドを使用します。"
 
@@ -132,6 +153,17 @@ msgstr "パスワードは `password` でログインしてください。"
 
 #. type: Plain text
 msgid ""
+"On some later operating systems, you might also need to use the SSH "
+"command's -o option `-o HostKeyAlgorithms=+ssh-dss` because later SSH "
+"clients do not allow use of the `ssh-dss` algorithm, by default. However, by"
+" default, it is currently used in {fuse7Version}."
+msgstr ""
+"最近のオペレーティング・システムでは、SSHコマンドの-oオプション `-o HostKeyAlgorithms=+ssh-dss` "
+"を使用する必要があります。これは、最近のSSHクライアントではデフォルトで `ssh-dss` "
+"アルゴリズムの使用は許可されていないためです。しかし、{fuse7Version}では現在デフォルトで使用されています。"
+
+#. type: Plain text
+msgid ""
 "Note that the user needs to have realm role `admin` to perform all "
 "operations or another role to perform a subset of operations (for example, "
 "the *viewer* role that restricts the user to run only read-only Karaf "
@@ -148,6 +180,17 @@ msgstr ""
 #, no-wrap
 msgid "Using JMX Authentication"
 msgstr "JMX認証の使用"
+
+#. type: Plain text
+msgid ""
+"JMX authentication might be necessary if you want to use jconsole or another"
+" external tool to remotely connect to JMX through RMI. Otherwise it might be"
+" better to use hawt.io/jolokia, since the jolokia agent is installed in "
+"hawt.io by default. For more details see <<_fuse7_hawtio,Hawtio Admin "
+"Console>>."
+msgstr ""
+"jconsoleまたは別の外部ツールを使用してRMI経由でJMXにリモート接続する場合は、JMX認証が必要になることがあります。そうでなければ、jolokiaエージェントがデフォルトでhawt.ioにインストールされているので、hawt.io/jolokiaを使用する方が良いかもしれません。詳細については、<<_fuse7_hawtio,Hawtio"
+" Admin Console>>を参照してください。"
 
 #. type: Plain text
 msgid "To use JMX authentication, complete the following steps:"
@@ -189,41 +232,3 @@ msgid ""
 "and credentials: admin/password (based on the user with admin privileges "
 "according to your environment)."
 msgstr "クレデンシャルはadmin/password（利用環境の管理者権限を持つユーザー次第）です。"
-
-#. type: Plain text
-msgid ""
-"Start Fuse and install the `keycloak` JAAS realm. The easiest way is to "
-"install the `keycloak-jaas` feature, which has the JAAS realm predefined. "
-"You can override the feature's predefined realm by using your own `keycloak`"
-" JAAS realm with higher ranking. For details see the "
-"https://access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html-"
-"single/security_guide/#ESBSecureContainer[JBoss Fuse documentation]."
-msgstr ""
-"Fuseを起動し、 `keycloak` のJAASレルムをインストールしてください。最も簡単な方法は、JAASレルムがあらかじめ定義された "
-"`keycloak-jaas` 機能をインストールすることです。独自の `keycloak` "
-"JAASレルムを使用して、より高いランクでその機能の定義済みレルムを上書きすることができます。詳細については、 "
-"https://access.redhat.com/documentation/en-us/red_hat_fuse/7.0/html-"
-"single/security_guide/#ESBSecureContainer[JBoss Fuse documentation] "
-"を参照してください。"
-
-#. type: Plain text
-msgid ""
-"On some later operating systems, you might also need to use the SSH "
-"command's -o option `-o HostKeyAlgorithms=+ssh-dss` because later SSH "
-"clients do not allow use of the `ssh-dss` algorithm, by default. However, by"
-" default, it is currently used in {fuse7Version}."
-msgstr ""
-"最近のオペレーティング・システムでは、SSHコマンドの-oオプション `-o HostKeyAlgorithms=+ssh-dss` "
-"を使用する必要があります。これは、最近のSSHクライアントではデフォルトで `ssh-dss` "
-"アルゴリズムの使用は許可されていないためです。しかし、{fuse7Version}では現在デフォルトで使用されています。"
-
-#. type: Plain text
-msgid ""
-"JMX authentication might be necessary if you want to use jconsole or another"
-" external tool to remotely connect to JMX through RMI. Otherwise it might be"
-" better to use hawt.io/jolokia, since the jolokia agent is installed in "
-"hawt.io by default. For more details see <<_fuse7_hawtio,Hawtio Admin "
-"Console>>."
-msgstr ""
-"jconsoleまたは別の外部ツールを使用してRMI経由でJMXにリモート接続する場合は、JMX認証が必要になることがあります。そうでなければ、jolokiaエージェントがデフォルトでhawt.ioにインストールされているので、hawt.io/jolokiaを使用する方が良いかもしれません。詳細については、<<_fuse7_hawtio,Hawtio"
-" Admin Console>>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/fuse-admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__fuse-admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
