### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -142,13 +142,13 @@ msgstr "Jetty 9.xアダプター"
 
 #. type: Plain text
 msgid ""
-"Keycloak has a separate adapter for Jetty 9.1.x, Jetty 9.2.x and Jetty 9.3.x"
+"Keycloak has a separate adapter for Jetty 9.2.x, Jetty 9.3.x and Jetty 9.4.x"
 " that you will have to install into your Jetty installation.  You then have "
 "to provide some extra configuration in each WAR you deploy to Jetty.  Let's "
 "go over these steps."
 msgstr ""
-"Keycloakには、Jetty 9.1.x、Jetty 9.2.x、Jetty "
-"9.3.x用の個別のアダプターがあります。これらをJettyにインストールする必要があります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
+"Keycloakには、Jetty 9.2.x、Jetty 9.3.x、Jetty "
+"9.4.x用の個別のアダプターがあります。これらをJettyにインストールする必要があります。Jettyにデプロイする各WARには、さらにいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
 msgid ""
@@ -227,11 +227,11 @@ msgstr "この設定ファイルの形式は、<<_java_adapter_config,Javaアダ
 
 #. type: Plain text
 msgid ""
-"The Jetty 9.1.x adapter will not be able to find the `keycloak.json` file.  "
+"The Jetty 9.x adapter will not be able to find the `keycloak.json` file.  "
 "You will have to define all adapter settings within the `jetty-web.xml` file"
 " as described below."
 msgstr ""
-"Jetty 9.1.xアダプターは、 `keycloak.json` ファイルを見つけることができません。下記のように `jetty-web.xml` "
+"Jetty 9.xアダプターは、 `keycloak.json` ファイルを見つけることができません。下記のように `jetty-web.xml` "
 "ファイル内にすべてのアダプター設定を定義する必要があります。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jetty9-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
