### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/offline.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/offline.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/offline.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -116,5 +116,5 @@ msgstr ""
 "クライアントは、{project_name}に認可リクエストを送信するときに、パラメーター `scope=offline_access` "
 "を追加することにより、オフライントークンを要求できます。{project_name} "
 "OIDCクライアント・アダプターは、アプリケーションのセキュリティー保護されたURL（$$http://localhost:8080/customer-"
-"portal/secured?scope=offline_access$$）にアクセスするときに、このパラメータを自動的に追加します。ダイレクト・アクセス・グラントとサービス・アカウントは、認証リクエストのボディーに"
+"portal/secured?scope=offline_access$$）にアクセスするときに、このパラメーターを自動的に追加します。ダイレクト・アクセス・グラントとサービス・アカウントは、認証リクエストのボディーに"
 " `scope=offline_access` を含めると、オフライントークンもサポートします。"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/offline.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/offline.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -115,6 +115,7 @@ msgid ""
 msgstr ""
 "クライアントは、{project_name}に認可リクエストを送信するときに、パラメーター `scope=offline_access` "
 "を追加することにより、オフライントークンを要求できます。{project_name} "
-"OIDCクライアント・アダプターは、アプリケーションのセキュリティー保護されたURL（$$http://localhost:8080/customer-"
+"OIDCクライアント・アダプターは、アプリケーションのセキュリティー保護されたURL（例： $$http://localhost:8080"
+"/customer-"
 "portal/secured?scope=offline_access$$）にアクセスするときに、このパラメーターを自動的に追加します。ダイレクト・アクセス・グラントとサービス・アカウントは、認証リクエストのボディーに"
 " `scope=offline_access` を含めると、オフライントークンもサポートします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/offline.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__offline
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
