### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,7 +66,7 @@ msgstr ""
 msgid ""
 "The `claim_token` parameter expects a BASE64 encoded JSON with a format "
 "similar to the example below:"
-msgstr "`claim_token` パラメーターは、以下の例のようなフォーマットのBASE64でエンコードされたJSONを期待します。"
+msgstr "`claim_token` パラメーターは、以下の例のような形式のBASE64でエンコードされたJSONを期待します。"
 
 #. type: Code block
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po
@@ -83,7 +83,7 @@ msgstr ""
 msgid ""
 "The format expects one or more claims where the value for each claim must be"
 " an array of strings."
-msgstr "このフォーマットでは、1つまたは複数のクレームを想定しており、各クレームの値は文字列型の配列である必要があります。"
+msgstr "この形式では、1つ以上のクレームを想定しており、各クレームの値は文字列型の配列である必要があります。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-pushing-claims.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-pushing-claims
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
