### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -203,3 +203,24 @@ msgid ""
 "`clientHost`: The remote host name of the service account authenticated "
 "device"
 msgstr "`clientHost` ：サービス・アカウントの認証済みデバイスのリモートホスト名"
+
+#. type: Title ====
+#, no-wrap
+msgid "Script Mapper"
+msgstr "Script Mapper"
+
+#. type: Plain text
+msgid ""
+"The `Script Mapper` allows you to map claims to tokens by running a user-"
+"defined JavaScript code. For more details about how to deploy scripts to the"
+" server, please take a look at "
+"link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]."
+msgstr ""
+"`Script Mapper` "
+"を使用すると、ユーザー定義のJavaScriptコードを実行して、クレームをトークンにマッピングできます。サーバーにスクリプトをデプロイする方法の詳細については、link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Once you have your scripts deployed, you should be able to select the "
+"scripts you deployed from the list of available mappers."
+msgstr "スクリプトをデプロイしたら、使用可能なマッパーのリストからデプロイしたスクリプトを選択できるはずです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
