### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
@@ -164,7 +164,7 @@ msgid ""
 "Account Service>>."
 msgstr ""
 "デフォルトでは、Protection "
-"API経由で作成されたリソースは、リソースオーナーが<<_service_authorization_my_resources, "
+"API経由で作成されたリソースを、リソースオーナーが<<_service_authorization_my_resources, "
 "ユーザー・アカウント・サービス>>を介して管理することはできません。"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
@@ -45,7 +45,7 @@ msgstr "このエンドポイントは、以下に概説されている操作を
 
 #. type: Plain text
 msgid "Create resource set description: POST /resource_set"
-msgstr "リソースセットの説明を作成する: POST /resource_set"
+msgstr "リソースセット・ディスクリプションを作成する: POST /resource_set"
 
 #. type: Plain text
 msgid "Read resource set description: GET /resource_set/{_id}"

--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
@@ -45,7 +45,7 @@ msgstr "このエンドポイントは、以下に概説されている操作を
 
 #. type: Plain text
 msgid "Create resource set description: POST /resource_set"
-msgstr "リソースセット・ディスクリプションを作成する: POST /resource_set"
+msgstr "リソースセットの説明を作成する: POST /resource_set"
 
 #. type: Plain text
 msgid "Read resource set description: GET /resource_set/{_id}"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-resources-api-papi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
