### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
@@ -89,7 +89,7 @@ msgid ""
 "{project_name}. For instance, client_id/client_secret or JWT."
 msgstr ""
 "クライアントは、{project_name}でサポートされているクライアント認証方式を使用できます。たとえば、client_id / "
-"client_secretまたはJWTです。"
+"client_secretやJWTです。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -76,7 +76,7 @@ msgid ""
 "issued to Client A acting on behalf of User A, permissions will be granted "
 "depending on the resources and scopes to which User A has access."
 msgstr ""
-"この方法は、クライアントがユーザーに代わって動作している場合に特に便利です。この場合、ベアラトークンは以前に{project_name}により、ユーザーの代わりに（またはそれ自体のために）動作しているクライアントに発行されたアクセストークンです。パーミッションは、アクセストークンによって表されるアクセス・コンテキストを考慮して評価されます。例えば、アクセストークンがユーザーAの代わりに動作するクライアントAに発行された場合、ユーザーAがアクセスするリソース及びスコープに応じてパーミッションが与えられます。"
+"この方法は、クライアントがユーザーに代わって動作している場合に特に便利です。この場合、ベアラートークンは以前に{project_name}により、ユーザーの代わりに（またはそれ自体のために）動作しているクライアントに発行されたアクセストークンです。パーミッションは、アクセストークンによって表されるアクセス・コンテキストを考慮して評価されます。例えば、アクセストークンがユーザーAの代わりに動作するクライアントAに発行された場合、ユーザーAがアクセス権を持つリソース及びスコープに応じてパーミッションが与えられます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-authentication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission-authentication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
