### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgid ""
 msgstr ""
 "SSLが無効でも、 `localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 "
 "`172.16.x.x` "
-"のようなプライベートIPアドレス以外であれば、{project_name}をそのまま実行することは可能です。サーバーにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスする場合はエラーになります。"
+"のようなプライベートIPアドレスであれば、{project_name}をそのまま実行することは可能です。サーバーにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスする場合はエラーになります。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -57,7 +57,7 @@ msgid ""
 msgstr ""
 "SSLが無効でも、 `localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 "
 "`172.16.x.x` "
-"のようなプライベートIPアドレスであれば、{project_name}をそのまま実行することは可能です。サーバーにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスする場合はエラーになります。"
+"のようなプライベートIPアドレスであれば、{project_name}をそのまま実行することは可能です。サーバーにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスするとエラーになります。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po
@@ -57,7 +57,7 @@ msgid ""
 msgstr ""
 "SSLが無効でも、 `localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 "
 "`172.16.x.x` "
-"のようなプライベートIPアドレスであれば、{project_name}をそのまま実行することは可能です。サーバーにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスするとエラーになります。"
+"のようなプライベートIPアドレスであれば、{project_name}をそのまま実行することは可能です。サーバーにSSL/HTTPSが設定されていない場合、またはプライベートIPアドレス以外からHTTP経由で{project_name}にアクセスする場合はエラーになります。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/https.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__https
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
