### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
@@ -231,7 +231,7 @@ msgid ""
 "uses the following scopes: `openid` `profile` `email`."
 msgstr ""
 "Google用の `Add identity provider` ページで注意が必要な1つの設定オプションは、 `Default Scopes` "
-"フィールドです。 このフィールドでは、プロバイダで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、 "
+"フィールドです。 このフィールドでは、プロバイダーで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、 "
 "https://developers.google.com/oauthplayground/ を参照してください。 "
 "デフォルトでは、{project_name}は `openid` `profile` `email` のスコープを使用します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
