### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -5,20 +5,24 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid "Possible configuration options are:"
+msgstr "設定可能なオプションは、以下のとおりです。"
 
 #. type: Title ===
 #, no-wrap
@@ -61,10 +65,6 @@ msgstr ""
 "        </properties>\n"
 "    </provider>\n"
 "</spi>\n"
-
-#. type: Plain text
-msgid "Possible configuration options are:"
-msgstr "設定可能なオプションは、以下のとおりです。"
 
 #. type: Labeled list
 #, no-wrap
@@ -186,6 +186,23 @@ msgstr ""
 "送信するHTTPリクエストのプロキシー設定を示します。詳細については、<<_proxymappings, "
 "送信HTTPリクエストのプロキシー・マッピング>>のセクションを参照してください。"
 
+#. type: Labeled list
+#, no-wrap
+msgid "disable-trust-manager"
+msgstr "disable-trust-manager"
+
+#. type: Plain text
+msgid ""
+"If an outgoing request requires HTTPS and this config option is set to "
+"`true` you do not have to specify a truststore.  This setting should only be"
+" used during development and *never* in production as it will disable "
+"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
+" `false`."
+msgstr ""
+"外部へのリクエストがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、プロダクション環境では"
+" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Proxy Mappings for Outgoing HTTP Requests"
@@ -215,6 +232,23 @@ msgid ""
 msgstr ""
 "送信するHTTPリクエストのプロキシーを判別するために、ターゲットホスト名が、設定されたホスト名パターンと照合されます。最初に一致するパターンで"
 "、使用するproxy-uriが決定します。指定されたホスト名と一致する設定済みのパターンが無い場合、プロキシーは使用されません。"
+
+#. type: Plain text
+msgid ""
+"If the proxy server requires authentication, include the proxy user's "
+"credentials in this format `username:password@`.  For example:"
+msgstr ""
+"プロキシー・サーバーが認証を必要とする場合、プロキシーユーザのクレデンシャルを `username:password@` "
+"という形式で含めてください。たとえば、以下のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+".*\\.(google|googleapis)\\.com;http://user01:pas2w0rd@www-"
+"proxy.acme.com:8080\n"
+msgstr ""
+".*\\.(google|googleapis)\\.com;http://user01:pas2w0rd@www-"
+"proxy.acme.com:8080\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__outgoing
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
