### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,4 +80,4 @@ msgid ""
 "*uma_protection*."
 msgstr ""
 "このAPIの重要な要件は、Protection APIトークン（PAT）と呼ばれる特別なOAuth2アクセストークンを使用して、リソースサーバー "
-"_だけ_ がエンドポイントにアクセスできることです。 UMAでは、PATはスコープ *uma_protection* を持つトークンです。"
+"_だけ_ がエンドポイントにアクセスできることです。UMAでは、PATはスコープ *uma_protection* を持つトークンです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-protection-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-protection-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
