### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po
@@ -20,6 +20,19 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Code block
+#, no-wrap
+msgid ""
+"HTTP/1.1 401 Unauthorized\n"
+"WWW-Authenticate: UMA realm=\"${realm}\",\n"
+"    as_uri=\"https://${host}:${port}/auth/realms/${realm}\",\n"
+"    ticket=\"016f84e8-f9b9-11e0-bd6f-0021cc6004de\"\n"
+msgstr ""
+"HTTP/1.1 401 Unauthorized\n"
+"WWW-Authenticate: UMA realm=\"${realm}\",\n"
+"    as_uri=\"https://${host}:${port}/auth/realms/${realm}\",\n"
+"    ticket=\"016f84e8-f9b9-11e0-bd6f-0021cc6004de\"\n"
+
 #. type: Title =
 #, no-wrap
 msgid "JavaScript Integration"
@@ -102,19 +115,6 @@ msgid ""
 msgstr ""
 "リソースサーバーがポリシー・エンフォーサーによって保護されている場合、リソースサーバーは、ベアラートークンとともに搬送されるパーミッションに基づいてクライアント・リクエストに応答します。通常、保護されたリソースにアクセスする権限がないベアラトークンを使用してリソースサーバーにアクセスしようとすると、リソースサーバーは"
 " *401* ステータスコードと `WWW-Authenticate` ヘッダーで応答します。"
-
-#. type: Code block
-#, no-wrap
-msgid ""
-"HTTP/1.1 401 Unauthorized\n"
-"WWW-Authenticate: UMA realm=\"${realm}\",\n"
-"    as_uri=\"https://${host}:${post}/auth/realms/${realm}\",\n"
-"    ticket=\"016f84e8-f9b9-11e0-bd6f-0021cc6004de\"\n"
-msgstr ""
-"HTTP/1.1 401 Unauthorized\n"
-"WWW-Authenticate: UMA realm=\"${realm}\",\n"
-"    as_uri=\"https://${host}:${post}/auth/realms/${realm}\",\n"
-"    ticket=\"016f84e8-f9b9-11e0-bd6f-0021cc6004de\"\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-js-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-js-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
