### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +34,7 @@ msgid ""
 "Server."
 msgstr ""
 "{project_name}サーバーには、ポリシー・エンフォーサーによって保護されたリソースサーバーと対話するために使用できるJavaScriptライブラリーが付属しています。このライブラリーは{project_name}"
-" JavaScriptアダプターに基づいています。これを統合すると、クライアントは{project_name}サーバーからアクセス権を取得できます。"
+" JavaScriptアダプターに基づいています。これを統合すると、クライアントは{project_name}サーバーからパーミッションを取得できます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -171,7 +171,8 @@ msgid ""
 "`onGrant`: The first argument of the function. If authorization was "
 "successful and the server returned an RPT with the requested permissions, "
 "the callback receives the RPT."
-msgstr "`onGrant`: 関数の第1引数。認可が成功し、サーバーが要求された権限でRPTを返した場合、コールバックはRPTを受け取ります。"
+msgstr ""
+"`onGrant`: 関数の第1引数。認可が成功し、サーバーが要求されたパーミッションでRPTを返した場合、コールバックはRPTを受け取ります。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -41,7 +41,7 @@ msgid ""
 "You can obtain this library from a running a {project_name} Server instance "
 "by including the following `script` tag in your web page:"
 msgstr ""
-"次の `script` タグをWebページに含めることで、実行中の{project_name}サーバー・インスタンスからこのライブラリを入手できます。"
+"次の `script` タグをWebページに含めることで、実行中の{project_name}サーバー・インスタンスからこのライブラリーを入手できます。"
 
 #. type: Code block
 msgid "<script src=\"http://.../auth/js/keycloak-authz.js\"></script>"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-js-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
