### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po
@@ -4,8 +4,8 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -27,14 +27,6 @@ msgstr "前提条件"
 
 #. type: Plain text
 msgid ""
-"With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
-" repository. In these instructions only the term repository is used."
-msgstr ""
-"Red Hat Enterprise Linux "
-"7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
-
-#. type: Plain text
-msgid ""
 "Ensure that your Red Hat Enterprise Linux system is registered to your "
 "account using Red Hat Subscription Manager. For more information see the "
 "link:https://access.redhat.com/documentation/en-"
@@ -48,6 +40,26 @@ msgstr ""
 "single/quick_registration_for_rhel/index[Red Hat Subscription Management "
 "documentation]のリンクを参照してください。"
 
+#. type: Plain text
+msgid ""
+"For Red Hat Enterprise Linux 6, 7: Using Red Hat Subscription Manager, "
+"subscribe to the {appserver_name} {appserver_version} repository using the "
+"following command. Replace <RHEL_VERSION> with either 6 or 7 depending on "
+"your Red Hat Enterprise Linux version."
+msgstr ""
+"Red Hat Enterprise Linux 6、7の場合：Red Hat Subscription "
+"Managerを使用して、次のコマンドで{appserver_name} {appserver_version}リポジトリーに登録します。Red Hat"
+" Enterprise Linuxバージョンに応じて、 <RHEL_VERSION> を6または7のいずれかに置き換えてください。"
+
+#. type: Plain text
+msgid ""
+"For Red Hat Enterprise Linux 8: Using Red Hat Subscription Manager, "
+"subscribe to the {appserver_name} {appserver_version} repository using the "
+"following command:"
+msgstr ""
+"Red Hat Enterprise Linux 8の場合：Red Hat Subscription "
+"Managerを使用して、次のコマンドで{appserver_name} {appserver_version}リポジトリーに登録します。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Installing JBoss EAP Adapter from an RPM"
@@ -56,6 +68,14 @@ msgstr "RPMからのJBoss EAPアダプターのインストール"
 #. type: Plain text
 msgid "Install the EAP 7 Adapters from an RPM:"
 msgstr "次のように、RPMからEAP 7アダプターをインストールします。"
+
+#. type: Plain text
+msgid ""
+"With Red Hat Enterprise Linux 7, the term channel was replaced with the term"
+" repository. In these instructions only the term repository is used."
+msgstr ""
+"Red Hat Enterprise Linux "
+"7では、チャンネルという用語はリポジトリーという用語に置き換えられました。これらの説明では、リポジトリーという用語のみが使用されています。"
 
 #. type: Plain text
 msgid ""
@@ -71,6 +91,26 @@ msgid ""
 msgstr ""
 "$ sudo subscription-manager repos --enable=jb-eap-7-for-rhel-<RHEL_VERSION"
 ">-server-rpms\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ sudo subscription-manager repos --enable=jb-eap-{appserver_version}-for-"
+"rhel-8-x86_64-rpms --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8"
+"-for-x86_64-appstream-rpms\n"
+msgstr ""
+"$ sudo subscription-manager repos --enable=jb-eap-{appserver_version}-for-"
+"rhel-8-x86_64-rpms --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8"
+"-for-x86_64-appstream-rpms\n"
+
+#. type: Plain text
+msgid "or use following one for Red Hat Red Hat Enterprise Linux 8:"
+msgstr "または、次のいずれかをRed Hat Enterprise Linux 8に使用します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo dnf install eap7-keycloak-adapter-sso7_3\n"
+msgstr "$ sudo dnf install eap7-keycloak-adapter-sso7_3\n"
 
 #. type: Plain text
 msgid ""
@@ -90,6 +130,22 @@ msgstr "インストールは完了です。"
 msgid "Install the EAP 6 Adapters from an RPM:"
 msgstr "次のように、RPMからEAP 6アダプターをインストールします。"
 
+#. type: Plain text
+msgid ""
+"You must subscribe to the JBoss EAP 6 repository before you can install the "
+"EAP 6 adapters from an RPM."
+msgstr "RPMからEAP 6アダプターをインストールする前に、JBoss EAP 6リポジトリーにサブスクライブする必要があります。"
+
+#. type: Plain text
+msgid ""
+"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 6 repository "
+"using the following command. Replace <RHEL_VERSION> with either 6 or 7 "
+"depending on your Red Hat Enterprise Linux version."
+msgstr ""
+"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
+"6リポジトリーにサブスクライブします。Red Hat Enterprise "
+"Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
+
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -107,22 +163,19 @@ msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/
 
 #. type: Plain text
 msgid ""
-"You must subscribe to the JBoss EAP 7.2 repository before you can install "
-"the EAP 7 adapters from an RPM."
-msgstr "RPMからEAP 7アダプターをインストールする前に、JBoss EAP 7.2リポジトリーにサブスクライブする必要があります。"
+"You must subscribe to the {appserver_name} {appserver_version} repository "
+"before you can install the {appserver_name} 7 adapters from an RPM."
+msgstr ""
+"RPMから{appserver_name} 7アダプターをインストールする前に、{appserver_name} "
+"{appserver_version}リポジトリーをサブスクライブする必要があります。"
 
 #. type: Plain text
 msgid ""
-"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 7.2 "
-"repository using the following command. Replace <RHEL_VERSION> with either 6"
-" or 7 depending on your Red Hat Enterprise Linux version."
+"Install the {appserver_name} 7 adapters for OIDC using the following command"
+" at Red Hat Enterprise Linux 6, 7:"
 msgstr ""
-"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP 7.2リポジトリーを登録します。Red "
-"Hat Enterprise Linuxのバージョンに応じて、 <RHEL_VERSION> を6または7のいずれかに置き換えてください。"
-
-#. type: Plain text
-msgid "Install the EAP 7 adapters for OIDC using the following command:"
-msgstr "次のコマンドを使用して、OIDC用のEAP 7アダプターをインストールします。"
+"Red Hat Enterprise Linux 6、7で次のコマンドを使用して、OIDC用の{appserver_name} "
+"7アダプターをインストールします。"
 
 #. type: delimited block -
 #, no-wrap
@@ -139,22 +192,6 @@ msgid ""
 "$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install.cli\n"
 msgstr ""
 "$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install.cli\n"
-
-#. type: Plain text
-msgid ""
-"You must subscribe to the JBoss EAP 6.0 repository before you can install "
-"the EAP 6 adapters from an RPM."
-msgstr "RPMからEAP 6アダプターをインストールする前に、JBoss EAP 6.0リポジトリーにサブスクライブする必要があります。"
-
-#. type: Plain text
-msgid ""
-"Using Red Hat Subscription Manager, subscribe to the JBoss EAP 6.0 "
-"repository using the following command. Replace <RHEL_VERSION> with either 6"
-" or 7 depending on your Red Hat Enterprise Linux version."
-msgstr ""
-"Red Hat Subscription Managerを使用して、次のコマンドを使用してJBoss EAP "
-"6.0リポジトリーにサブスクライブします。Red Hat Enterprise "
-"Linuxのバージョンに応じて、<RHEL_VERSION>を6または7のいずれかに置き換えてください。"
 
 #. type: Plain text
 msgid "Install the EAP 6 adapters for OIDC using the following command:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
