### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,25 +20,22 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/server_admin/topics/groups/groups-vs-roles.adoc:3
 #, no-wrap
 msgid "Groups vs. Roles"
 msgstr "グループ VS ロール"
 
 #. type: Plain text
-#: source/server_admin/topics/groups/groups-vs-roles.adoc:8
 msgid ""
 "In the IT world the concepts of Group and Role are often blurred and "
 "interchangeable.  In {project_name}, Groups are just a collection of users "
 "that you can apply roles and attributes to in one place.  Roles define a "
-"type of user and applications assign permission and access control to roles"
+"type of user and applications assign permission and access control to roles."
 msgstr ""
 "ITの世界では、グループとロールの概念はしばしば曖昧になり、互換性があります。 "
 "{project_name}では、グループはロールと属性を1か所に適用できるユーザーのコレクションです。 "
 "ロールはユーザーのタイプを定義し、アプリケーションはロールにパーミッションとアクセス制御を割り当てます。"
 
 #. type: Plain text
-#: source/server_admin/topics/groups/groups-vs-roles.adoc:13
 msgid ""
 "Aren't <<_composite-roles,Composite Roles>> also similar to Groups? "
 "Logically they provide the same exact functionality, but the difference is "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/groups/groups-vs-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__groups__groups-vs-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
