### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -762,7 +762,7 @@ msgid ""
 " `promiseType: 'native'` to future-proof your code."
 msgstr ""
 "{project_name}の将来のバージョンでは、デフォルトのPromiseタイプが `legacy` から `native` "
-"に変更されます。最終的に、レガシーなPromiseのサポートは完全に削除されます。 したがって、コードを将来にわたって保証するために、常に "
+"に変更されます。最終的に、レガシーなPromiseのサポートは完全に削除されます。したがって、コードを将来にわたって保証するために、常に "
 "`promiseType: 'native'` を指定することを強くお勧めします。"
 
 #. type: Title ====

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,11 +74,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"You also need to configure valid redirect URIs and valid web origins. Be as "
+"You also need to configure `Valid Redirect URIs` and `Web Origins`. Be as "
 "specific as possible as failing to do so may result in a security "
 "vulnerability."
 msgstr ""
-"また、有効なリダイレクトURIと有効なWebオリジンを設定する必要があります。できるだけ具体的にする理由は、そうしなければセキュリティー上の脆弱性が生じる可能性があるためです。"
+"また、 `Valid Redirect URIs` と `Web Origins` "
+"を設定する必要があります。できるだけ具体的にする理由は、そうしなければセキュリティー上の脆弱性が生じる可能性があるためです。"
 
 #. type: Plain text
 msgid ""
@@ -107,10 +108,10 @@ msgid ""
 "<head>\n"
 "    <script src=\"keycloak.js\"></script>\n"
 "    <script>\n"
-"        var keycloak = Keycloak();\n"
-"        keycloak.init().success(function(authenticated) {\n"
+"        var keycloak = new Keycloak();\n"
+"        keycloak.init({ promiseType: 'native' }).then(function(authenticated) {\n"
 "            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
-"        }).error(function() {\n"
+"        }).catch(function() {\n"
 "            alert('failed to initialize');\n"
 "        });\n"
 "    </script>\n"
@@ -119,10 +120,10 @@ msgstr ""
 "<head>\n"
 "    <script src=\"keycloak.js\"></script>\n"
 "    <script>\n"
-"        var keycloak = Keycloak();\n"
-"        keycloak.init().success(function(authenticated) {\n"
+"        var keycloak = new Keycloak();\n"
+"        keycloak.init({ promiseType: 'native' }).then(function(authenticated) {\n"
 "            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
-"        }).error(function() {\n"
+"        }).catch(function() {\n"
 "            alert('failed to initialize');\n"
 "        });\n"
 "    </script>\n"
@@ -135,8 +136,10 @@ msgstr "`keycloak.json` ファイルが別の場所にある場合、以下の�
 
 #. type: delimited block -
 #, no-wrap
-msgid "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
-msgstr "var keycloak = Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
+msgid ""
+"var keycloak = new Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
+msgstr ""
+"var keycloak = new Keycloak('http://localhost:8080/myapp/keycloak.json');\n"
 
 #. type: Plain text
 msgid ""
@@ -147,13 +150,13 @@ msgstr "または、以下のように必要な設定でJavaScriptオブジェ�
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"var keycloak = Keycloak({\n"
+"var keycloak = new Keycloak({\n"
 "    url: 'http://keycloak-server/auth',\n"
 "    realm: 'myrealm',\n"
 "    clientId: 'myapp'\n"
 "});\n"
 msgstr ""
-"var keycloak = Keycloak({\n"
+"var keycloak = new Keycloak({\n"
 "    url: 'http://keycloak-server/auth',\n"
 "    realm: 'myrealm',\n"
 "    clientId: 'myapp'\n"
@@ -203,11 +206,17 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.init({ onLoad: 'check-sso', silentCheckSsoRedirectUri: "
-"window.location.origin + '/silent-check-sso.html'})\n"
+"keycloak.init({\n"
+"    onLoad: 'check-sso',\n"
+"    silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',\n"
+"    promiseType: 'native',\n"
+"})\n"
 msgstr ""
-"keycloak.init({ onLoad: 'check-sso', silentCheckSsoRedirectUri: "
-"window.location.origin + '/silent-check-sso.html'})\n"
+"keycloak.init({\n"
+"    onLoad: 'check-sso',\n"
+"    silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',\n"
+"    promiseType: 'native',\n"
+"})\n"
 
 #. type: Plain text
 msgid ""
@@ -223,17 +232,17 @@ msgstr ""
 msgid ""
 "<html>\n"
 "<body>\n"
-"  <script>\n"
-"    parent.postMessage(location.href, location.origin)\n"
-"  </script>\n"
+"    <script>\n"
+"        parent.postMessage(location.href, location.origin)\n"
+"    </script>\n"
 "</body>\n"
 "</html>\n"
 msgstr ""
 "<html>\n"
 "<body>\n"
-"  <script>\n"
-"    parent.postMessage(location.href, location.origin)\n"
-"  </script>\n"
+"    <script>\n"
+"        parent.postMessage(location.href, location.origin)\n"
+"    </script>\n"
 "</body>\n"
 "</html>\n"
 
@@ -255,8 +264,16 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "keycloak.init({ onLoad: 'login-required' })\n"
-msgstr "keycloak.init({ onLoad: 'login-required' })\n"
+msgid ""
+"keycloak.init({\n"
+"    onLoad: 'login-required',\n"
+"    promiseType: 'native',\n"
+"})\n"
+msgstr ""
+"keycloak.init({\n"
+"    onLoad: 'login-required',\n"
+"    promiseType: 'native',\n"
+"})\n"
 
 #. type: Plain text
 msgid ""
@@ -331,27 +348,26 @@ msgid ""
 "One thing to keep in mind is that the access token by default has a short "
 "life expiration so you may need to refresh the access token prior to sending"
 " the request. You can do this by the `updateToken` method. The `updateToken`"
-" method returns a promise object which makes it easy to invoke the service "
-"only if the token was successfully refreshed and for example display an "
-"error to the user if it wasn't. For example:"
+" method returns a promise which makes it easy to invoke the service only if "
+"the token was successfully refreshed and display an error to the user if it "
+"wasn't. For example:"
 msgstr ""
 "注意すべきことは、デフォルトではアクセス・トークンの有効期限が短いため、リクエストを送信する前にアクセス・トークンを更新する必要があることです。これは "
 "`updateToken` メソッドで行うことができます。 `updateToken` "
-"メソッドは、トークンが正常にリフレッシュされた場合にのみ、サービスの呼び出しを容易にするプロミス・オブジェクトを返し、そうでない場合は、たとえば、ユーザーにエラーを表示します。"
-" 以下に例を示します。"
+"メソッドは、トークンが正常にリフレッシュされた場合にのみ、サービスの呼び出しを容易にするPromiseを返し、そうでない場合は、ユーザーにエラーを表示します。以下に例を示します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.updateToken(30).success(function() {\n"
+"keycloak.updateToken(30).then(function() {\n"
 "    loadData();\n"
-"}).error(function() {\n"
+"}).catch(function() {\n"
 "    alert('Failed to refresh token');\n"
 "});\n"
 msgstr ""
-"keycloak.updateToken(30).success(function() {\n"
+"keycloak.updateToken(30).then(function() {\n"
 "    loadData();\n"
-"}).error(function() {\n"
+"}).catch(function() {\n"
 "    alert('Failed to refresh token');\n"
 "});\n"
 
@@ -435,8 +451,16 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "keycloak.init({ flow: 'implicit' })\n"
-msgstr "keycloak.init({ flow: 'implicit' })\n"
+msgid ""
+"keycloak.init({\n"
+"    flow: 'implicit',\n"
+"    promiseType: 'native',\n"
+"})\n"
+msgstr ""
+"keycloak.init({\n"
+"    flow: 'implicit',\n"
+"    promiseType: 'native',\n"
+"})\n"
 
 #. type: Plain text
 msgid ""
@@ -484,8 +508,16 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "keycloak.init({ flow: 'hybrid' })\n"
-msgstr "keycloak.init({ flow: 'hybrid' })\n"
+msgid ""
+"keycloak.init({\n"
+"    flow: 'hybrid',\n"
+"    promiseType: 'native',\n"
+"})\n"
+msgstr ""
+"keycloak.init({\n"
+"    flow: 'hybrid',\n"
+"    promiseType: 'native',\n"
+"})\n"
 
 #. type: Title ====
 #, no-wrap
@@ -575,8 +607,16 @@ msgstr ""
 
 #. type: delimited block -
 #, no-wrap
-msgid "keycloak.init({ adapter: 'cordova-native' })\n"
-msgstr "keycloak.init({ adapter: 'cordova-native' })\n"
+msgid ""
+"keycloak.init({\n"
+"    adapter: 'cordova-native',\n"
+"    promiseType: 'native',\n"
+"})\n"
+msgstr ""
+"keycloak.init({\n"
+"    adapter: 'cordova-native',\n"
+"    promiseType: 'native',\n"
+"})\n"
 
 #. type: Plain text
 msgid "This adapter required two additional plugins:"
@@ -695,6 +735,67 @@ msgstr "HTML5 History - https://github.com/devote/HTML5-History-API"
 #. type: Plain text
 msgid "Promise - https://github.com/stefanpenner/es6-promise"
 msgstr "Promise - https://github.com/stefanpenner/es6-promise"
+
+#. type: Title ====
+#, no-wrap
+msgid "A note about `promiseType`"
+msgstr "A note about `promiseType`"
+
+#. type: Plain text
+msgid ""
+"Throughout the examples in the documentation you will find `promiseType: "
+"'native'` specified wherever {project_name} is initialized.  Historically "
+"{project_name} has used its own implementation of promises that is not "
+"compatible with native promises as provided by the browser.  By default "
+"{project_name}'s own promise implementation (also known as `promiseType: "
+"'legacy'`) will be used if no promise type is specified."
+msgstr ""
+"ドキュメントの例全体を通して、{project_name}が初期化されている場所で指定された `promiseType: 'native'` "
+"が見つかります。歴史的に、{project_name}はブラウザーが提供するネイティブのPromiseと互換性のないPromiseの独自の実装を使用していました。デフォルトでは、{project_name}の独自のPromise実装（"
+" `promiseType: 'legacy'` としても知られています）が、Promiseタイプが指定されていない場合に使用されます。"
+
+#. type: Plain text
+msgid ""
+"In future versions of {project_name} the default promise type will change "
+"from `legacy` to `native`. Eventually, support for legacy promises will be "
+"removed entirely. It is therefore highly recommended that you always specify"
+" `promiseType: 'native'` to future-proof your code."
+msgstr ""
+"{project_name}の将来のバージョンでは、デフォルトのPromiseタイプが `legacy` から `native` "
+"に変更されます。最終的に、レガシーなPromiseのサポートは完全に削除されます。 したがって、コードを将来にわたって保証するために、常に "
+"`promiseType: 'native'` を指定することを強くお勧めします。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Native promises and TypeScript"
+msgstr "ネイティブPromiseとTypeScript"
+
+#. type: Plain text
+msgid ""
+"If you want to use native promises and get correct type information when "
+"using TypeScript you will have to specify the `promiseType` when "
+"constructing a new instance of Keycloak."
+msgstr ""
+"ネイティブPromiseを使用して、TypeScript使用時に正しい型情報を取得したい場合は、Keycloakの新しいインスタンスを構築するときに "
+"`promiseType` を指定する必要があります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"// Typescript assumes this is a 'legacy' promise, all methods return .success() and .error()\n"
+"const keycloak = new Keycloak();\n"
+msgstr ""
+"// Typescript assumes this is a 'legacy' promise, all methods return .success() and .error()\n"
+"const keycloak = new Keycloak();\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"// Typescript assumes this is a native promise, all methods return standard promises\n"
+"const keycloak = new Keycloak<'native'>();\n"
+msgstr ""
+"// Typescript assumes this is a native promise, all methods return standard promises\n"
+"const keycloak = new Keycloak<'native'>();\n"
 
 #. type: Title ====
 #, no-wrap
@@ -1024,8 +1125,14 @@ msgstr ""
 "に設定すると、Promiseを返すすべてのメソッドはネイティブのJavaScriptのPromiseを返します。設定されていない場合は、Keycloak固有のPromiseオブジェクトが返されます。"
 
 #. type: Plain text
-msgid "Returns promise to set functions to be invoked on success or error."
-msgstr "成功またはエラー発生時に呼び出される関数を設定するPromiseを返します。"
+msgid ""
+"enableLogging - Enables logging messages from Keycloak to the console "
+"(default is false)."
+msgstr "enableLogging - Keycloakからコンソールへのメッセージのロギングを有効にします（デフォルトはfalse）。"
+
+#. type: Plain text
+msgid "Returns a promise that resolves when initialization completes."
+msgstr "初期化が完了すると解決するPromiseを返します。"
 
 #. type: Title ======
 #, no-wrap
@@ -1260,25 +1367,25 @@ msgid "Loads the users profile."
 msgstr "ユーザーのプロファイルを読み込みます。"
 
 #. type: Plain text
-msgid ""
-"Returns promise to set functions to be invoked if the profile was loaded "
-"successfully, or if the profile could not be loaded."
-msgstr "プロファイルが正常にロードされた場合、またはプロファイルをロードできなかった場合に、呼び出される関数を設定するPromiseを返します。"
+msgid "Returns a promise that resolves with the profile."
+msgstr "プロファイルで解決されるPromiseを返します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.loadUserProfile().success(function(profile) {\n"
-"        alert(JSON.stringify(profile, null, \"  \"));\n"
-"    }).error(function() {\n"
+"keycloak.loadUserProfile()\n"
+"    .then(function(profile) {\n"
+"        alert(JSON.stringify(profile, null, \"  \"))\n"
+"    }).catch(function() {\n"
 "        alert('Failed to load user profile');\n"
 "    });\n"
 msgstr ""
-"keycloak.loadUserProfile().success(function(profile) {\n"
-" alert(JSON.stringify(profile, null, \" \"));\n"
-" }).error(function() {\n"
-" alert('Failed to load user profile');\n"
-" });\n"
+"keycloak.loadUserProfile()\n"
+"    .then(function(profile) {\n"
+"        alert(JSON.stringify(profile, null, \"  \"))\n"
+"    }).catch(function() {\n"
+"        alert('Failed to load user profile');\n"
+"    });\n"
 
 #. type: Title ======
 #, no-wrap
@@ -1307,30 +1414,32 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Returns promise to set functions that can be invoked if the token is still "
-"valid, or if the token is no longer valid.  For example:"
-msgstr "トークンが有効な場合、またはトークンがもはや有効でない場合に呼び出される関数を設定するPromiseを返します。以下に例を示します。"
+"Returns a promise that resolves with a boolean indicating whether or not the"
+" token has been refreshed."
+msgstr "トークンがリフレッシュされたかどうかを示すブール値で解決されるPromiseを返します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"keycloak.updateToken(5).success(function(refreshed) {\n"
+"keycloak.updateToken(5)\n"
+"    .then(function(refreshed) {\n"
 "        if (refreshed) {\n"
 "            alert('Token was successfully refreshed');\n"
 "        } else {\n"
 "            alert('Token is still valid');\n"
 "        }\n"
-"    }).error(function() {\n"
+"    }).catch(function() {\n"
 "        alert('Failed to refresh the token, or the session has expired');\n"
 "    });\n"
 msgstr ""
-"keycloak.updateToken(5).success(function(refreshed) {\n"
+"keycloak.updateToken(5)\n"
+"    .then(function(refreshed) {\n"
 "        if (refreshed) {\n"
 "            alert('Token was successfully refreshed');\n"
 "        } else {\n"
 "            alert('Token is still valid');\n"
 "        }\n"
-"    }).error(function() {\n"
+"    }).catch(function() {\n"
 "        alert('Failed to refresh the token, or the session has expired');\n"
 "    });\n"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
