### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,7 +19,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title ===
 #, no-wrap
 msgid "OpenID Connect"
 msgstr "OpenID Connect"
@@ -24,8 +28,8 @@ msgstr "OpenID Connect"
 msgid ""
 "This section describes how you can secure applications and services with "
 "OpenID Connect using either {project_name} adapters or generic OpenID "
-"Connect Resource Provider libraries."
+"Connect Relying Party libraries."
 msgstr ""
 "このセクションでは、{project_name}アダプターまたは汎用OpenID "
-"Connectリソース・プロバイダーのライブラリーを使用して、アプリケーションとサービスをOpenID "
+"Connectリライング・パーティーのライブラリーを使用して、アプリケーションとサービスをOpenID "
 "Connectでセキュリティー保護する方法について説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
