### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgstr "ロードバランサーまたはプロキシーの設定"
 msgid ""
 "This section discusses a number of things you need to configure before you "
 "can put a reverse proxy or load balancer in front of your clustered "
-"{project_name} deployment.  It also covers configuring the built in load "
+"{project_name} deployment.  It also covers configuring the built-in load "
 "balancer that was <<_clustered-domain-example, Clustered Domain Example>>."
 msgstr ""
 "このセクションでは、クラスター構成の{project_name}の前にリバース・プロキシーまたはロードバランサーを配置するにあたって、設定が必要な項目について説明します。また、組み込みのロードバランサーの設定についても説明します。これは"
@@ -315,11 +315,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "You should also verify that {project_name} sees the correct source IP "
-"address for requests. Do check this you can try to login to the admin "
+"address for requests. To check this, you can try to login to the admin "
 "console with an invalid username and/or password. This should show a warning"
 " in the server log something like this:"
 msgstr ""
-"また、{project_name}がリクエストのソースIPアドレスを正しく認識しているか確認する必要があります。無効なユーザー名とパスワードの両方またはいずれかで管理コンソールにログインし、確認してください。これを行うと、サーバーログに以下のような警告が表示されます。"
+"また、{project_name}がリクエストのソースIPアドレスを正しく認識しているか確認する必要があります。これを確認するためには、無効なユーザー名とパスワードの両方またはいずれかで管理コンソールにログインします。これを行うと、サーバーログに以下のような警告が表示されます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -356,7 +356,7 @@ msgstr "組み込みロードバランサーの使用"
 
 #. type: Plain text
 msgid ""
-"This section covers configuring the built in load balancer that is discussed"
+"This section covers configuring the built-in load balancer that is discussed"
 " in the <<_clustered-domain-example, Clustered Domain Example>>."
 msgstr ""
 "このセクションでは、<<_clustered-domain-example, "
@@ -546,12 +546,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The values of `jboss.bind.address` and `jboss.bind.addres.management` "
+"The values of `jboss.bind.address` and `jboss.bind.address.management` "
 "pertain to the host slave's IP address.  The value of "
-"`jboss.domain.master.address` need to be the IP address of the domain "
-"controller which is the management address of the master host."
+"`jboss.domain.master.address` needs to be the IP address of the domain "
+"controller, which is the management address of the master host."
 msgstr ""
-"`jboss.bind.address` と `jboss.bind.addres.management` "
+"`jboss.bind.address` と `jboss.bind.address.management` "
 "の値はホストスレーブのIPアドレスに関係します。 `jboss.domain.master.address` "
 "の値は、マスターホストの管理アドレスであるドメイン・コントローラーのIPアドレスとする必要があります。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__load-balancer
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
