### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,21 +20,35 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/camel.adoc:76
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:71
-#: source/securing_apps/topics/oidc/java/fuse/servlet-whiteboard.adoc:60
 #, no-wrap
 msgid "</blueprint>\n"
 msgstr "</blueprint>\n"
 
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
+"           xsi:schemaLocation=\"\n"
+"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
+"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
+msgstr ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
+"           xsi:schemaLocation=\"\n"
+"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
+"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
+
 #. type: Title =====
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:3
 #, no-wrap
 msgid "Securing an Apache CXF Endpoint on the Default Jetty Engine"
 msgstr "デフォルトのJettyエンジンでのApache CXFエンドポイントの保護"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:6
 msgid ""
 "Some services automatically come with deployed servlets on startup. One such"
 " service is the CXF servlet running in the $$http://localhost:8181/cxf$$ "
@@ -46,7 +64,6 @@ msgstr ""
 "で、これは組み込みのサーブレットを起動時にアンデプロイし、{project_name}によってセキュリティー保護されたコンテキストに再デプロイできるようにします。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:8
 msgid ""
 "The configuration file `OSGI-INF/blueprint/blueprint.xml` inside your "
 "application might resemble the one below. Note that it adds the JAX-RS "
@@ -58,33 +75,11 @@ msgstr ""
 "コンテキスト全体をセキュリティー保護することです。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:18
-#, no-wrap
-msgid ""
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
-"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
-"           xsi:schemaLocation=\"\n"
-"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
-"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
-msgstr ""
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
-"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
-"           xsi:schemaLocation=\"\n"
-"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
-"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
-
-#. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:20
 #, no-wrap
 msgid "    <!-- JAXRS Application -->\n"
 msgstr "    <!-- JAXRS Application -->\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:22
 #, no-wrap
 msgid ""
 "    <bean id=\"customerBean\" "
@@ -94,7 +89,6 @@ msgstr ""
 "class=\"org.keycloak.example.rs.CxfCustomerService\" />\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:31
 #, no-wrap
 msgid ""
 "    <jaxrs:server id=\"cxfJaxrsServer\" address=\"/customerservice\">\n"
@@ -116,7 +110,6 @@ msgstr ""
 "    </jaxrs:server>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:34
 #, no-wrap
 msgid ""
 "    <!-- Securing of whole /cxf context by unregister default cxf servlet "
@@ -126,7 +119,6 @@ msgstr ""
 "from paxweb and re-register with applied security constraints -->\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:50
 #, no-wrap
 msgid ""
 "    <bean id=\"cxfConstraintMapping\" class=\"org.eclipse.jetty.security.ConstraintMapping\">\n"
@@ -162,7 +154,6 @@ msgstr ""
 "    </bean>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:61
 #, no-wrap
 msgid ""
 "    <bean id=\"cxfKeycloakPaxWebIntegration\" class=\"org.keycloak.adapters.osgi.PaxWebIntegrationService\"\n"
@@ -188,7 +179,6 @@ msgstr ""
 "    </bean>\n"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:69
 #, no-wrap
 msgid ""
 "    <bean id=\"defaultCxfReregistration\" class=\"org.keycloak.adapters.osgi.ServletReregistrationService\" depends-on=\"cxfKeycloakPaxWebIntegration\"\n"
@@ -208,7 +198,6 @@ msgstr ""
 "    </bean>\n"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:75
 msgid ""
 "As a result, all other CXF services running on the default CXF HTTP "
 "destination are also secured. Similarly, when the application is undeployed,"
@@ -225,7 +214,6 @@ msgstr ""
 "CXFエンドポイントの保護>>で説明されているように、独自のJettyエンジンをアプリケーションに使用すると、個々のアプリケーションのセキュリティーをより詳細に制御できます。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:78
 msgid ""
 "The `WEB-INF` directory might need to be inside your project (even if your "
 "project is not a web application). You might also need to edit the `/WEB-INF"
@@ -241,13 +229,11 @@ msgstr ""
 "ファイルは必要ないことに注意してください。"
 
 #. type: Plain text
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:80
 msgid ""
 "The `Import-Package` in `META-INF/MANIFEST.MF` must contain these imports:"
 msgstr "`META-INF/MANIFEST.MF` の `Import-Package` は以下のインポートを含まなければなりません。"
 
 #. type: delimited block -
-#: source/securing_apps/topics/oidc/java/fuse/cxf-builtin.adoc:93
 #, no-wrap
 msgid ""
 "META-INF.cxf;version=\"[2.7,3.2)\",\n"
@@ -255,8 +241,8 @@ msgid ""
 "org.apache.cxf.transport.http;version=\"[2.7,3.2)\",\n"
 "org.apache.cxf.*;version=\"[2.7,3.2)\",\n"
 "com.fasterxml.jackson.jaxrs.json;version=\"[2.5,3)\",\n"
-"org.eclipse.jetty.security;version=\"[8,10)\",\n"
-"org.eclipse.jetty.util.security;version=\"[8,10)\",\n"
+"org.eclipse.jetty.security;version=\"[9,10)\",\n"
+"org.eclipse.jetty.util.security;version=\"[9,10)\",\n"
 "org.keycloak.*;version=\"{project_versionMvn}\",\n"
 "org.keycloak.adapters.jetty;version=\"{project_versionMvn}\",\n"
 "*;resolution:=optional\n"
@@ -266,8 +252,8 @@ msgstr ""
 "org.apache.cxf.transport.http;version=\"[2.7,3.2)\",\n"
 "org.apache.cxf.*;version=\"[2.7,3.2)\",\n"
 "com.fasterxml.jackson.jaxrs.json;version=\"[2.5,3)\",\n"
-"org.eclipse.jetty.security;version=\"[8,10)\",\n"
-"org.eclipse.jetty.util.security;version=\"[8,10)\",\n"
+"org.eclipse.jetty.security;version=\"[9,10)\",\n"
+"org.eclipse.jetty.util.security;version=\"[9,10)\",\n"
 "org.keycloak.*;version=\"{project_versionMvn}\",\n"
 "org.keycloak.adapters.jetty;version=\"{project_versionMvn}\",\n"
 "*;resolution:=optional\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__cxf-builtin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
