### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -40,6 +40,26 @@ msgstr ""
 "single/quick_registration_for_rhel/index[Red Hat Subscription Management "
 "documentation]のリンクを参照してください。"
 
+#. type: Plain text
+msgid ""
+"For Red Hat Enterprise Linux 6, 7: Using Red Hat Subscription Manager, "
+"subscribe to the {appserver_name} {appserver_version} repository using the "
+"following command. Replace <RHEL_VERSION> with either 6 or 7 depending on "
+"your Red Hat Enterprise Linux version."
+msgstr ""
+"Red Hat Enterprise Linux 6、7の場合：Red Hat Subscription "
+"Managerを使用して、次のコマンドで{appserver_name} {appserver_version}リポジトリーに登録します。Red Hat"
+" Enterprise Linuxバージョンに応じて、 <RHEL_VERSION> を6または7のいずれかに置き換えてください。"
+
+#. type: Plain text
+msgid ""
+"For Red Hat Enterprise Linux 8: Using Red Hat Subscription Manager, "
+"subscribe to the {appserver_name} {appserver_version} repository using the "
+"following command:"
+msgstr ""
+"Red Hat Enterprise Linux 8の場合：Red Hat Subscription "
+"Managerを使用して、次のコマンドで{appserver_name} {appserver_version}リポジトリーに登録します。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Installing JBoss EAP Adapter from an RPM"
@@ -69,15 +89,6 @@ msgid ""
 "unsubscribe from that repository first."
 msgstr "すでに別のJBoss EAPリポジトリーに登録している場合は、まずそのリポジトリーから登録を解除する必要があります。"
 
-#. type: Plain text
-msgid ""
-"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 7 repository "
-"using the following command. Replace <RHEL_VERSION> with either 6 or 7 "
-"depending on your Red Hat Enterprise Linux version."
-msgstr ""
-"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP 7リポジトリーを登録します。Red Hat"
-" Enterprise Linuxのバージョンに応じて、 <RHEL_VERSION> を6または7のいずれかに置き換えてください。"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -86,6 +97,17 @@ msgid ""
 msgstr ""
 "$ sudo subscription-manager repos --enable=jb-eap-7-for-rhel-<RHEL_VERSION"
 ">-server-rpms\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ sudo subscription-manager repos --enable=jb-eap-{appserver_version}-for-"
+"rhel-8-x86_64-rpms --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8"
+"-for-x86_64-appstream-rpms\n"
+msgstr ""
+"$ sudo subscription-manager repos --enable=jb-eap-{appserver_version}-for-"
+"rhel-8-x86_64-rpms --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8"
+"-for-x86_64-appstream-rpms\n"
 
 #. type: Plain text
 msgid "Install the EAP 7 adapters for SAML using the following command:"
@@ -93,8 +115,17 @@ msgstr "次のコマンドを使用して、SAML用のEAP 7アダプターをイ
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
-msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_2\n"
+msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_3\n"
+msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_3\n"
+
+#. type: Plain text
+msgid "or use following one for Red Hat Red Hat Enterprise Linux 8:"
+msgstr "または、次のいずれかをRed Hat Enterprise Linux 8に使用します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo dnf install eap7-keycloak-adapter-sso7_3\n"
+msgstr "$ sudo dnf install eap7-keycloak-adapter-sso7_3\n"
 
 #. type: Plain text
 msgid ""
@@ -158,8 +189,8 @@ msgstr "次のコマンドを使用して、SAML用のEAP 6アダプターをイ
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ sudo yum install keycloak-saml-adapter-sso7_2-eap6\n"
-msgstr "$ sudo yum install keycloak-saml-adapter-sso7_2-eap6\n"
+msgid "$ sudo yum install keycloak-saml-adapter-sso7_3-eap6\n"
+msgstr "$ sudo yum install keycloak-saml-adapter-sso7_3-eap6\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
