### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po
@@ -4,17 +4,17 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,8 +165,8 @@ msgstr ""
 msgid ""
 "The `addUser()` method will be called if the provider implements the "
 "`UserRegistrationProvider` interface. If your provider has a configuration "
-"switch to turn of adding a user, returning `null` from this method will skip"
-" the provider and call the next one."
+"switch to turn off adding a user, returning `null` from this method will "
+"skip the provider and call the next one."
 msgstr ""
 "プロバイダーが `UserRegistrationProvider` インターフェイスを実装している場合、 `addUser()` "
 "メソッドが呼び出されます。プロバイダーがユーザーの追加をオフにする設定スイッチを持っている場合、このメソッドから  `null` "
@@ -358,13 +358,13 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The `getUser()` method iterates over the key set of the property file, "
+"The `getUsers()` method iterates over the key set of the property file, "
 "delegating to `getUserByUsername()` to load a user.  Notice that we are "
 "indexing this call based on the `firstResult` and `maxResults` parameter. If"
 " your external store does not support pagination, you will have to do "
 "similar logic."
 msgstr ""
-"`getUser()` メソッドはプロパティー・ファイルのキーセットを反復し、 `getUserByUsername()` "
+"`getUsers()` メソッドはプロパティー・ファイルのキーセットを反復し、 `getUserByUsername()` "
 "に委譲してユーザーをロードします。 `firstResult` と `maxResults` "
 "パラメーターに基づいてこの呼び出しにインデックスを付けることに注目してください。外部ストアがページネーションをサポートしていない場合は、同様のロジックを実行する必要があります。"
 
@@ -416,13 +416,13 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The first declaration of `searchForUser()` takes a string parameter. This is"
-" supposed to be a string that you use to search username and email "
+"The first declaration of `searchForUser()` takes a `String` parameter. This "
+"is supposed to be a string that you use to search username and email "
 "attributes to find the user. This string can be a substring, which is why we"
 " use the `String.contains()` method when doing our search."
 msgstr ""
-"`searchForUser()` "
-"の最初の宣言は文字列パラメーターを受け取ります。これは、ユーザー名と電子メールの属性を検索してユーザーを見つけるために使用する文字列です。この文字列は部分文字列にすることができるので、検索を行うときに"
+"`searchForUser()` の最初の宣言は `String` "
+"パラメーターを受け取ります。これは、ユーザー名と電子メールの属性を検索してユーザーを見つけるために使用する文字列です。この文字列は部分文字列にすることができるので、検索を行うときに"
 " `String.contains()` メソッドを使用しています。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/registration-query.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__registration-query
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
