### PR TITLE
Translations for i18n/po/ja_JP/release_notes/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/master.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/master.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,6 +28,11 @@ msgstr "{releasenotes_name}"
 #, no-wrap
 msgid "{project_name_full} 7.3"
 msgstr "{project_name_full} 7.3"
+
+#. type: Title ==
+#, no-wrap
+msgid "{project_name_full} 7"
+msgstr "{project_name_full} 7"
 
 #. type: Title ==
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
