### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/5_0_0.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/5_0_0.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/5_0_0.ja_JP.po
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "WildFly 15 Upgrade"
+msgstr "WildFly 15 アップグレード"
+
+#. type: Plain text
+msgid "Keycloak server was upgraded to use WildFly 15 under the covers."
+msgstr "{project_name}サーバーは内部でWildFly 15を使用するようにアップグレードされました。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/5_0_0.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__5_0_0
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
