### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po
@@ -214,7 +214,7 @@ msgid ""
 "permissions for the resource and scope(s) associated with the permission "
 "ticket."
 msgstr ""
-"パーミッション・チケットに関連付けられているリソースおよびスコープのパーミッションを評価する際に、これらのクレームをポリシーで使用できる場所。"
+"ここで、パーミッション・チケットに関連付けられているリソースおよびスコープのパーミッションを評価する際に、これらのクレームをポリシーで利用できます。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-permission-api-papi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-permission-api-papi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
