### PR TITLE
Translations for i18n/po/ja_JP/release_notes/master.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/master.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/master.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,40 +26,5 @@ msgstr "{releasenotes_name}"
 
 #. type: Title ==
 #, no-wrap
-msgid "{project_name_full} 7.3"
-msgstr "{project_name_full} 7.3"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 8"
-msgstr "{project_name_full} 8"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 7"
-msgstr "{project_name_full} 7"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 6"
-msgstr "{project_name_full} 6"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 7.3.CD05"
-msgstr "{project_name_full} 7.3.CD05"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 7.3.CD04"
-msgstr "{project_name_full} 7.3.CD04"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 7.3.CD03"
-msgstr "{project_name_full} 7.3.CD03"
-
-#. type: Title ==
-#, no-wrap
-msgid "{project_name_full} 7.3.CD02"
-msgstr "{project_name_full} 7.3.CD02"
+msgid "{project_name_full} 7.3.0.GA"
+msgstr "{project_name_full} 7.3.0.GA"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/master.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__master
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
