### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -8,14 +8,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # naoto watanabe <nabenao11@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -99,7 +99,7 @@ msgstr "このセクションでは、{project_name}クロスデータセンタ�
 #. type: Labeled list
 #, no-wrap
 msgid "Data"
-msgstr "データ"
+msgstr "Data"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po
@@ -8,14 +8,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # naoto watanabe <nabenao11@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,12 +27,6 @@ msgstr ""
 #, no-wrap
 msgid "Cross-Datacenter Replication Mode"
 msgstr "クロスデータセンター・レプリケーション・モード"
-
-#. type: Plain text
-msgid ""
-"Cross-Datacenter Replication Mode is Technology Preview and is not fully "
-"supported."
-msgstr "クロスデータセンター・レプリケーション・モードはテクノロジー・プレビューであり、完全にはサポートされていません。"
 
 #. type: Plain text
 msgid ""
@@ -102,7 +96,7 @@ msgid ""
 "{project_name} Cross-Datacenter Replication is accomplished."
 msgstr "このセクションでは、{project_name}クロスデータセンター・レプリケーションの仕組みについて概念と詳細について説明します。"
 
-#. type: Block title
+#. type: Labeled list
 #, no-wrap
 msgid "Data"
 msgstr "データ"
@@ -2131,9 +2125,8 @@ msgid ""
 "{project_name} as described in <<requestprocessing>>) will be always "
 "processed on same site. This is true, for example, if: ** You use "
 "active/passive mode as described <<modes>>.  ** All your client applications"
-" are using the {project_name} "
-"link:https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter[JavaScript"
-" Adapter]. The JavaScript adapter sends the backchannel requests within the "
+" are using the {project_name} {adapterguide_link_js_adapter}[JavaScript "
+"Adapter]. The JavaScript adapter sends the backchannel requests within the "
 "browser and hence they participate on the browser sticky session and will "
 "end on same cluster node (hence on same site) as the other browser requests "
 "of this user.  ** Your load balancer is able to serve the requests based on "
@@ -2142,7 +2135,7 @@ msgid ""
 msgstr ""
 "`sessions` と `clientSessions` キャッシュを `SYNC` で保持しておくことをお勧めします。ユーザーのリクエストとバックチャネル・リクエスト（<<requestprocessing>>で説明したクライアント・アプリケーションから{project_name}へのリクエスト）が常に同じサイトで処理されることが確かな場合にのみ、それらを `ASYNC` へ切り替えることが可能になります。たとえば、次のような場合はこれが当てはまります。\n"
 "** <<modes>>で説明した通り、アクティブ/パッシブモードを使用しています。\n"
-"** クライアント・アプリケーションはすべて{project_name} link:https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter[JavaScriptアダプター]を使用しています。JavaScriptアダプターは、ブラウザー内でバックチャネル・リクエストを送信するため、それらはブラウザーのスティッキー・セッションに参加し、このユーザーの別のブラウザー・リクエストと同じクラスターノード（したがって同じサイト）で終了します。\n"
+"** クライアント・アプリケーションはすべて{project_name} {adapterguide_link_js_adapter}[JavaScriptアダプター]を使用しています。JavaScriptアダプターは、ブラウザー内でバックチャネル・リクエストを送信するため、それらはブラウザーのスティッキー・セッションに参加し、このユーザーの別のブラウザー・リクエストと同じクラスターノード（したがって同じサイト）で終了します。\n"
 "** ロードバランサーは、クライアントIPアドレス（ロケーション）に基づいてリクエストを処理でき、クライアント・アプリケーションは両方のサイトにデプロイされています。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
