### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -143,7 +143,7 @@ msgid ""
 "encryption-key: <ENCRYPTION_KEY>\n"
 "# the upstream endpoint which we should proxy request\n"
 "upstream-url: http://127.0.0.1:80\n"
-"# additional scopes to add to add to the default (openid+email+profile)\n"
+"# additional scopes to add to the default (openid+email+profile)\n"
 "scopes:\n"
 "- vpn-user\n"
 "# a collection of resource i.e. urls that you wish to protect\n"
@@ -407,9 +407,8 @@ msgstr "HTTPルーティング"
 #. type: Plain text
 msgid ""
 "By default all requests will be proxyed on to the upstream, if you wish to "
-"ensure all requests are authentication you can use this:"
-msgstr ""
-"デフォルトでは、すべてのリクエストがアップストリームにプロキシーされます。すべてのリクエストが認証であることを確認したい場合は、これを使用できます。"
+"ensure all requests are authenticated you can use this:"
+msgstr "デフォルトでは、すべてのリクエストがアップストリームにプロキシーされます。すべてのリクエストを確実に認証したい場合はこれを使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1354,15 +1353,16 @@ msgstr "既知の問題"
 
 #. type: Plain text
 msgid ""
-"There is a known issue with the Keycloak server 4.7.0.Final in which "
+"There is a known issue with the Keycloak server 4.6.0.Final in which "
 "Gatekeeper is unable to find the _client_id_ in the _aud_ claim. This is due"
 " to the fact the _client_id_ is not in the audience anymore. The workaround "
 "is to add the \"Audience\" protocol mapper to the client with the audience "
 "pointed to the _client_id_. For more information, see "
-"link:https://issues.jboss.org/browse/KEYCLOAK-8954[KEYCLOAK-8954]."
+"link:https://issues.redhat.com/browse/KEYCLOAK-8954[KEYCLOAK-8954]."
 msgstr ""
-"Keycloak Server 4.7.0.Finalには、Gatekeeperが _aud_ クレームで _client_id_ "
+"Keycloak Server 4.6.0.Finalには、Gatekeeperが _aud_ クレームで _client_id_ "
 "を見つけることができない既知の問題があります。これは、 _client_id_ がもうAudienceに含まれないためです。これを回避するには、 "
 "\"Audience\" プロトコル・マッパーをそのクライアントに追加し、 _client_id_ "
 "を指すようにAudienceを設定します。詳細については、 "
-"link:https：//issues.jboss.org/browse/KEYCLOAK-8954[KEYCLOAK-8954] を参照してください。"
+"link:https://issues.redhat.com/browse/KEYCLOAK-8954[KEYCLOAK-8954] "
+"を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/keycloak-gatekeeper.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__keycloak-gatekeeper
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
