### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# hitanaka156 <thiroya@fsi.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,4 +48,4 @@ msgid ""
 "permissions. In doing so, you are conceptually turning the client "
 "application into a resource server."
 msgstr ""
-"きめ細かいパーミッションをサポートするクライアント・アプリケーションを設定することができます。その際に、概念的にクライアント・アプリケーションをリソースサーバーに変換します。"
+"どのクライアント・アプリケーションも、きめ細かいパーミッションをサポートするように設定できます。そうすることで、概念的にクライアント・アプリケーションをリソースサーバーに変えています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
