### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,8 +36,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"If ${project_name} assessment process results in issuance of permissions, it"
-" issues the RPT with which it has associated the permissions:"
+"If {project_name} assessment process results in issuance of permissions, it "
+"issues the RPT with which it has associated the permissions:"
 msgstr "{project_name}の評価処理の結果、パーミッションが発行されると、そのパーミッションに関連付けられているRPTが発行されます。"
 
 #. type: Block title
@@ -139,7 +139,7 @@ msgstr "**claim_token**\n"
 msgid ""
 "This parameter is *optional*. A string representing additional claims that "
 "should be considered by the server when evaluating permissions for the "
-"resource(s) and scope(s) being requested. This parameter allow clients to "
+"resource(s) and scope(s) being requested. This parameter allows clients to "
 "push claims to {project_name}. For more details about all supported token "
 "formats see `claim_token_format` parameter."
 msgstr ""
@@ -233,7 +233,7 @@ msgstr "**response_include_resource_name**\n"
 #. type: Plain text
 msgid ""
 "This parameter is *optional*. A boolean value indicating to the server "
-"whether resource names should be included in the RPT's permissions. if "
+"whether resource names should be included in the RPT's permissions. If "
 "false, only the resource identifier is included."
 msgstr ""
 "このパラメーターは *optional* "
@@ -279,7 +279,7 @@ msgid ""
 "This parameter is *optional*. A string value indicating how the server "
 "should respond to authorization requests. This parameter is specially useful"
 " when you are mainly interested in either the overall decision or the "
-"permissions granted by the server, instead of an standard OAuth2 response. "
+"permissions granted by the server, instead of a standard OAuth2 response. "
 "Possible values are:"
 msgstr ""
 "このパラメーターは *optional* "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
