### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/export-import.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/export-import.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/export-import.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -109,12 +109,8 @@ msgstr ""
 "-Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=<DIR TO EXPORT TO>\n"
 
 #. type: Plain text
-msgid ""
-"And similarly for import just use `-Dkeycloak.migration.action=import` "
-"instead of `export` .  To export into single JSON file you can use:"
-msgstr ""
-"同様にインポートするには `export` の代わりに `-Dkeycloak.migration.action=import` "
-"を使います。単一のJSONファイルにエクスポートするには、以下を使用できます。"
+msgid "To export into single JSON file you can use:"
+msgstr "一つのJSONファイルにエクスポートするには、次のようにします。"
 
 #. type: delimited block -
 #, no-wrap
@@ -126,8 +122,12 @@ msgstr ""
 "-Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=<FILE TO EXPORT TO>\n"
 
 #. type: Plain text
-msgid "Here's an example of importing:"
-msgstr "インポートの例を次に示します。"
+msgid ""
+"And similarly for import just use `-Dkeycloak.migration.action=import` "
+"instead of `export` .  Here's an example of importing:"
+msgstr ""
+"同様にインポートするには `export` の代わりに `-Dkeycloak.migration.action=import` "
+"を使います。次はインポートの例です。"
 
 #. type: delimited block -
 #, no-wrap
@@ -276,22 +276,25 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Note: Attributes containing secrets or private information will be masked in"
-" export file. Export files obtained via Admin Console are thus not "
+"Attributes containing secrets or private information will be masked in "
+"export file. Export files obtained via Admin Console are thus not "
 "appropriate for backups or data transfer between servers. Only boot-time "
 "exports are appropriate for that."
 msgstr ""
-"注意：エクスポート・ファイルの中の機密情報または個人情報を含む属性は、マスクされます。管理コンソールから取得したエクスポート・ファイルは、バックアップやサーバー間のデータ転送には適切ではありません。ブート時のエクスポートだけが、それらに対して適切です。"
+"エクスポート・ファイルの中の機密情報または個人情報を含む属性は、マスクされます。管理コンソールから取得したエクスポート・ファイルは、バックアップやサーバー間のデータ転送には適切ではありません。ブート時のエクスポートだけが、それらに対して適切です。"
 
 #. type: Plain text
 msgid ""
 "The files created during a \"startup\" export can also be used to import "
 "from the admin UI.  This way, you can export from one realm and import to "
-"another realm. Or, you can export from one server and import to another.  "
-"Note: The admin console export/import allows just one realm per file."
+"another realm. Or, you can export from one server and import to another."
 msgstr ""
 "\"スタートアップ\" "
-"エクスポート中に作成されたファイルは、管理UIからインポートするために使用することもできます。これにより、あるレルムからエクスポートして別のレルムにインポートすることができます。また、あるサーバーからエクスポートして別のサーバーにインポートすることもできます。注：管理コンソールでのエクスポート/インポートでは、ファイルごとに1つのレルムしか使用できません。"
+"エクスポート中に作成されたファイルは、管理UIからインポートするために使用することもできます。これにより、あるレルムからエクスポートして別のレルムにインポートすることができます。また、あるサーバーからエクスポートして別のサーバーにインポートすることもできます。"
+
+#. type: Plain text
+msgid "The admin console export/import allows just one realm per file."
+msgstr "管理コンソールでのエクスポート/インポートでは、ファイルごとに1つのレルムしか使用できません。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/export-import.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__export-import
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
