### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
@@ -115,10 +115,12 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "For the OpenID Connect protocol, there are client scopes `profile`, `email`,"
-" `address`, `phone`, `offline_access`, `roles` and `web-origins`."
+" `address`, `phone`, `offline_access`, `roles`, `web-origins` and "
+"`microprofile-jwt`."
 msgstr ""
 "OpenID Connectプロトコルには、 `profile` 、 `email` 、 `address` 、 `phone` 、 "
-"`offline_access` 、 `roles` 、 `web-origins` のクライアント・スコープがあります。"
+"`offline_access` 、 `roles` 、 `web-origins` 、 `microprofile-jwt` "
+"のクライアント・スコープがあります。"
 
 #. type: Plain text
 msgid ""
@@ -207,6 +209,21 @@ msgstr ""
 "クライアント・スコープ `web-origins` もOpenID Connect仕様で定義されておらず、`scope` "
 "クレームに追加されていません。これは、許可されたWebオリジンをアクセストークンの `allowed-origins` "
 "クレームに追加するために使用されます。"
+
+#. type: Plain text
+msgid ""
+"The client scope `microprofile-jwt` was created to handle the claims defined"
+" in the https://wiki.eclipse.org/MicroProfile/JWT_Auth[MicroProfile/JWT Auth"
+" Specification].  This client scope defines a user property mapper for the "
+"`upn` claim and also a realm role mapper for the `groups` claim. These "
+"mappers can be changed as needed so that different properties can be used to"
+" create the MicroProfile/JWT specific claims."
+msgstr ""
+"クライアント・スコープ `microprofile-jwt` は、 "
+"https://wiki.eclipse.org/MicroProfile/JWT_Auth[MicroProfile/JWT Auth "
+"Specification] で定義されているクレームを処理するために作成されました。このクライアント・スコープは、 `upn` "
+"クレーム用のユーザー・プロパティー・マッパーと `groups` "
+"クレーム用のレルム・ロール・マッパーを定義します。MicroProfile/JWT固有のクレームを作成するためさまざまなプロパティーを使用できるように、これらのマッパーは必要に応じて変更できます。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
