### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po
@@ -8,12 +8,13 @@
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -141,6 +142,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"If a user already has a password, it can be reset in the `Reset Password` "
+"section."
+msgstr "ユーザーがパスワードを既に持っている場合、 `Reset Password` セクションでリセットすることが出来ます。"
+
+#. type: Plain text
+msgid ""
 "Alternatively, if you have <<_email, email>> set up, you can send an email "
 "to the user that asks them to reset their password.  Choose `Update "
 "Password` from the `Reset Actions` list box and click `Send Email`. You can "
@@ -167,7 +174,7 @@ msgid ""
 "You cannot configure other types of credentials for a specific user within "
 "the Admin Console. This is the responsibility of the user.  You can only "
 "delete credentials for a user on the `Credentials` tab, for example if the "
-"user has lost his OTP device, or if a credential has been compromised."
+"user has lost an OTP device, or if a credential has been compromised."
 msgstr ""
 "管理コンソール内で特定のユーザーに他の種類のクレデンシャルを設定することはできません。これはユーザーの責任です。ユーザーがOTPデバイスを紛失した場合、またはクレデンシャルが侵害された場合は、"
 " `Credentials` タブでユーザーのクレデンシャルを削除だけできます。"
@@ -180,12 +187,11 @@ msgstr "OTPの作成"
 #. type: Plain text
 msgid ""
 "If OTP is conditional in your realm, the user will have to go to the User "
-"Account Management service to re-configure a new OTP generator. A user can "
-"set up any number of OTP credentials in this manner. If OTP is required, "
-"then the user will be asked to re-configure a new OTP generator when they "
-"log in."
+"Account Management service to re-configure a new OTP generator. If OTP is "
+"required, then the user will be asked to re-configure a new OTP generator "
+"when they log in."
 msgstr ""
-"レルムでOTPがconditionalである場合、ユーザーはユーザーアカウント管理サービスにアクセスして、新しいOTPジェネレーターを再設定する必要があります。ユーザーは、この方法で任意の数のOTPクレデンシャルを設定できます。OTPが必要な場合、ユーザーはログイン時に新しいOTPジェネレーターを再設定するよう求められます。"
+"レルムでOTPがconditionalである場合、ユーザーはユーザーアカウント管理サービスにアクセスして、新しいOTPジェネレーターを再設定する必要があります。OTPが必要な場合、ユーザーはログイン時に新しいOTPジェネレーターを再設定するよう求められます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/credentials.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__credentials
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
