### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,15 +29,6 @@ msgid ""
 "This chapter walks you through the directory structure of the server "
 "distribution."
 msgstr "この章では、サーバー配布物のディレクトリー構造について説明します。"
-
-#. type: Block title
-#, no-wrap
-msgid "distribution directory structure"
-msgstr "配布物のディレクトリー構造"
-
-#. type: Plain text
-msgid "image:{project_images}/files.png[alt=\"distribution\"]"
-msgstr "image:{project_images}/files.png[alt=\"distribution\"]"
 
 #. type: Plain text
 msgid "Let's examine the purpose of some of the directories:"
@@ -78,19 +69,6 @@ msgstr "サーバー上で使用されるすべてのJavaライブラリーで�
 
 #. type: Labeled list
 #, no-wrap
-msgid "_providers/_"
-msgstr "_providers/_"
-
-#. type: Plain text
-msgid ""
-"If you are writing extensions to keycloak, you can put your extensions here."
-"  See the link:{developerguide_link}[{developerguide_name}] for more "
-"information on this."
-msgstr ""
-"Keycloakの拡張を作成する場合、ここに配置することができます。詳しくは、link:{developerguide_link}[{developerguide_name}]を参照してください。"
-
-#. type: Labeled list
-#, no-wrap
 msgid "_standalone/_"
 msgstr "_standalone/_"
 
@@ -101,6 +79,20 @@ msgid ""
 msgstr ""
 "<<_standalone-"
 "mode,スタンドアローン・モード>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリーは含まれません。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "_standalone/deployments/_"
+msgstr "_standalone/deployments/_"
+
+#. type: Plain text
+msgid ""
+"If you are writing extensions to {project_name}, you can put your extensions"
+" here.  See the link:{developerguide_link}[{developerguide_name}] for more "
+"information on this."
+msgstr ""
+"{project_name},の拡張を作成する場合、ここに配置することができます。詳しくは、 "
+"link:{developerguide_link}[{developerguide_name}] を参照してください。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__installation__directory-structure
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
