### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,4 +62,4 @@ msgid ""
 "localization."
 msgstr ""
 "`description` フィールドの値は、置換変数に文字列 `$\\{var-name}` を指定することによってローカライズ可能です。 "
-"ローカライズされた値は、テーマのプロパティー・ファイル内で設定されます。ローカリゼーションの詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+"ローカライズされた値は、テーマのプロパティー・ファイル内で設定されます。ローカライゼーションの詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/realm-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__realm-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
