### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -227,8 +227,8 @@ msgstr "*Valid Redirect URIs*\n"
 msgid ""
 "This is a required field.  Enter in a URL pattern and click the + sign to "
 "add.  Click the - sign next to URLs you want to remove.  Remember that you "
-"still have to click the `Save` button! Wildcards (\\*) are only allowed at "
-"the end of a URI, i.e. $$http://host.com/*$$"
+"still have to click the `Save` button! Wildcards (*) are only allowed at the"
+" end of a URI, i.e. $$http://host.com/*$$"
 msgstr ""
 "これは必須項目です。追加するには、URLパターンを入力し + 記号をクリックします。削除するには、URLの横にある - 記号をクリックします。 "
 "`Save` ボタンもクリックしなければならないことを覚えておいてください。ワイルドカード（*）は $$http://host.com/*$$ "
@@ -277,13 +277,13 @@ msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,�
 
 #. type: Plain text
 #, no-wrap
-msgid "*Direct Grants Enabled*\n"
-msgstr "*Direct Grants Enabled*\n"
+msgid "*Direct Access Grants Enabled*\n"
+msgstr "*Direct Access Grants Enabled*\n"
 
 #. type: Plain text
 msgid ""
 "If this is on, clients are allowed to use the OIDC <<_oidc-auth-flows,Direct"
-" Grants>>."
+" Access Grants>>."
 msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,ダイレクト・アクセス・グラント>>を使用できます。"
 
 #. type: Plain text
@@ -352,8 +352,8 @@ msgstr "高度な設定"
 
 #. type: Plain text
 #, no-wrap
-msgid "*OAuth 2.0 Mutual TLS Client Certificate Bound Access Token*\n"
-msgstr "*OAuth 2.0 Mutual TLS Client Certificate Bound Access Token*\n"
+msgid "*OAuth 2.0 Mutual TLS Certificate Bound Access Tokens Enabled*\n"
+msgstr "*OAuth 2.0 Mutual TLS Certificate Bound Access Tokens Enabled*\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
