### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -833,6 +833,24 @@ msgid ""
 "by setting this value."
 msgstr ""
 "{project_name}にログイン・リクエストとともに送信されたレスポンスタイプ。これは、初期化中に使用されたフロー値に基づいて決定されますが、この値を設定することで上書きできます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "pkceMethod"
+msgstr "pkceMethod"
+
+#. type: Plain text
+msgid ""
+"The method for Proof Key Code Exchange "
+"(https://tools.ietf.org/html/rfc7636[PKCE]) to use. Configuring this value "
+"enables the PKCE mechanism.  Available options:"
+msgstr ""
+"Proof Key Code Exchange "
+"(https://tools.ietf.org/html/rfc7636[PKCE])が使用するメソッド。この値を設定すると、PKCEメカニズムが有効になります。利用可能なオプションは、以下の通りです。"
+
+#. type: Plain text
+msgid "\"S256\" - The SHA256 based PKCE method"
+msgstr "\"S256\" - SHA256ベースのPKCEメソッド"
 
 #. type: Title =====
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -845,8 +845,8 @@ msgid ""
 "(https://tools.ietf.org/html/rfc7636[PKCE]) to use. Configuring this value "
 "enables the PKCE mechanism.  Available options:"
 msgstr ""
-"Proof Key Code Exchange "
-"(https://tools.ietf.org/html/rfc7636[PKCE])が使用するメソッド。この値を設定すると、PKCEメカニズムが有効になります。利用可能なオプションは、以下の通りです。"
+"Proof Key Code Exchange（ https://tools.ietf.org/html/rfc7636[PKCE] "
+"）が使用するメソッド。この値を設定すると、PKCEメカニズムが有効になります。利用可能なオプションは、以下の通りです。"
 
 #. type: Plain text
 msgid "\"S256\" - The SHA256 based PKCE method"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
