### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -131,16 +131,18 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "You can secure Apache Camel endpoints implemented with the "
-"http://camel.apache.org/jetty.html[camel-jetty] component by adding "
-"securityHandler with `KeycloakJettyAuthenticator` and the proper security "
-"constraints injected. You can add the `OSGI-INF/blueprint/blueprint.xml` "
-"file to your Camel application with a similar configuration as below. The "
-"roles, security constraint mappings, and {project_name} adapter "
-"configuration might differ slightly depending on your environment and needs."
+"https://camel.apache.org/components/latest/jetty-component.html[camel-jetty]"
+" component by adding the securityHandler with `KeycloakJettyAuthenticator` "
+"and the proper security constraints injected. You can add the `OSGI-"
+"INF/blueprint/blueprint.xml` file to your Camel application with a similar "
+"configuration as below. The roles, security constraint mappings, and "
+"{project_name} adapter configuration might differ slightly depending on your"
+" environment and needs."
 msgstr ""
 "`KeycloakJettyAuthenticator` とsecurityHandlerを追加し、適切なセキュリティー制約を注入することで、 "
-"http://camel.apache.org/jetty.html[camel-jetty]コンポーネントで実装されたApache "
-"Camelエンドポイントをセキュリティー保護できます。 `OSGI-INF/blueprint/blueprint.xml` "
+"https://camel.apache.org/components/latest/jetty-component.html[camel-"
+"jetty]コンポーネントで実装されたApache Camelエンドポイントをセキュリティー保護できます。 `OSGI-"
+"INF/blueprint/blueprint.xml` "
 "ファイルを、以下のような設定でCamelアプリケーションに追加できます。ロール、セキュリティー制約のマッピング、および{project_name}アダプターの設定は、使用する環境と必要性により若干異なる場合があります。"
 
 #. type: delimited block -

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -140,8 +140,8 @@ msgid ""
 " environment and needs."
 msgstr ""
 "`KeycloakJettyAuthenticator` とsecurityHandlerを追加し、適切なセキュリティー制約を注入することで、 "
-"https://camel.apache.org/components/latest/jetty-component.html[camel-"
-"jetty]コンポーネントで実装されたApache Camelエンドポイントをセキュリティー保護できます。 `OSGI-"
+"https://camel.apache.org/components/latest/jetty-component.html[camel-jetty]"
+" コンポーネントで実装されたApache Camelエンドポイントをセキュリティー保護できます。 `OSGI-"
 "INF/blueprint/blueprint.xml` "
 "ファイルを、以下のような設定でCamelアプリケーションに追加できます。ロール、セキュリティー制約のマッピング、および{project_name}アダプターの設定は、使用する環境と必要性により若干異なる場合があります。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/camel.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__camel
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
