### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -41,8 +41,7 @@ msgid ""
 "perform this configuration within the administration console UI."
 msgstr ""
 "`PropertyFileUserStorageProvider` "
-"のサンプルには少し工夫された点があります。これはプロバイダーのjarに組み込まれたプロパティー・ファイルにハードコードされていて、これはあまり便利ではありません。プロバイダーのインスタンス毎にこのファイルのロケーションを設定できるようにする必要があります。つまり、複数の異なるレルムで複数回にわたりこのプロバイダーを利用して、完全に異なるユーザー・プロパティー・ファイルを指し示す必要があるということです。また、この設定は管理コンソールのUI内でも実行する必要があります。"
-" "
+"のサンプルには少し工夫が必要です。プロバイダーのjarに組み込まれたプロパティー・ファイルにハードコードされていて、これはあまり便利ではありません。プロバイダーのインスタンス毎にこのファイルの場所を設定できるようにすることをお勧めします。つまり、複数の異なるレルムで複数回にわたりこのプロバイダーを利用して、完全に異なるユーザー・プロパティー・ファイルを指し示す必要があるということです。また、この設定は管理コンソールのUI内でも変更できるようにすることをお勧めします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
