### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po
@@ -8,14 +8,14 @@
 # KojiNose <knose.dev@gmail.com>, 2017
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -61,12 +61,12 @@ msgstr "ルールベースのポリシー"
 #. type: Plain text
 msgid ""
 "With this type of policy you can define conditions for your permissions "
-"using http://www.drools.org[Drools], which is a rule evaluation environment."
-" It is one of the _Rule-Based_ policy types supported by {project_name}, and"
-" provides flexibility to write any policy based on the "
+"using https://www.drools.org/[Drools], which is a rule evaluation "
+"environment. It is one of the _Rule-Based_ policy types supported by "
+"{project_name}, and provides flexibility to write any policy based on the "
 "<<_policy_evaluation_api, Evaluation API>>."
 msgstr ""
-"このタイプのポリシーでは、ルール評価環境である http://www.drools.org[Drools] "
+"このタイプのポリシーでは、ルール評価環境である https://www.drools.org[Drools] "
 "を使用してパーミッションの条件を定義できます。これは{project_name}でサポートされている _ルールベース_ のポリシー・タイプの1つであり、"
 " <<_policy_evaluation_api, Evaluation API>> に基づいたポリシーを柔軟に作成できます。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-drools-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-drools-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
