### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgstr "ユーザー・キャッシュ"
 #. type: Plain text
 msgid ""
 "When a user object is loaded by ID, username, or email queries it is cached."
-" When a user object is bing cached, it iterates through the entire "
+" When a user object is being cached, it iterates through the entire "
 "`UserModel` interface and pulls this information to a local in-memory-only "
 "cache. In a cluster, this cache is still local, but it becomes an "
 "invalidation cache. When a user object is modified, it is evicted. This "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
