### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po
@@ -5,15 +5,15 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # KojiNose <knose.dev@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -102,7 +102,7 @@ msgid ""
 "to obtain the groups the user is a member of. If not defined, user's groups "
 "are obtained from your realm configuration."
 msgstr ""
-"グループ名および/またはパスを保持するトークン内のクレームの名前を指定します。通常、認可リクエストは、一部のユーザーに代わって動作するクライアントに、以前に発行されたIDトークンまたはアクセストークンに基づいて処理されます。これが定義されている場合、トークンには、このポリシーがユーザーの所属するグループを取得する場所を示すクレームが含まれている必要があります。定義されていない場合、ユーザーのグループはレルム設定から取得されます。"
+"グループの名前および/またはパスを保持するトークン内のクレームの名前を指定します。通常、認可リクエストは、ユーザーに代わって動作するクライアントに対して、以前に発行されたIDトークンまたはアクセストークンに基づいて処理されます。これが定義されている場合、トークンには、このポリシーがユーザーの所属するグループを取得する場所を示すクレームが含まれている必要があります。定義されていない場合、ユーザーのグループはレルム設定から取得されます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-group-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-group-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
