### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po
@@ -28,8 +28,7 @@ msgstr "WARごとの設定"
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
-msgstr ""
-"このセクションでは、直接WARパッケージ内に設定ファイルを追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
+msgstr "このセクションでは、直接WARパッケージ内に設定を追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_per_war_config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_per_war_config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
