### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -109,7 +109,7 @@ msgid ""
 "functionalities like <<_extensions_spi, Adding your own SPI>> or "
 "<<_extensions_jpa,Extending datamodel with your own JPA entities>>."
 msgstr ""
-"このメソッドにより、https://github.com/jax-rs[JAX-RSリソース] "
+"このメソッドにより、 https://github.com/jax-rs[JAX-RSリソース] "
 "として機能するオブジェクトを返却できます。詳しくは、Javadocとサンプルを参照してください。 `providers/rest` "
 "のサンプル配布物には非常に簡単なサンプルがあり、 `providers/domain-extension` "
 "にはさらに高度なサンプルがあります。この高度なサンプルには、認証されるRESTエンドポイントと、<<_extensions_spi,独自のSPIの追加>>や<<_extensions_jpa,独自のJPAエンティティーによるデータモデルの拡張>>のようなその他の機能を、追加する方法が示されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
