### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po
@@ -6,12 +6,13 @@
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -52,60 +53,10 @@ msgid ""
 "set."
 msgstr "クライアントキー用のパスワードです。 `client-keystore` が設定されている場合、これは _REQUIRED_ です。"
 
-#. type: Plain text
-msgid ""
-"This should be set to __true__ if your application serves both a web "
-"application and web services (e.g. SOAP or REST).  It allows you to redirect"
-" unauthenticated users of the web application to the Keycloak login page, "
-"but send an HTTP `401` status code to unauthenticated SOAP or REST clients "
-"instead as they would not understand a redirect to the login page.  Keycloak"
-" auto-detects SOAP or REST clients based on typical headers like `X"
-"-Requested-With`, `SOAPAction` or `Accept`.  The default value is _false_."
-msgstr ""
-"アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
-"に設定する必要があります。 "
-"Webアプリケーションの未認証のユーザーをKeycloakのログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPクライアントまたはRESTクライアントにはHTTPの"
-" `401` ステータスコードを送信します。Keycloakは、 `X-Requested-With` 、 `SOAPAction` 、 "
-"`Accept` のような典型的なヘッダーに基づいて、SOAPクライアントまたはRESTクライアントを自動検出します。デフォルト値は _false_ "
-"です。"
-
 #. type: Labeled list
 #, no-wrap
-msgid "resource"
-msgstr "resource"
-
-#. type: Plain text
-msgid ""
-"If the {project_name} server requires HTTPS and this config option is set to"
-" `true` you do not have to specify a truststore.  This setting should only "
-"be used during development and *never* in production as it will disable "
-"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
-" `false`."
-msgstr ""
-"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
-"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、プロダクション環境では"
-" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "truststore"
-msgstr "truststore"
-
-#. type: Plain text
-msgid ""
-"Password for the truststore.  This is _REQUIRED_ if `truststore` is set and "
-"the truststore requires a password."
-msgstr ""
-"トラストストアのパスワードです。これは _REQUIRED_ で、 `truststore` を設定すると、トラストストアはパスワードを必要とします。"
-
-#. type: Plain text
-msgid ""
-"This is the file path to a keystore file.  This keystore contains client "
-"certificate for two-way SSL when the adapter makes HTTPS requests to the "
-"{project_name} server.  This is _OPTIONAL_."
-msgstr ""
-"キーストア・ファイルへのファイルパスです。このキーストアには、アダプターが{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライアント証明書を含めます。これは"
-" _OPTIONAL_ です。"
+msgid "disable-trust-manager"
+msgstr "disable-trust-manager"
 
 #. type: Title ====
 #, no-wrap
@@ -228,6 +179,11 @@ msgstr "realm"
 #. type: Plain text
 msgid "Name of the realm.  This is _REQUIRED._"
 msgstr "レルムの名前。 これは _REQUIRED_ です。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "resource"
+msgstr "resource"
 
 #. type: Plain text
 msgid ""
@@ -420,6 +376,23 @@ msgstr ""
 msgid "autodetect-bearer-only"
 msgstr "autodetect-bearer-only"
 
+#. type: Plain text
+msgid ""
+"This should be set to __true__ if your application serves both a web "
+"application and web services (e.g. SOAP or REST).  It allows you to redirect"
+" unauthenticated users of the web application to the Keycloak login page, "
+"but send an HTTP `401` status code to unauthenticated SOAP or REST clients "
+"instead as they would not understand a redirect to the login page.  Keycloak"
+" auto-detects SOAP or REST clients based on typical headers like `X"
+"-Requested-With`, `SOAPAction` or `Accept`.  The default value is _false_."
+msgstr ""
+"アプリケーションがWebアプリケーションとWebサービス（SOAPやRESTなど）の両方を提供する場合は、これを __true__ "
+"に設定する必要があります。 "
+"Webアプリケーションの未認証のユーザーをKeycloakのログインページにリダイレクトできますが、ログインページへのリダイレクトを理解できない未認証のSOAPクライアントまたはRESTクライアントにはHTTPの"
+" `401` ステータスコードを送信します。Keycloakは、 `X-Requested-With` 、 `SOAPAction` 、 "
+"`Accept` のような典型的なヘッダーに基づいて、SOAPクライアントまたはRESTクライアントを自動検出します。デフォルト値は _false_ "
+"です。"
+
 #. type: Labeled list
 #, no-wrap
 msgid "enable-basic-auth"
@@ -468,18 +441,23 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Adapters will make separate HTTP invocations to the {project_name} server to"
-" turn an access code into an access token.  This config option defines how "
-"many connections to the {project_name} server should be pooled.  This is "
-"_OPTIONAL_.  The default value is `20`."
+"This config option defines how many connections to the {project_name} server"
+" should be pooled.  This is _OPTIONAL_.  The default value is `20`."
 msgstr ""
-"アダプターは、アクセスコードをアクセストークンに変換するために、{project_name}サーバーに別のHTTP呼び出しを行います。この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。これは"
-" _OPTIONAL_ です。デフォルトは `20` です。"
+"この設定オプションは、{project_name}サーバーにプールすべき接続数を定義します。これは _OPTIONAL_ です。デフォルトは `20` "
+"です。"
 
-#. type: Labeled list
-#, no-wrap
-msgid "disable-trust-manager"
-msgstr "disable-trust-manager"
+#. type: Plain text
+msgid ""
+"If the {project_name} server requires HTTPS and this config option is set to"
+" `true` you do not have to specify a truststore.  This setting should only "
+"be used during development and *never* in production as it will disable "
+"verification of SSL certificates.  This is _OPTIONAL_.  The default value is"
+" `false`."
+msgstr ""
+"{project_name}サーバーがHTTPSを必要とし、この設定オプションを `true` "
+"に設定する場合は、トラストストアを指定する必要はありません。この設定は、SSL証明書の検証を無効とするため、開発時にのみ使用すべきで、プロダクション環境では"
+" *決して使用してはいけません* 。これは _OPTIONAL_ です。デフォルトは `false` です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -508,6 +486,11 @@ msgstr "proxy-url"
 msgid "The URL for the HTTP proxy if one is used."
 msgstr "HTTPプロキシーを使用する場合はそのURLを設定します。"
 
+#. type: Labeled list
+#, no-wrap
+msgid "truststore"
+msgstr "truststore"
+
 #. type: Plain text
 msgid ""
 "The value is the file path to a truststore file.  If you prefix the path "
@@ -530,6 +513,22 @@ msgstr ""
 #, no-wrap
 msgid "truststore-password"
 msgstr "truststore-password"
+
+#. type: Plain text
+msgid ""
+"Password for the truststore.  This is _REQUIRED_ if `truststore` is set and "
+"the truststore requires a password."
+msgstr ""
+"トラストストアのパスワードです。これは _REQUIRED_ で、 `truststore` を設定すると、トラストストアはパスワードを必要とします。"
+
+#. type: Plain text
+msgid ""
+"This is the file path to a keystore file.  This keystore contains client "
+"certificate for two-way SSL when the adapter makes HTTPS requests to the "
+"{project_name} server.  This is _OPTIONAL_."
+msgstr ""
+"キーストア・ファイルへのファイルパスです。このキーストアには、アダプターが{project_name}サーバーにHTTPSリクエストを行う際の、双方向SSLのためのクライアント証明書を含めます。これは"
+" _OPTIONAL_ です。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/java-adapter-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__java-adapter-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
