### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,6 +24,25 @@ msgstr ""
 #, no-wrap
 msgid "Token Endpoint"
 msgstr "トークン・エンドポイント"
+
+#. type: Title ===
+#, no-wrap
+msgid "Protection API"
+msgstr "Protection API"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Resource Management*\n"
+msgstr "*リソースの管理*\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Permission Management*\n"
+msgstr "*パーミッション管理*\n"
+
+#. type: Plain text
+msgid "image:images/pep-pattern-diagram.png[alt=\"PEP Overview\"]"
+msgstr "image:images/pep-pattern-diagram.png[alt=\"PEPの概要\"]"
 
 #. type: Title =
 #, no-wrap
@@ -110,11 +129,6 @@ msgid ""
 "{project_name} to enable fine-grained authorization to your applications:"
 msgstr ""
 "アプリケーションに対するきめ細かな認可を可能にするために、{project_name}の使用方法を理解する上で必要な手順を定義する3つの主要なプロセスは、以下のとおりです。"
-
-#. type: Plain text
-#, no-wrap
-msgid "*Resource Management*\n"
-msgstr "*リソースの管理*\n"
 
 #. type: Plain text
 #, no-wrap
@@ -248,11 +262,9 @@ msgstr ""
 msgid ""
 "{project_name} provides a few built-in policy types (and their respective "
 "policy providers) covering the most common access control mechanisms. You "
-"can even create policies based on rules written using JavaScript or JBoss "
-"Drools."
+"can even create policies based on rules written using JavaScript."
 msgstr ""
-"{project_name}には、最も一般的なアクセス・コントロール機構をカバーするいくつかの組み込みのポリシー・タイプ（およびそれぞれのポリシー・プロバイダー）が用意されています。JavaScriptやJBoss"
-" Droolsを使用して作成されたルールに基づいてポリシーを作成することもできます。"
+"{project_name}には、最も一般的なアクセス・コントロール機構をカバーするいくつかの組み込みのポリシー・タイプ（およびそれぞれのポリシー・プロバイダー）が用意されています。JavaScriptを使用して作成されたルールに基づいてポリシーを作成することもできます。"
 
 #. type: Plain text
 msgid ""
@@ -284,10 +296,6 @@ msgstr ""
 "またはPEPを有効にし、サーバーによって返された決定とパーミッションに基づいて認可データを要求し、保護されたリソースへのアクセスを制御することによって実現されます。\n"
 
 #. type: Plain text
-msgid "image:images/pep-pattern-diagram.png[alt=\"PEP Overview\"]"
-msgstr "image:images/pep-pattern-diagram.png[alt=\"PEPの概要\"]"
-
-#. type: Plain text
 msgid ""
 "{project_name} provides some built-in <<_enforcer_overview, Policy "
 "Enforcers>> implementations that you can use to protect your applications "
@@ -296,7 +304,7 @@ msgstr ""
 "{project_name}には、実行中のプラットフォームに応じてアプリケーションを保護するために使用できる組み込みの<<_enforcer_overview,"
 " ポリシー・エンフォーサー>>実装がいくつか用意されています。"
 
-#. type: Title =
+#. type: Attribute :authorizationguide_name_short:
 #, no-wrap
 msgid "Authorization Services"
 msgstr "認可サービス"
@@ -347,11 +355,6 @@ msgid ""
 "Permissions>>."
 msgstr "詳細については、<<_service_obtaining_permissions, パーミッションの取得>>を参照してください。"
 
-#. type: Title =
-#, no-wrap
-msgid "Protection API"
-msgstr "Protection API"
-
 #. type: Plain text
 msgid ""
 "The *Protection API* is a set of https://docs.kantarainitiative.org/uma/wg"
@@ -383,11 +386,6 @@ msgstr ""
 "** Delete Resource\n"
 "** Find by Id\n"
 "** Query\n"
-
-#. type: Plain text
-#, no-wrap
-msgid "*Permission Management*\n"
-msgstr "*パーミッション管理*\n"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-architecture
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
