### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -210,7 +210,7 @@ msgid ""
 "Whether or not users are allowed to retrieve the stored identity provider token.  This also applies to the _broker_ client-level\n"
 " role _read token_.\n"
 msgstr ""
-"ユーザーは保存されたアイデンティティー・プロバイダー・トークンを取得できるかどうか。 _broker_ クライアント・レベルのロール _read "
+"ユーザーが保存されたアイデンティティー・プロバイダー・トークンを取得できるかどうか。 _broker_ クライアント・レベルのロール _read "
 "token_ にも適用されます。\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
