### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/personal_data.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/personal_data.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/personal_data.ja_JP.po
@@ -1,0 +1,82 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Personal data collected by {project_name}"
+msgstr "{project_name}によって収集された個人データ"
+
+#. type: Plain text
+msgid "By default, {project_name} collects the following:"
+msgstr "デフォルトでは、{project_name}は次のものを収集します。"
+
+#. type: Plain text
+msgid "Basic user profile, such as email, firstname, and lastname"
+msgstr "電子メール、名、姓などの基本的なユーザー・プロファイル"
+
+#. type: Plain text
+msgid ""
+"Basic user profile used for social accounts and references to the social "
+"account when using a social login"
+msgstr "ソーシャル・ログインに使用するときにソーシャル・アカウントとソーシャル・アカウントへの参照に使用される基本的なユーザー・プロファイル"
+
+#. type: Plain text
+msgid ""
+"Device information collected for audit and security purposes, such as the IP"
+" address, operating system name, and browser name"
+msgstr "IPアドレス、オペレーティング・システム名、ブラウザー名など、監査とセキュリティーの目的で収集されたデバイス情報"
+
+#. type: Plain text
+msgid ""
+"The information collected in {project_name} is highly customizable.  Be "
+"aware of the following guidelines when making customizations:"
+msgstr "{project_name}で収集された情報は高度にカスタマイズできます。カスタマイズを行うときは、次のガイドラインに注意してください。"
+
+#. type: Plain text
+msgid ""
+"Registration and account forms could contain custom fields, such as "
+"birthday, gender, and nationality.  An administrator could configure "
+"{project_name} to retrieve that data from a social provider or a user "
+"storage provider such as LDAP."
+msgstr ""
+"登録およびアカウント・フォームには、誕生日、性別、国籍などのカスタム・フィールドを含めることができます。管理者は、{project_name}を設定して、ソーシャル・プロバイダーまたはLDAPなどのユーザー・ストレージ・プロバイダーからそのデータを取得できます。"
+
+#. type: Plain text
+msgid ""
+"{project_name} collects user credentials, such as password, OTP codes, and "
+"WebAuthn public keys. This information is encrypted and saved in a database,"
+" so it is not visible to {project_name} administrators. However, each type "
+"of credential can include non-confidential metadata that is visible to "
+"administrators such as the algorithm that is used to hash the password and "
+"the number of hash iterations used to hash the password."
+msgstr ""
+"{project_name}は、パスワード、OTPコード、WebAuthn公開鍵などのユーザー・クレデンシャルを収集します。この情報は暗号化されてデータベースに保存されるため、{project_name}管理者には表示されません。ただし、クレデンシャルの各タイプには、パスワードのハッシュに使用されるアルゴリズムやパスワードのハッシュに使用されるハッシュ反復回数など、管理者に表示される非機密メタデータを含めることができます。"
+
+#. type: Plain text
+msgid ""
+"With authorization services and UMA support enabled, {project_name} can hold"
+" information about some objects for which a particular user is the owner. "
+"For example, {project_name} can track that the user *john* is the owner of a"
+" photoalbum *album with animals* and a few photos called *lion picture* and "
+"*cow picture* in this album."
+msgstr ""
+"認可サービスとUMAサポートを有効にすると、{project_name}は特定のユーザーが所有者であるオブジェクトに関する情報を保持できます。たとえば、{project_name}は、ユーザー"
+" *john* はフォトアルバム *album with animals* と、このアルバムの *lion picture* と *cow "
+"picture* と呼ばれるいくつかの写真の所有者であることを追跡できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/personal_data.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__personal_data
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
