### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -131,6 +131,13 @@ msgid ""
 "These server instances pull their configuration from the domain controller."
 msgstr ""
 "ドメインモードでは、マスターノード上でドメイン・コントローラーが起動されます。クラスターの設定は、ドメイン・コントローラー内にあります。次に、ホスト・コントローラーがクラスター内の各マシンで起動されます。各ホスト・コントローラーのデプロイ設定では、そのマシンで起動する{project_name}サーバー・インスタンスの数を指定します。ホスト・コントローラーが起動すると、指定された数の{project_name}サーバー・インスタンスが起動します。これらのサーバー・インスタンスは、ドメイン・コントローラーから設定を取得します。"
+
+#. type: Plain text
+msgid ""
+"In some environments, such as Microsoft Azure, the domain mode is not "
+"applicable. Please consult the {appserver_name} documentation."
+msgstr ""
+"Microsoft Azureなどの一部の環境では、ドメインモードは適用されません。{appserver_name}のドキュメントを参照してください。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
