### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -274,6 +274,26 @@ msgstr "    var app = express();\n"
 #, no-wrap
 msgid "    app.use( keycloak.middleware() );\n"
 msgstr "    app.use( keycloak.middleware() );\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Checking Authentication"
+msgstr "認証のチェック"
+
+#. type: Plain text
+msgid ""
+"To check that a user is authenticated before accessing a resource, simply "
+"use `keycloak.checkSso()`. It will only authenticate if the user is already "
+"logged-in. If the user is not logged-in, the browser will be redirected back"
+" to the originally-requested URL and remain unauthenticated:"
+msgstr ""
+"リソースにアクセスする前にユーザーが認証されていることを確認するには、単に `keycloak.checkSso()` "
+"を使います。ユーザーがすでにログインしている場合にのみ認証されます。ユーザーがログインしていない場合、ブラウザーは最初に要求されたURLにリダイレクトされ、ユーザーは未認証のままになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    app.get( '/check-sso', keycloak.checkSso(), checkSsoHandler );\n"
+msgstr "    app.get( '/check-sso', keycloak.checkSso(), checkSsoHandler );\n"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
