### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -164,7 +164,7 @@ msgid ""
 "Considering you have a ```keycloak.json``` file in your classpath, you can "
 "create a new ```AuthzClient``` instance as follows:"
 msgstr ""
-"クラスパスに ```keycloak.json``` ファイルがあることを考慮して、次のように新しい ```AuthzClient``` "
+"クラスパスに ```keycloak.json``` ファイルがあることを前提として、次のように新しい ```AuthzClient``` "
 "インスタンスを作成することができます。"
 
 #. type: Code block

--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -3,11 +3,17 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# KojiNose <knose.dev@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,7 +46,7 @@ msgid ""
 "endpoints provided by the server such as the Token Endpoint, Resource, and "
 "Permission management endpoints."
 msgstr ""
-"これは、トークン・エンドポイント、リソースエンドポイント、およびパーミッション管理エンドポイントなど、サーバーが提供するさまざまなエンドポイントに、アクセスするリソースサーバーを対象としています。"
+"これは、トークン・エンドポイント、リソース・エンドポイント、およびパーミッション管理エンドポイントなど、サーバーが提供するさまざまなエンドポイントに、アクセスするリソースサーバーを対象としています。"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-client-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
