### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,13 +21,13 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "OpenID Connect"
-msgstr "OpenID Connect"
+msgid "Supported Platforms"
+msgstr "サポートされているプラットフォーム"
 
 #. type: Title ===
 #, no-wrap
-msgid "Supported Platforms"
-msgstr "サポートされているプラットフォーム"
+msgid "OpenID Connect"
+msgstr "OpenID Connect"
 
 #. type: Title =====
 #, no-wrap
@@ -47,8 +51,8 @@ msgid "<<_tomcat_adapter,Tomcat>>"
 msgstr "<<_tomcat_adapter,Tomcat>>"
 
 #. type: Plain text
-msgid "<<_jetty8_adapter,Jetty 8>>"
-msgstr "<<_jetty8_adapter,Jetty 8>>"
+msgid "<<_jetty9_adapter,Jetty 9>>"
+msgstr "<<_jetty9_adapter,Jetty 9>>"
 
 #. type: Plain text
 msgid "<<_servlet_filter_adapter,Servlet Filter>>"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__supported-platforms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
