### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po
@@ -3,11 +3,17 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,6 +64,6 @@ msgid ""
 "Roles`.  `Effective Roles` are all roles that are explicitly assigned to the"
 " user as well as any roles that are inherited from composites."
 msgstr ""
-"`developer` ロールが割り当てられると、 `developer` のコンポジットに関連付けられた `employee` ロールが "
+"`developer` ロールが割り当てられると、 `developer` の複合ロールに関連付けられた `employee` ロールが "
 "`Effective Roles` に現れます。 `Effective Roles` "
-"は、ユーザーに明示的に割り当てられたすべてのロールと、コンポジットから継承されたロールです。"
+"は、ユーザーに明示的に割り当てられたすべてのロールと、複合ロールから継承されたロールです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles/user-role-mappings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles__user-role-mappings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
