### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
@@ -36,7 +36,7 @@ msgid ""
 "the token is an RPT. When a client requests a resource at the resource "
 "server without a permission ticket:"
 msgstr ""
-"UMAで保護されたリソースサーバーは、トークンがRPTであるリクエスト内のベアラートークンを想定しています。クライアントがパーミッション・チケットなしでリソースサーバーにリソースを要求すると、次のようになります。"
+"UMAで保護されたリソースサーバーは、リクエスト内のベアラートークンがRPTであることを想定しています。クライアントがパーミッション・チケットなしでリソースサーバーにリソースを要求する場合、次のようになります。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
@@ -95,7 +95,7 @@ msgid ""
 "{project_name} server, the client can use the discovery document to obtain "
 "the location of the token endpoint and send an authorization request."
 msgstr ""
-"クライアントはパーミッション・チケットとともに{project_name}サーバーの場所も持っているので、クライアントはディスカバリー文書を使用してトークン・エンドポイントの場所を取得し、認可リクエストを送信できます。"
+"クライアントはパーミッション・チケットを持つとともに{project_name}サーバーの場所も知っているので、クライアントはディスカバリー文書を使用してトークン・エンドポイントの場所を取得し、認可リクエストを送信できます。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
@@ -122,8 +122,7 @@ msgstr ""
 msgid ""
 "If ${project_name} assessment process results in issuance of permissions, it"
 " issues the RPT with which it has associated the permissions:"
-msgstr ""
-"${project_name}の評価プロセスの結果、パーミッションが発行されると、そのパーミッションに関連付けられているRPTが発行されます。"
+msgstr "{project_name}の評価処理の結果、パーミッションが発行されると、そのパーミッションに関連付けられているRPTが発行されます。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-authz-process
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
