### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -120,8 +120,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"If ${project_name} assessment process results in issuance of permissions, it"
-" issues the RPT with which it has associated the permissions:"
+"If {project_name} assessment process results in issuance of permissions, it "
+"issues the RPT with which it has associated the permissions:"
 msgstr "{project_name}の評価処理の結果、パーミッションが発行されると、そのパーミッションに関連付けられているRPTが発行されます。"
 
 #. type: Block title


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-authz-process
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
