### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
@@ -7,12 +7,13 @@
 # Shinsuke UEDA, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,6 +25,15 @@ msgstr ""
 #, no-wrap
 msgid "W3C Web Authentication (WebAuthn)"
 msgstr "W3C Web Authentication（WebAuthn）"
+
+#. type: Title =====
+#, no-wrap
+msgid "Setup"
+msgstr "セットアップ"
+
+#. type: Plain text
+msgid "Configuration|Description"
+msgstr "設定|説明"
 
 #. type: Plain text
 msgid ""
@@ -53,38 +63,20 @@ msgid ""
 msgstr ""
 "WebAuthnの操作が成功するかどうかは、オーセンティケーター、ブラウザー、およびプラットフォームをサポートするユーザーのWebAuthnに依存します。このWebAuthnサポートを使用する場合は、それらのエンティティーがWebAuthn仕様をサポートする範囲を明確にしてください。"
 
-#. type: Title =====
-#, no-wrap
-msgid "Setup"
-msgstr "セットアップ"
-
 #. type: Plain text
 msgid "The setup procedure of WebAuthn support for 2FA is the following :"
 msgstr "2FAのWebAuthnサポートのセットアップ手順は次のとおりです。"
 
 #. type: Title =====
 #, no-wrap
-msgid "Enable User Registration"
-msgstr "ユーザー登録の有効化"
+msgid "Enable Webauthn Authenticator Registration"
+msgstr "Webauthnオーセンティケーターの登録の有効化"
 
 #. type: Plain text
 msgid ""
 "An administrator carries out the following operations on the `Admin Console`"
 " :"
 msgstr "管理者は、 `管理コンソール` で次の操作を行います。"
-
-#. type: Plain text
-msgid "Open the `Realm Settings -> Login` tab."
-msgstr "`Realm Settings -> Login` タブを開きます。"
-
-#. type: Plain text
-msgid "Set the `User Registration` to ON and click `Save`."
-msgstr "`User Registration` をオンに設定し、 `Save` をクリックします。"
-
-#. type: Title =====
-#, no-wrap
-msgid "Enable Webauthn Authenticator Registration"
-msgstr "Webauthnオーセンティケーターの登録の有効化"
 
 #. type: Plain text
 msgid "Open the `Authentication -> Required Actions` tab."
@@ -99,8 +91,12 @@ msgid "Select `Webauthn Register` as `Required Action`."
 msgstr "`Required Action` として `Webauthn Register` を選択します。"
 
 #. type: Plain text
-msgid "Mark `Enabled` and `Default Action` checkbox."
-msgstr "`Enabled` と `Default Action` のチェックボックスをマークします。"
+msgid ""
+"Mark `Enabled` checkbox. Optionally mark `Default Action` checkbox if you "
+"want all new created users to be required to register WebAuthn credential."
+msgstr ""
+"`Enabled` チェックボックスをチェックしてください。新しく作成された全てのユーザーにWebAuthnクレデンシャルを登録するよう要求したい場合は"
+" `Default Action` チェックボックスにチェックして下さい。"
 
 #. type: Title =====
 #, no-wrap
@@ -108,8 +104,9 @@ msgid "Adding WebAuthn Authentication to a Browser Flow"
 msgstr "ブラウザーフローへのWebAuthn認証の追加"
 
 #. type: Plain text
-msgid "Select a realm, click on Authentication link, select the \"Browser\" flow"
-msgstr "レルムを選択し、Authenticationのリンクをクリックし、\"Browser\"フローを選択します。"
+msgid ""
+"Select a realm, click on `Authentication` link, select the `Browser` flow"
+msgstr "レルムを選択し、 `Authentication` のリンクをクリックし、 `Browser` フローを選択します。"
 
 #. type: Plain text
 msgid ""
@@ -143,8 +140,9 @@ msgstr ""
 "`WebAuthn Browser Forms` の `Actions` メニューを使用して、 `Add execution` をクリックします"
 
 #. type: Plain text
-msgid "Select `WebAuthn Authenticator` using the drop down and click on \"Save\""
-msgstr "ドロップダウンを使用して `WebAuthn Authenticator` を選択し、 \"Save\" をクリックします"
+msgid ""
+"Select `WebAuthn Authenticator` using the drop down and click on `Save`"
+msgstr "ドロップダウンを使用して `WebAuthn Authenticator` を選択し、 `Save` をクリックします"
 
 #. type: Plain text
 msgid "Set its Requirement to _Required_."
@@ -153,6 +151,10 @@ msgstr "Requirementを _Required_ に変更してください。"
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-required.png[]"
 msgstr "image:images/webauthn-browser-flow-required.png[]"
+
+#. type: Plain text
+msgid "In the `Bindings` menu, change the browser flow to `WebAuthn Browser`"
+msgstr "`Bindings` メニューで、ブラウザーフローを `WebAuthn Browser` に変更します"
 
 #. type: Plain text
 msgid ""
@@ -177,8 +179,8 @@ msgid ""
 msgstr "`WebAuthn Browser Forms` の `Actions` メニューを使用して、 `Add flow` をクリックします"
 
 #. type: Plain text
-msgid "Set the alias to \"Conditional 2FA\""
-msgstr "エイリアスを\"Conditional 2FA\"に設定します"
+msgid "Set the alias to \"Conditional 2FA\" and click on `Save`"
+msgstr "エイリアスを\"Conditional 2FA\"に設定し、 `Save` をクリックします"
 
 #. type: Plain text
 msgid "Set the Requirement of `Conditional 2FA` to _Conditional_"
@@ -191,9 +193,13 @@ msgstr "`Conditional 2FA` の `Actions` メニューを使用して、 `Add exec
 
 #. type: Plain text
 msgid ""
-"Select `Condition - User Configured` using the drop down and click on "
-"\"Save\""
-msgstr "ドロップダウンを使用して `Condition - User Configured` を選択し、\"Save\"をクリックします"
+"Select `Condition - User Configured` using the drop down and click on `Save`"
+msgstr "ドロップダウンを使用して `Condition - User Configured` を選択し、 `Save` をクリックします"
+
+#. type: Plain text
+msgid ""
+"Set the Requirement of `Condition - User Configured` execution to _Required_"
+msgstr "`Condition - User Configured` のRequirementを _Required_ に設定します"
 
 #. type: Plain text
 msgid "Set its Requirement to _Alternative_."
@@ -210,8 +216,8 @@ msgid ""
 msgstr "ユーザーが2番目の要素としてWebAuthnとOTPのどちらを使用するかを選択できるようにすることもできます。"
 
 #. type: Plain text
-msgid "Select `OTP Form` using the drop down and click on \"Save\""
-msgstr "ドロップダウンを使用して `OTP Form` を選択し、\"Save\" をクリックします"
+msgid "Select `OTP Form` using the drop down and click on `Save`"
+msgstr "ドロップダウンを使用して `OTP Form` を選択し、 `Save` をクリックします"
 
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-conditional-with-OTP.png[]"
@@ -224,27 +230,18 @@ msgstr "WebAuthnオーセンティケーターで認証する"
 
 #. type: Plain text
 msgid ""
-"After registering their WebAuthn authenticator, the user carries out the "
-"following operations :"
-msgstr "WebAuthnオーセンティケーターを登録した後、ユーザーは次の操作を実行します。"
-
-#. type: Plain text
-msgid "Open the login form."
-msgstr "ログインフォームを開きます。"
-
-#. type: Plain text
-msgid ""
-"Select the credential or credentials that {project_name} must accept for "
-"login. Then click `Save` and click `Login`."
+"After registering a WebAuthn authenticator, the user carries out the "
+"following operations assuming that authentication flow configuration above "
+"with the conditional subflow using `WebAuthn Authenticator` was used:"
 msgstr ""
-"{project_name}がログインにおいて受け入れる必要があるクレデンシャルを選択します。次に、 `Save` をクリックして `Login` "
-"をクリックします。"
+"`WebAuthn Authenticator` "
+"を用いた条件サブフローが使用された認証フロー設定の場合、WebAuthnオーセンティケーターの登録後、ユーザーは以下の操作を行います："
 
 #. type: Plain text
 msgid ""
-"The list of registered Webauthn Authenticators' labels appears. Click "
-"`Authenticate`."
-msgstr "登録済みのWebauthnオーセンティケーターのラベルのリストが表示されます。 `Authenticate` をクリックします。"
+"Open the login form. The user must authenticate with a username and "
+"password."
+msgstr "ログインフォームを開きます。ユーザーはユーザー名とパスワードで認証する必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -265,9 +262,9 @@ msgstr "クレデンシャルの管理"
 #. type: Plain text
 msgid ""
 "WebAuthn credentials are managed in a similar manner as other credentials, "
-"such as OTP, from the <<user-credentials, User credential management>>:"
+"such as OTP, from the <<_user-credentials, User credential management>>:"
 msgstr ""
-"WebAuthnクレデンシャルは、OTPなどの他のクレデンシャルと同様の方法で、<<user-credentials, "
+"WebAuthnクレデンシャルは、OTPなどの他のクレデンシャルと同様の方法で、<<_user-credentials, "
 "ユーザー・クレデンシャル管理>>から管理されます。"
 
 #. type: Plain text
@@ -317,10 +314,6 @@ msgstr "アイテムを設定し、 `Save` をクリックします。"
 #. type: Plain text
 msgid "The configurable items and their description follow."
 msgstr "設定可能な項目とその説明は次のとおりです。"
-
-#. type: Plain text
-msgid "Configuration|Description"
-msgstr "設定|説明"
 
 #. type: Plain text
 msgid "Relying Party Entity Name"
@@ -520,8 +513,17 @@ msgid "New user"
 msgstr "新規ユーザー"
 
 #. type: Plain text
-msgid "A new user carries out the following operations :"
-msgstr "新しいユーザーで次の操作を実行します。"
+msgid ""
+"If the `WebAuthn Register` required action is set as `Default Action` in a "
+"realm, new users are required to set up the WebAuthn security key after the "
+"first successful login. A new user carries out the following operations :"
+msgstr ""
+"レルムで `WebAuthn Register` 必須アクションが `Default Action` "
+"として設定された場合、新しいユーザーは最初のログイン成功時にWebAuthnセキュリティキーをセットアップすることが要求されます。新しいユーザーは以下の操作を実行します："
+
+#. type: Plain text
+msgid "Open the login form."
+msgstr "ログインフォームを開きます。"
 
 #. type: Plain text
 msgid "Click the `Register` link."
@@ -550,9 +552,12 @@ msgstr "既存のユーザー"
 
 #. type: Plain text
 msgid ""
-"When existing users try to log in, they are required to register their "
-"WebAuthn authenticator automatically :"
-msgstr "既存のユーザーがログインしようとすると、WebAuthnオーセンティケーターを自動的に登録する必要があります。"
+"If `WebAuthn Authenticator` is set up as required as shown in the first "
+"example, then when existing users try to log in, they are required to "
+"register their WebAuthn authenticator automatically :"
+msgstr ""
+"最初の例で示されたように、 `WebAuthn Authenticator` "
+"が必須として設定された場合、既存のユーザーがログインを試みた際もWebAuthnオーセンティケーターを登録することが自動的に要求されます："
 
 #. type: Plain text
 msgid "Fill in items, click `Save` and click `Login`."
@@ -564,39 +569,137 @@ msgid ""
 "authenticator."
 msgstr "ユーザーがログインしたら、WebAuthnオーセンティケーターを登録する必要があります。"
 
-#. type: Title =====
+#. type: Title ====
 #, no-wrap
-msgid "View Registered WebAuthn Authenticator"
-msgstr "登録済みのWebAuthnオーセンティケーターを表示"
+msgid "Passwordless WebAuthn together with Two-Factor"
+msgstr "パスワードレスWebAuthnと二要素認証の併用"
 
 #. type: Plain text
 msgid ""
-"A user carries out the following operations on the <<_account-service, `User"
-" Account Service`>> :"
-msgstr "ユーザーは<<_account-service, `User Account Service`>>で以下の操作を実行します。"
-
-#. type: Plain text
-msgid "View the `Account` page."
-msgstr "`Account` ページを表示します。"
-
-#. type: Title =====
-#, no-wrap
-msgid "Edit Registered WebAuthn Authenticator"
-msgstr "登録済みのWebAuthnオーセンティケーターを編集"
-
-#. type: Plain text
-msgid "A user can edit the following information :"
-msgstr "ユーザーは次の情報を編集できます。"
+"WebAuthn is often used for two-factor authentication, however it can be "
+"desired to use it also as first factor authentication. In this case, a user "
+"with `passwordless` WebAuthn credential will be able to authenticate to "
+"{project_name} without a password. {project_name} allows to use WebAuthn as "
+"both the passwordless and two-factor authentication mechanism in the context"
+" of a single realm and even in the context of a single authentication flow."
+msgstr ""
+"WebAuthnは二要素認証によく使用されますが、認証の第一要素として使用したい場合もあります。この場合、 `passwordless`  "
+"WebAuthnクレデンシャルを持つユーザーは {project_name} にパスワード無しで認証することが出来ます。 {project_name} "
+"は単一のレルムのコンテキスト、更には単一の認証フローのコンテキストでも、パスワードレスと二要素認証の両方でWebAuthnを使用することが出来ます。"
 
 #. type: Plain text
 msgid ""
-"Label (WebAuthn authenticator's label the user entered on registering it)"
-msgstr "ラベル（登録時にユーザーが入力したWebAuthnオーセンティケーターのラベル）"
+"Administrator may typically require that Security Keys registered by users "
+"for the WebAuthn passwordless authentication must meet different (usually "
+"stronger) requirements. For example, those security keys may require users "
+"to authenticate to that security key using a PIN, or the security key should"
+" be attested with stronger certificate authority."
+msgstr ""
+"管理者は一般に、WebAuthnパスワードレス認証にユーザーが登録したセキュリティキーに対して、異なる（通常より強力な）要件を満たすことを要求する場合があります。たとえば、それらのセキュリティキーは、ユーザーがそのセキュリティキーに対してPINを用いて認証することを要求したり、そのセキュリティキーが強力な認証局で構成証明されていることを要求する場合があります。"
 
 #. type: Plain text
-msgid "Edit the text in `Public Key Credential Label`."
-msgstr "`Public Key Credential Label` のテキストを編集します。"
+msgid ""
+"Because of this situation, {project_name} allows administrator to configure "
+"separate `WebAuthn Passwordless Policy`. There is a separate required action"
+" of type `Webauthn Register Passwordless` and separate authenticator of type"
+" `WebAuthn Passwordless Authenticator`."
+msgstr ""
+"このため、 {project_name} では管理者が 個別に `WebAuthn Passwordless Policy` を設定できます。個別の "
+"`Webauthn Register Passwordless` タイプの必須アクションや、 個別の `WebAuthn Passwordless "
+"Authenticator` タイプのオーセンティケーターを設定します。"
 
 #. type: Plain text
-msgid "Click `Save`."
-msgstr "`Save` をクリックします。"
+msgid ""
+"The setup procedure of WebAuthn passwordless support is the following :"
+msgstr "WebAuthnパスワードレス・サポートのセットアップ手順は次のとおりです。"
+
+#. type: Plain text
+msgid ""
+"Register new required action for WebAuthn passwordless support. Use the same"
+" steps as described <<_webauthn-register, above>> with the only difference, "
+"that you need to register the action called `Webauthn Register "
+"Passwordless`."
+msgstr ""
+"WebAuthnパスワードレスサポートの為の新しい必須アクションを登録します。 <<_webauthn-register, 上記>> "
+"と同じ手順を使用しますが、一点異なることとして、 `Webauthn Register Passwordless` "
+"というアクションを登録する必要があります。"
+
+#. type: Plain text
+msgid ""
+"Configure the policy. You can use same steps and configuration options as "
+"described <<_webauthn-policy, above>>, however you need to configure them in"
+" the admin console in the tab `WebAuthn Passwordless Policy`. You can "
+"configure this policy as you want, however typically the requirements for "
+"the security key will be stronger than for the two-factor policy. For "
+"example the `User Verification Requirement` can be set to `Required` when "
+"you configure the passwordless policy."
+msgstr ""
+"ポリシーを設定します。 <<_webauthn-policy, 上記>> と同じ手順と設定を使用できますが、管理コンソールの `WebAuthn "
+"Passwordless Policy` "
+"タブで設定する必要があります。このポリシーは必要に応じて設定できますが、一般にセキュリティキーに対する要件は二要素認証の場合のポリシーに比べて協力になるでしょう。たとえば、パスワードレスポリシーを設定する際は、`User"
+" Verification Requirement` を `Required` に設定出来ます。"
+
+#. type: Plain text
+msgid ""
+"Finally configure the authentication flow. Let's assume that we will use "
+"same flow called `WebAuthn Browser` as described <<_webauthn-authenticator-"
+"setup, above>>, but we will configure it as follows:"
+msgstr ""
+"最後に、認証フローを設定します。<<_webauthn-authenticator-setup, 上記>> で解説した `WebAuthn "
+"Browser` と同一のフローを使用すると仮定し、以下のように設定します："
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"** The `WebAuthn Browser Forms` subflow will contain `Username Form` as the first authenticator. Delete the default `Username Password Form`\n"
+"authenticator and add the `Username Form` authenticator instead. This setting means that the user will provide just his or her username as the first step.\n"
+msgstr ""
+"** `WebAuthn Browser Forms` サブフローは `Username Form` を第一のオーセンティケーターとして含みます。デフォルトの `Username Password Form` \n"
+"オーセンティケーターは削除し、 `Username Form` オーセンティケーターを代わりに追加します。 この設定はユーザーがユーザー名だけを最初のステップで提供することを意味します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"** There will be a required subflow, which can be named for example `Passwordless Or Two-factor` . This setting indicates that user can\n"
+"authenticate either with Passwordless WebAuthn credential or with Two-factor authentication.\n"
+msgstr ""
+"必須サブフローもあるべきで、たとえば `Passwordless Or Two-factor` と命名することが出来ます。この設定はユーザーが\n"
+"パスワードレスWebAuthnクレデンシャルでも、二要素認証のどちらでも認証出来ることを示します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"** Flow will contain `WebAuthn Passwordless Authenticator` as the first "
+"alternative.\n"
+msgstr "** フローは `WebAuthn Passwordless Authenticator` を第一の選択肢として含みます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"** The second alternative will be a subflow named for example `Password And Two-factor Webauthn`. This subflow will contain a `Password Form` and\n"
+"a `WebAuthn Authenticator`.\n"
+msgstr ""
+"** 第二の選択肢は、例えば `Password And Two-factor Webauthn` という命名をしたサブフローです。そこのサブフローは `Password Form` と\n"
+"`WebAuthn Authenticator` を含みます。\n"
+
+#. type: Plain text
+msgid "The final configuration of the flow will look like the following:"
+msgstr "フローの最終的な設定は、次のとおりです。"
+
+#. type: Plain text
+msgid "image:images/webauthn-passwordless-flow.png[]"
+msgstr "image:images/webauthn-passwordless-flow.png[]"
+
+#. type: Plain text
+msgid ""
+"You can now add `WebAuthn Register Passwordless` as the required action to "
+"some user, already known to {project_name}, to test this.  During the first "
+"authentication, the user will be still required to use the password and "
+"second-factor WebAuthn credential. However, once the user registers the "
+"credentials, that user will be able to choose during future authentications."
+" If he uses his or her WebAuthn Passwordless credential, he won't need to "
+"provide the password and second-factor WebAuthn credential at all."
+msgstr ""
+"これで、{project_name}に既に存在している任意のユーザーに必須アクションとして `WebAuthn Register "
+"Passwordless` を追加してテストすることが出来ます。 "
+"最初の認証では、ユーザーは依然としてパスワードと第二要素WebAuthnクレデンシャルを使用することが要求されます。しかしながら、一度ユーザーが資格情報を登録すれば、ユーザーは今後の認証において、選択することが出来ます。ユーザーがWebAuthnパスワードレスクレデンシャルを使用した場合、パスワードも、第二要素WebAuthnクレデンシャルも投入する必要はありません。"

--- a/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -235,7 +235,7 @@ msgid ""
 "with the conditional subflow using `WebAuthn Authenticator` was used:"
 msgstr ""
 "`WebAuthn Authenticator` "
-"を用いた条件サブフローが使用された認証フロー設定の場合、WebAuthnオーセンティケーターの登録後、ユーザーは以下の操作を行います："
+"を用いた条件サブフローが使用された認証フロー設定の場合、WebAuthnオーセンティケーターの登録後、ユーザーは以下の操作を行います。"
 
 #. type: Plain text
 msgid ""
@@ -519,7 +519,7 @@ msgid ""
 "first successful login. A new user carries out the following operations :"
 msgstr ""
 "レルムで `WebAuthn Register` 必須アクションが `Default Action` "
-"として設定された場合、新しいユーザーは最初のログイン成功時にWebAuthnセキュリティキーをセットアップすることが要求されます。新しいユーザーは以下の操作を実行します："
+"として設定された場合、新しいユーザーは最初のログイン成功時にWebAuthnセキュリティキーをセットアップすることが要求されます。新しいユーザーは以下の操作を実行します。"
 
 #. type: Plain text
 msgid "Open the login form."
@@ -557,7 +557,7 @@ msgid ""
 "register their WebAuthn authenticator automatically :"
 msgstr ""
 "最初の例で示されたように、 `WebAuthn Authenticator` "
-"が必須として設定された場合、既存のユーザーがログインを試みた際もWebAuthnオーセンティケーターを登録することが自動的に要求されます："
+"が必須として設定された場合、既存のユーザーがログインを試みた際もWebAuthnオーセンティケーターを登録することが自動的に要求されます。"
 
 #. type: Plain text
 msgid "Fill in items, click `Save` and click `Login`."
@@ -583,9 +583,8 @@ msgid ""
 "both the passwordless and two-factor authentication mechanism in the context"
 " of a single realm and even in the context of a single authentication flow."
 msgstr ""
-"WebAuthnは二要素認証によく使用されますが、認証の第一要素として使用したい場合もあります。この場合、 `passwordless`  "
-"WebAuthnクレデンシャルを持つユーザーは {project_name} にパスワード無しで認証することが出来ます。 {project_name} "
-"は単一のレルムのコンテキスト、更には単一の認証フローのコンテキストでも、パスワードレスと二要素認証の両方でWebAuthnを使用することが出来ます。"
+"WebAuthnは二要素認証によく使用されますが、認証の第一要素として使用したい場合もあります。この場合、 `passwordless` "
+"WebAuthnクレデンシャルを持つユーザーは{project_name}にパスワード無しで認証することが出来ます。{project_name}は単一のレルムのコンテキスト、更には単一の認証フローのコンテキストでも、パスワードレスと二要素認証の両方でWebAuthnを使用することができます。"
 
 #. type: Plain text
 msgid ""
@@ -604,8 +603,8 @@ msgid ""
 " of type `Webauthn Register Passwordless` and separate authenticator of type"
 " `WebAuthn Passwordless Authenticator`."
 msgstr ""
-"このため、 {project_name} では管理者が 個別に `WebAuthn Passwordless Policy` を設定できます。個別の "
-"`Webauthn Register Passwordless` タイプの必須アクションや、 個別の `WebAuthn Passwordless "
+"このため、{project_name}では管理者が個別に `WebAuthn Passwordless Policy` を設定できます。個別の "
+"`Webauthn Register Passwordless` タイプの必須アクションや、個別の `WebAuthn Passwordless "
 "Authenticator` タイプのオーセンティケーターを設定します。"
 
 #. type: Plain text
@@ -620,8 +619,8 @@ msgid ""
 "that you need to register the action called `Webauthn Register "
 "Passwordless`."
 msgstr ""
-"WebAuthnパスワードレスサポートの為の新しい必須アクションを登録します。 <<_webauthn-register, 上記>> "
-"と同じ手順を使用しますが、一点異なることとして、 `Webauthn Register Passwordless` "
+"WebAuthnパスワードレス・サポートの為の新しい必須アクションを登録します。<<_webauthn-register, "
+"上記>>と同じ手順を使用しますが、一点異なることとして、 `Webauthn Register Passwordless` "
 "というアクションを登録する必要があります。"
 
 #. type: Plain text
@@ -634,10 +633,10 @@ msgid ""
 "example the `User Verification Requirement` can be set to `Required` when "
 "you configure the passwordless policy."
 msgstr ""
-"ポリシーを設定します。 <<_webauthn-policy, 上記>> と同じ手順と設定を使用できますが、管理コンソールの `WebAuthn "
+"ポリシーを設定します。<<_webauthn-policy, 上記>>と同じ手順と設定を使用できますが、管理コンソールの `WebAuthn "
 "Passwordless Policy` "
-"タブで設定する必要があります。このポリシーは必要に応じて設定できますが、一般にセキュリティキーに対する要件は二要素認証の場合のポリシーに比べて協力になるでしょう。たとえば、パスワードレスポリシーを設定する際は、`User"
-" Verification Requirement` を `Required` に設定出来ます。"
+"タブで設定する必要があります。このポリシーは必要に応じて設定できますが、一般にセキュリティキーに対する要件は二要素認証の場合のポリシーに比べて強力になるでしょう。たとえば、パスワードレス・ポリシーを設定する際は、"
+" `User Verification Requirement` を `Required` に設定できます。"
 
 #. type: Plain text
 msgid ""
@@ -645,8 +644,8 @@ msgid ""
 "same flow called `WebAuthn Browser` as described <<_webauthn-authenticator-"
 "setup, above>>, but we will configure it as follows:"
 msgstr ""
-"最後に、認証フローを設定します。<<_webauthn-authenticator-setup, 上記>> で解説した `WebAuthn "
-"Browser` と同一のフローを使用すると仮定し、以下のように設定します："
+"最後に、認証フローを設定します。<<_webauthn-authenticator-setup, 上記>>で解説した `WebAuthn "
+"Browser` と同一のフローを使用すると仮定し、以下のように設定します。"
 
 #. type: Plain text
 #, no-wrap
@@ -655,7 +654,7 @@ msgid ""
 "authenticator and add the `Username Form` authenticator instead. This setting means that the user will provide just his or her username as the first step.\n"
 msgstr ""
 "** `WebAuthn Browser Forms` サブフローは `Username Form` を第一のオーセンティケーターとして含みます。デフォルトの `Username Password Form` \n"
-"オーセンティケーターは削除し、 `Username Form` オーセンティケーターを代わりに追加します。 この設定はユーザーがユーザー名だけを最初のステップで提供することを意味します。\n"
+"オーセンティケーターは削除し、 `Username Form` オーセンティケーターを代わりに追加します。この設定はユーザーがユーザー名だけを最初のステップで提供することを意味します。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -663,8 +662,8 @@ msgid ""
 "** There will be a required subflow, which can be named for example `Passwordless Or Two-factor` . This setting indicates that user can\n"
 "authenticate either with Passwordless WebAuthn credential or with Two-factor authentication.\n"
 msgstr ""
-"必須サブフローもあるべきで、たとえば `Passwordless Or Two-factor` と命名することが出来ます。この設定はユーザーが\n"
-"パスワードレスWebAuthnクレデンシャルでも、二要素認証のどちらでも認証出来ることを示します。\n"
+"必須サブフローもあるべきで、たとえば `Passwordless Or Two-factor` "
+"と命名することが出来ます。この設定はユーザーがパスワードレスWebAuthnクレデンシャルでも、二要素認証のどちらでも認証できることを示します。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -679,8 +678,8 @@ msgid ""
 "** The second alternative will be a subflow named for example `Password And Two-factor Webauthn`. This subflow will contain a `Password Form` and\n"
 "a `WebAuthn Authenticator`.\n"
 msgstr ""
-"** 第二の選択肢は、例えば `Password And Two-factor Webauthn` という命名をしたサブフローです。そこのサブフローは `Password Form` と\n"
-"`WebAuthn Authenticator` を含みます。\n"
+"** 第二の選択肢は、例えば `Password And Two-factor Webauthn` という命名をしたサブフローです。このサブフローは "
+"`Password Form` と `WebAuthn Authenticator` を含みます。\n"
 
 #. type: Plain text
 msgid "The final configuration of the flow will look like the following:"
@@ -701,5 +700,5 @@ msgid ""
 "provide the password and second-factor WebAuthn credential at all."
 msgstr ""
 "これで、{project_name}に既に存在している任意のユーザーに必須アクションとして `WebAuthn Register "
-"Passwordless` を追加してテストすることが出来ます。 "
-"最初の認証では、ユーザーは依然としてパスワードと第二要素WebAuthnクレデンシャルを使用することが要求されます。しかしながら、一度ユーザーが資格情報を登録すれば、ユーザーは今後の認証において、選択することが出来ます。ユーザーがWebAuthnパスワードレスクレデンシャルを使用した場合、パスワードも、第二要素WebAuthnクレデンシャルも投入する必要はありません。"
+"Passwordless` "
+"を追加してテストすることができます。最初の認証では、ユーザーは依然としてパスワードと第二要素WebAuthnクレデンシャルを使用することが要求されます。しかしながら、一度ユーザーがクレデンシャルを登録すれば、ユーザーは今後の認証において、選択することが出来ます。ユーザーがWebAuthnパスワードレス・クレデンシャルを使用した場合、パスワードも、第二要素WebAuthnクレデンシャルも投入する必要はありません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__webauthn
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
