### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -68,26 +68,27 @@ msgstr "Pax Web Whiteboard Extenderを使用して、FuseにOSGIサービスと�
 
 #. type: Plain text
 msgid ""
-"http://camel.apache.org/[Apache Camel] Jetty endpoints running with the "
-"http://camel.apache.org/jetty.html[Camel Jetty] component"
+"https://camel.apache.org/[Apache Camel] Jetty endpoints running with the "
+"https://camel.apache.org/components/latest/jetty-component.html[Camel Jetty]"
+" component"
 msgstr ""
-"http://camel.apache.org/jetty.html[Camel Jetty] コンポーネントで動作する "
-"http://camel.apache.org/[Apache Camel] Jettyエンドポイント"
+"https://camel.apache.org/components/latest/jetty-component.html[Camel Jetty]"
+"  コンポーネントで動作する https://camel.apache.org/[Apache Camel] Jettyエンドポイント"
 
 #. type: Plain text
 msgid ""
-"http://cxf.apache.org/[Apache CXF] endpoints running on their own separate "
-"http://cxf.apache.org/docs/jetty-configuration.html[Jetty engine]"
+"https://cxf.apache.org/[Apache CXF] endpoints running on their own separate "
+"https://cxf.apache.org/docs/jetty-configuration.html[Jetty engine]"
 msgstr ""
-"独自の分離された http://cxf.apache.org/docs/jetty-configuration.html[Jettyエンジン] "
-"で動作する http://cxf.apache.org/[Apache CXF] エンドポイント"
+"独自の分離された https://cxf.apache.org/docs/jetty-configuration.html[Jettyエンジン] "
+"で動作する https://cxf.apache.org/[Apache CXF] エンドポイント"
 
 #. type: Plain text
 msgid ""
-"http://cxf.apache.org/[Apache CXF] endpoints running on the default engine "
+"https://cxf.apache.org/[Apache CXF] endpoints running on the default engine "
 "provided by the CXF servlet"
 msgstr ""
-"CXFサーブレットによって提供されるデフォルト・エンジンで実行されている http://cxf.apache.org/[Apache CXF] "
+"CXFサーブレットによって提供されるデフォルト・エンジンで実行されている https://cxf.apache.org/[Apache CXF] "
 "エンドポイント"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
