### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -66,11 +66,11 @@ msgid ""
 "    // some claims are expected here\n"
 "\n"
 "    // these are the main claims in the discovery document about Authorization Services endpoints location\n"
-"    \"token_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/protocol/openid-connect/token\",\n"
-"    \"token_introspection_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/protocol/openid-connect/token/introspect\",\n"
-"    \"resource_registration_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/authz/protection/resource_set\",\n"
-"    \"permission_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/authz/protection/permission\",\n"
-"    \"policy_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/authz/protection/uma-policy\"\n"
+"    \"token_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token\",\n"
+"    \"token_introspection_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token/introspect\",\n"
+"    \"resource_registration_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/authz/protection/resource_set\",\n"
+"    \"permission_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/authz/protection/permission\",\n"
+"    \"policy_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/authz/protection/uma-policy\"\n"
 "}\n"
 msgstr ""
 "{\n"
@@ -78,11 +78,11 @@ msgstr ""
 "    // some claims are expected here\n"
 "\n"
 "    // these are the main claims in the discovery document about Authorization Services endpoints location\n"
-"    \"token_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/protocol/openid-connect/token\",\n"
-"    \"token_introspection_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/protocol/openid-connect/token/introspect\",\n"
-"    \"resource_registration_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/authz/protection/resource_set\",\n"
-"    \"permission_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/authz/protection/permission\",\n"
-"    \"policy_endpoint\": \"http://${host}:${post}/auth/realms/${realm}/authz/protection/uma-policy\"\n"
+"    \"token_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token\",\n"
+"    \"token_introspection_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token/introspect\",\n"
+"    \"resource_registration_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/authz/protection/resource_set\",\n"
+"    \"permission_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/authz/protection/permission\",\n"
+"    \"policy_endpoint\": \"http://${host}:${port}/auth/realms/${realm}/authz/protection/uma-policy\"\n"
 "}\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-discovery-document.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-discovery-document
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
