### PR TITLE
Translations for i18n/po/ja_JP/release_notes/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/master.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/master.ja_JP.po
@@ -31,6 +31,11 @@ msgstr "{project_name_full} 7.3"
 
 #. type: Title ==
 #, no-wrap
+msgid "{project_name_full} 6"
+msgstr "{project_name_full} 6"
+
+#. type: Title ==
+#, no-wrap
 msgid "{project_name_full} 7.3.CD05"
 msgstr "{project_name_full} 7.3.CD05"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
