### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,12 +28,12 @@ msgstr "管理エンドポイントと管理コンソール"
 #. type: Plain text
 msgid ""
 "The {project_name} administrative REST API and the web console are exposed "
-"by default on the same port as non-admin usage. If you are exposing "
-"{project_name} on the Internet, we recommend not also exposing the admin "
+"by default on the same port as non-admin usage. If access to the admin "
+"console is not needed externally, we recommend not exposing the admin "
 "endpoints on the Internet."
 msgstr ""
 "{project_name}管理REST "
-"APIとWebコンソールは、非管理用途と同じポートにデフォルトで公開されています。{project_name}をインターネットで公開している場合は、管理エンドポイントをインターネットに公開しないことをお勧めします。"
+"APIとWebコンソールは、非管理用途と同じポートにデフォルトで公開されています。管理コンソールへのアクセスが外部から必要ない場合は、管理エンドポイントをインターネットに公開しないことをお勧めします。"
 
 #. type: Plain text
 msgid ""
@@ -55,6 +55,14 @@ msgid ""
 "document covers two options, IP restriction and separate ports."
 msgstr ""
 "これを{project_name}で直接実現するには、いくつかのオプションがあります。このドキュメントでは、IP制限とポートの分離の2つのオプションについて説明します。"
+
+#. type: Plain text
+msgid ""
+"Once the admin console is no longer accessible on the frontend URL of "
+"Keycloak, you need to configure a fixed admin URL in the default hostname "
+"provider."
+msgstr ""
+"{project_name}のフロントエンドURLで管理コンソールにアクセスできなくなったら、デフォルトのホスト名プロバイダーで固定値の管理URLを設定する必要があります。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
