### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,15 +19,13 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ===
-#: source/securing_apps/topics/overview/what-are-client-adapters.adoc:1
 #, no-wrap
 msgid "What are Client Adapters?"
 msgstr "クライアント・アダプターとは？"
 
 #. type: Plain text
-#: source/securing_apps/topics/overview/what-are-client-adapters.adoc:6
 msgid ""
-"{project_name} client adapters are libraries that makes it very easy to "
+"{project_name} client adapters are libraries that make it very easy to "
 "secure applications and services with {project_name}. We call them adapters "
 "rather than libraries as they provide a tight integration to the underlying "
 "platform and framework. This makes our adapters easy to use and they require"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/overview/what-are-client-adapters.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__overview__what-are-client-adapters
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
