### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/identity-brokering/tokens.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/identity-brokering/tokens.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/identity-brokering/tokens.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,8 +35,8 @@ msgid ""
 "authentication process with the external IDP.  For that, you can use the "
 "`Store Token` configuration option on the IDP's settings page."
 msgstr ""
-"{project_name}では、外部IDPを使用して認証プロセスからのトークンとレスポンスを保存できます。そのために、IDPの設定ページで "
-"`Store Token` の設定オプションを使用できます。"
+"{project_name}は、外部IDPとの認証プロセスから取得したトークンとレスポンスを保存できます。そのために、IDPの設定ページで `Store"
+" Token` の設定オプションを使用できます。"
 
 #. type: Plain text
 #: source/server_admin/topics/identity-broker/tokens.adoc:10


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/identity-brokering/tokens.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__identity-brokering__tokens
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
