### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -144,13 +144,13 @@ msgstr "WildFly 10・Windows"
 
 #. type: Block title
 #, no-wrap
-msgid "Wildfly 11 and Linux/Unix"
-msgstr "WildFly 11・Linux/Unix"
+msgid "Wildfly 11+ and Linux/Unix"
+msgstr "WildFly 11+・Linux/Unix"
 
 #. type: Block title
 #, no-wrap
-msgid "Wildfly 11 and Windows"
-msgstr "WildFly 11・Windows"
+msgid "Wildfly 11+ and Windows"
+msgstr "WildFly 11+・Windows"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__install-client-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
