### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,12 +27,11 @@ msgstr "Policy Evaluation API"
 
 #. type: Plain text
 msgid ""
-"When writing rule-based policies using JavaScript or JBoss Drools, "
-"{project_name} provides an Evaluation API that provides useful information "
-"to help determine whether a permission should be granted."
+"When writing rule-based policies using JavaScript, {project_name} provides "
+"an Evaluation API that provides useful information to help determine whether"
+" a permission should be granted."
 msgstr ""
-"JavaScriptまたはJBoss "
-"Droolsを使用してルールベースのポリシーを作成する場合、{project_name}は、パーミッションを与える必要があるかどうかの判断に役立つ情報を提供するEvaluation"
+"JavaScriptを使用してルールベースのポリシーを作成する場合、{project_name}は、パーミッションを与える必要があるかどうかの判断に役立つ情報を提供するEvaluation"
 " APIを提供します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-evaluation-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-evaluation-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
