### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -137,11 +137,11 @@ msgstr "クライアントの設定"
 #. type: Plain text
 msgid ""
 "The application needs to be configured as a `public` OpenID Connect client "
-"with `Standard Flow Enabled` and pass:[http://localhost:*] as an allowed "
+"with `Standard Flow Enabled` and pass:[http://localhost] as an allowed "
 "`Valid Redirect URI`."
 msgstr ""
 "アプリケーションは、 `Standard Flow Enabled` で `public` なOpenID Connectクライアントであり、許可される"
-" `Valid Redirect URI` としてpass:[http://localhost:*]が設定される必要があります。"
+" `Valid Redirect URI` として pass:[http://localhost] が設定される必要があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__installed-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
