### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/vault.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/vault.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/vault.ja_JP.po
@@ -39,9 +39,9 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The built-in `plaintext` provider is an example of the implementation of "
-"this SPI. In general the following rules apply:"
-msgstr "ビルトインの `plaintext` プロバイダーは、このSPIの実装の一例です。一般的に、次のルールが適用されます。"
+"The built-in `files-plaintext` provider is an example of the implementation "
+"of this SPI. In general the following rules apply:"
+msgstr "ビルトインの `files-plaintext` プロバイダーは、このSPIの実装の一例です。一般的に、次のルールが適用されます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/vault.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__vault
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
