### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po
@@ -89,8 +89,8 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Kubernetes / OpenShift plaintext vault provider"
-msgstr "Kubernetes / OpenShift平文ボールト・プロバイダー"
+msgid "Kubernetes / OpenShift files plaintext vault provider"
+msgstr "Kubernetes / OpenShift files plaintext ボールト・プロバイダー"
 
 #. type: Plain text
 msgid ""
@@ -122,23 +122,24 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"To use this type of secret store, you have to declare the `plaintext` vault "
-"provider in standalone.xml, and set its parameter for the directory that "
-"contains the mounted volume. The following example shows the `plaintext` "
-"provider with the directory where vault files are searched for set to "
-"`standalone/configuration/vault` relative to {project_name} base directory:"
+"To use this type of secret store, you have to declare the `files-plaintext` "
+"vault provider in standalone.xml, and set its parameter for the directory "
+"that contains the mounted volume. The following example shows the `files-"
+"plaintext` provider with the directory where vault files are searched for "
+"set to `standalone/configuration/vault` relative to {project_name} base "
+"directory:"
 msgstr ""
-"このタイプのシークレット・ストアを使用するには、standalone.xmlで `plaintext` "
+"このタイプのシークレット・ストアを使用するには、standalone.xmlで `files-plaintext` "
 "ボールト・プロバイダーを宣言し、マウントされたボリュームを含むディレクトリーのパラメーターを設定する必要があります。次の例は、{project_name}ベース・ディレクトリーに対して"
-" `standalone/configuration/vault` に設定されたボールトファイルが検索されるディレクトリーを持つ `plaintext`"
-" プロバイダーを示しています。"
+" `standalone/configuration/vault` に設定されたボールトファイルが検索されるディレクトリーを持つ `files-"
+"plaintext` プロバイダーを示しています。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
 "<spi name=\"vault\">\n"
-"    <default-provider>plaintext</default-provider>\n"
-"    <provider name=\"plaintext\" enabled=\"true\">\n"
+"    <default-provider>files-plaintext</default-provider>\n"
+"    <provider name=\"files-plaintext\" enabled=\"true\">\n"
 "        <properties>\n"
 "            <property name=\"dir\" value=\"${jboss.home.dir}/standalone/configuration/vault/\" />\n"
 "        </properties>\n"
@@ -146,8 +147,8 @@ msgid ""
 "</spi>\n"
 msgstr ""
 "<spi name=\"vault\">\n"
-"    <default-provider>plaintext</default-provider>\n"
-"    <provider name=\"plaintext\" enabled=\"true\">\n"
+"    <default-provider>files-plaintext</default-provider>\n"
+"    <provider name=\"files-plaintext\" enabled=\"true\">\n"
 "        <properties>\n"
 "            <property name=\"dir\" value=\"${jboss.home.dir}/standalone/configuration/vault/\" />\n"
 "        </properties>\n"
@@ -162,10 +163,10 @@ msgstr "CLIコマンドを使用した同等の設定は以下になります。
 #, no-wrap
 msgid ""
 "/subsystem=keycloak-server/spi=vault/:add\n"
-"/subsystem=keycloak-server/spi=vault/provider=plaintext/:add(enabled=true,properties={dir => \"${jboss.home.dir}/standalone/configuration/vault\"})\n"
+"/subsystem=keycloak-server/spi=vault/provider=files-plaintext/:add(enabled=true,properties={dir => \"${jboss.home.dir}/standalone/configuration/vault\"})\n"
 msgstr ""
 "/subsystem=keycloak-server/spi=vault/:add\n"
-"/subsystem=keycloak-server/spi=vault/provider=plaintext/:add(enabled=true,properties={dir => \"${jboss.home.dir}/standalone/configuration/vault\"})\n"
+"/subsystem=keycloak-server/spi=vault/provider=files-plaintext/:add(enabled=true,properties={dir => \"${jboss.home.dir}/standalone/configuration/vault\"})\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__vault
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
