### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Shinsuke UEDA, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,7 +40,7 @@ msgid ""
 "persisting you'll need to enable storage.  Go to the `Events` left menu item"
 " and select the `Config` tab."
 msgstr ""
-"ログインイベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、イベントは保存されず、管理コンソールに表示されることもありません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、ストレージを有効にする必要があります。左側の"
+"ログインイベントは、ユーザーが正常にログインしたとき、誰かが間違ったパスワードを入力したとき、またはユーザー・アカウントが更新されたときなどに発生します。ユーザーに起こるすべてのイベントを記録して表示することができます。デフォルトでは、イベントは保存されず、管理コンソールに表示されることもありません。エラーイベントのみがコンソールとサーバーのログファイルに記録されます。永続化を開始するには、保存を有効にする必要があります。左側の"
 " `Events` メニュー項目に行き、 `Config` タブを選択してください。"
 
 #. type: Block title


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
