### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -195,9 +195,10 @@ msgstr "Regular Expression"
 
 #. type: Plain text
 msgid ""
-"Define one or more Perl regular expression patterns that passwords must "
-"match."
-msgstr "パスワードが一致する必要のある１つ以上のPerl正規表現パターンを定義します。"
+"Define one or more regular expression patterns (defined in "
+"`java.util.regex.Pattern`) that passwords must match."
+msgstr ""
+"パスワードが一致する必要のある１つ以上の正規表現パターン（ `java.util.regex.Pattern` で定義される）を定義します。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__password-policies
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
