### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -122,10 +122,10 @@ msgstr "max-connection-idle-time-millis"
 msgid ""
 "Maximum time the connection might stay idle in the connection pool (900 "
 "seconds by default). Will start background cleaner thread of Apache HTTP "
-"client.  Set to -`1` to disable this checking and the background thread."
+"client.  Set to `-1` to disable this checking and the background thread."
 msgstr ""
 "接続プール内でアイドル状態を維持する最大時間です（デフォルトでは900秒）。Apache "
-"HTTPクライアントのバックグラウンド・クリーナー・スレッドを開始します。　`-1` "
+"HTTPクライアントのバックグラウンド・クリーナー・スレッドを開始します。 `-1` "
 "にセットすると、このチェックとバックグラウンド・スレッドは無効になります。"
 
 #. type: Labeled list
@@ -179,8 +179,8 @@ msgstr "proxy-mappings"
 
 #. type: Plain text
 msgid ""
-"Dennotes proxy configurations for outgoing HTTP requests.  See the section "
-"on <<_proxymappings, Proxy Mappings for Outgoing HTTP Requests>> for more "
+"Denotes proxy configurations for outgoing HTTP requests.  See the section on"
+" <<_proxymappings, Proxy Mappings for Outgoing HTTP Requests>> for more "
 "details."
 msgstr ""
 "送信するHTTPリクエストのプロキシー設定を示します。詳細については、<<_proxymappings, "
@@ -291,9 +291,9 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The `jboss-cli` command results in the following subsystem configuration.  "
-"Note that one needs to encode `\"` characters with `&quot;`."
+"Note that one needs to encode `\"` characters with `\\&quot;`."
 msgstr ""
-"`jboss-cli` コマンドの結果、以下のサブシステム設定になります。 `&quot;` で `\"` "
+"`jboss-cli` コマンドの結果、以下のサブシステム設定になります。 `\\&quot;` で `\"` "
 "文字をエンコードする必要があることに注意してください。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__outgoing
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
