### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po
@@ -5,7 +5,6 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -178,7 +177,7 @@ msgid ""
 " provider won't work."
 msgstr ""
 "`@Local` "
-"アノテーションを定義して、そこにプロバイダー・クラスを指定する必要があります。これをしないと、EJBはユーザーを正しくプロキシしないので、プロバイダーは動作しません。"
+"アノテーションを定義して、そこにプロバイダー・クラスを指定する必要があります。これをしないと、EJBはユーザーを正しくプロキシーしないので、プロバイダーは動作しません。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__javaee
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
