### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -7,14 +7,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -358,13 +358,13 @@ msgstr "Valid Redirect URIs"
 msgid ""
 "This is an optional field.  Enter in a URL pattern and click the + sign to "
 "add.  Click the - sign next to URLs you want to remove.  Remember that you "
-"still have to click the `Save` button! Wildcards (\\*) are only allowed at "
-"the end of of a URI, i.e. $$http://host.com/*$$.  This field is used when "
-"the exact SAML endpoints are not registered and {project_name} is pulling "
-"the Assertion Consumer URL from the request."
+"still have to click the `Save` button! Wildcards (*) are only allowed at the"
+" end of a URI, i.e. $$http://host.com/*$$.  This field is used when the "
+"exact SAML endpoints are not registered and {project_name} is pulling the "
+"Assertion Consumer URL from the request."
 msgstr ""
 "これはオプションのフィールドです。 URLパターンを入力し、+ 記号をクリックして追加します。削除するにはURLの横にある - "
-"記号をクリックします。反映には `Save` ボタンをクリックする必要があることに留意してください。ワイルドカード（\\*）は "
+"記号をクリックします。反映には `Save` ボタンをクリックする必要があることに留意してください。ワイルドカード（*）は "
 "$$http://host.com/*$$ のように、URIの最後にのみ使用できます。 "
 "このフィールドは、正確なSAMLエンドポイントが登録されておらず、{project_name}がリクエストからアサーション・コンシューマURLを取得している場合に使用されます。"
 
@@ -388,9 +388,10 @@ msgid ""
 "directed to the SP.  It will be used as the Assertion Consumer Service URL "
 "and the Single Logout Service URL.  If a login request contains the "
 "Assertion Consumer Service URL, that will take precedence, but this URL must"
-" be valided by a registered Valid Redirect URI pattern"
+" be validated by a registered Valid Redirect URI pattern"
 msgstr ""
-"このURLはすべてのSAMLリクエストに使用され、レスポンスはSPに送信されます。アサーション・コンシューマー・サービスURLとシングル・ログアウト・サービスURLとして使用されます。ログイン・リクエストにアサーション・コンシューマー・サービスのURLが含まれている場合、そのURLが優先されますが、URLは登録済みのValid"
+"このURLはすべてのSAMLリクエストに使用され、レスポンスはSPに送信されます。 "
+"アサーション・コンシューマー・サービスURLとシングル・ログアウト・サービスURLとして使用されます。ログイン・リクエストにアサーション・コンシューマー・サービスのURLが含まれている場合、そのURLが優先されますが、URLは登録済みのValid"
 " Redirect URIパターンで妥当性を確認する必要があります。"
 
 #. type: Labeled list


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
