### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -285,7 +285,7 @@ msgid ""
 "The frontend client itself is not automatically added to the access token "
 "audience. This allows for easy differentiation between the access token and "
 "the ID token, because the access token will not contain the client for which"
-" the token was issued as an audience. So in he example above, the `my-app` "
+" the token was issued as an audience. So in the example above, the `my-app` "
 "won't be added as an audience. If you need the client itself as an audience,"
 " see the <<_audience_hardcoded, hardcoded audience>> option. However, using "
 "the same client as both frontend and REST service is not recommended."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/audience.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__audience
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
