### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
@@ -158,6 +158,18 @@ msgstr ""
 "バインディングとほぼ同じ方法で動作しますが、GETリクエストではなく、POSTリクエストによってXMLドキュメントが交換されます。 _POST_ "
 "バインディングは、JavaScriptを使用して、ドキュメントを交換するときに{project_name}サーバーまたはアプリケーションに対してPOSTリクエストを行うようにブラウザーを操作します。基本的にHTTPレスポンスには、JavaScriptが埋め込まれたフォームを含むHTMLが含まれています。ページが読み込まれると、JavaScriptはフォームを自動的に呼び出します。このことについて実際に知る必要はありませんが、これはかなり巧妙なトリックです。"
 
+#. type: Plain text
+msgid ""
+"_POST_ binding is usually recommended because of security and size "
+"restrictions. When using _REDIRECT_ the SAML response is part of the URL (it"
+" is a query parameter as it was explained before), so it can be captured in "
+"logs and it is considered less secure. Regarding size, if the assertion "
+"contains a lot or large attributes sending the document inside the HTTP "
+"payload is always better than in the more limited URL."
+msgstr ""
+"セキュリティーとサイズの制限のため、通常 _POST_ バインディングが推奨されます。 _REDIRECT_ "
+"を使用する場合、SAMLレスポンスはURLの一部になります（前に説明したようにクエリー・パラメーターです）。したがって、ログに記録される可能性があり、安全性が低いと見なされます。サイズに関しては、ドキュメントを送信する多量または大量の属性がアサーション内に含まれている場合は、制限されたURLよりもHTTPペイロードが常に優れています。"
+
 #. type: Title =====
 #, no-wrap
 msgid "ECP"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
