### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,7 +51,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "This chapter discusses some configuration options for these caches for both "
-"clustered a non-clustered deployments."
+"clustered and non-clustered deployments."
 msgstr "この章では、クラスター構成と非クラスター構成の両方のためのキャッシュ用設定オプションについて説明します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
