### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -167,7 +167,7 @@ msgid ""
 "_Note: to connect to a remote server, you pass the `--connect` option as "
 "well.  Use the --help option for more details._"
 msgstr ""
-"_Note: リモートサーバーに接続するには、 `--connect` オプションも渡します。詳しくは、 --helpオプションを参照してください。_"
+"_注意: リモートサーバーに接続するには、 `--connect` オプションも渡します。詳しくは、 --helpオプションを参照してください。_"
 
 #. type: Plain text
 msgid ""
@@ -216,7 +216,7 @@ msgid ""
 "To execute the script, I can follow the `Scripts` menu in CLI GUI, or "
 "execute the script from the command line as follows:"
 msgstr ""
-"スクリプトを実行するには、CLI GUI の `Scripts` メニューに従う、または以下のようにコマンドラインからスクリプトを実行します。"
+"スクリプトを実行するには、CLI GUIの `Scripts` メニューに従うか、または以下のようにコマンドラインからスクリプトを実行します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
