### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # KojiNose <knose.dev@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -188,7 +188,7 @@ msgstr "ユーザー・エンタイトルメントを取得する方法の例を
 #. type: Code block
 #, no-wrap
 msgid ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// create an authorization request\n"
@@ -203,7 +203,7 @@ msgid ""
 "\n"
 "// now you can use the RPT to access protected resources on the resource server\n"
 msgstr ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// create an authorization request\n"
@@ -227,7 +227,7 @@ msgstr "1つ以上のリソースのセットに対してユーザー・エン�
 #. type: Code block
 #, no-wrap
 msgid ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// create an authorization request\n"
@@ -245,7 +245,7 @@ msgid ""
 "\n"
 "// now you can use the RPT to access protected resources on the resource server\n"
 msgstr ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// create an authorization request\n"
@@ -271,7 +271,7 @@ msgstr "Protection APIを使用したリソースの作成"
 #. type: Code block
 #, no-wrap
 msgid ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// create a new resource representation with the information we want\n"
@@ -298,7 +298,7 @@ msgid ""
 "\n"
 "System.out.println(resource);\n"
 msgstr ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// create a new resource representation with the information we want\n"
@@ -333,7 +333,7 @@ msgstr "RPTのイントロスペクション"
 #. type: Code block
 #, no-wrap
 msgid ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// send the authorization request to the server in order to\n"
@@ -351,7 +351,7 @@ msgid ""
 "    System.out.println(granted);\n"
 "}\n"
 msgstr ""
-"// create a new instance based on the configuration defined in keycloak-authz.json\n"
+"// create a new instance based on the configuration defined in keycloak.json\n"
 "AuthzClient authzClient = AuthzClient.create();\n"
 "\n"
 "// send the authorization request to the server in order to\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-client-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
