### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -5,14 +5,15 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -52,17 +53,25 @@ msgid "Let's walk through each of the items on this page."
 msgstr "このページの各項目を見てみましょう。"
 
 #. type: Plain text
+msgid "Default Signature Algorithm"
+msgstr "デフォルトの署名アルゴリズム"
+
+#. type: Plain text
+msgid "The default algorithm that is used to assign tokens for this realm."
+msgstr "このレルムでトークンの割り当てに使用されるデフォルトのアルゴリズム。"
+
+#. type: Plain text
 msgid "Revoke Refresh Token"
 msgstr "Revoke Refresh Token"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"For OIDC clients that are doing the refresh token flow, this flag, if on, will revoke that refresh token and issue another with the request that the client has to use.\n"
-" This basically means that refresh tokens have a one time use.\n"
+"For OIDC clients that are doing the refresh token flow, this flag, if on, "
+"will revoke that refresh token and issue another token with the request that"
+" the client has to use. The result is that each refresh token is used only "
+"once."
 msgstr ""
-"リフレッシュ・トークン・フローを実行しているOIDCクライアントの場合、このフラグをオンにすると、クライアントが使用しなければならないリクエストでそのリフレッシュ・トークンを取り消し、別のリフレッシュ・トークンを発行します。\n"
-"これは、基本的にリフレッシュ・トークンが1回限りの使用となることを意味します。\n"
+"リフレッシュ・トークン・フローを実行しているOIDCクライアントの場合、このフラグをオンにすると、クライアントが使用しなければならないリクエストでそのリフレッシュ・トークンを取り消し、別のリフレッシュ・トークンを発行します。結果、各リフレッシュ・トークンは一回限りの使用となります。"
 
 #. type: Plain text
 msgid "SSO Session Idle"
@@ -71,25 +80,23 @@ msgstr "SSO Session Idle"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"Also pertains to OIDC clients.  If the user is not active for longer than this timeout, the user session will be invalidated.  How is idle time checked?\n"
-"A client requesting authentication will bump the idle timeout.  Refresh token requests will also bump the idle timeout.\n"
-"There is a small window of time that is always added to the idle timeout before the session is actually invalidated (See note below).\n"
+"Also pertains to OIDC clients.  If the user is not active for longer than this timeout, the user session will be invalidated.  The idle timeout is reset by a client requesting authentication or by a refresh token request.\n"
+"There is a small window of time that is always added to the idle timeout before the session  invalidation takes effect. See the note below.\n"
 msgstr ""
-"OIDCクライアントにも関係します。ユーザーがこのタイムアウトよりも長くアクティブでない場合、ユーザー・セッションは無効になります。どのようにアイドル時間はチェックされるでしょうか？\n"
-"認証を要求するクライアントはアイドル・タイムアウトになります。リフレッシュトークン・リクエストもアイドル・タイムアウトになります。\n"
-"セッションが実際に無効になる前にアイドル・タイムアウトに常に追加される小さなウィンドウがあります（下記の注釈を参照）。\n"
+"OIDCクライアントにも関係します。ユーザーがこのタイムアウトよりも長くアクティブでない場合、ユーザー・セッションは無効になります。アイドル・タイムアウトはクライアントが認証を要求するか、リフレッシュ・トークンを要求することでリセットされます。\n"
+"セッションが無効になる前にアイドル・タイムアウトに常に追加される小さなウィンドウがあります（下記の注釈を参照）。\n"
 
 #. type: Plain text
 msgid "SSO Session Max"
 msgstr "SSO Session Max"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Maximum time before a user session is expired and invalidated.  This is a hard number and time.  It controls the maximum time\n"
-" a user session can remain active, regardless of activity.\n"
+"Maximum time before a user session is expired and invalidated. This option "
+"controls the maximum time that a user session can remain active, regardless "
+"of user activity."
 msgstr ""
-"ユーザー・セッションが期限切れで無効になるまでの最大時間。これは具体的な数字と時間です。最大時間を制御します。アクティビティに関係なく、ユーザー・セッションがアクティブのままにできる最大時間を制御します。\n"
+"ユーザー・セッションが期限切れで無効になるまでの最大時間。このオプションはユーザーのアクティビティに関係なく、ユーザー・セッションがアクティブのままにできる最大時間を制御します。"
 
 #. type: Plain text
 msgid "SSO Session Idle Remember Me"
@@ -98,9 +105,9 @@ msgstr "SSO Session Idle Remember Me"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"Same as the standard SSO Session Idle configuration but specific to logins with remember me enabled. It allows for the specification of longer\n"
-" session idle timeouts when remember me is selected during the login process. It is an optional configuration and if not set to a value\n"
-" bigger than 0 it uses the same idle timeout set in the SSO Session Idle configuration.\n"
+"Same as the standard SSO Session Idle configuration but specific to logins with Remember Me enabled. It allows for the specification of longer\n"
+" session idle timeouts when Remember Me is selected during the login process. It is an optional configuration and if not set to a value\n"
+"greater than 0 it uses the same idle timeout as set in the SSO Session Idle configuration.\n"
 msgstr ""
 "標準のSSOセッション・アイドル設定と同じですが、リメンバーミーを有効にしたログインに固有の設定です。ログイン処理中にリメンバーミーが選択されている場合は、より長いセッション・アイドル・タイムアウトを指定できます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
 " Session Idleで設定されているものと同じアイドル・タイムアウトが使用されます。\n"
@@ -112,9 +119,9 @@ msgstr "SSO Session Max Remember Me"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"Same as the standard SSO Session Max but specific to logins with remember me enabled. It allows for the specification of longer lived\n"
-" sessions when remember me is selected during the login process. It is an optional configuration and if not set to a value bigger than 0\n"
-" it uses the same session lifespan set in the SSO Session Max configuration.\n"
+"Same as the standard SSO Session Max but specific to logins with Remember Me enabled. It allows for the specification of longer lived\n"
+" sessions when Remember Me is selected during the login process. It is an optional configuration and if not set to a value greater than 0\n"
+" it uses the same session lifespan as set in the SSO Session Max configuration.\n"
 msgstr ""
 "標準のSSO Session "
 "Maxの設定と同じですが、リメンバーミーの有効化とともにログインに固有の設定です。ログイン処理中にリメンバーミーが選択されている場合は、より長い存続期間のセッションを指定できます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
@@ -128,10 +135,10 @@ msgstr "Offline Session Idle"
 #, no-wrap
 msgid ""
 "For <<_offline-access, offline access>>, this is the time the session is allowed to remain idle before the offline token is revoked.\n"
-"There is a small window of time that is always added to the idle timeout before the session is actually invalidated (See note below).\n"
+"There is a small window of time that is always added to the idle timeout before the session  invalidation takes effect. See the note below.\n"
 msgstr ""
 "<<_offline-access, "
-"オフライン・アクセス>>では、これはオフライントークンが取り消される前にセッションがアイドル状態を維持できる時間です。セッションが実際に無効になる前に、アイドル・タイムアウトに常に追加されるわずかな時間のウインドウがあります（下記の注意を参照）。\n"
+"オフライン・アクセス>>では、これはオフライントークンが取り消される前にセッションがアイドル状態を維持できる時間です。セッションが無効になる前に、アイドル・タイムアウトに常に追加されるわずかな時間のウインドウがあります（下記の注意を参照）。\n"
 
 #. type: Plain text
 msgid "Offline Session Max Limited"
@@ -141,10 +148,10 @@ msgstr "Offline Session Max Limited"
 msgid ""
 "For <<_offline-access, offline access>>, if this flag is on, Offline Session"
 " Max is enabled to control the maximum time the offline token can remain "
-"active, regardless of activity."
+"active, regardless of user activity."
 msgstr ""
 "<<_offline-access, オフライン・アクセス>>では、このフラグがオンの場合、Offline Session "
-"Maxを有効にして、アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。"
+"Maxを有効にして、ユーザー・アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。"
 
 #. type: Plain text
 msgid "Offline Session Max"
@@ -153,12 +160,11 @@ msgstr "Offline Session Max"
 #. type: Plain text
 msgid ""
 "For <<_offline-access, offline access>>, this is the maximum time before the"
-" corresponding offline token is revoked. This is a hard number and time. It "
-"controls the maximum time the offline token can remain active, regardless of"
-" activity."
+" corresponding offline token is revoked.  This option controls the maximum "
+"time the offline token can remain active, regardless of user activity."
 msgstr ""
 "<<_offline-access, "
-"オフライン・アクセス>>では、これは対応するオフライントークンが取り消されるまでの最大時間です。これは具体的な数字と時間です。アクティビティーに関係なく、オフライントークンがアクティブのままになる最大時間を制御します。"
+"オフライン・アクセス>>では、これは対応するオフライントークンが取り消されるまでの最大時間です。このオプションはユーザー・アクティビティーに関係なく、オフライントークンがアクティブのままになる最大時間を制御します。"
 
 #. type: Plain text
 msgid "Access Token Lifespan"
@@ -240,13 +246,13 @@ msgstr "Override User-Initiated Action Lifespan"
 
 #. type: Plain text
 msgid ""
-"Permits the possibility of having independent timeouts per operation (e.g. "
-"e-mail verification, forgot password, user actions and Identity Provider "
-"E-mail Verification). This field is non mandatory and if nothing is "
-"specified it defaults to the value configured at _User-Initiated Action "
+"Permits the possibility of having independent timeouts per operation (for "
+"example, e-mail verification, forgot password, user actions and Identity "
+"Provider E-mail Verification). This field is optional. If nothing is "
+"specified, it defaults to the value configured at _User-Initiated Action "
 "Lifespan_."
 msgstr ""
-"操作ごとに独立したタイムアウトがある可能性があります（電子メールの確認、パスワード忘れ、ユーザーの操作、アイデンティティー・プロバイダーの電子メールの確認など）。このフィールドは必須ではなく、未指定の場合、"
+"操作ごとに独立したタイムアウトがある可能性があります（たとえば、電子メールの確認、パスワード忘れ、ユーザーの操作、アイデンティティー・プロバイダーの電子メールの確認など）。このフィールドはオプションです。未指定の場合、"
 " _User-Initiated Action Lifespan_ で設定された値がデフォルトになります。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__timeouts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
