### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -38,7 +38,7 @@ msgid ""
 "menu>>."
 msgstr ""
 "デフォルトでは、新しいクライアント・アプリケーションごとに無制限の `role scope mappings` "
-"があります。つまり、そのクライアント用に作成されたすべてのアクセストークンには、ユーザーが持つすべての権限が含まれます。クライアントが侵害されてアクセストークンが漏洩した場合、ユーザーがアクセス許可を持つ各システムも侵害されます。クライアントごとに<<_role_scope_mappings,"
+"があります。つまり、そのクライアント用に作成されたすべてのアクセストークンには、ユーザーが持つすべてのパーミッションが含まれます。クライアントが侵害されてアクセストークンが漏洩した場合、ユーザーがパーミッションを持つ各システムも侵害されます。クライアントごとに<<_role_scope_mappings,"
 " "
 "スコープメニュー>>を使用してアクセストークンが割り当てられるロールを制限することを強くお勧めします。または、クライアント・スコープ・レベルでロール・スコープ・マッピングを設定し、<<_client_scopes_linking,"
 " クライアント・スコープ・メニュー>>を使用してクライアント・スコープをクライアントに割り当てることができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/scope.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__scope
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
