### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -107,7 +107,7 @@ msgstr "`X-Forwarded-For` ヘッダーからクライアントのIPアドレス�
 msgid ""
 "Configuring your proxy to generate the `X-Forwarded-For` and `X-Forwarded-Proto` HTTP headers and preserving the\n"
 " original `Host` HTTP header is beyond the scope of this guide.  Take extra precautions to ensure that the\n"
-"`X-Forwared-For` header is set by your proxy.  If your proxy isn't configured correctly, then _rogue_ clients can set this header themselves and trick {project_name}\n"
+"`X-Forwarded-For` header is set by your proxy.  If your proxy isn't configured correctly, then _rogue_ clients can set this header themselves and trick {project_name}\n"
 "into thinking the client is connecting from a different IP address than it actually is.  This becomes really important if you are doing\n"
 "any black or white listing of IP addresses.\n"
 msgstr ""
@@ -440,7 +440,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The `output-socket-binding` is a logical name pointing to a `socket-binding`"
-" configured later in the _domain.xml_ file.  the `instance-id` attribute "
+" configured later in the _domain.xml_ file.  The `instance-id` attribute "
 "must also be unique to the new host as this value is used by a cookie to "
 "enable sticky sessions when load balancing."
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__load-balancer
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
