### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,19 +43,28 @@ msgstr ""
 "INF/libディレクトリー内にアダプターのjarを含めても動作しません！Keycloak "
 "SAMLアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリーに存在する必要があります。"
 
+#. type: Plain text
+msgid "Install on Tomcat 7:"
+msgstr "Tomcat 7へのインストールは次のとおりです。"
+
 #. type: delimited block -
 #, no-wrap
 msgid ""
 "$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-saml-tomcat6-adapter-dist.zip\n"
-"    or\n"
 "$ unzip keycloak-saml-tomcat7-adapter-dist.zip\n"
-"    or\n"
-"$ unzip keycloak-saml-tomcat8-adapter-dist.zip\n"
 msgstr ""
 "$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-saml-tomcat6-adapter-dist.zip\n"
-"    or\n"
 "$ unzip keycloak-saml-tomcat7-adapter-dist.zip\n"
-"    or\n"
-"$ unzip keycloak-saml-tomcat8-adapter-dist.zip\n"
+
+#. type: Plain text
+msgid "Install on Tomcat 8 or 9:"
+msgstr "Tomcat 8、9へのインストールは次のとおりです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-saml-tomcat-adapter-dist.zip\n"
+msgstr ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-saml-tomcat-adapter-dist.zip\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter__tomcat_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
