### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # KojiNose <knose.dev@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,10 +42,6 @@ msgstr ""
 #, no-wrap
 msgid "Java Servlet Filter Adapter"
 msgstr "Javaサーブレット・フィルター・アダプター"
-
-#. type: Plain text
-msgid "To use this filter, include this maven artifact in your WAR poms:"
-msgstr "このフィルタを使用するには、WARのpomに次のmavenアーティファクトを含めます。"
 
 #. type: Plain text
 msgid ""
@@ -166,6 +162,10 @@ msgid ""
 "context params."
 msgstr ""
 "{project_name}フィルターは、コンテキスト・パラメーターの代わりにフィルター初期化パラメーターとして定義する必要がある以外は、他のアダプターと同じ設定パラメーターを持ちます。"
+
+#. type: Plain text
+msgid "To use this filter, include this maven artifact in your WAR poms:"
+msgstr "このフィルタを使用するには、WARのpomに次のmavenアーティファクトを含めます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -403,10 +403,9 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Please refer to http://felix.apache.org/documentation/subprojects/apache-"
-"felix-http-service.html#using-the-osgi-http-whiteboard[Apache Felix HTTP "
-"Service] for more info on programmatic registration."
+"Please refer to https://github.com/apache/felix-dev/tree/master/http#using-"
+"the-osgi-http-whiteboard[Apache Felix HTTP Service] for more info on "
+"programmatic registration."
 msgstr ""
-"プログラムによる登録の詳細については、 http://felix.apache.org/documentation/subprojects"
-"/apache-felix-http-service.html#using-the-osgi-http-whiteboard[Apache Felix "
-"HTTP Service] を参照してください。"
+"プログラムによる登録の詳細については、 https://github.com/apache/felix-dev/tree/master/http"
+"#using-the-osgi-http-whiteboard[Apache Felix HTTP Service] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__servlet-filter-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
