### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# masahiro suzuki <suzmasah@fsi.co.jp>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,7 +24,7 @@ msgstr ""
 #. type: Labeled list
 #, no-wrap
 msgid "Data"
-msgstr "データ"
+msgstr "Data"
 
 #. type: Title ===
 #, no-wrap
@@ -68,7 +68,7 @@ msgstr ""
 #. type: Plain text
 #, no-wrap
 msgid "Type"
-msgstr "タイプ"
+msgstr "Type"
 
 #. type: Plain text
 msgid ""
@@ -94,7 +94,8 @@ msgid ""
 "It is originally hidden, but you can press `Show data...` to reveal it for a"
 " credential."
 msgstr ""
-"これは、クレデンシャルに関する非機密の技術情報を示しています。元々非表示ですが、「データを表示...」をクリックしてクレデンシャルを表示できます。"
+"これは、クレデンシャルに関する非機密の技術情報を示しています。元々非表示ですが、 `Show data...` "
+"をクリックしてクレデンシャルを表示できます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -122,7 +123,7 @@ msgstr ""
 #. type: Block title
 #, no-wrap
 msgid "Credential Management - Set Password"
-msgstr "Credential Management - Set Password"
+msgstr "クレデンシャルの管理 - パスワードの設定"
 
 #. type: Plain text
 msgid "image:images/user-credentials-set-password.png[]"
@@ -168,8 +169,8 @@ msgid ""
 "delete credentials for a user on the `Credentials` tab, for example if the "
 "user has lost his OTP device, or if a credential has been compromised."
 msgstr ""
-"管理コンソール内で特定のユーザーに他の種類のクレデンシャルを設定することはできません。これはユーザーの責任です。ユーザーがOTPデバイスを紛失した場合、またはクレデンシャルが侵害された場合など、"
-" `Credentials` タブでユーザーのクレデンシャルのみを削除できます。"
+"管理コンソール内で特定のユーザーに他の種類のクレデンシャルを設定することはできません。これはユーザーの責任です。ユーザーがOTPデバイスを紛失した場合、またはクレデンシャルが侵害された場合は、"
+" `Credentials` タブでユーザーのクレデンシャルを削除だけできます。"
 
 #. type: Title =====
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po
@@ -6,6 +6,7 @@
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
+# masahiro suzuki <suzmasah@fsi.co.jp>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # 
 #, fuzzy
@@ -20,50 +21,124 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Labeled list
+#, no-wrap
+msgid "Data"
+msgstr "データ"
+
 #. type: Title ===
-#: source/server_admin/topics/users/credentials.adoc:3
 #, no-wrap
 msgid "User Credentials"
 msgstr "ユーザー・クレデンシャル"
 
 #. type: Plain text
-#: source/server_admin/topics/users/credentials.adoc:6
 msgid ""
 "When viewing a user if you go to the `Credentials` tab you can manage a "
 "user's credentials."
 msgstr "ユーザーを参照しているときに、 `Credentials` タブをクリックすると、ユーザーのクレデンシャルを管理することができます。"
 
 #. type: Block title
-#: source/server_admin/topics/users/credentials.adoc:7
 #, no-wrap
 msgid "Credential Management"
 msgstr "クレデンシャルの管理"
 
 #. type: Plain text
-#: source/server_admin/topics/users/credentials.adoc:9
 msgid "image:{project_images}/user-credentials.png[]"
 msgstr "image:{project_images}/user-credentials.png[]"
 
-#. type: Title ====
-#: source/server_admin/topics/users/credentials.adoc:10
+#. type: Plain text
+msgid "The credentials are listed in a table, which has the following fields:"
+msgstr "クレデンシャルは表に一覧表示され、次のフィールドがあります。"
+
+#. type: Labeled list
 #, no-wrap
-msgid "Changing Passwords"
-msgstr "パスワード変更"
+msgid "Position"
+msgstr "Position"
 
 #. type: Plain text
-#: source/server_admin/topics/users/credentials.adoc:15
 msgid ""
-"To change a user's password, type in a new one.  A `Reset Password` button "
-"will show up that you click after you've typed everything in.  If the "
-"`Temporary` switch is on, this new password can only be used once and the "
-"user will be asked to change their password after they have logged in."
+"The arrow buttons in this column allows you to shift the priority of the "
+"credential for the user, with the topmost credential having the highest "
+"priority.  This priority determines which credential will be shown first to "
+"a user in case of a choice during login. The highest priority of those "
+"available to the user will be the one selected."
 msgstr ""
-"ユーザーのパスワードを変更するには、新しいパスワードを入力します。 すべてを入力した後にクリックする `Reset Password` "
-"ボタンが表示されます。 `Temporary` "
-"スイッチがオンの場合、新しいパスワードは一度しか使用できません。ユーザーはログイン後にパスワードを変更するよう求められます。 "
+"この列の矢印ボタンを使用すると、ユーザーのクレデンシャルの優先度を変更できます。最上位のクレデンシャルが最高の優先度を持ちます。この優先度は、ログイン時に選択した場合にユーザーに最初に表示されるクレデンシャルを決定します。ユーザーが使用できるものの中で最も高い優先度が選択されます。"
 
 #. type: Plain text
-#: source/server_admin/topics/users/credentials.adoc:20
+#, no-wrap
+msgid "Type"
+msgstr "タイプ"
+
+#. type: Plain text
+msgid ""
+"This shows the type of the credential, for example `password` or `otp`."
+msgstr "これは、 `password` や `otp` などのクレデンシャルのタイプを示します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "User Label"
+msgstr "User Label"
+
+#. type: Plain text
+msgid ""
+"This is an assignable label to recognise the credential when presented as a "
+"selection option during login. It can be set to any value to describe the "
+"credential."
+msgstr ""
+"これは、ログイン時に選択オプションとして提示されたときにクレデンシャルを認識するための割り当て可能なラベルです。クレデンシャルを説明する任意の値に設定できます。"
+
+#. type: Plain text
+msgid ""
+"This shows the non-confidential technical information about the credential. "
+"It is originally hidden, but you can press `Show data...` to reveal it for a"
+" credential."
+msgstr ""
+"これは、クレデンシャルに関する非機密の技術情報を示しています。元々非表示ですが、「データを表示...」をクリックしてクレデンシャルを表示できます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Actions"
+msgstr "Actions"
+
+#. type: Plain text
+msgid ""
+"This column has two buttons. `Save` records the value of the User Label, "
+"while `Delete` will remove the credential."
+msgstr "この列には2つのボタンがあります。 `Save` はユーザーラベルの値を記録し、 `Delete` はクレデンシャルを削除します。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Creating a Password for the User"
+msgstr "ユーザーのパスワードの作成"
+
+#. type: Plain text
+msgid ""
+"If a user doesn't have a password, or if the password has been deleted, the "
+"`Set Password` section will be shown on the page."
+msgstr ""
+"ユーザーがパスワードを持っていない場合、またはパスワードが削除されている場合、 `Set Password` セクションがページに表示されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Credential Management - Set Password"
+msgstr "Credential Management - Set Password"
+
+#. type: Plain text
+msgid "image:images/user-credentials-set-password.png[]"
+msgstr "image:images/user-credentials-set-password.png[]"
+
+#. type: Plain text
+msgid ""
+"To create a password for a user, type in a new one. Click on the `Set "
+"Password` button after you've typed everything in.  If the `Temporary` "
+"switch is on, this new password can only be used once and the user will be "
+"asked to change their password after they have logged in."
+msgstr ""
+"ユーザーのパスワードを作成するには、新しいパスワードを入力します。すべてを入力したら、 `Set Password` ボタンをクリックします。 "
+"`Temporary` スイッチがオンの場合、この新しいパスワードは1回しか使用できず、ユーザーはログイン後にパスワードの変更を求められます。"
+
+#. type: Plain text
 msgid ""
 "Alternatively, if you have <<_email, email>> set up, you can send an email "
 "to the user that asks them to reset their password.  Choose `Update "
@@ -77,35 +152,49 @@ msgstr ""
 "必要に応じて、レルム設定の `Tokens` タブから、電子メールのリンクの有効時間を変更することができます。 "
 "送信された電子メールには、パスワードの更新画面へのリンクが含まれています。"
 
+#. type: Plain text
+msgid "Note that a user can only have a single credential of type password."
+msgstr "ユーザーは、パスワードタイプのクレデンシャルを1つしか持てないことに注意してください。"
+
 #. type: Title ====
-#: source/server_admin/topics/users/credentials.adoc:21
 #, no-wrap
-msgid "Changing OTPs"
-msgstr "OTPの変更"
+msgid "Creating other credentials"
+msgstr "他のクレデンシャルの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/users/credentials.adoc:27
 msgid ""
-"You cannot configure One-Time Passwords for a specific user within the Admin"
-" Console.  This is the responsibility of the user.  If the user has lost "
-"their OTP generator all you can do is disable OTP for them on the "
-"`Credentials` tab.  If OTP is optional in your realm, the user will have to "
-"go to the User Account Management service to re-configure a new OTP "
-"generator. If OTP is required, then the user will be asked to re-configure a"
-" new OTP generator when they log in."
+"You cannot configure other types of credentials for a specific user within "
+"the Admin Console. This is the responsibility of the user.  You can only "
+"delete credentials for a user on the `Credentials` tab, for example if the "
+"user has lost his OTP device, or if a credential has been compromised."
 msgstr ""
-"管理コンソール内の特定のユーザーに対してワンタイム・パスワードを設定することはできません。 これはユーザーの責任で行われます。 "
-"ユーザーがOTPジェネレーターを無くした場合は、 `Credentials` "
-"タブからOTPを無効にします。レルム設定において、OTPがオプションの場合、ユーザーは新しいOTPジェネレーターを、ユーザー・アカウント管理サービスから再設定することができます。OTPが必須の場合は、ログイン時に新しいOTPジェネレーターを再設定するように求められます。"
+"管理コンソール内で特定のユーザーに他の種類のクレデンシャルを設定することはできません。これはユーザーの責任です。ユーザーがOTPデバイスを紛失した場合、またはクレデンシャルが侵害された場合など、"
+" `Credentials` タブでユーザーのクレデンシャルのみを削除できます。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Creating an OTP"
+msgstr "OTPの作成"
 
 #. type: Plain text
-#: source/server_admin/topics/users/credentials.adoc:30
+msgid ""
+"If OTP is conditional in your realm, the user will have to go to the User "
+"Account Management service to re-configure a new OTP generator. A user can "
+"set up any number of OTP credentials in this manner. If OTP is required, "
+"then the user will be asked to re-configure a new OTP generator when they "
+"log in."
+msgstr ""
+"レルムでOTPがconditionalである場合、ユーザーはユーザーアカウント管理サービスにアクセスして、新しいOTPジェネレーターを再設定する必要があります。ユーザーは、この方法で任意の数のOTPクレデンシャルを設定できます。OTPが必要な場合、ユーザーはログイン時に新しいOTPジェネレーターを再設定するよう求められます。"
+
+#. type: Plain text
 msgid ""
 "Like passwords, you can alternatively send an email to the user that will "
 "ask them to reset their OTP generator.  Choose `Configure OTP` in the `Reset"
 " Actions` list box and click the `Send Email` button.  The sent email "
-"contains a link that will bring the user to the OTP setup screen."
+"contains a link that will bring the user to the OTP setup screen. You can "
+"use this method even if the user already has an OTP credential, and would "
+"like to set up some more."
 msgstr ""
-"パスワードのように、ユーザーにOTPジェネレーターをリセットするように依頼する電子メールを送信することもできます。 `Reset Actions` "
-"リストボックスで `Configure OTP` を選択し、 `Send Email` "
-"ボタンをクリックしてください。送信されたメールには、OTP設定画面へのリンクが含まれています。"
+"パスワードと同様に、OTPジェネレーターをリセットするように求めるメールをユーザーに送信することもできます。 `Reset Actions` "
+"のリストボックスで `Configure OTP` を選択し、 `Send Email` "
+"ボタンをクリックします。送信されたメールには、ユーザーをOTP設定画面に移動するリンクが含まれています。ユーザーが既にOTPクレデンシャルを持っている場合でも、この方法を使用できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__credentials
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
