### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po
@@ -21,13 +21,13 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Supported Platforms"
-msgstr "サポートされているプラットフォーム"
+msgid "OpenID Connect"
+msgstr "OpenID Connect"
 
 #. type: Title ===
 #, no-wrap
-msgid "OpenID Connect"
-msgstr "OpenID Connect"
+msgid "Supported Platforms"
+msgstr "サポートされているプラットフォーム"
 
 #. type: Title =====
 #, no-wrap
@@ -84,7 +84,7 @@ msgstr "Node.js（サーバーサイド）"
 msgid "<<_nodejs_adapter,Node.js>>"
 msgstr "<<_nodejs_adapter,Node.js>>"
 
-#. type: Title ====
+#. type: Title =====
 #, no-wrap
 msgid "C#"
 msgstr "C#"
@@ -95,7 +95,7 @@ msgid ""
 msgstr ""
 "https://github.com/dylanplecki/KeycloakOwinAuthentication[OWIN] (community)"
 
-#. type: Title ====
+#. type: Title =====
 #, no-wrap
 msgid "Python"
 msgstr "Python"
@@ -104,7 +104,7 @@ msgstr "Python"
 msgid "https://pypi.org/project/oic/[oidc] (generic)"
 msgstr "https://pypi.org/project/oic/[oidc] (generic)"
 
-#. type: Title ====
+#. type: Title =====
 #, no-wrap
 msgid "Android"
 msgstr "Android"
@@ -113,12 +113,7 @@ msgstr "Android"
 msgid "https://github.com/openid/AppAuth-Android[AppAuth] (generic)"
 msgstr "https://github.com/openid/AppAuth-Android[AppAuth] (generic)"
 
-#. type: Plain text
-msgid "https://github.com/aerogear/aerogear-android-authz[AeroGear] (generic)"
-msgstr ""
-"https://github.com/aerogear/aerogear-android-authz[AeroGear] (generic)"
-
-#. type: Title ====
+#. type: Title =====
 #, no-wrap
 msgid "iOS"
 msgstr "iOS"
@@ -126,10 +121,6 @@ msgstr "iOS"
 #. type: Plain text
 msgid "https://github.com/openid/AppAuth-iOS[AppAuth] (generic)"
 msgstr "https://github.com/openid/AppAuth-iOS[AppAuth] (generic)"
-
-#. type: Plain text
-msgid "https://github.com/aerogear/aerogear-ios-oauth2[AeroGear] (generic)"
-msgstr "https://github.com/aerogear/aerogear-ios-oauth2[AeroGear] (generic)"
 
 #. type: Title =====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/supported-platforms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__supported-platforms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
