### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -116,7 +116,7 @@ msgid ""
 "any other information associated with the token, such as the permissions "
 "granted by {project_name}."
 msgstr ""
-"クライアントがRPTのアクティブな状態を判断し、トークンに関連付けられているその他の情報（{project_name}によって付与されたパーミッションなど）を決定するため、サーバーの検索に使用できるOAuth2準拠のトークン・イントロスペクション・エンドポイント。"
+"OAuth2準拠のトークン・イントロスペクション・エンドポイント。クライアントは、RPTの状態がアクティブか判断したり、トークンに関連付けられたその他の情報（{project_name}によって付与されたパーミッションなど）を判断したりするために、サーバーに問い合わせるためにこのエンドポイントを使用できます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-discovery-document
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
