### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
@@ -724,7 +724,7 @@ msgid ""
 "from a {project_name} provider might include the following claims:"
 msgstr ""
 "`--add-claims` "
-"オプションを使用して、アクセストークンから追加のクレームを認可ヘッダーに追加することができます。たとえば、{project_name}のあるプロバイダーから取得したトークンには、次のようなクレームが含まれています。"
+"オプションを使用して、アクセストークンから取得した追加のクレームを認証ヘッダーに追加することができます。たとえば、{project_name}のあるプロバイダーから取得したトークンには、次のようなクレームが含まれています。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
@@ -724,7 +724,7 @@ msgid ""
 "from a {project_name} provider might include the following claims:"
 msgstr ""
 "`--add-claims` "
-"オプションを使用して、アクセストークンから取得した追加のクレームを認証ヘッダーに追加することができます。たとえば、{project_name}のあるプロバイダーから取得したトークンには、次のようなクレームが含まれています。"
+"オプションを使用して、アクセストークンから取得した追加のクレームを認可ヘッダーに追加することができます。たとえば、{project_name}のあるプロバイダーから取得したトークンには、次のようなクレームが含まれています。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__keycloak-gatekeeper
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
