### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -241,7 +241,7 @@ msgstr "Automatically Set Existing User"
 msgid ""
 "Automatically sets an existing user to the authentication context without "
 "any verification. Set the authenticator requirement to \"Alternative\"."
-msgstr "検証なしで、既存のユーザーを認証コンテキストに自動的に設定します。オーセンティケーターの要件は\"Alternative\"に設定します。"
+msgstr "検証なしで、既存のユーザーを認証コンテキストに自動的に設定します。オーセンティケーターの要求は\"Alternative\"に設定します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po
@@ -4,7 +4,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
@@ -234,28 +234,27 @@ msgstr "このオーセンティケーターは、一意にユーザーが処理
 
 #. type: Labeled list
 #, no-wrap
-msgid "Automatically Link Brokered Account"
-msgstr "Automatically Link Brokered Account"
+msgid "Automatically Set Existing User"
+msgstr "Automatically Set Existing User"
 
 #. type: Plain text
 msgid ""
-"Automatically link brokered identities without any validation with this "
-"authenticator. This is useful in an intranet environment of multiple user "
-"databases each with overlapping usernames/email addresses, but different "
-"passwords, and you want to allow users to use any password without having to"
-" validate. This is only reasonable if you manage all internal databases, and"
-" usernames/email addresses from one database matching those in another "
-"database belong to the same person. Set the authenticator requirement to "
-"\"Alternative\"."
-msgstr ""
-"このオーセンティケーターとともに検証無しで仲介されたアイデンティティーを自動的にリンクします。これは、重複するユーザー名/電子メールアドレスを持ち、パスワードが異なる複数のユーザー・データベースにあるイントラネット環境で便利です。ユーザーは、検証することなくパスワードを使用できるようにしたいと考えています。これは、すべての内部データベースを管理し、同じデータベースにあるユーザー名と電子メールアドレスが、同じ人物に属している場合にのみ妥当です。オーセンティケーターの要件は\"Alternative\"に設定します。"
+"Automatically sets an existing user to the authentication context without "
+"any verification. Set the authenticator requirement to \"Alternative\"."
+msgstr "検証なしで、既存のユーザーを認証コンテキストに自動的に設定します。オーセンティケーターの要件は\"Alternative\"に設定します。"
 
 #. type: Plain text
 msgid ""
-"The described setup uses two authenticators, and is the simplest one, but it"
-" is possible to use other authenticators according to your needs. For "
-"example, you can add the Review Profile authenticator to the beginning of "
-"the flow if you still want end users to confirm their profile information."
+"The described setup uses two authenticators. This setup is the simplest one,"
+" but it is possible to use other authenticators according to your needs. For"
+" example, you can add the Review Profile authenticator to the beginning of "
+"the flow if you still want end users to confirm their profile information. "
+"You can also add authentication mechanisms to this flow, forcing a user to "
+"verify his credentials. This would require a more complex flow, for example "
+"setting the \"Automatically Set Existing User\" and \"Password Form\" as "
+"\"Required\" in an \"Alternative\" sub-flow."
 msgstr ""
-"記載されたセットアップでは2つのオーセンティケーターが使用され（最も簡単なもの）、必要に応じて他のオーセンティケーターを使用することもできます。たとえば、エンドユーザーにプロファイル情報の確認を依頼したい場合は、フローの先頭にReview"
-" Profileオーセンティケーターを追加することができます。"
+"記載されたセットアップでは2つのオーセンティケーターが使用されます。このセットアップは最も簡単なものですが、必要に応じて他のオーセンティケーターを使用することもできます。たとえば、エンドユーザーにプロファイル情報の確認を依頼したい場合は、フローの先頭にReview"
+" "
+"Profileオーセンティケーターを追加することができます。また、このフローに認証メカニズムを追加して、ユーザーにクレデンシャルの確認を強制することもできます。これには、より複雑なフローが必要になります。たとえば、\"Alternative\"サブフローで\"Automatically"
+" Set Existing User\"と\"Password Form\"を\"Required\"に設定します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/first-login-flow.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__first-login-flow
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
