### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,18 +43,19 @@ msgstr "Apache Camelアプリケーションのセキュリティー保護"
 #. type: Plain text
 msgid ""
 "You can secure Apache Camel endpoints implemented with the "
-"http://camel.apache.org/undertow.html[camel-undertow] component by injecting"
-" the proper security constraints via blueprint and updating the used "
-"component to `undertow-keycloak`. You have to add the `OSGI-"
-"INF/blueprint/blueprint.xml` file to your Camel application with a similar "
-"configuration as below. The roles and security constraint mappings, and "
-"adapter configuration might differ slightly depending on your environment "
-"and needs."
+"https://camel.apache.org/components/latest/undertow-component.html[camel-"
+"undertow] component by injecting the proper security constraints via "
+"blueprint and updating the used component to `undertow-keycloak`. You have "
+"to add the `OSGI-INF/blueprint/blueprint.xml` file to your Camel application"
+" with a similar configuration as below. The roles, security constraint "
+"mappings, and adapter configuration might differ slightly depending on your "
+"environment and needs."
 msgstr ""
-"http://camel.apache.org/undertow.html[camel-undertow]コンポーネントで実装されたApache "
+"https://camel.apache.org/components/latest/undertow-component.html[camel-"
+"undertow]コンポーネントで実装されたApache "
 "Camelエンドポイントをセキュリティー保護するには、適切なセキュリティー制約をBlueprintを介して注入し、使用されるコンポーネントを "
 "`undertow-keycloak` に更新します。以下のような設定で、 `OSGI-INF/blueprint/blueprint.xml` "
-"ファイルをCamelアプリケーションに追加する必要があります。ロールとセキュリティー制約のマッピング、およびアダプターの設定は、使用する環境と必要性により若干異なる場合があります。"
+"ファイルをCamelアプリケーションに追加する必要があります。ロール、セキュリティー制約のマッピング、およびアダプターの設定は、使用する環境と必要性により若干異なる場合があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__camel
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
