### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -114,7 +114,7 @@ msgid ""
 "Backchannel logout is a background, out-of-band, REST invocation to the IDP to logout the user.  Some IDPs can only perform logout through browser redirects as they may\n"
 " only be able to identity sessions via a browser cookie.\n"
 msgstr ""
-"バックチャネル・ログアウトは、バックグラウンド（帯域外）で、IDPへのREST呼び出しでユーザーをログアウトします。一部のIDPは、ブラウザーのリダイレクトを介してのみログアウトを実行できます。ブラウザーのCookieを使用してセッションを識別できる場合があるためです。\n"
+"バックチャネル・ログアウトは、バックグラウンド（アウトオブバンド）で、IDPへのREST呼び出しでユーザーをログアウトします。一部のIDPは、ブラウザーのリダイレクトを介してのみログアウトを実行できます。ブラウザーのCookieを使用してセッションを識別できる場合があるためです。\n"
 
 #. type: Plain text
 msgid "User Info URL"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
