### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,7 +54,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "As an example, given the realm `master` and the client-id `account`:"
-msgstr "一例として、レルムの `master` とクライアントIDの `account` が指定されているとします。"
+msgstr "レルム `master` とクライアントID `account` が指定されている例を、以下に示します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-link.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-link
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
