### PR TITLE
Translations for i18n/po/ja_JP/topics/templates/release-header.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/topics/templates/release-header.ja_JP.po
+++ b/i18n/po/ja_JP/topics/templates/release-header.ja_JP.po
@@ -1,0 +1,66 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: delimited block =
+#, no-wrap
+msgid "*{release_header_guide}* icon:angle-down[]\n"
+msgstr "*{release_header_guide}* icon:angle-down[]\n"
+
+#. type: delimited block =
+msgid "{gettingstarted_link}[{gettingstarted_name_short}]"
+msgstr "{gettingstarted_link}[{gettingstarted_name_short}]"
+
+#. type: delimited block =
+msgid "{installguide_link}[{installguide_name_short}]"
+msgstr "{installguide_link}[{installguide_name_short}]"
+
+#. type: delimited block =
+msgid "{adapterguide_link}[{adapterguide_name_short}]"
+msgstr "{adapterguide_link}[{adapterguide_name_short}]"
+
+#. type: delimited block =
+msgid "{adminguide_link}[{adminguide_name_short}]"
+msgstr "{adminguide_link}[{adminguide_name_short}]"
+
+#. type: delimited block =
+msgid "{developerguide_link}[{developerguide_name_short}]"
+msgstr "{developerguide_link}[{developerguide_name_short}]"
+
+#. type: delimited block =
+msgid "{authorizationguide_link}[{authorizationguide_name_short}]"
+msgstr "{authorizationguide_link}[{authorizationguide_name_short}]"
+
+#. type: delimited block =
+msgid "{upgradingguide_link}[{upgradingguide_name_short}]"
+msgstr "{upgradingguide_link}[{upgradingguide_name_short}]"
+
+#. type: delimited block =
+msgid "{releasenotes_link}[{releasenotes_name_short}]"
+msgstr "{releasenotes_link}[{releasenotes_name_short}]"
+
+#. type: delimited block =
+msgid "Version *{project_version}* _Latest_"
+msgstr "バージョン *{project_version}* _Latest_"
+
+#. type: delimited block =
+msgid ""
+"Version *{project_version}* _{release_header_latest_link}[Click here for "
+"latest]_"
+msgstr "バージョン *{project_version}* _{release_header_latest_link}[最新はこちらをクリック]_"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/topics/templates/release-header.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/topics__templates__release-header
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
