### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,7 +20,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title ===
 #, no-wrap
 msgid "Packaging and Deployment"
 msgstr "パッケージ化とデプロイ"
@@ -25,11 +30,12 @@ msgid ""
 "User Storage providers are packaged in a JAR and deployed or undeployed to "
 "the {project_name} runtime in the same way you would deploy something in the"
 " {appserver_name} application server. You can either copy the JAR directly "
-"to the `deploy/` directory of the server, or use the JBoss CLI to execute "
-"the deployment."
+"to the `standalone/deployments/` directory of the server, or use the JBoss "
+"CLI to execute the deployment."
 msgstr ""
 "ユーザー・ストレージ・プロバイダーは、{appserver_name}アプリケーション・サーバーに何かをデプロイするのと同じ方法で、JARにパッケージ化され、{project_name}ランタイムにデプロイまたはアンデプロイされます。JARをサーバーの"
-" `deploy/` ディレクトリーに直接コピーするか、またはJBoss CLIを使用してデプロイを実行することができます。"
+" `standalone/deployments/` ディレクトリーに直接コピーするか、またはJBoss "
+"CLIを使用してデプロイを実行することができます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__packaging
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
