### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# masahiro suzuki <suzmasah@fsi.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,59 +19,47 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title =
-#: source/authorization_services/topics/permission-decision-strategy.adoc:2
-#, no-wrap
-msgid "Policy Decision Strategies"
-msgstr "ポリシー決定戦略"
-
 #. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:5
-msgid ""
-"When associating policies with a permission, you can also define a decision "
-"strategy to specify how to evaluate the outcome of the associated policies "
-"to determine access."
-msgstr ""
-"ポリシーにパーミッションを関連付けるときに、決定戦略を定義して、関連付けされたポリシーの結果を評価して最終的なアクセスを判断する方法を指定できます"
-
-#. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:7
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:47
 #, no-wrap
 msgid "*Unanimous*\n"
 msgstr "*Unanimous*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:9
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:49
 msgid ""
 "The default strategy if none is provided. In this case, _all_ policies must "
 "evaluate to a positive decision for the final decision to be also positive."
 msgstr "デフォルトの戦略。この場合、最終的に _全て_ のポリシー判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:11
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:51
 #, no-wrap
 msgid "*Affirmative*\n"
 msgstr "*Affirmative*\n"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:13
+#, no-wrap
+msgid "*Consensus*\n"
+msgstr "*Consensus*\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Policy Decision Strategies"
+msgstr "ポリシー決定戦略"
+
+#. type: Plain text
+msgid ""
+"When associating policies with a permission, you can also define a decision "
+"strategy to specify how to evaluate the outcome of the associated policies "
+"to determine access."
+msgstr ""
+"ポリシーにパーミッションを関連付けるときに、決定戦略を定義して、関連付けされたポリシーの結果を評価して最終的なアクセスを判断する方法を指定できます。"
+
+#. type: Plain text
 msgid ""
 "In this case, _at least one_ policy must evaluate to a positive decision for"
 " the final decision to be also positive."
 msgstr "この場合、最終的に _少なくとも1つの_ ポリシーの判定結果が肯定と判定される必要があります。"
 
 #. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:15
-#: source/authorization_services/topics/policy-aggregated-policy.adoc:55
-#, no-wrap
-msgid "*Consensus*\n"
-msgstr "*Consensus*\n"
-
-#. type: Plain text
-#: source/authorization_services/topics/permission-decision-strategy.adoc:16
 msgid ""
 "In this case, the number of positive decisions must be greater than the "
 "number of negative decisions. If the number of positive and negative "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/permission-decision-strategy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__permission-decision-strategy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
