### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -202,4 +202,4 @@ msgstr "`clientAddress` ：サービス・アカウントの認証済みデバ�
 msgid ""
 "`clientHost`: The remote host name of the service account authenticated "
 "device"
-msgstr "`clientHost` ：サービス・アカウント認証済みデバイスのリモートホスト名"
+msgstr "`clientHost` ：サービス・アカウントの認証済みデバイスのリモートホスト名"

--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -196,7 +196,7 @@ msgstr "`clientId` ：サービス・アカウントのクライアントID"
 msgid ""
 "`clientAddress`: The remote host IP of the service account authenticated "
 "device"
-msgstr "`clientAddress` ：サービス・アカウント認証済みデバイスのリモートホストIP"
+msgstr "`clientAddress` ：サービス・アカウントの認証済みデバイスのリモートホストIP"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
