### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -61,10 +61,6 @@ msgid "Support level"
 msgstr "サポートレベル"
 
 #. type: Plain text
-msgid "ifeval::[{project_community}==true]"
-msgstr "ifeval::[{project_community}==true]"
-
-#. type: Plain text
 msgid "account2"
 msgstr "account2"
 
@@ -77,13 +73,8 @@ msgid "No"
 msgstr "No"
 
 #. type: Plain text
-#, no-wrap
-msgid ""
-"Experimental\n"
-"endif::[]\n"
-msgstr ""
-"Experimental\n"
-"endif::[]\n"
+msgid "Preview"
+msgstr "Preview"
 
 #. type: Plain text
 msgid "account_api"
@@ -94,24 +85,12 @@ msgid "Account Management REST API"
 msgstr "アカウント管理REST API"
 
 #. type: Plain text
-msgid "Preview"
-msgstr "Preview"
-
-#. type: Plain text
 msgid "admin_fine_grained_authz"
 msgstr "admin_fine_grained_authz"
 
 #. type: Plain text
 msgid "Fine-Grained Admin Permissions"
 msgstr "きめ細かい管理権限"
-
-#. type: Plain text
-msgid "authz_drools_policy"
-msgstr "authz_drools_policy"
-
-#. type: Plain text
-msgid "Drools Policy for Authorization Services"
-msgstr "認可サービス用のDroolsポリシー"
 
 #. type: Plain text
 msgid "docker"
@@ -172,6 +151,41 @@ msgstr "{project_name} REST APIによるスクリプトのアップロード"
 #. type: Plain text
 msgid "Deprecated"
 msgstr "非推奨"
+
+#. type: Plain text
+msgid "web_authn"
+msgstr "web_authn"
+
+#. type: Title ===
+#, no-wrap
+msgid "W3C Web Authentication (WebAuthn)"
+msgstr "W3C Web Authentication（WebAuthn）"
+
+#. type: Plain text
+msgid "ifeval::[{project_community}==true]"
+msgstr "ifeval::[{project_community}==true]"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Experimental\n"
+"endif::[]\n"
+msgstr ""
+"Experimental\n"
+"endif::[]\n"
+
+#. type: Plain text
+msgid "ifeval::[{project_product}==true]"
+msgstr "ifeval::[{project_product}==true]"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Preview\n"
+"endif::[]\n"
+msgstr ""
+"Preview\n"
+"endif::[]\n"
 
 #. type: Plain text
 msgid "To enable all preview features start the server with:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
