### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -170,7 +171,8 @@ msgid ""
 "different roles, then these roles are set in the result set. If no mapping "
 "is found for the role then it is included as is in the result set."
 msgstr ""
-"`properties`ファイルには、キーとしてロールとプリンシパルの両方を、値としてカンマで区切られたゼロ以上のロールのリストを含めることができます。呼び出されると、実装はアサーションから抽出された一連のロールを反復処理し、各ロールについてマッピングが存在するかどうかを確認します。ロールが空のロールにマップされている場合は、破棄されます。1つ以上の異なるロールのセットにマップされる場合、これらのロールは結果セットに設定されます。ロールのマッピングが見つからない場合は、結果セットにそのまま含まれます。"
+"`properties` "
+"ファイルには、キーとしてロールとプリンシパルの両方を、値としてカンマで区切られたゼロ以上のロールのリストを含めることができます。呼び出されると、実装はアサーションから抽出された一連のロールを反復処理し、各ロールについてマッピングが存在するかどうかを確認します。ロールが空のロールにマップされている場合は、破棄されます。1つ以上の異なるロールのセットにマップされる場合、これらのロールは結果セットに設定されます。ロールのマッピングが見つからない場合は、結果セットにそのまま含まれます。"
 
 #. type: Plain text
 msgid ""
@@ -214,7 +216,7 @@ msgstr ""
 "プリンシパル `kc_user` がロール `roleA` 、 `roleB` および `roleC` "
 "を持つアサーションから抽出される場合、プリンシパルに割り当てられるロールの最終セットは `roleC` 、 `roleX` 、 `roleY` および "
 "`roleZ` になります。 `roleA` は `roleX` と `roleY` の両方にマップされ、 `roleB` "
-"は空のロールにマップされているので破棄され、 ` roleC` はそのまま使用され、最後に追加のロールが `kc_user` プリンシパル（ "
+"は空のロールにマップされているので破棄され、 `roleC` はそのまま使用され、最後に追加のロールが `kc_user` プリンシパル（ "
 "`roleZ` ）に追加されるためです。"
 
 #. type: Title ======

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po
@@ -1,0 +1,235 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "RoleMappingsProvider Element"
+msgstr "RoleMappingsProvider要素"
+
+#. type: Plain text
+msgid ""
+"The `RoleMappingsProvider` is an optional element that allows for the "
+"specification of the id and configuration of the "
+"`org.keycloak.adapters.saml.RoleMappingsProvider` SPI implementation that is"
+" to be used by the SAML adapter."
+msgstr ""
+"`RoleMappingsProvider` は、SAMLアダプターによって使用される "
+"`org.keycloak.adapters.saml.RoleMappingsProvider` "
+"SPIの実装のidと設定を指定できるオプションの要素です。"
+
+#. type: Plain text
+msgid ""
+"When {project_name} is used as the IDP, it is possible to use the built in "
+"role mappers to map any roles before adding them to the SAML assertion. "
+"However, the SAML adapters can be used to send SAML requests to third party "
+"IDPs and in this case it might be necessary to map the roles extracted from "
+"the assertion into a different set of roles as required by the SP. The "
+"`RoleMappingsProvider` SPI allows for the configuration of pluggable role "
+"mappers that can be used to perform the necessary mappings."
+msgstr ""
+"{project_name}をIDPとして使用する場合、組み込みのロールマッパーを使用して、ロールをSAMLアサーションに追加する前にマッピングできます。ただし、SAMLアダプターを使用することでSAMLリクエストをサードパーティーのIDPに送信できるため、この場合、SPの要求に応じて、アサーションから抽出されたロールを異なるロールセットにマッピングする必要があります。"
+" `RoleMappingsProvider` SPIは、必要なマッピングを実行するために使用できるプラグ可能なロールマッパーの設定を可能にします。"
+
+#. type: Plain text
+msgid "The configuration of the provider looks as follows:"
+msgstr "プロバイダーの設定は次のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"...\n"
+"<RoleIdentifiers>\n"
+"    ...\n"
+"</RoleIdentifiers>\n"
+"<RoleMappingsProvider id=\"properties-based-role-mapper\">\n"
+"    <Property name=\"properties.resource.location\" value=\"/WEB-INF/role-mappings.properties\"/>\n"
+"</RoleMappingsProvider>\n"
+"<IDP>\n"
+"    ...\n"
+"</IDP>\n"
+msgstr ""
+"...\n"
+"<RoleIdentifiers>\n"
+"    ...\n"
+"</RoleIdentifiers>\n"
+"<RoleMappingsProvider id=\"properties-based-role-mapper\">\n"
+"    <Property name=\"properties.resource.location\" value=\"/WEB-INF/role-mappings.properties\"/>\n"
+"</RoleMappingsProvider>\n"
+"<IDP>\n"
+"    ...\n"
+"</IDP>\n"
+
+#. type: Plain text
+msgid ""
+"The `id` attribute identifies which of the installed providers is to be "
+"used. The `Property` sub-element can be used multiple times to specify "
+"configuration properties for the provider."
+msgstr ""
+"`id` 属性は、インストールされているプロバイダーのどれを使用するかを識別します。 `Property` "
+"サブ要素を複数回使用して、プロバイダーの設定プロパティーを指定できます。"
+
+#. type: Title ======
+#, no-wrap
+msgid "Properties Based Role Mappings Provider"
+msgstr "プロパティー・ベースのロールマッピング・プロバイダー"
+
+#. type: Plain text
+msgid ""
+"{project_name} includes a `RoleMappingsProvider` implementation that "
+"performs the role mappings using a `properties` file. This provider is "
+"identified by the id `properties-based-role-mapper` and is implemented by "
+"the `org.keycloak.adapters.saml.PropertiesBasedRoleMapper` class."
+msgstr ""
+"{project_name}には、 `properties` ファイルを使用してロールマッピングを実行する `RoleMappingsProvider`"
+" の実装が含まれます。このプロバイダーは、ID `properties-based-role-mapper` によって識別され、 "
+"`org.keycloak.adapters.saml.PropertiesBasedRoleMapper` クラスによって実装されます。"
+
+#. type: Plain text
+msgid ""
+"This provider relies on two configuration properties that can be used to "
+"specify the location of the `properties` file that will be used. First, it "
+"checks if the `properties.file.location` property has been specified, using "
+"the configured value to locate the `properties` file in the filesystem. If "
+"the configured file is not located, the provider throws a "
+"`RuntimeException`. The following snippet shows an example of provider using"
+" the `properties.file.configuration` option to load the `roles.properties` "
+"file from the `/opt/mappers/` directory in the filesystem:"
+msgstr ""
+"このプロバイダーは、使用される `properties` ファイルの場所を指定するために使用できる2つの設定プロパティーに依存しています。まず、 "
+"`properties.file.location` プロパティーが指定されているかどうかを確認し、設定された値を使用してファイルシステム内の "
+"`properties` ファイルを見つけます。設定されたファイルが見つからない場合、プロバイダーは `RuntimeException` "
+"をスローします。次のスニペットは、 `properties.file.configuration` オプションを使用して、ファイルシステムの `/opt"
+" /mappers/` ディレクトリーから `roles.properties` ファイルをロードするプロバイダーの例を示しています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <RoleMappingsProvider id=\"properties-based-role-mapper\">\n"
+"        <Property name=\"properties.file.location\" value=\"/opt/mappers/roles.properties\"/>\n"
+"    </RoleMappingsProvider>\n"
+msgstr ""
+"    <RoleMappingsProvider id=\"properties-based-role-mapper\">\n"
+"        <Property name=\"properties.file.location\" value=\"/opt/mappers/roles.properties\"/>\n"
+"    </RoleMappingsProvider>\n"
+
+#. type: Plain text
+msgid ""
+"If the `properties.file.location` configuration has not been set, the "
+"provider checks the `properties.resource.location` property, using the "
+"configured value to load the `properties` file from the `WAR` resource. If "
+"this configuration property is also not present, the provider attempts to "
+"load the file from `/WEB-INF/role-mappings.properties` by default. Failure "
+"to load the file from the resource will result in the provider throwing a "
+"`RuntimeException`. The following snippet shows an example of provider using"
+" the `properties.resource.location` to load the `roles.properties` file from"
+" the application's `/WEB-INF/conf/` directory:"
+msgstr ""
+"`properties.file.location` が設定されていない場合、プロバイダーは "
+"`properties.resource.location` プロパティーをチェックし、設定された値を使用して `WAR` リソースから "
+"`properties` ファイルをロードします。この設定プロパティーが存在しない場合、プロバイダーはデフォルトで `/WEB-INF/role-"
+"mappings.properties` からファイルをロードしようとします。リソースからファイルをロードできないと、プロバイダーは "
+"`RuntimeException` をスローします。 次のスニペットは、 `properties.resource.location` "
+"を使用してアプリケーションの `/WEB-INF/conf/` ディレクトリーから `roles.properties` "
+"ファイルをロードするプロバイダーの例を示しています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <RoleMappingsProvider id=\"properties-based-role-mapper\">\n"
+"        <Property name=\"properties.resource.location\" value=\"/WEB-INF/conf/roles.properties\"/>\n"
+"    </RoleMappingsProvider>\n"
+msgstr ""
+"    <RoleMappingsProvider id=\"properties-based-role-mapper\">\n"
+"        <Property name=\"properties.resource.location\" value=\"/WEB-INF/conf/roles.properties\"/>\n"
+"    </RoleMappingsProvider>\n"
+
+#. type: Plain text
+msgid ""
+"The `properties` file can contain both roles and principals as keys, and a "
+"list of zero or more roles separated by comma as values. When invoked, the "
+"implementation iterates through the set of roles that were extracted from "
+"the assertion and checks, for each role, if a mapping exists. If the role "
+"maps to an empty role, it is discarded. If it maps to a set of one ore more "
+"different roles, then these roles are set in the result set. If no mapping "
+"is found for the role then it is included as is in the result set."
+msgstr ""
+"`properties`ファイルには、キーとしてロールとプリンシパルの両方を、値としてカンマで区切られたゼロ以上のロールのリストを含めることができます。呼び出されると、実装はアサーションから抽出された一連のロールを反復処理し、各ロールについてマッピングが存在するかどうかを確認します。ロールが空のロールにマップされている場合は、破棄されます。1つ以上の異なるロールのセットにマップされる場合、これらのロールは結果セットに設定されます。ロールのマッピングが見つからない場合は、結果セットにそのまま含まれます。"
+
+#. type: Plain text
+msgid ""
+"Once the roles have been processed, the implementation checks if the "
+"principal extracted from the assertion contains an entry `properties` file. "
+"If a mapping for the principal exists, any roles listed as value are added "
+"to the result set. This allows the assignment of extra roles to a principal."
+msgstr ""
+"ロールが処理されると、実装はアサーションから抽出されたプリンシパルにエントリーの `properties` "
+"ファイルが含まれているかどうかを確認します。プリンシパルのマッピングが存在する場合、値としてリストされているロールが結果セットに追加されます。これにより、プリンシパルに追加のロールを割り当てることができます。"
+
+#. type: Plain text
+msgid ""
+"As an example, let's assume the provider has been configured with the "
+"following properties file:"
+msgstr "例として、プロバイダーが次のプロパティー・ファイルで設定されていると仮定します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"roleA=roleX,roleY\n"
+"roleB=\n"
+msgstr ""
+"roleA=roleX,roleY\n"
+"roleB=\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "kc_user=roleZ\n"
+msgstr "kc_user=roleZ\n"
+
+#. type: Plain text
+msgid ""
+"If the principal `kc_user` is extracted from the assertion with roles "
+"`roleA`, `roleB` and `roleC`, the final set of roles assigned to the "
+"principal will be `roleC`, `roleX`, `roleY` and `roleZ` because `roleA` is "
+"being mapped into both `roleX` and `roleY`, `roleB` was mapped into an empty"
+" role - thus being discarded, `roleC` is used as is and finally an "
+"additional role was added to the `kc_user` principal (`roleZ`)."
+msgstr ""
+"プリンシパル `kc_user` がロール `roleA` 、 `roleB` および `roleC` "
+"を持つアサーションから抽出される場合、プリンシパルに割り当てられるロールの最終セットは `roleC` 、 `roleX` 、 `roleY` および "
+"`roleZ` になります。 `roleA` は `roleX` と `roleY` の両方にマップされ、 `roleB` "
+"は空のロールにマップされているので破棄され、 ` roleC` はそのまま使用され、最後に追加のロールが `kc_user` プリンシパル（ "
+"`roleZ` ）に追加されるためです。"
+
+#. type: Title ======
+#, no-wrap
+msgid "Adding Your Own Role Mappings Provider"
+msgstr "独自のロールマッピング・プロバイダーの追加"
+
+#. type: Plain text
+msgid ""
+"To add a custom role mappings provider one simply needs to implement the "
+"`org.keycloak.adapters.saml.RoleMappingsProvider` SPI.  For more details see"
+" the `SAML Role Mappings SPI` section in "
+"link:{developerguide_link}[{developerguide_name}]."
+msgstr ""
+"カスタム・ロールマッピング・プロバイダーを追加するには、単に "
+"`org.keycloak.adapters.saml.RoleMappingsProvider` SPIを実装する必要があります。詳細については、 "
+"link:{developerguide_link}[{developerguide_name}] の `SAML Role Mappings SPI`"
+" のセクションを参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp_role_mappings_provider_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
