### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +31,7 @@ msgid ""
 "check its validity or obtain the permissions within the token to enforce "
 "authorization decisions on the resource server side."
 msgstr ""
-"場合によっては、リクエスティング・パーティー・トークン（RPT）をイントロスペクトして、その有効性をチェックしたり、トークン内の権限を取得して、リソースサーバー側で認可の決定を行うことがあります。"
+"場合によっては、リクエスティング・パーティー・トークン（RPT）をイントロスペクトして、その有効性をチェックしたり、トークン内のパーミッションを取得して、リソースサーバー側で認可の決定を行うことがあります。"
 
 #. type: Plain text
 msgid "There are two main use cases where token introspection can help you:"

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
@@ -35,7 +35,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "There are two main use cases where token introspection can help you:"
-msgstr "トークンのイントロスペクションが役立つ2つの主な使用例があります。"
+msgstr "トークン・イントロスペクションが役立つ2つの主なユースケースがあります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
@@ -217,4 +217,4 @@ msgstr "RPTのシグネチャーを検証する（レルムの公開鍵に基づ
 
 #. type: Plain text
 msgid "Query for token validity based on its _exp_, _iat_, and _aud_ claims"
-msgstr "_exp_ 、_iat_ 、および_aud_のクレームに基づいてトークンの有効性を問い合わせる"
+msgstr "_exp_ 、_iat_ 、および _aud_ のクレームに基づいてトークンの有効性を問い合わせる"

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
@@ -41,7 +41,7 @@ msgstr "トークン・イントロスペクションが役立つ2つの主な�
 msgid ""
 "When client applications need to query the token validity to obtain a new "
 "one with the same or additional permissions"
-msgstr "クライアント・アプリケーションがトークンの有効性を問い合わせて、同じまたは追加の権限を持つ新しいトークンを取得する必要がある場合"
+msgstr "クライアント・アプリケーションがトークンの有効性を問い合わせて、同じまたは追加のパーミッションを持つ新しいトークンを取得する必要がある場合"
 
 #. type: Plain text
 msgid ""
@@ -185,7 +185,7 @@ msgstr ""
 #. type: Title =
 #, no-wrap
 msgid "Do I Need to Invoke the Server Every Time I Want to Introspect an RPT?"
-msgstr "RPTをイントロスペクションするたびにサーバーを呼び出す必要がありますか？"
+msgstr "RPTをイントロスペクションするたびにサーバーを呼び出す必要があるか？"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po
@@ -203,7 +203,7 @@ msgid ""
 "locally. Once you decode the token, you can also use the permissions within "
 "the token to enforce authorization decisions."
 msgstr ""
-"リモート・イントロスペクション・エンドポイントを呼び出さずにこれらのトークンを検証する場合は、RPTをデコードしてローカルでその有効性を問い合わせることができます。トークンをデコードすると、トークン内の権限を使用して認可の決定を行うこともできます。"
+"リモート・イントロスペクション・エンドポイントを呼び出さずにこれらのトークンを検証する場合は、RPTをデコードしてローカルでその有効性を問い合わせることができます。トークンをデコードすると、トークン内のパーミッションを使用して認可の決定を行うこともできます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-rpt-token-introspection.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-rpt-token-introspection
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
