### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -26,6 +26,10 @@ msgstr ""
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
+#. type: Plain text
+msgid "Select a realm, click on Authentication link, select the \"Browser\" flow"
+msgstr "レルムを選択し、Authenticationのリンクをクリックし、\"Browser\"フローを選択します。"
+
 #. type: Title ===
 #, no-wrap
 msgid "X.509 Client Certificate User Authentication"
@@ -524,10 +528,6 @@ msgid "Adding X.509 Client Certificate Authentication to a Browser Flow"
 msgstr "ブラウザーフローへのX.509クライアント証明書認証の追加"
 
 #. type: Plain text
-msgid "Select a realm, click on Authentication link, select the \"Browser\" flow"
-msgstr "レルムを選択し、Authenticationのリンクをクリックし、\"Browser\"フローを選択します。"
-
-#. type: Plain text
 msgid ""
 "Make a copy of the built-in \"Browser\" flow. You may want to give the new "
 "flow a distinctive name, i.e. \"X.509 Browser\""
@@ -607,9 +607,9 @@ msgid ""
 "#getName-java.lang.String-[Java API documentation] .  This option only "
 "affects the two User Identity Sources _Match SubjectDN using regular "
 "expression_ and _Match IssuerDN using regular expression_.  If you setup a "
-"new keycloak instance it is recommended to enable this option. Leave this "
-"option disabled to remain beckward compatible with existing Keycloak "
-"instances."
+"new {project_name} instance it is recommended to enable this option. Leave "
+"this option disabled to remain beckward compatible with existing "
+"{project_name} instances."
 msgstr ""
 "標準形式を使用して識別名を決定するかどうかを定義します。形式については、公式 "
 "link:https://docs.oracle.com/javase/8/docs/api/javax/security/auth/x500/X500Principal.html"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
