### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -7,13 +7,13 @@
 # Shinsuke UEDA, 2017
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3390,13 +3390,13 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"$ kcadm.sh get testLDAPConnection -q action=testConnection -q "
-"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
-"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
+"$ kcadm.sh create testLDAPConnection -s action=testConnection -s "
+"bindCredential=secret -s bindDn=uid=admin,ou=system -s "
+"connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=ldapsOnly\n"
 msgstr ""
-"$ kcadm.sh get testLDAPConnection -q action=testConnection -q "
-"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
-"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
+"$ kcadm.sh create testLDAPConnection -s action=testConnection -s "
+"bindCredential=secret -s bindDn=uid=admin,ou=system -s "
+"connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=ldapsOnly\n"
 
 #. type: Title ====
 #, no-wrap
@@ -3416,13 +3416,13 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"$ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
-"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
-"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
+"$ kcadm.sh create testLDAPConnection -s action=testAuthentication -s "
+"bindCredential=secret -s bindDn=uid=admin,ou=system -s "
+"connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=ldapsOnly\n"
 msgstr ""
-"$ kcadm.sh get testLDAPConnection -q action=testAuthentication -q "
-"bindCredential=secret -q bindDn=uid=admin,ou=system -q "
-"connectionUrl=ldap://localhost:10389 -q useTruststoreSpi=ldapsOnly\n"
+"$ kcadm.sh create testLDAPConnection -s action=testAuthentication -s "
+"bindCredential=secret -s bindDn=uid=admin,ou=system -s "
+"connectionUrl=ldap://localhost:10389 -s useTruststoreSpi=ldapsOnly\n"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
