### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# katakura__pro <h.katakura@pro-japan.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -142,7 +147,9 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "If your SMTP server requires authentication click on `Enable Authentication`"
-" and insert the `Username` and `Password`."
+" and insert the `Username` and `Password`. The value of the `Password` field"
+" can refer a value from an external <<_vault-administration,vault>>."
 msgstr ""
 "SMTPサーバーが認証を必要とする場合は、 `Enable Authentication` をクリックし、 `Username` と "
-"`Password` を入力します。"
+"`Password` を入力します。 `Password` フィールドの値は、外部<<_vault-"
+"administration,ボールト>>からの値を参照できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__email
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
