### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/compromised-codes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/compromised-codes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/compromised-codes.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -47,5 +47,5 @@ msgid ""
 "clients. See <<_proof-key-for-code-exchange, Proof Key for Code Exchange "
 "(PKCE)>> to learn how."
 msgstr ""
-"また、クライアントにPKCEを適用することにより、認可コードの漏洩を軽減できます。方法については、<<_proof-key-for-code-"
-"exchange, Proof Key for Code Exchange (PKCE)>>を参照してください。"
+"また、クライアントにPKCEを適用することにより、認可コードの漏洩を軽減できます。方法については、 <<_proof-key-for-code-"
+"exchange, Proof Key for Code Exchange（PKCE）>> を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/threat/compromised-codes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/compromised-codes.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/threat/compromised-codes.adoc:2
 #, no-wrap
 msgid "Compromised Authorization Code"
 msgstr "侵害された認可コード"
 
 #. type: Plain text
-#: source/server_admin/topics/threat/compromised-codes.adoc:9
 msgid ""
 "For the <<_oidc-auth-flows, OIDC Auth Code Flow>>, it would be very hard for"
 " an attacker to compromise {project_name} authorization codes.  "
@@ -38,3 +40,12 @@ msgstr ""
 "OIDC認可コードフロー>>では、攻撃者が{project_name}認可コードを侵害することは非常に困難です。{project_name}は、認可コードに対して暗号的に強いランダムな値を生成するので、アクセストークンを推測することは非常に困難です。認可コードは、アクセストークンを取得するために1回しか使用できません。管理コンソールの<<_timeouts,"
 " "
 "タイムアウト・ページ>>で認可コードの有効期間を指定できます。この値は、実際には数秒と短く、クライアントがコードからトークンを取得するリクエストを行うのに十分な長さでなければなりません。"
+
+#. type: Plain text
+msgid ""
+"You can also mitigate against leaked autorization codes by applying PKCE to "
+"clients. See <<_proof-key-for-code-exchange, Proof Key for Code Exchange "
+"(PKCE)>> to learn how."
+msgstr ""
+"また、クライアントにPKCEを適用することにより、認可コードの漏洩を軽減できます。方法については、<<_proof-key-for-code-"
+"exchange, Proof Key for Code Exchange (PKCE)>>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/compromised-codes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__compromised-codes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
