### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -139,8 +139,9 @@ msgid ""
 " is used.  In the other cases, a client secret has to be defined.\n"
 " For more details, see the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[Client Authentication specifications].\n"
 msgstr ""
-"認可コードフローで使用されるクライアント認証方法を定義するために切り替えます。秘密鍵で署名されたJWTの場合、レルム秘密鍵が使用されます。それ以外の場合、クライアントシークレットを定義する必要があります。詳細については、https：//openid.net/specs"
-"/openid-connect-core-1_0.html#ClientAuthentication [クライアント認証の仕様]を参照してください。\n"
+"認可コードフローで使用されるクライアント認証方法を定義するために切り替えます。秘密鍵で署名されたJWTの場合、レルム秘密鍵が使用されます。それ以外の場合、クライアントシークレットを定義する必要があります。詳細については、"
+" https://openid.net/specs/openid-connect-core-"
+"1_0.html#ClientAuthentication[クライアント認証の仕様] を参照してください。\n"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -25,6 +25,11 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
+#. type: Plain text
+#, no-wrap
+msgid "Client Authentication"
+msgstr "クライアント認証"
+
 #. type: Block title
 #, no-wrap
 msgid "Add Identity Provider"
@@ -127,6 +132,16 @@ msgid ""
 msgstr ""
 "OIDCプロトコルで定義されたUserInfo URLエンドポイント。これは、ユーザー・プロファイル情報をダウンロードできるエンドポイントです。"
 
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Switch to define the Client Authentication method to be used with the Authorization Code Flow.  In the case of JWT signed with private key, the realm private key\n"
+" is used.  In the other cases, a client secret has to be defined.\n"
+" For more details, see the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[Client Authentication specifications].\n"
+msgstr ""
+"認可コードフローで使用されるクライアント認証方法を定義するために切り替えます。秘密鍵で署名されたJWTの場合、レルム秘密鍵が使用されます。それ以外の場合、クライアントシークレットを定義する必要があります。詳細については、https：//openid.net/specs"
+"/openid-connect-core-1_0.html#ClientAuthentication [クライアント認証の仕様]を参照してください。\n"
+
 #. type: Labeled list
 #, no-wrap
 msgid "Client ID"
@@ -147,8 +162,11 @@ msgstr "Client Secret"
 #. type: Plain text
 msgid ""
 "This realm will need a client secret to use when using the Authorization "
-"Code Flow."
-msgstr "このレルムには、認可コードフローを使用する際に利用するクライアント・シークレットが必要です。"
+"Code Flow. The value of this field can refer a value from an external "
+"<<_vault-administration,vault>>."
+msgstr ""
+"このレルムには、認可コードフローを使用するときに使用するクライアント・シークレットが必要です。このフィールドの値は、外部<<_vault-"
+"administration,ボールト>>の値を参照できます。"
 
 #. type: Plain text
 msgid "Issuer"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
