### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -162,6 +162,18 @@ msgid "Token Exchange Service"
 msgstr "Token Exchangサービス"
 
 #. type: Plain text
+msgid "upload_scripts"
+msgstr "upload_scripts"
+
+#. type: Plain text
+msgid "Upload scripts through the {project_name} REST API"
+msgstr "{project_name} REST APIによるスクリプトのアップロード"
+
+#. type: Plain text
+msgid "Deprecated"
+msgstr "非推奨"
+
+#. type: Plain text
 msgid "To enable all preview features start the server with:"
 msgstr "すべてのプレビュー機能を有効にするには、次のようにサーバーを起動します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
