### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -843,10 +843,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Q: When logging in, I get an error: *Parameter client_assertion_type is "
-"missing [invalid_client]."
+"missing [invalid_client]*."
 msgstr ""
 "Q：ログインすると、次のエラーが表示されます：*Parameter client_assertion_type is missing "
-"[invalid_client]"
+"[invalid_client]*."
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration__client-registration-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
