### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -7,14 +7,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -176,10 +176,15 @@ msgstr "Include AuthnStatement"
 #. type: Plain text
 msgid ""
 "SAML login responses may specify the authentication method used (password, "
-"etc.) as well as a timestamp of the login.  Setting this to on will include "
-"that statement in the response document."
+"etc.) as well as timestamps of the login and the session expiration.  This "
+"is enabled by default, which means that `AuthStatement` element will be "
+"included in login responses. Note that setting this to off would prevent the"
+" client from determining the maximum session length which could result into "
+"never expiring client session."
 msgstr ""
-"SAMLログイン・レスポンスは、使用された認証方法（パスワードなど）とログインのタイムスタンプを含めることができます。これをONに設定すると、そのステートメントがレスポンス・ドキュメントに含まれます。"
+"SAMLログイン・レスポンスでは、使用される認証方法（パスワードなど）、ログインのタイムスタンプ、およびセッションの有効期限を指定できます。これはデフォルトで有効になっています。つまり、"
+" `AuthStatement` "
+"要素がログイン・レスポンスに含まれます。これをオフに設定すると、クライアントは最大セッション長を決定できなくなり、クライアント・セッションが期限切れにならないことに注意してください。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
