### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -60,7 +60,7 @@ msgid ""
 msgstr ""
 "OIDCを使用するユースケースは、実際には2つの種類があります。1つ目は、{project_name}サーバーにユーザーの認証を要求するアプリケーションのユースケースです。ログインが成功すると、アプリケーションは"
 " _IDトークン_ と _アクセストークン_ を受け取ります。 _IDトークン_ "
-"には、ユーザー名、電子メール、その他のプロファイル情報など、ユーザーに関する情報が含まれています。 _アクセストークン_ "
+"には、ユーザーに関する情報（ユーザー名、電子メール、その他のプロファイル情報など）が含まれています。 _アクセストークン_ "
 "はレルムによってデジタル署名されており、アプリケーションがユーザーのアクセス可能なリソースを決定するために使用できるアクセス情報（ユーザー・ロール・マッピングのような）が含まれています。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/supported-protocols.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__supported-protocols
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
