### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po
@@ -7,7 +7,7 @@
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -354,12 +354,15 @@ msgstr ""
 msgid ""
 "Clients need to install kerberos client and setup krb5.conf as described "
 "above.  Additionally they need to enable SPNEGO login support in their "
-"browser.  See "
-"link:http://www.microhowto.info/howto/configure_firefox_to_authenticate_using_spnego_and_kerberos.html[configuring"
-" Firefox for Kerberos] if you are using that browser.  URI `.mydomain.org` "
+"browser.  See link:https://access.redhat.com/documentation/en-"
+"us/red_hat_enterprise_linux/7/html/system-"
+"level_authentication_guide/configuring_applications_for_sso[configuring "
+"Firefox for Kerberos] if you are using that browser.  URI `.mydomain.org` "
 "must be allowed in the `network.negotiate-auth.trusted-uris` config option."
 msgstr ""
-"クライアントはKerberosクライアントをインストールし、上記のようにkrb5.confを設定する必要があります。さらに、ブラウザーでSPNEGOログインを有効にする必要があります。そのブラウザーを使用している場合は、link:http://www.microhowto.info/howto/configure_firefox_to_authenticate_using_spnego_and_kerberos.html[KerberosのためのFirefoxの設定]を参照してください。URI"
+"クライアントはKerberosクライアントをインストールし、上記のようにkrb5.confを設定する必要があります。さらに、ブラウザーでSPNEGOログインを有効にする必要があります。そのブラウザーを使用している場合は、link:https://access.redhat.com/documentation"
+"/en-us/red_hat_enterprise_linux/7/html/system-"
+"level_authentication_guide/configuring_applications_for_sso[KerberosのためのFirefoxの設定]を参照してください。URI"
 " `.mydomain.org` は、 `network.negotiate-auth.trusted-uris` "
 "設定オプションで許可する必要があります。"
 
@@ -528,12 +531,13 @@ msgstr ""
 msgid ""
 "Credential delegation has some security implications so only use it if you really need it.\n"
 "         It's highly recommended to use it together with HTTPS.\n"
-"         See for example http://www.microhowto.info/howto/configure_firefox_to_authenticate_using_spnego_and_kerberos.html[this article] for more details.\n"
+"         See for example https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/configuring_applications_for_sso[this article] for more details.\n"
 msgstr ""
 "クレデンシャルの委任にはいくつかのセキュリティー上の影響があります。本当に必要な場合にのみ使用してください。HTTPSと一緒に使用することを強くお勧めします。詳細については、"
-" "
-"http://www.microhowto.info/howto/configure_firefox_to_authenticate_using_spnego_and_kerberos.html[この記事]"
-" の例を参照してください。\n"
+" https://access.redhat.com/documentation/en-"
+"us/red_hat_enterprise_linux/7/html/system-"
+"level_authentication_guide/configuring_applications_for_sso[この記事] "
+"の例を参照してください。\n"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/kerberos.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__kerberos
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
