### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,24 +19,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_installation/topics/operating-mode.adoc:4
 #, no-wrap
 msgid "Choosing an Operating Mode"
 msgstr "動作モードの選択"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode.adoc:9
 msgid ""
 "Before deploying {project_name} in a production environment you need to "
 "decide which type of operating mode you are going to use.  Will you run "
 "{project_name} within a cluster? Do you want a centralized way to manage "
-"your server configurations? Your choice of operating mode effects how you "
+"your server configurations? Your choice of operating mode affects how you "
 "configure databases, configure caching and even how you boot the server."
 msgstr ""
 "プロダクション環境で{project_name}をデプロイする前に、どのタイプの動作モードを使用するか決定する必要があります。クラスター内で{project_name}を実行しますか？サーバー設定を一元管理しますか？どの動作モードを選択するかによって、データベースやキャッシュをどのように設定するか、さらにはサーバーをどのように起動するかさえ変わってきます。"
 
 #. type: Plain text
-#: source/server_installation/topics/operating-mode.adoc:12
 #, no-wrap
 msgid ""
 "The {project_name} is built on top of the {appserver_name} Application Server.  This guide will only\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
