### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
@@ -45,11 +45,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The IDP initiated login implementation prefers _POST_ over _REDIRECT_ "
-"binding (check <<saml-bindings, saml bindings>> for more information).  "
-"Therefore the final binding and SP URL are selected in the following way:"
+"binding (check <<_saml, saml bindings>> for more information).  Therefore "
+"the final binding and SP URL are selected in the following way:"
 msgstr ""
 "IdP initiated loginの実装は、_REDIRECT_ バインディングよりも _POST_ "
-"バインディングを優先します（詳細については<<samlバインディング, "
+"バインディングを優先します（詳細については<<_saml, "
 "SAMLバインディング>>をチェックしてください）。したがって、最終的なバインディングとSPのURLは次のように選択されます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__saml__idp-initiated-login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
