### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,13 +44,13 @@ msgstr ""
 msgid ""
 "The Keycloak Spring Boot adapter takes advantage of Spring Boot's "
 "autoconfiguration so all you need to do is add the Keycloak Spring Boot "
-"starter to your project.  They Keycloak Spring Boot Starter is also directly"
-" available from the https://start.spring.io/[Spring Start Page].  To add it "
-"manually using Maven, add the following to your dependencies:"
+"starter to your project.  The Keycloak Spring Boot Starter is also directly "
+"available from the https://start.spring.io/[Spring Initializr Page].  To add"
+" it manually using Maven, add the following to your dependencies:"
 msgstr ""
 "Keycloak Spring Bootアダプターは、Spring Bootの自動設定を利用するので、Keycloak Spring Boot "
 "Starterをプロジェクトに追加するだけです。Keycloak Spring Boot Starterも "
-"https://start.spring.io/[Spring Start Page] "
+"https://start.spring.io/[Spring Initializr Page] "
 "から直接入手できます。Mavenを使用していて手動で追加するためには、依存関係に以下を追加します。"
 
 #. type: delimited block -


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/spring-boot-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__spring-boot-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
