### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -212,12 +212,9 @@ msgstr "org.acme.provider.MyThemeSelectorProviderFactory\n"
 #. type: Plain text
 msgid ""
 "You can configure your provider through `standalone.xml`, `standalone-"
-"ha.xml`, or `domain.xml`.  See the "
-"link:{installguide_link}[{installguide_name}] for more details on where to "
-"find these files."
+"ha.xml`, or `domain.xml`."
 msgstr ""
-"`standalone.xml` 、 `standalone-ha.xml` 、または `domain.xml` "
-"を介してプロバイダーを設定することができます。これらのファイルがある場所についての詳細は、link:{installguide_link}[{installguide_name}]を参照してください。"
+"プロバイダーは、 `standalone.xml` 、 `standalone-ha.xml` 、または `domain.xml` で設定できます。"
 
 #. type: Plain text
 msgid "For example by adding the following to `standalone.xml`:"
@@ -260,13 +257,6 @@ msgstr ""
 #. type: Plain text
 msgid "Your provider can also lookup other providers if needed. For example:"
 msgstr "また、プロバイダーも必要に応じて他のプロバイダーを参照することができます。以下が例です。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"public class MyThemeSelectorProvider implements EventListenerProvider {\n"
-msgstr ""
-"public class MyThemeSelectorProvider implements EventListenerProvider {\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -335,10 +325,10 @@ msgstr "前のサンプルの `MyThemeSelectorProviderFactory` のサンプル�
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"public class MyThemeSelectorProvider implements ThemeSelectorProvider, ServerInfoAwareProviderFactory {\n"
+"public class MyThemeSelectorProviderFactory implements ThemeSelectorProviderFactory, ServerInfoAwareProviderFactory {\n"
 "    ...\n"
 msgstr ""
-"public class MyThemeSelectorProvider implements ThemeSelectorProvider, ServerInfoAwareProviderFactory {\n"
+"public class MyThemeSelectorProviderFactory implements ThemeSelectorProviderFactory, ServerInfoAwareProviderFactory {\n"
 "    ...\n"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
