### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-uma.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-uma.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-uma.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +31,7 @@ msgid ""
 "following ways:"
 msgstr ""
 "{project_name}認可サービスは、User-Managed "
-"Accessまたは略すとUMAに基づいています。UMAは、以下の方法でOAuth2機能を強化する仕様です。"
+"Access（略してUMA）に基づいています。UMAは、以下の方法でOAuth2の機能を強化する仕様です。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission-uma.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission-uma
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
