### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po
@@ -3,17 +3,29 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# KojiNose <knose.dev@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Configuration"
+msgstr "設定"
 
 #. type: Plain text
 #, no-wrap
@@ -25,10 +37,9 @@ msgstr "*Name*\n"
 msgid "*Description*\n"
 msgstr "*Description*\n"
 
-#. type: Title ==
-#, no-wrap
-msgid "Configuration"
-msgstr "設定"
+#. type: Plain text
+msgid "A string containing details about this policy."
+msgstr "このポリシーに関する詳細情報を含む文字列。"
 
 #. type: Plain text
 #, no-wrap
@@ -40,18 +51,6 @@ msgid ""
 "The <<_policy_logic, Logic>> of this policy to apply after the other "
 "conditions have been evaluated."
 msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
-
-#. type: Plain text
-msgid "A string containing details about this policy."
-msgstr "このポリシーに関する詳細情報を含む文字列。"
-
-#. type: Plain text
-msgid ""
-"A human-readable and unique string describing the policy. A best practice is"
-" to use names that are closely related to your business and security "
-"requirements, so you can identify them more easily."
-msgstr ""
-"ポリシーを説明する、人が判読可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
 
 #. type: Title =
 #, no-wrap
@@ -88,7 +87,7 @@ msgid ""
 "consent pages or even enforce clients to explicitly provide a scope when "
 "obtaining access tokens from a {project_name} server."
 msgstr ""
-"ロールのポリシーは、オブジェクトへのアクセスを許可するのに特定のロールを強制する必要がある、より限定されたロールベースのアクセス・コントロール（RBAC）が必要な場合に役立ちます。たとえば、ユーザーがクライアント・アプリケーション（ユーザーの代理として動作している）がユーザーのリソースにアクセスできるようにするのにユーザーが同意する必要があることを強制できます。{project_name}クライアント・スコープ・マッピングを使用して同意ページを有効にしたり、{project_name}サーバーからアクセス・トークンを取得するときに明示的にスコープを指定したりすることもできます。"
+"ロールのポリシーは、オブジェクトへのアクセスを許可するのに特定のロールを強制する必要がある、より限定されたロールベースのアクセス・コントロール（RBAC）が必要な場合に役立ちます。たとえば、（ユーザーの代理として動作している）クライアント・アプリケーションがユーザーのリソースにアクセスできるようにするために、ユーザーの同意が必要であることを強制するようにできます。{project_name}クライアント・スコープ・マッピングを使用して同意ページを有効にしたり、{project_name}サーバーからアクセス・トークンを取得するときに明示的にスコープを指定したりすることもできます。"
 
 #. type: Plain text
 msgid ""
@@ -105,6 +104,14 @@ msgstr "ロールベース・ポリシーの追加"
 msgid ""
 "image:{project_images}/policy/create-role.png[alt=\"Add Role-Based Policy\"]"
 msgstr "image:{project_images}/policy/create-role.png[alt=\"ロールベース・ポリシーの追加\"]"
+
+#. type: Plain text
+msgid ""
+"A human-readable and unique string describing the policy. A best practice is"
+" to use names that are closely related to your business and security "
+"requirements, so you can identify them more easily."
+msgstr ""
+"ポリシーを説明する、人が判読可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-role-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-role-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
