### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -237,8 +237,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"This example has just one protected location: \\https://$sp_host/protected."
-msgstr "この例では、保護された場所は \\https://$sp_host/protected 1つだけです。"
+"This example has just one protected location: \\https://$sp_host/private."
+msgstr "この例では、保護された場所は \\https://$sp_host/private 1つだけです。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__mod-auth-mellon
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
