### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -101,9 +101,10 @@ msgid ""
 " file whose name is the secret name, and contents of that file is the secret"
 " value."
 msgstr ""
-"{project_name}は、https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes"
-" "
-"secrets]のボールト実装をサポートしています。これらのシークレットはデータボリュームとしてマウントでき、フラットファイル構造のディレクトリーとして表示されます。各シークレットは名前がシークレット名であり、そのファイルの内容がシークレット値です。"
+"{project_name}は、 "
+"https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes "
+"secrets] "
+"のボールト実装をサポートしています。これらのシークレットはデータボリュームとしてマウントでき、フラットファイル構造のディレクトリーとして表示されます。各シークレットは名前がシークレット名であり、そのファイルの内容がシークレット値です。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/vault.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__vault
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
