### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/rest.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/rest.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/rest.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -168,7 +172,7 @@ msgid ""
 "provider type of the string `org.keycloak.storage.UserStorageProvider`, as "
 "well as the configuration."
 msgstr ""
-"ユーザー・ストレージ・プロバイダーを作成するには、プロバイダID、文字列  "
+"ユーザー・ストレージ・プロバイダーを作成するには、プロバイダーID、文字列  "
 "`org.keycloak.storage.UserStorageProvider` のプロバイダー・タイプ、および設定を指定する必要があります。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/rest.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__rest
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
