### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -426,7 +426,7 @@ msgstr "ハイブリッド・アプリとCordova"
 #. type: Plain text
 msgid ""
 "Keycloak support hybrid mobile apps developed with "
-"https://cordova.apache.org/[Apache Cordova]. The Javascript adapter has two "
+"https://cordova.apache.org/[Apache Cordova]. The JavaScript adapter has two "
 "modes for this: `cordova` and `cordova-native`:"
 msgstr ""
 "Keycloakは https://cordova.apache.org/[Apache Cordova] "
@@ -488,8 +488,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The alternative mode `cordova-nativei` takes a different approach.  It opens"
-" the login page using the system's browser.  After the user has "
+"The alternative mode `cordova-native` takes a different approach.  It opens "
+"the login page using the system's browser.  After the user has "
 "authenticated, the browser redirects back into the app using a special URL."
 "  From there, the {project_name} adapter can finish the login by reading the"
 " code or token from the URL."
@@ -531,7 +531,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The technical details for linking to an app differ on each plattform and "
+"The technical details for linking to an app differ on each platform and "
 "special setup is needed.  Please refer to the Android and iOS sections of "
 "the https://github.com/e-imaxina/cordova-plugin-"
 "deeplinks/blob/master/README.md[deeplinks plugin documentation] for further "
@@ -896,9 +896,9 @@ msgstr "checkLoginIframeInterval - ログイン状態を確認する間隔を設
 #. type: Plain text
 msgid ""
 "responseMode - Set the OpenID Connect response mode send to {project_name} "
-"server at login request. Valid values are query or fragment . Default value "
+"server at login request. Valid values are query or fragment. Default value "
 "is fragment, which means that after successful authentication will "
-"{project_name} redirect to javascript application with OpenID Connect "
+"{project_name} redirect to JavaScript application with OpenID Connect "
 "parameters added in URL fragment. This is generally safer and recommended "
 "over query."
 msgstr ""
@@ -1006,9 +1006,13 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"locale - Sets the 'ui_locales' query param in compliance with section "
-"3.1.2.1 of the OIDC 1.0 specification."
-msgstr "locale - OIDC 1.0仕様のセクション3.1.2.1に準拠した 'ui_locales' クエリー・パラメーターを設定します。"
+"locale - Sets the 'ui_locales' query param in compliance with "
+"https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[section "
+"3.1.2.1 of the OIDC 1.0 specification]."
+msgstr ""
+"locale - https://openid.net/specs/openid-connect-core-"
+"1_0.html#AuthRequest[OIDC 1.0仕様のセクション3.1.2.1] に準拠した 'ui_locales' "
+"クエリー・パラメーターを設定します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
