### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -143,8 +143,8 @@ msgid ""
 " Max is enabled to control the maximum time the offline token can remain "
 "active, regardless of activity."
 msgstr ""
-"<<_offline-access, "
-"オフライン・アクセス>>では、このフラグがオンの場合、オフライン・セッションの最大値を有効にして、アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。"
+"<<_offline-access, オフライン・アクセス>>では、このフラグがオンの場合、Offline Session "
+"Maxを有効にして、アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。"
 
 #. type: Plain text
 msgid "Offline Session Max"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -76,7 +76,7 @@ msgid ""
 "There is a small window of time that is always added to the idle timeout before the session is actually invalidated (See note below).\n"
 msgstr ""
 "OIDCクライアントにも関係します。ユーザーがこのタイムアウトよりも長くアクティブでない場合、ユーザー・セッションは無効になります。どのようにアイドル時間はチェックされるでしょうか？\n"
-"認証を要求するクライアントは、アイドル・タイムアウトがあります。リフレッシュ・トークン・リクエストもアイドル・タイムアウトがあります。\n"
+"認証を要求するクライアントはアイドル・タイムアウトになります。リフレッシュトークン・リクエストもアイドル・タイムアウトになります。\n"
 "セッションが実際に無効になる前にアイドル・タイムアウトに常に追加される小さなウィンドウがあります（下記の注釈を参照）。\n"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -167,7 +167,7 @@ msgstr "Access Token Lifespan"
 #. type: Plain text
 msgid ""
 "When an OIDC access token is created, this value affects the expiration."
-msgstr "OIDCアクセス・トークンが作成される時、この値が有効期限に反映されます。"
+msgstr "OIDCのアクセストークンが作成される時、この値が有効期限に反映されます。"
 
 #. type: Plain text
 msgid "Access Token Lifespan For Implicit Flow"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -102,7 +102,8 @@ msgid ""
 " session idle timeouts when remember me is selected during the login process. It is an optional configuration and if not set to a value\n"
 " bigger than 0 it uses the same idle timeout set in the SSO Session Idle configuration.\n"
 msgstr ""
-"標準のSSOセッション・アイドル設定と同じですが、リメンバーミーの有効化とともにログインに固有の設定です。ログイン処理中にリメンバーミーが選択されている場合は、より長いセッション・アイドル・タイムアウトを指定できます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSOセッション・アイドルで設定されているものと同じアイドル・タイムアウトが使用されます。\n"
+"標準のSSOセッション・アイドル設定と同じですが、リメンバーミーを有効にしたログインに固有の設定です。ログイン処理中にリメンバーミーが選択されている場合は、より長いセッション・アイドル・タイムアウトを指定できます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
+" Session Idleで設定されているものと同じアイドル・タイムアウトが使用されます。\n"
 
 #. type: Plain text
 msgid "SSO Session Max Remember Me"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__timeouts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
