### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -128,6 +128,14 @@ msgid ""
 msgstr ""
 "アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
 
+#. type: Plain text
+msgid "Install on Tomcat 7:"
+msgstr "Tomcat 7へのインストールは次のとおりです。"
+
+#. type: Plain text
+msgid "Install on Tomcat 8 or 9:"
+msgstr "Tomcat 8、9へのインストールは次のとおりです。"
+
 #. type: Title =====
 #, no-wrap
 msgid "Required Per WAR Configuration"
@@ -141,18 +149,18 @@ msgstr "次に、WARの `WEB-INF` ディレクトリーに `keycloak.json` ア�
 
 #. type: Title ====
 #, no-wrap
-msgid "Tomcat 6, 7 and 8 Adapters"
-msgstr "Tomcat  6、7、8アダプター"
+msgid "Tomcat 7 and 8 Adapters"
+msgstr "Tomcat 7、8アダプター"
 
 #. type: Plain text
 msgid ""
-"To be able to secure WAR apps deployed on Tomcat 6, 7 and 8 you must install"
-" the Keycloak Tomcat 6, 7 or 8 adapter into your Tomcat installation.  You "
-"then have to provide some extra configuration in each WAR you deploy to "
-"Tomcat.  Let's go over these steps."
+"To be able to secure WAR apps deployed on Tomcat 7, 8 and 9 you must install"
+" the Keycloak Tomcat 7 adapter or Keycloak Tomcat adapter into your Tomcat "
+"installation.  You then have to provide some extra configuration in each WAR"
+" you deploy to Tomcat.  Let's go over these steps."
 msgstr ""
-"Tomcat 6、7、8にデプロイされたWARアプリケーションをセキュリティー保護するには、Keycloak Tomcat 6、7、8 "
-"アダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
+"Tomcat 7、8、9にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 7アダプターまたはKeycloak "
+"TomcatアダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
 
 #. type: Plain text
 msgid ""
@@ -168,18 +176,19 @@ msgstr ""
 #, no-wrap
 msgid ""
 "$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-tomcat6-adapter-dist.zip\n"
-"    or\n"
 "$ unzip keycloak-tomcat7-adapter-dist.zip\n"
-"    or\n"
-"$ unzip keycloak-tomcat8-adapter-dist.zip\n"
 msgstr ""
 "$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-tomcat6-adapter-dist.zip\n"
-"    or\n"
 "$ unzip keycloak-tomcat7-adapter-dist.zip\n"
-"    or\n"
-"$ unzip keycloak-tomcat8-adapter-dist.zip\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat-adapter-dist.zip\n"
+msgstr ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat-adapter-dist.zip\n"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__tomcat-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
