### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -4,21 +4,32 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Signature Algorithm"
+msgstr "Signature Algorithm"
+
+#. type: Plain text
+#, no-wrap
+msgid "SAML Signature Key Name"
+msgstr "SAML Signature Key Name"
 
 #. type: Block title
 #, no-wrap
@@ -116,6 +127,32 @@ msgstr ""
 "format:persistent` です。"
 
 #. type: Plain text
+msgid "Principal Type"
+msgstr "Principal Type"
+
+#. type: Plain text
+msgid ""
+"Specifies which part of the SAML assertion will be used to identify and "
+"track external user identities. Can be either Subject NameID or SAML "
+"attribute (either by name or by friendly name)."
+msgstr ""
+"SAMLアサーションのどの箇所が外部ユーザーアイデンティティを一意に特定しトラックするのに使用されるかを示します。Subject NameID、SAML"
+" attributeのいずれか（名前もしくはフレンドリ名）です。"
+
+#. type: Plain text
+msgid "Principal Attribute"
+msgstr "Principal Attribute"
+
+#. type: Plain text
+msgid ""
+"If Principal is set to either \"Attribute [Name]\" or \"Attribute [Friendly "
+"Name]\", this field will specify the name or the friendly name of the "
+"identifying attribute, respectively."
+msgstr ""
+"プリンシパルが\"Attribute [Name]\"、もしくは\"Attribute [Friendly "
+"Name]\"に設定された場合、このフィールドには対応する識別する属性の名前もしくはフレンドリー名を指定します。"
+
+#. type: Plain text
 msgid "HTTP-POST Binding Response"
 msgstr "HTTP-POST Binding Response"
 
@@ -151,21 +188,11 @@ msgid ""
 "external SAML IDP."
 msgstr "trueの場合、レルムの鍵ペアを使用して、外部SAML IDPに送信されたリクエストに署名します。"
 
-#. type: Labeled list
-#, no-wrap
-msgid "Signature Algorithm"
-msgstr "Signature Algorithm"
-
 #. type: Plain text
 msgid ""
 "If `Want AuthnRequests Signed` is on, then you can also pick the signature "
 "algorithm to use."
 msgstr "`Want AuthnRequests Signed` がonの場合、使用する署名アルゴリズムを選択することもできます。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "SAML Signature Key Name"
-msgstr "SAML Signature Key Name"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -136,8 +136,8 @@ msgid ""
 "track external user identities. Can be either Subject NameID or SAML "
 "attribute (either by name or by friendly name)."
 msgstr ""
-"SAMLアサーションのどの箇所が外部ユーザーアイデンティティを一意に特定しトラックするのに使用されるかを示します。Subject NameID、SAML"
-" attributeのいずれか（名前もしくはフレンドリ名）です。"
+"SAMLアサーションのどの部分を外部ユーザー・アイデンティティを一意に特定しトラックするのに使用するかを指定します。Subject "
+"NameID、SAML attributeのいずれか（名前もしくはフレンドリー名）です。"
 
 #. type: Plain text
 msgid "Principal Attribute"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
