### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -130,9 +130,9 @@ msgstr ""
 msgid ""
 "Finally note that you don't even need to import certificate if you choose to"
 " `Use JWKS URL` . In that case, you can provide the URL where client "
-"publishes it's public key in https://self-issued.info/docs/draft-ietf-jose-"
+"publishes its public key in https://self-issued.info/docs/draft-ietf-jose-"
 "json-web-key.html[JWK] format. This is flexible because when client changes "
-"it's keys, {project_name} will automatically download them without need to "
+"its keys, {project_name} will automatically download them without need to "
 "re-import anything on {project_name} side."
 msgstr ""
 "最後に注意ですが、 `Use JWKS URL` を選択した場合は、証明書をインポートする必要はありません。その場合、クライアントが公開鍵を https"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__confidential
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
