### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -81,9 +81,9 @@ msgid ""
 "permissions associated with the resource will be examined before granting "
 "access."
 msgstr ""
-"このリソースは `Type` 、すなわち `urn:my-resource-server:resources:default` と `URI` `/*`"
-" "
-"を定義します。ここで、URIフィールドは、このリソースがアプリケーションのすべてのパスを表すことを{project_name}が示すワイルドカード・パターンで定義します。つまり、アプリケーションの<<_enforcer_overview,"
+"このリソースは、 `Type` を `urn:my-resource-server:resources:default` という名前で、 `URI` を"
+" `/*` "
+"で定義します。ここで、URIフィールドは、このリソースがアプリケーションのすべてのパスを表すことを{project_name}に示すワイルドカード・パターンで定義します。つまり、アプリケーションの<<_enforcer_overview,"
 " ポリシー適用>>を有効にすると、アクセス権を付与する前に、リソースに関連付けられているすべてのパーミッションが検査されます。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
@@ -124,8 +124,8 @@ msgid ""
 "policy. If you click this policy you can see that it defines a rule as "
 "follows:"
 msgstr ""
-"このポリシーは、ポリシーで保護されているリソースへのアクセスを常に許可する条件を定義した<<_policy_js, "
-"JavaScriptベースのポリシー>>です。このポリシーをクリックすると、次のようにルールが定義されていることが分かります。"
+"このポリシーは<<_policy_js, "
+"JavaScriptベースのポリシー>>で、このポリシーによって保護されているリソースへのアクセスを常に許可する条件を定義しています。このポリシーをクリックすると、次のようにルールが定義されていることが分かります。"
 
 #. type: Code block
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po
@@ -183,8 +183,8 @@ msgid ""
 "resources, permissions and policies, make sure the default configuration "
 "doesn't conflict with your own settings."
 msgstr ""
-"デフォルトのリソースは、 **/*** パターンを使用してアプリケーション内のリソースまたはパスにマップされる **URI** "
-"で作成されます。独自のリソース、権限、ポリシーを作成する前に、デフォルト設定が自分の設定と矛盾しないことを確認してください。"
+"デフォルトのリソースは、 **/*** パターンを使用してアプリケーション内の任意のリソースまたはパスにマップされる **URI** "
+"で作成されます。独自のリソース、パーミッション、ポリシーを作成する前に、デフォルト設定が自分の設定と競合しないことを確認してください。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-default-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-default-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
