### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/openshift.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/openshift.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/openshift.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,8 +27,8 @@ msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ====
 #, no-wrap
-msgid "OpenShift"
-msgstr "OpenShift"
+msgid "OpenShift 3"
+msgstr "OpenShift 3"
 
 #. type: Plain text
 msgid ""
@@ -59,7 +59,7 @@ msgstr "image:images/openshift-add-identity-provider.png[]"
 msgid "Registering OAuth client"
 msgstr "OAuthクライアントの登録"
 
-#. type: Plain text
+#. type: delimited block =
 msgid "You can register your client using `oc` command line tool."
 msgstr "`oc` コマンドライン・ツールを使ってクライアントを登録することができます。"
 
@@ -139,3 +139,113 @@ msgstr ""
 "詳細なガイドについては、 "
 "https://docs.okd.io/latest/architecture/additional_concepts/authentication.html#oauth[official"
 " OpenShift documentation] を参照してください。"
+
+#. type: Title ====
+#, no-wrap
+msgid "OpenShift 4"
+msgstr "OpenShift 4"
+
+#. type: delimited block =
+#, no-wrap
+msgid ""
+"Prior to configuring OpenShift 4 Identity Provider, please locate the correct OpenShift 4 API URL up.\n"
+"In some scenarios, that URL might be hidden from users. The easiest way to obtain it is to invoke the following command (this might require installing `jq` command separately) `curl -s -k -H \"Authorization: Bearer $(oc whoami -t)\" \\https://<openshift-user-facing-api-url>/apis/config.openshift.io/v1/infrastructures/cluster | jq \".status.apiServerURL\"`. In most cases, the address will be protected by HTTPS. Therefore, it is essential to configure `X509_CA_BUNDLE` in the container and set it to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. Otherwise, {project_name} won't be able to communicate\n"
+" with the API Server.\n"
+msgstr ""
+"OpenShift 4 Identity Providerを設定する前に、正しいOpenShift 4 API URLを見つけてください。一部のシナリオでは、そのURLはユーザーから隠されている場合があります。これを取得する最も簡単な方法は、次のコマンドを呼び出すことです（ `jq` コマンドを個別にインストールする必要がある場合があります） `curl -s -k -H \"Authorization: Bearer $(oc whoami -t)\" \\https://<openshift-user-facing-api-url>/apis/config.openshift.io/v1/infrastructures/cluster | jq \".status.apiServerURL\"` \n"
+"ほとんどの場合、アドレスはHTTPSによって保護されます。したがって、コンテナで `X509_CA_BUNDLE` を設定し、 `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` に設定することが不可欠です。そうしないと、{project_name}はAPIサーバーと通信できません。\n"
+
+#. type: delimited block =
+msgid ""
+"There are a just a few steps you have to complete to be able to enable login"
+" with OpenShift 4.  First, go to the `Identity Providers` left menu item and"
+" select `OpenShift v4` from the `Add provider` drop down list.  This will "
+"bring you to the `Add identity provider` page."
+msgstr ""
+"OpenShift 4でログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
+"Providers` に移動し、 `Add provider` のドロップダウン・リストから `OpenShift 4` を選択します。これにより、 "
+"`Add identity provider` ページが表示されます。"
+
+#. type: delimited block =
+msgid "image:images/openshift-4-add-identity-provider.png[]"
+msgstr "image:images/openshift-4-add-identity-provider.png[]"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ oc create -f <(echo '\n"
+"kind: OAuthClient\n"
+"apiVersion: v1\n"
+"metadata:\n"
+" name: keycloak-broker <1>\n"
+"secret: \"...\" <2>\n"
+"redirectURIs:\n"
+" - \"<copy pasted Redirect URI from OpenShift 4 Identity Providers page>\" <3>\n"
+"grantMethod: prompt <4>\n"
+"')\n"
+msgstr ""
+"$ oc create -f <(echo '\n"
+"kind: OAuthClient\n"
+"apiVersion: v1\n"
+"metadata:\n"
+" name: keycloak-broker <1>\n"
+"secret: \"...\" <2>\n"
+"redirectURIs:\n"
+" - \"<copy pasted Redirect URI from OpenShift 4 Identity Providers page>\" <3>\n"
+"grantMethod: prompt <4>\n"
+"')\n"
+
+#. type: Plain text
+msgid ""
+"The `name` of your OAuth client. Passed as `client_id` request parameter "
+"when making requests to `_<openshift_master>_/oauth/authorize` and "
+"`_<openshift_master>_/oauth/token`. The `name` parameter needs to be the "
+"same"
+msgstr ""
+"OAuthクライアントの `name` です。 `_<openshift_master>_/oauth/authorize` と "
+"`_<openshift_master>_/oauth/token` へのリクエストを行うときに `client_id` "
+"リクエスト・パラメーターとして渡されます。 `name` パラメーターは、"
+
+#. type: Plain text
+msgid "in `OAuthClient` object as well as in {project_name} configuration."
+msgstr "`OAuthClient` オブジェクトと{project_name}の設定で同じにする必要があります。。"
+
+#. type: Plain text
+msgid ""
+"The `redirect_uri` parameter specified in requests to "
+"`_<openshift_master>_/oauth/authorize` and "
+"`_<openshift_master>_/oauth/token` must be equal to (or prefixed by) one of "
+"the URIs in `redirectURIs`. The easiest way to configure it correctly is to "
+"copy-paste"
+msgstr ""
+"`_<openshift_master>_/oauth/authorize` および "
+"`_<openshift_master>_/oauth/token` へのリクエストで指定された `redirect_uri` パラメーターは、 "
+"`redirectURIs` のURIの1つと一致する（または前方一致する）必要があります。正しく設定する最も簡単な方法は、"
+
+#. type: Plain text
+msgid ""
+"it from {project_name} OpenShift 4 Identity Provider configuration page "
+"(`Redirect URI` field)."
+msgstr ""
+"{project_name} OpenShift 4 Identity Providerの設定ページから（ `Redirect URI` "
+"フィールド）、コピー・アンド・ペーストすることです。"
+
+#. type: delimited block =
+msgid ""
+"Use the client ID and secret defined by `oc create` command to enter them "
+"back on the {project_name} `Add identity provider` page.  Go back to "
+"{project_name} and specify those items."
+msgstr ""
+"`oc create` コマンドで定義されたクライアントIDとシークレットを使用して、{project_name}の `Add identity "
+"provider` ページに入力します。{project_name}に戻り、それらの項目を入力します。"
+
+#. type: delimited block =
+#, no-wrap
+msgid ""
+"The OpenShift API server returns `The client is not authorized to request a token using this method` whenever `OAuthClient`\n"
+" `name`, `secret` or `redirectURIs` is incorrect. Make sure you copy-pasted them into {project_name} OpenShift 4 Identity Provider page correctly.\n"
+msgstr ""
+"OpenShift APIサーバーは、 `OAuthClient` 、 `name` 、 `secret` 、または `redirectURIs` "
+"が正しくない場合、 `The client is not authorized to request a token using this "
+"method` を返します。それらを{project_name} OpenShift 4 Identity "
+"Providerページに正しくコピー・アンド・ペーストしてください。\n"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/openshift.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/openshift.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -208,7 +208,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "in `OAuthClient` object as well as in {project_name} configuration."
-msgstr "`OAuthClient` オブジェクトと{project_name}の設定で同じにする必要があります。。"
+msgstr "`OAuthClient` オブジェクトと{project_name}の設定で同じにする必要があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/openshift.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__openshift
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
