### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,7 +35,7 @@ msgstr "Dockerレジストリーv2認証"
 #. type: Plain text
 msgid ""
 "link:https://docs.docker.com/registry/spec/auth/[Docker Registry V2 "
-"Authentciation] is an OIDC-Like protocol used to authenticate users against "
+"Authentication] is an OIDC-Like protocol used to authenticate users against "
 "a Docker registry.  {project_name}'s implementation of this protocol allows "
 "for a {project_name} authentication server to be used by a Docker client to "
 "authenticate against a registry.  While this protocol uses fairly standard "
@@ -40,7 +45,7 @@ msgid ""
 "ability to understand how to map repository names and permissions to the "
 "OAuth scope mechanism."
 msgstr ""
-"link:https://docs.docker.com/registry/spec/auth/[Dockerレジストリーv2認証]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}はこのプロトコルを実装しており、Dockerクライアントがレジストリーに対しての認証に{project_name}認証サーバーを使用することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装としては扱うことができない問題点があります。最大の問題点は、リクエストとレスポンスが非常に特殊なJSON形式であり、リポジトリー名とパーミッションをOAuthのスコープ・メカニズムにマップする方法を理解する必要がある点です。"
+"link:https://docs.docker.com/registry/spec/auth/[Dockerレジストリーv2認証]は、Dockerレジストリーに対してユーザーを認証するために使用されるOIDCのようなプロトコルです。{project_name}がこのプロトコルを実装することで、{project_name}認証サーバーをDockerクライアントがレジストリーに対して認証することができます。このプロトコルはかなり標準的なトークンと署名メカニズムを使用しますが、真のOIDC実装として扱われるのを防ぐための方法があります。最大の偏りには、リクエストとレスポンスのための非常に特殊なJSON形式と、リポジトリー名とパーミッションをOAuthスコープ・メカニズムにマップする方法を理解する機能が含まれています。"
 
 #. type: Title ====
 #, no-wrap
@@ -99,7 +104,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"When the Docker registry recieves the new request for the protected resource"
+"When the Docker registry receives the new request for the protected resource"
 " with the token from the {project_name} server, the registry validates the "
 "token and grants access to the requested resource (if appropriate)."
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__docker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
