### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,18 +20,17 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ====
-#: source/securing_apps/topics/saml/java/tomcat-adapter.adoc:3
 #, no-wrap
 msgid "Tomcat SAML adapters"
 msgstr "Tomcat SAMLアダプター"
 
 #. type: Plain text
-#: source/securing_apps/topics/saml/java/tomcat-adapter.adoc:8
 msgid ""
-"To be able to secure WAR apps deployed on Tomcat 6, 7 and 8 you must install"
-" the Keycloak Tomcat 6, 7 or 8 SAML adapter into your Tomcat installation.  "
-"You then have to provide some extra configuration in each WAR you deploy to "
-"Tomcat.  Let's go over these steps."
+"To be able to secure WAR apps deployed on Tomcat 7, 8 and 9 you must install"
+" the Keycloak Tomcat 7 SAML adapter or Keycloak Tomcat SAML adapter into "
+"your Tomcat installation.  You then have to provide some extra configuration"
+" in each WAR you deploy to Tomcat.  Let's go over these steps."
 msgstr ""
-"Tomcat 6、7、8にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 6、7、8 "
+"Tomcat 7、8、9にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 7 "
+"SAMLアダプターまたはKeycloak Tomcat "
 "SAMLアダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
