### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -215,6 +215,39 @@ msgstr ""
 
 #. type: Plain text
 #, no-wrap
+msgid "*Standard Flow Enabled*\n"
+msgstr "*Standard Flow Enabled*\n"
+
+#. type: Plain text
+msgid ""
+"If this is on, clients are allowed to use the OIDC <<_oidc-auth-"
+"flows,Authorization Code Flow>>."
+msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,認可コードフロー>>を使用できます。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Implicit Flow Enabled*\n"
+msgstr "*Implicit Flow Enabled*\n"
+
+#. type: Plain text
+msgid ""
+"If this is on, clients are allowed to use the OIDC <<_oidc-auth-"
+"flows,Implicit Flow>>."
+msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,インプリシット・フロー>>を使用できます。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Direct Access Grants Enabled*\n"
+msgstr "*Direct Access Grants Enabled*\n"
+
+#. type: Plain text
+msgid ""
+"If this is on, clients are allowed to use the OIDC <<_oidc-auth-flows,Direct"
+" Access Grants>>."
+msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,ダイレクト・アクセス・グラント>>を使用できます。"
+
+#. type: Plain text
+#, no-wrap
 msgid "*Root URL*\n"
 msgstr "*Root URL*\n"
 
@@ -252,39 +285,6 @@ msgstr "*Base URL*\n"
 #. type: Plain text
 msgid "If {project_name} needs to link to the client, this URL is used."
 msgstr "{project_name}がクライアントにリンクする必要がある場合、このURLが使用されます。"
-
-#. type: Plain text
-#, no-wrap
-msgid "*Standard Flow Enabled*\n"
-msgstr "*Standard Flow Enabled*\n"
-
-#. type: Plain text
-msgid ""
-"If this is on, clients are allowed to use the OIDC <<_oidc-auth-"
-"flows,Authorization Code Flow>>."
-msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,認可コードフロー>>を使用できます。"
-
-#. type: Plain text
-#, no-wrap
-msgid "*Implicit Flow Enabled*\n"
-msgstr "*Implicit Flow Enabled*\n"
-
-#. type: Plain text
-msgid ""
-"If this is on, clients are allowed to use the OIDC <<_oidc-auth-"
-"flows,Implicit Flow>>."
-msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,インプリシット・フロー>>を使用できます。"
-
-#. type: Plain text
-#, no-wrap
-msgid "*Direct Access Grants Enabled*\n"
-msgstr "*Direct Access Grants Enabled*\n"
-
-#. type: Plain text
-msgid ""
-"If this is on, clients are allowed to use the OIDC <<_oidc-auth-flows,Direct"
-" Access Grants>>."
-msgstr "これがオンの場合、クライアントはOIDC<<_oidc-auth-flows,ダイレクト・アクセス・グラント>>を使用できます。"
 
 #. type: Plain text
 #, no-wrap
@@ -449,11 +449,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"WARNING: None of the keycloak client adapters currently support holder-of-"
-"key token verification.  Instead, keycloak adapters currently treat access "
-"and refresh tokens as bearer tokens."
+"None of the keycloak client adapters currently support holder-of-key token "
+"verification.  Instead, keycloak adapters currently treat access and refresh"
+" tokens as bearer tokens."
 msgstr ""
-"警告：現在、Keycloakクライアント・アダプターのどれも、holder-of-"
+"現在、Keycloakクライアント・アダプターのどれも、holder-of-"
 "keyトークンの検証をサポートしていません。代わりに、Keycloakアダプターはアクセストークンとリフレッシュトークンをベアラートークンとして扱います。"
 
 #. type: Plain text
@@ -481,8 +481,8 @@ msgstr "*Proof Key for Code Exchange Code Challenge Method*\n"
 #. type: Plain text
 msgid ""
 "(blank) : {project_name} does not apply PKCE unless the client sends PKCE's "
-"parameters appropriately to keycloak's authorization endpoint. It is the "
-"default setting."
+"parameters appropriately to {project_name}'s authorization endpoint. It is "
+"the default setting."
 msgstr ""
 "(blank) : "
 "クライアントがPKCEのパラメーターを{project_name}の認可エンドポイントに適切に送信しない限り、{project_name}はPKCEを適用しません。これがデフォルト設定です。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -578,7 +578,7 @@ msgstr "`Client Authenticator` のプルダウン・メニューから `Signed J
 
 #. type: Plain text
 msgid "set ON to `JWKS URL` switch"
-msgstr "`JWKS URL`スイッチをONに設定します"
+msgstr "`JWKS URL` スイッチをONに設定します"
 
 #. type: Plain text
 msgid "input the client's public key providing URL on `JWKS URL` textbox"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
