### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -94,7 +94,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Don't forget to configure the `rootcertbundle` field with the location of "
-"the {project_name} realm's pulic certificate.  The auth configuration will "
+"the {project_name} realm's public certificate.  The auth configuration will "
 "not work without this argument."
 msgstr ""
 "`rootcertbundle` "
@@ -131,8 +131,8 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Don't forget to configure the `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` override "
-"with the location of the {project_name} realm's pulic certificate.  The auth"
-" configuration will not work without this argument."
+"with the location of the {project_name} realm's public certificate.  The "
+"auth configuration will not work without this argument."
 msgstr ""
 "`REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` "
 "オーバーライドを{project_name}レルムの公開証明書の場所で設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
