### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,9 +27,9 @@ msgstr "JBoss Fuse 6アダプター"
 #. type: Plain text
 msgid ""
 "{project_name} supports securing your web applications running inside "
-"https://developers.redhat.com/products/fuse/overview/[JBoss Fuse 6]."
+"https://developers.redhat.com/products/fuse/overview[JBoss Fuse 6]."
 msgstr ""
-"{project_name}は https://developers.redhat.com/products/fuse/overview/[JBoss "
+"{project_name}は https://developers.redhat.com/products/fuse/overview[JBoss "
 "Fuse 6] 内で実行されているWebアプリケーションのセキュリティー保護をサポートしています。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
