### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -278,19 +278,19 @@ msgstr ""
 #. type: Plain text
 #, no-wrap
 msgid ""
-"/realms/{realm-name}/protocol/openid-connect/token::\n"
+"/realms/{realm-name}/protocol/openid-connect/auth::\n"
 "  This is the URL endpoint for obtaining a temporary code in the Authorization Code Flow or for obtaining tokens via the\n"
 "  Implicit Flow, Direct Grants, or Client Grants.\n"
-"/realms/{realm-name}/protocol/openid-connect/auth::\n"
+"/realms/{realm-name}/protocol/openid-connect/token::\n"
 "  This is the URL endpoint for the Authorization Code Flow to turn a temporary code into a token.\n"
 "/realms/{realm-name}/protocol/openid-connect/logout::\n"
 "  This is the URL endpoint for performing logouts.\n"
 "/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
 "  This is the URL endpoint for the User Info service described in the OIDC specification.\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/token::\n"
-"  これは、認可コード・フローで一時コードを取得するため、またはインプリシット・フロー、ダイレクト・グラント、またはクライアント・グラントを使用してトークンを取得するためのURLエンドポイントです。\n"
 "/realms/{realm-name}/protocol/openid-connect/auth::\n"
+"  これは、認可コード・フローで一時コードを取得するため、またはインプリシット・フロー、ダイレクト・グラント、またはクライアント・グラントを使用してトークンを取得するためのURLエンドポイントです。\n"
+"/realms/{realm-name}/protocol/openid-connect/token::\n"
 "  これは、一時コードをトークンに変換する認可コード・フローのURLエンドポイントです。\n"
 "/realms/{realm-name}/protocol/openid-connect/logout::\n"
 "  これは、ログアウトを実行するためのURLエンドポイントです。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
