### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po
@@ -7,12 +7,13 @@
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,41 +21,19 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-#, no-wrap
-msgid "*Decision Strategy*\n"
-msgstr "*Decision Strategy*\n"
-
-#. type: Block title
+#. type: Title =
 #, no-wrap
 msgid "Enabling Authorization Services"
 msgstr "認可サービスの有効化"
 
 #. type: Plain text
 msgid ""
-"(default mode) Requests are denied by default even when there is no policy "
-"associated with a given resource."
-msgstr "（デフォルトモード）特定のリソースに関連付けられたポリシーがない場合でも、デフォルトでリクエストは拒否されます。"
-
-#. type: Plain text
-msgid ""
-"Requests are allowed even when there is no policy associated with a given "
-"resource."
-msgstr "特定のリソースに関連付けられたポリシーがない場合でも、リクエストは許可されます。"
-
-#. type: Plain text
-#, no-wrap
-msgid "*Resource*\n"
-msgstr "*Resource*\n"
-
-#. type: Plain text
-msgid ""
 "To turn your OIDC Client Application into a resource server and enable fine-"
-"grained authorization, click the *Authorization Enabled* switch to *ON* and "
-"click *Save*."
+"grained authorization, select *Access type* *confidential* and click the "
+"*Authorization Enabled* switch to *ON* then click *Save*."
 msgstr ""
-"OIDCクライアント・アプリケーションをリソースサーバーに変えて、きめ細かい認可を有効にするには、 *Authorization Enabled* を "
-"*ON* にして *Save* をクリックします。"
+"OIDCクライアント・アプリケーションをリソースサーバーに仕立て、きめ細かい認可を有効にするには、*Access type* を "
+"*confidential* 、 *Authorization Enabled* を *ON* にして *Save* をクリックします。"
 
 #. type: Plain text
 msgid ""
@@ -105,6 +84,11 @@ msgid ""
 "see the xref:resource_server_settings[Resource Server Settings] section."
 msgstr ""
 "リソースサーバーの一般設定。このページの詳細については、xref:resource_server_settings[リソースサーバーの設定]のセクションを参照してください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Resource*\n"
+msgstr "*Resource*\n"
 
 #. type: Plain text
 msgid ""
@@ -195,9 +179,21 @@ msgid "** *Enforcing*\n"
 msgstr "** *Enforcing*\n"
 
 #. type: Plain text
+msgid ""
+"(default mode) Requests are denied by default even when there is no policy "
+"associated with a given resource."
+msgstr "（デフォルトモード）特定のリソースに関連付けられたポリシーがない場合でも、デフォルトでリクエストは拒否されます。"
+
+#. type: Plain text
 #, no-wrap
 msgid "** *Permissive*\n"
 msgstr "** *Permissive*\n"
+
+#. type: Plain text
+msgid ""
+"Requests are allowed even when there is no policy associated with a given "
+"resource."
+msgstr "特定のリソースに関連付けられたポリシーがない場合でも、リクエストは許可されます。"
 
 #. type: Plain text
 #, no-wrap
@@ -208,6 +204,11 @@ msgstr "** *Disabled*\n"
 msgid ""
 "Disables the evaluation of all policies and allows access to all resources."
 msgstr "すべてのポリシーの評価を無効にし、すべてのリソースへのアクセスを許可します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Decision Strategy*\n"
+msgstr "*Decision Strategy*\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/resource-server-enable-authorization.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__resource-server-enable-authorization
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
