### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -110,7 +110,7 @@ msgid ""
 "with that, you will be brought to the dashboard for the application.  Click "
 "the `Settings` left menu item."
 msgstr ""
-"メールアドレスとアプリのカテゴリは必須フィールドです。作業が完了すると、アプリケーションのダッシュボードに移動します。 `Settings` "
+"メールアドレスとアプリのカテゴリーは必須フィールドです。作業が完了すると、アプリケーションのダッシュボードに移動します。 `Settings` "
 "の左のメニュー項目をクリックしてください。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__facebook
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
