### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
@@ -106,7 +106,7 @@ msgid ""
 "potentially many _verbs_ that can logically apply to a resource."
 msgstr ""
 "リソースのスコープは、リソース上で実行可能な限定されたアクセスの範囲です。認可ポリシーの用語では、スコープは論理的にリソースに適用できる、潜在的に多くの"
-" _verbs_ の1つです。"
+" _動詞_ の1つです。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,7 +54,8 @@ msgid ""
 " information in the user's session and retrieve it from there for each "
 "request."
 msgstr ""
-"通常、リソースサーバーは、保護されたリソースへのアクセスを許可するかどうかを決定するために、何らかの情報に依存しています。RESTfulベースのリソースサーバーの場合、大抵、その情報はセキュリティー・トークンに格納され、一般的に、サーバーへのすべてのリクエストと一緒にベアラートークンとして送信されます。セッションを利用してユーザーを認証するWebアプリケーションは、その情報をユーザーのセッションに格納し、リクエストごとにそこから取得します。"
+"通常、リソースサーバーは、保護されたリソースへのアクセスを許可するかどうかを決定するために、何らかの情報を頼りにします。 "
+"RESTfulベースのリソースサーバーの場合、大抵、その情報はセキュリティー・トークンに格納され、一般的に、サーバーへのすべてのリクエストと一緒にベアラートークンとして送信されます。セッションを利用してユーザーを認証するWebアプリケーションは、その情報をユーザーのセッションに格納し、リクエストごとにそこから取得します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
@@ -79,7 +79,7 @@ msgid ""
 "the _object_ being protected."
 msgstr ""
 "リソースは、アプリケーションと組織の資産の一部です。これは、1つ以上のエンドポイントのセット（HTMLページなどの古典的なWebリソースなど）です。認可ポリシーの用語では、リソースは保護される"
-" _object_ です。"
+" _オブジェクト_ です。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po
@@ -171,7 +171,7 @@ msgid ""
 "Make changes at runtime; applications are only concerned about the resources"
 " and scopes being protected and not how they are protected."
 msgstr ""
-"ランタイムに変更を加えます。アプリケーションは、保護されているリソースとスコープについてのみに関係し、それらがどのように保護されるかには関係ありません。"
+"実行時に変更を加えます。アプリケーションは、保護されているリソースとスコープについてのみに考慮し、それらがどのように保護されるかについては考慮しません。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-terminology.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-terminology
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
