### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -917,8 +917,8 @@ msgid ""
 "the `requested_subject` parameter.  The value of this parameter must be a "
 "username or user id."
 msgstr ""
-"`requested_subject` "
-"パラメーターを追加で指定しない限り、他の章で説明したようにリクエストを行います。このパラメーターの値は、ユーザー名またはユーザーIDでなければなりません。"
+"追加で `requested_subject` "
+"パラメーターを指定している点を除いて、他の章で説明したようにリクエストを行います。このパラメーターの値は、ユーザー名またはユーザーIDでなければなりません。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -914,10 +914,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Make the request as described in other chapters except additionally specify "
-"the `request_subject` parameter.  The value of this parameter must be a "
+"the `requested_subject` parameter.  The value of this parameter must be a "
 "username or user id."
 msgstr ""
-"`request_subject` "
+"`requested_subject` "
 "パラメーターを追加で指定しない限り、他の章で説明したようにリクエストを行います。このパラメーターの値は、ユーザー名またはユーザーIDでなければなりません。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
