### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
@@ -66,7 +66,7 @@ msgid ""
 " mappings."
 msgstr ""
 "このページには `Create` ボタンがあります。このボタンをクリックすると、ブローカー・マッパーを作成できます。 "
-"ブローカー・マッパーは、SAML属性またはOIDCのID/アクセストークンのクレームをユーザー属性およびユーザーロールのマッピングにインポートできます。"
+"ブローカー・マッパーは、SAML属性またはOIDCのIDトークン/アクセストークンのクレームをユーザー属性およびユーザー・ロール・マッピングにインポートできます。"
 
 #. type: Plain text
 msgid "image:{project_images}/identity-provider-mapper.png[]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
