### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -94,7 +94,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "When the user choose to detail own of his resources by clicking on any "
-"resource in the \"My resources\" listing, he is redirect to a page as "
+"resource in the \"My resources\" listing, he is redirected to a page as "
 "follows:"
 msgstr ""
 "ユーザーが \"My resources\" "
@@ -113,12 +113,12 @@ msgid "From this page the users are able to:"
 msgstr "このページから、ユーザーは以下を行うことができます。"
 
 #. type: Plain text
-msgid "Manage *People with access to the resource*"
-msgstr "*People with access to the resource* の管理"
+msgid "Manage *People with access to this resource*"
+msgstr "*People with access to this resource* の管理"
 
 #. type: Plain text
 msgid ""
-"This section contains a list of people with access to the resource. Users "
+"This section contains a list of people with access to this resource. Users "
 "are allowed to revoke access by clicking on the `Revoke` button or by "
 "removing a specific `Permission`."
 msgstr ""
@@ -132,6 +132,6 @@ msgstr "他の人とリソースを共有する"
 #. type: Plain text
 msgid ""
 "By typing the username or e-mail of another user, the user is able to share "
-"the resource and select the permissions he want to grant access."
+"the resource and select the permissions he wants to grant access."
 msgstr ""
 "別のユーザーのユーザー名または電子メールを入力することにより、ユーザーはリソースを共有し、アクセスを許可するパーミッションを選択することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-account-my-resources.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-account-my-resources
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
