### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -27,14 +27,6 @@ msgstr "前提条件"
 
 #. type: Plain text
 msgid ""
-"With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
-" repository. In these instructions only the term repository is used."
-msgstr ""
-"Red Hat Enterprise Linux "
-"7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
-
-#. type: Plain text
-msgid ""
 "Ensure that your Red Hat Enterprise Linux system is registered to your "
 "account using Red Hat Subscription Manager. For more information see the "
 "link:https://access.redhat.com/documentation/en-"
@@ -51,11 +43,19 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Installing JBoss EAP Adapter from an RPM"
-msgstr "RPMからJBoss EAPアダプターをインストールします。"
+msgstr "RPMからのJBoss EAPアダプターのインストール"
 
 #. type: Plain text
 msgid "Install the EAP 7 Adapters from an RPM:"
 msgstr "次のように、RPMからEAP 7アダプターをインストールします。"
+
+#. type: Plain text
+msgid ""
+"With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
+" repository. In these instructions only the term repository is used."
+msgstr ""
+"Red Hat Enterprise Linux "
+"7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
