### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
@@ -125,7 +125,7 @@ msgstr ""
 msgid ""
 "Changes to your security requirements can imply deep changes to application "
 "code to reflect these changes"
-msgstr "セキュリティー要件の変更を反映するためには、アプリケーション・コードの大幅な変更が必要となる可能性があります。"
+msgstr "セキュリティー要件の変更を反映するためには、アプリケーションのコードの大幅な変更が必要となる可能性があります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -82,8 +86,8 @@ msgid ""
 "policies, and enforce authorization decisions in your applications and "
 "services."
 msgstr ""
-"{project_name}は管理UIとRESTful "
-"APIのセットに基づいており、保護されるリソースとスコープのアクセス許可を作成し、そのアクセス許可を認可ポリシーに関連づけ、アプリケーションやサービスで認可判断を行うために必要な手段を提供します。"
+"{project_name}は、一連の管理UIとRESTful "
+"APIに基づいており、保護されるリソースとスコープのアクセス許可を作成し、そのアクセス許可を認可ポリシーに関連づけ、アプリケーションやサービスで認可判断を行うために必要な手段を提供します。"
 
 #. type: Plain text
 msgid ""
@@ -95,7 +99,9 @@ msgid ""
 "on a session to authenticate users, that information is usually stored in a "
 "user's session and retrieved from there for each request."
 msgstr ""
-"保護されたリソースへのアクセスを許可するかどうかを判定するために、リソースサーバー（保護されたリソースを処理するアプリケーションまたはサービス）は、通常、何らかの情報に依存しています。RESTfulベースのリソースサーバーの場合、通常、その情報はセキュリティー・トークンから取得されます。そのトークンは、通常、サーバーへのリクエストごとにベアラートークンとして送信されます。ユーザーを認証するためにセッションに依存するWebアプリケーションの場合、通常、その情報はユーザーのセッションに格納され、リクエストごとにそこから取得されます。"
+"リソースサーバー（保護されたリソースを提供するアプリケーションまたはサービス）は、保護されたリソースへのアクセスを許可すべきかどうかを判定するために、何らかの情報を頼りにします。"
+" "
+"RESTfulベースのリソースサーバーの場合、通常、その情報はセキュリティー・トークンから取得されます。そのトークンは、通常、サーバーへのリクエストごとにベアラートークンとして送信されます。ユーザーを認証するためにセッションに依存するWebアプリケーションの場合、通常、その情報はユーザーのセッションに格納され、リクエストごとにそこから取得されます。"
 
 #. type: Plain text
 msgid ""
@@ -105,7 +111,7 @@ msgid ""
 " same resources. While roles are very useful and used by applications, they "
 "also have a few limitations:"
 msgstr ""
-"多くの場合、リソースサーバーはロールベースのアクセス・コントロール（RBAC）に基づいて認可判断のみを行います。ロールベースのアクセス・コントロールでは、保護されたリソースにアクセスしようとするユーザーに付与されたロールが、同リソースにマップされたロールに対してチェックされます。ロールは非常に有用でアプリケーションで使用されますが、以下のようないくつかの制限もあります。"
+"多くの場合、リソースサーバーはロールベースのアクセス・コントロール（RBAC）に基づいて認可判断のみを行います。ロールベースのアクセス・コントロールでは、保護されたリソースにアクセスしようとするユーザーに付与されたロールが、同リソースにマップされたロールに対してチェックされます。ロールは非常に有用で、アプリケーションにより使用されますが、以下のようないくつかの制限もあります。"
 
 #. type: Plain text
 msgid ""
@@ -119,7 +125,7 @@ msgstr ""
 msgid ""
 "Changes to your security requirements can imply deep changes to application "
 "code to reflect these changes"
-msgstr "セキュリティー要件の変更は、反映するにはアプリケーション・コードに大幅な変更が必要となるでしょう。"
+msgstr "セキュリティー要件の変更を反映するためには、アプリケーション・コードの大幅な変更が必要となる可能性があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
