### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -5,15 +5,15 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -92,11 +92,11 @@ msgstr "`Require SSL` オプションにより、SSLモードが選択できま�
 #. type: Plain text
 msgid ""
 "Users can interact with {project_name} without SSL so long as they stick to "
-"private IP addresses like `localhost`, `127.0.0.1`, `10.0.x.x`, "
+"private IP addresses like `localhost`, `127.0.0.1`, `10.x.x.x`, "
 "`192.168.x.x`, and `172.16.x.x`.  If you try to access {project_name} "
 "without SSL from a non-private IP address you will get an error."
 msgstr ""
-"`localhost` 、 `127.0.0.1` 、 `10.0.x.x` 、 `192.168.x.x` 、 `172.16.x.x` "
+"`localhost` 、 `127.0.0.1` 、 `10.x.x.x` 、 `192.168.x.x` 、 `172.16.x.x` "
 "のようなプライベートIPアドレスに固定する限り、ユーザーはSSL無しで{project_name}と対話できます。非プライベートIPアドレスからSSL無しで{project_name}にアクセスしようとすると、エラーが発生します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
