### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
@@ -4,13 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +20,18 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_admin/topics/sessions.adoc:2
 #, no-wrap
 msgid "User Session Management"
 msgstr "ユーザー・セッションの管理"
 
 #. type: Plain text
-#: source/server_admin/topics/sessions.adoc:9
 msgid ""
 "When a user logs into a realm, {project_name} maintains a user session for "
 "them and remembers each and every client they have visited within the "
 "session.  There are a lot of administrative functions that realm admins can "
 "perform on these user sessions.  They can view login stats for the entire "
 "realm and dive down into each client to see who is logged in and where.  "
-"Admins can logout a user or set of users from the Admin Console. They can "
+"Admins can logout a user or a set of users from the Admin Console. They can "
 "revoke tokens and set up all the token and session timeouts there too."
 msgstr ""
 "ユーザーがレルムにログインすると、{project_name}はユーザー・セッションを維持し、セッション内でアクセスしたすべてのクライアントを記憶します。これらのユーザー・セッションに対してレルム管理者が実行できる多くの管理機能があります。レルム全体のログイン統計を表示し、各クライアントに誰がどこからログインしているのかを確認できます。管理者は、管理コンソールからユーザーまたはユーザーのセットをログアウトできます。トークンを取り消したり、すべてのトークンとセッションのタイムアウトを設定することも可能です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
