### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -30,6 +30,12 @@ msgstr "クロスデータセンター・レプリケーション・モード"
 
 #. type: Plain text
 msgid ""
+"Cross-Datacenter Replication Mode is Technology Preview and is not fully "
+"supported."
+msgstr "クロス・データセンター・レプリケーション・モードはテクノロジー・プレビューであり、完全にはサポートされていません。"
+
+#. type: Plain text
+msgid ""
 "Cross-Datacenter Replication mode is for when you want to run {project_name}"
 " in a cluster across multiple data centers, most typically using data center"
 " sites that are in different geographic regions. When using this mode, each "
@@ -245,13 +251,12 @@ msgstr ""
 "の{project_name}サーバーがデータをすぐに読み取ることができるようにする必要があります。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
 "The active/passive mode is better for performance. For more information "
-"about how to configure caches for either mode, see: <<backups>>.    \n"
+"about how to configure caches for either mode, see: <<backups>>."
 msgstr ""
 "アクティブ/パッシブモードは、パフォーマンスに優れています。いずれかのモードでキャッシュを設定する方法の詳細については、 <<backups>> "
-"を参照してください。\n"
+"を参照してください。"
 
 #. type: Attribute :installguide_database_name:
 #, no-wrap
@@ -434,24 +439,24 @@ msgid ""
 "{project_name} nodes from different data centers. {project_name} nodes use "
 "external JDG (actually {jdgserver_name} servers) for communication across "
 "data centers. This is done using the "
-"link:http://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
+"link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
 " HotRod protocol]."
 msgstr ""
 "{project_name}は、Infinispanキャッシュの分割されたクラスターを複数使用します。各{project_name}ノードは、同じデータセンター内の他の{project_name}ノードと共にクラスター内にありますが、異なるデータセンターの{project_name}ノードはそのクラスター内にありません。{project_name}ノードは、異なるデータセンターの{project_name}ノードと直接通信できません。{project_name}ノードは、データセンター間の通信に外部JDG"
 " "
-"（実際には{jdgserver_name}サーバー）を使用します。これは、link:http://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
+"（実際には{jdgserver_name}サーバー）を使用します。これは、link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
 " HotRodプロトコル]を使用して行われます。"
 
 #. type: Plain text
 msgid ""
 "The Infinispan caches on the {project_name} side must be configured with the"
 " "
-"link:http://infinispan.org/docs/8.2.x/user_guide/user_guide.html#remote_store[remoteStore]"
+"link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#remote_store[remoteStore]"
 " to ensure that data are saved to the remote cache. There is separate "
 "Infinispan cluster between JDG servers, so the data saved on JDG1 on `site1`"
 " are replicated to JDG2 on `site2` ."
 msgstr ""
-"{project_name}側のInfinispanキャッシュは、データがリモート・キャッシュに保存されていることを確認するために、link:http://infinispan.org/docs/8.2.x/user_guide/user_guide.html#remote_store[remoteStore]を使用して設定する必要があります。JDGサーバー間に分割されたInfinispanクラスターがあるので、"
+"{project_name}側のInfinispanキャッシュは、データがリモート・キャッシュに保存されていることを確認するために、link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#remote_store[remoteStore]を使用して設定する必要があります。JDGサーバー間に分割されたInfinispanクラスターがあるので、"
 " `site1` のJDG1に保存されていたデータは `site2` のJDG2にレプリケートされます。"
 
 #. type: Plain text
@@ -699,7 +704,7 @@ msgid ""
 "        <replicated-cache name=\"offlineClientSessions\" configuration=\"sessions-cfg\"/>\n"
 "        <replicated-cache name=\"actionTokens\" configuration=\"sessions-cfg\"/>\n"
 "        <replicated-cache name=\"loginFailures\" configuration=\"sessions-cfg\"/>\n"
-"                \n"
+"\n"
 "</cache-container>\n"
 msgstr ""
 "<cache-container name=\"clustered\" default-cache=\"default\" statistics=\"true\">\n"
@@ -723,7 +728,7 @@ msgstr ""
 "        <replicated-cache name=\"offlineClientSessions\" configuration=\"sessions-cfg\"/>\n"
 "        <replicated-cache name=\"actionTokens\" configuration=\"sessions-cfg\"/>\n"
 "        <replicated-cache name=\"loginFailures\" configuration=\"sessions-cfg\"/>\n"
-"                \n"
+"\n"
 "</cache-container>\n"
 
 #. type: Plain text
@@ -821,7 +826,7 @@ msgid ""
 "                <identity-role-mapper/>\n"
 "                <role name=\"___script_manager\" permissions=\"ALL\"/>\n"
 "            </authorization>\n"
-"        </security> \n"
+"        </security>\n"
 "        ...\n"
 msgstr ""
 "<subsystem xmlns=\"urn:infinispan:server:core:8.4\">\n"
@@ -831,7 +836,7 @@ msgstr ""
 "                <identity-role-mapper/>\n"
 "                <role name=\"___script_manager\" permissions=\"ALL\"/>\n"
 "            </authorization>\n"
-"        </security> \n"
+"        </security>\n"
 "        ...\n"
 
 #. type: Plain text
@@ -1042,14 +1047,13 @@ msgstr ""
 "KeycloakDSデータソースの共有データベースを設定します。テストを目的とする場合は、MySQLまたはMariaDBの使用をお勧めします。詳細は<<database>>を参照してください。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
 "In production you will likely need to have a separate database server in "
 "every data center and both database servers should be synchronously "
 "replicated to each other. In the example setup, we just use a single "
-"database and connect all 4 {project_name} servers to it.   \n"
+"database and connect all 4 {project_name} servers to it."
 msgstr ""
-"プロダクション環境では、すべてのデータセンターにおいて別々のデータベース・サーバーを用意する必要があり、両方のデータベース・サーバーを互いに同期してレプリケートする必要があります。設定例では、単一のデータベースを使用し、4つの{project_name}サーバーすべてに接続します。\n"
+"プロダクション環境では、すべてのデータセンターにおいて別々のデータベース・サーバーを用意する必要があり、両方のデータベース・サーバーを互いに同期してレプリケートする必要があります。設定例では、単一のデータベースを使用し、4つの{project_name}サーバーすべてに接続します。"
 
 #. type: Plain text
 msgid "Edit `NODE11/standalone/configuration/standalone-ha.xml` :"
@@ -1117,7 +1121,7 @@ msgstr "`session` キャッシュの下に `remote-store` を追加します。"
 #, no-wrap
 msgid ""
 "<distributed-cache name=\"sessions\" owners=\"1\">\n"
-"    <remote-store cache=\"sessions\" remote-servers=\"remote-cache\" passivation=\"false\" fetch-state=\"false\" purge=\"false\" preload=\"false\" shared=\"true\">   \n"
+"    <remote-store cache=\"sessions\" remote-servers=\"remote-cache\" passivation=\"false\" fetch-state=\"false\" purge=\"false\" preload=\"false\" shared=\"true\">\n"
 "        <property name=\"rawValues\">true</property>\n"
 "        <property name=\"marshaller\">org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory</property>\n"
 "ifeval::[{project_product}==true]\n"
@@ -1127,7 +1131,7 @@ msgid ""
 "</distributed-cache>\n"
 msgstr ""
 "<distributed-cache name=\"sessions\" owners=\"1\">\n"
-"    <remote-store cache=\"sessions\" remote-servers=\"remote-cache\" passivation=\"false\" fetch-state=\"false\" purge=\"false\" preload=\"false\" shared=\"true\">   \n"
+"    <remote-store cache=\"sessions\" remote-servers=\"remote-cache\" passivation=\"false\" fetch-state=\"false\" purge=\"false\" preload=\"false\" shared=\"true\">\n"
 "        <property name=\"rawValues\">true</property>\n"
 "        <property name=\"marshaller\">org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory</property>\n"
 "ifeval::[{project_product}==true]\n"
@@ -1471,10 +1475,10 @@ msgstr ""
 #. type: Code block
 #, no-wrap
 msgid ""
-"2017-08-25 17:35:17,737 DEBUG [org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheSessionListener] (Client-Listener-sessions-30012a77422542f5) Received event from remote store. \n"
+"2017-08-25 17:35:17,737 DEBUG [org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheSessionListener] (Client-Listener-sessions-30012a77422542f5) Received event from remote store.\n"
 "Event 'CLIENT_CACHE_ENTRY_REMOVED', key '193489e7-e2bc-4069-afe8-f1dfa73084ea', skip 'false'\n"
 msgstr ""
-"2017-08-25 17:35:17,737 DEBUG [org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheSessionListener] (Client-Listener-sessions-30012a77422542f5) Received event from remote store. \n"
+"2017-08-25 17:35:17,737 DEBUG [org.keycloak.models.sessions.infinispan.remotestore.RemoteCacheSessionListener] (Client-Listener-sessions-30012a77422542f5) Received event from remote store.\n"
 "Event 'CLIENT_CACHE_ENTRY_REMOVED', key '193489e7-e2bc-4069-afe8-f1dfa73084ea', skip 'false'\n"
 
 #. type: Title ====
@@ -1634,7 +1638,7 @@ msgstr "サイトをオフラインにするには2つの方法があります�
 #, no-wrap
 msgid ""
 "**Manually by admin** - Admin can use the `jconsole` or other tool and run some JMX operations to manually take the particular site offline.\n"
-"This is useful especially if the outage is planned. With `jconsole` or CLI, you can connect to the `jdg1` server and take the `site2` offline. \n"
+"This is useful especially if the outage is planned. With `jconsole` or CLI, you can connect to the `jdg1` server and take the `site2` offline.\n"
 "More details about this are available in the link:{jdgserver_crossdcdocs_link}#taking_a_site_offline[JDG documentation].\n"
 msgstr ""
 "**管理者による手作業** - 管理者は `jconsole` "
@@ -2226,10 +2230,10 @@ msgstr "{project_name}サーバーの場合、サーバーの起動時に次の�
 #. type: Code block
 #, no-wrap
 msgid ""
-"18:09:30,156 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ServerService Thread Pool -- 54) \n"
+"18:09:30,156 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ServerService Thread Pool -- 54)\n"
 "Node name: node11, Site name: site1\n"
 msgstr ""
-"18:09:30,156 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ServerService Thread Pool -- 54) \n"
+"18:09:30,156 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ServerService Thread Pool -- 54)\n"
 "Node name: node11, Site name: site1\n"
 
 #. type: Plain text
@@ -2286,16 +2290,15 @@ msgstr ""
 " ...\n"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
 "then check the log of corresponding {jdgserver_name} server of your site and"
 " check if has failed to backup to the other site. If the backup site is "
 "unavailable, then it is recommended to switch it offline, so that "
 "{jdgserver_name} server won't try to backup to the offline site causing the "
 "operations to pass successfully on {project_name} server side as well. See "
-"<<administration>> for more information.   \n"
+"<<administration>> for more information."
 msgstr ""
-"サイトの該当する{jdgserver_name}サーバーのログをチェックし、他のサイトへのバックアップに失敗したかどうかを確認します。バックアップ・サイトが利用できない場合は、{jdgserver_name}サーバーがオフラインサイトにバックアップしようとしないようにオフラインに切り替えて、{project_name}サーバー側で正常に操作が成功するようにすることをお勧めします。詳細については、<<administration>>を参照してください。\n"
+"サイトの該当する{jdgserver_name}サーバーのログをチェックし、他のサイトへのバックアップに失敗したかどうかを確認します。バックアップ・サイトが利用できない場合は、{jdgserver_name}サーバーがオフラインサイトにバックアップしようとしないようにオフラインに切り替えて、{project_name}サーバー側で正常に操作が成功するようにすることをお勧めします。詳細については、<<administration>>を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -2355,12 +2358,12 @@ msgstr "場合によっては、{jdgserver_name}サーバーログに次のよ�
 #. type: Code block
 #, no-wrap
 msgid ""
-"(HotRodServerHandler-6-35) ISPN000136: Error executing command ReplaceCommand, \n"
-"writing keys [[B0x033E243034396234..[39]]: org.infinispan.util.concurrent.TimeoutException: ISPN000299: Unable to acquire lock after \n"
+"(HotRodServerHandler-6-35) ISPN000136: Error executing command ReplaceCommand,\n"
+"writing keys [[B0x033E243034396234..[39]]: org.infinispan.util.concurrent.TimeoutException: ISPN000299: Unable to acquire lock after\n"
 "0 milliseconds for key [B0x033E243034396234..[39] and requestor GlobalTx:jdg1:4353. Lock is held by GlobalTx:jdg1:4352\n"
 msgstr ""
-"(HotRodServerHandler-6-35) ISPN000136: Error executing command ReplaceCommand, \n"
-"writing keys [[B0x033E243034396234..[39]]: org.infinispan.util.concurrent.TimeoutException: ISPN000299: Unable to acquire lock after \n"
+"(HotRodServerHandler-6-35) ISPN000136: Error executing command ReplaceCommand,\n"
+"writing keys [[B0x033E243034396234..[39]]: org.infinispan.util.concurrent.TimeoutException: ISPN000299: Unable to acquire lock after\n"
 "0 milliseconds for key [B0x033E243034396234..[39] and requestor GlobalTx:jdg1:4353. Lock is held by GlobalTx:jdg1:4352\n"
 
 #. type: Plain text

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -8,14 +8,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # naoto watanabe <nabenao11@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,7 +32,7 @@ msgstr "クロスデータセンター・レプリケーション・モード"
 msgid ""
 "Cross-Datacenter Replication Mode is Technology Preview and is not fully "
 "supported."
-msgstr "クロス・データセンター・レプリケーション・モードはテクノロジー・プレビューであり、完全にはサポートされていません。"
+msgstr "クロスデータセンター・レプリケーション・モードはテクノロジー・プレビューであり、完全にはサポートされていません。"
 
 #. type: Plain text
 msgid ""
@@ -442,9 +442,7 @@ msgid ""
 "link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
 " HotRod protocol]."
 msgstr ""
-"{project_name}は、Infinispanキャッシュの分割されたクラスターを複数使用します。各{project_name}ノードは、同じデータセンター内の他の{project_name}ノードと共にクラスター内にありますが、異なるデータセンターの{project_name}ノードはそのクラスター内にありません。{project_name}ノードは、異なるデータセンターの{project_name}ノードと直接通信できません。{project_name}ノードは、データセンター間の通信に外部JDG"
-" "
-"（実際には{jdgserver_name}サーバー）を使用します。これは、link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
+"{project_name}は、Infinispanキャッシュの分割されたクラスターを複数使用します。各{project_name}ノードは、同じデータセンター内の他の{project_name}ノードと共にクラスター内にありますが、異なるデータセンターの{project_name}ノードはそのクラスター内にありません。{project_name}ノードは、異なるデータセンターの{project_name}ノードと直接通信できません。{project_name}ノードは、データセンター間の通信に外部JDG（実際には{jdgserver_name}サーバー）を使用します。これは、link:https://infinispan.org/docs/8.2.x/user_guide/user_guide.html#using_hot_rod_server[Infinispan"
 " HotRodプロトコル]を使用して行われます。"
 
 #. type: Plain text
@@ -2298,7 +2296,8 @@ msgid ""
 "operations to pass successfully on {project_name} server side as well. See "
 "<<administration>> for more information."
 msgstr ""
-"サイトの該当する{jdgserver_name}サーバーのログをチェックし、他のサイトへのバックアップに失敗したかどうかを確認します。バックアップ・サイトが利用できない場合は、{jdgserver_name}サーバーがオフラインサイトにバックアップしようとしないようにオフラインに切り替えて、{project_name}サーバー側で正常に操作が成功するようにすることをお勧めします。詳細については、<<administration>>を参照してください。"
+"サイトの該当する{jdgserver_name}サーバーのログをチェックし、他のサイトへのバックアップに失敗したかどうかを確認します。バックアップ・サイトが利用できない場合は、{jdgserver_name}サーバーがオフラインサイトにバックアップしようとしないようにオフラインに切り替えて、{project_name}サーバー側で正常に操作が成功するようにすることをお勧めします。詳細については、"
+" <<administration>> を参照してください。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
