### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/themes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/themes.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/themes.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -554,11 +554,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "To add a new language create the file `<THEME "
-"TYPE>/messages/messages_<LOCALE>` in the directory of your theme. Then add "
-"it to the `locales` property in `<THEME TYPE>/theme.properties`. For a "
-"language to be available to users the realms `login`, `account` and `email` "
-"theme has to support the language, so you need to add your language for "
-"those theme types."
+"TYPE>/messages/messages_<LOCALE>.properties` in the directory of your theme."
+" Then add it to the `locales` property in `<THEME TYPE>/theme.properties`. "
+"For a language to be available to users the realms `login`, `account` and "
+"`email` theme has to support the language, so you need to add your language "
+"for those theme types."
 msgstr ""
 "新しく言語を追加するには、テーマのディレクトリー内で `<THEME "
 "TYPE>/messages/messages_<LOCALE>.properties` ファイルを作成します。次に、そのファイルを `<THEME "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/themes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__themes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
