### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -3,17 +3,26 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "Adapter Installation"
+msgstr "アダプターのインストール"
 
 #. type: Title ====
 #, no-wrap
@@ -105,11 +114,6 @@ msgid ""
 "tokens."
 msgstr "`KeycloakInstalled` アダプターは失効したトークンの更新をサポートします。"
 
-#. type: Title =====
-#, no-wrap
-msgid "Adapter Installation"
-msgstr "アダプターのインストール"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -138,6 +142,18 @@ msgid ""
 msgstr ""
 "アプリケーションは、 `Standard Flow Enabled` で `public` なOpenID Connectクライアントであり、許可される"
 " `Valid Redirect URI` としてpass:[http://localhost:*]が設定される必要があります。"
+
+#. type: Plain text
+msgid ""
+"The `KeycloakInstalled` adapter supports the `PKCE` [RFC 7636] mechanism to "
+"provide additional protection during code to token exchanges in the `OIDC` "
+"protocol. PKCE can be enabled with the `\"enable-pkce\": true` setting in "
+"the adapter configuration. Enabling PKCE is highly recommended, to avoid "
+"code injection and code replay attacks."
+msgstr ""
+"`KeycloakInstalled` アダプターは、 `OIDC` プロトコルでのコードからトークンへの交換中に追加の保護を提供する `PKCE` "
+"[RFC 7636] メカニズムをサポートします。PKCEは、アダプター設定の `\"enable-pkce\": true` "
+"の設定で有効にできます。コード・インジェクションおよびコードリプレイ攻撃を回避するために、PKCEを有効にすることを強くお勧めします。"
 
 #. type: Title ====
 #, no-wrap
@@ -170,7 +186,8 @@ msgid ""
 "  \"ssl-required\": \"external\",\n"
 "  \"resource\": \"desktop-app\",\n"
 "  \"public-client\": true,\n"
-"  \"use-resource-role-mappings\": true\n"
+"  \"use-resource-role-mappings\": true,\n"
+"  \"enable-pkce\": true\n"
 "}\n"
 msgstr ""
 "{\n"
@@ -179,7 +196,8 @@ msgstr ""
 "  \"ssl-required\": \"external\",\n"
 "  \"resource\": \"desktop-app\",\n"
 "  \"public-client\": true,\n"
-"  \"use-resource-role-mappings\": true\n"
+"  \"use-resource-role-mappings\": true,\n"
+"  \"enable-pkce\": true\n"
 "}\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__installed-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
