### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po
@@ -4,15 +4,16 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
 # Shinsuke UEDA, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Shinsuke UEDA, 2017\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,29 +44,29 @@ msgstr "image:{project_images}/sessions.png[]"
 #. type: Plain text
 msgid ""
 "A list of clients is given and how many active sessions there currently are "
-"for that client. You can also logout all users in the realm by clicking the "
-"`Logout all` button on the right side of this list."
+"for that client. You can also log out all users in the realm by clicking the"
+" `Logout all` button on the right side of this list."
 msgstr ""
 "クライアントと、そのクライアントに現在アクティブなセッションの数が一覧表示されます。また、この一覧表示の右側にある `Logout all` "
 "ボタンをクリックして、レルム内のすべてのユーザーをログアウトすることもできます。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Logout All Limitations"
-msgstr "Logout allの制限事項"
+msgid "Limitations of the `Logout all` Operation"
+msgstr "`Logout all`の制限事項"
 
 #. type: Plain text
 msgid ""
 "Any SSO cookies set will now be invalid and clients that request "
 "authentication in active browser sessions will now have to re-login.  Only "
 "certain clients are notified of this logout event, specifically clients that"
-" are using the {project_name} OIDC client adapter. Other client types (i.e. "
-"SAML) will not receive a backchannel logout request."
+" are using the {project_name} OIDC client adapter. Other client types, such "
+"as SAML, will not receive a backchannel logout request."
 msgstr ""
 "すべてのSSO "
 "Cookieセットが無効になり、アクティブなブラウザー・セッションで認証を要求するクライアントは再ログインする必要があります。このログアウト・イベントは、特定のクライアント（特に、{project_name}"
 " "
-"OIDCクライアント・アダプターを使用しているクライアント）にのみ通知されます。他のクライアント・タイプ（SAML）はバックチャネル・ログアウト・リクエストを受信しません。"
+"OIDCクライアント・アダプターを使用しているクライアント）にのみ通知されます。SAMLのような他のクライアント・タイプはバックチャネル・ログアウト・リクエストを受信しません。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/administering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__administering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
