### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -70,7 +73,7 @@ msgid ""
 " on how to make things more secure if you are uncomfortable with that setup."
 msgstr ""
 "ここでユーザー名もパスワードも入力していないと思うかもしれませんが、 `jboss-cli` "
-"を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配でよりセキュアにしたい場合は、詳しくはlink:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。"
+"を実行中のスタンドアローン・サーバーまたはドメイン・コントローラーと同じマシンで実行し、アカウントに適切なファイル・アクセス権限がある場合は、管理者のユーザー名とパスワードを設定または入力する必要はありません。この設定では心配で、よりセキュアにしたい場合の詳細は、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/manage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__manage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
