### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -210,7 +210,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Provider factory classses must specify the concrete provider class as a "
+"Provider factory classes must specify the concrete provider class as a "
 "template parameter when implementing the `UserStorageProviderFactory`.  This"
 " is a must as the runtime will introspect this class to scan for its "
 "capabilities (the other interfaces it implements).  So for example, if your "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/provider-interfaces.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__provider-interfaces
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
