### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -3,17 +3,31 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Login Tab"
+msgstr "Loginタブ"
+
+#. type: Plain text
+msgid "image:{project_images}/login-tab.png[]"
+msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Title ===
 #, no-wrap
@@ -29,15 +43,6 @@ msgid ""
 msgstr ""
 "これを有効にすると、ユーザーはパスワードを忘れたり、OTPジェネレーターを無くした場合でも、クレデンシャルをリセットできます。左のメニュー項目の "
 "`Realm Settings` に移動し、 `Login` タブをクリックします。 `Forgot Password` スイッチをオンにします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Login Tab"
-msgstr "Loginタブ"
-
-#. type: Plain text
-msgid "image:{project_images}/login-tab.png[]"
-msgstr "image:{project_images}/login-tab.png[]"
 
 #. type: Plain text
 msgid "A `forgot password` link will now show up on your login pages."
@@ -104,3 +109,11 @@ msgid ""
 "If you do not want OTP reset, then just chose the `disabled` radio button to"
 " the right of `Reset OTP`."
 msgstr "OTPをリセットしたくない場合は、 `Reset OTP` の右にある `disabled` ラジオボタンを選択してください。"
+
+#. type: Plain text
+msgid ""
+"Be sure to leave Update Password enabled on the Required Actions tab.  "
+"Otherwise, Forgot Password does not work."
+msgstr ""
+"Required ActionsタブでUpdate Passwordを有効のままにしてください。そうしないと、Forgot "
+"Passwordは機能しません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__login-settings__forgot-password
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
