### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/8_0_1.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/8_0_1.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/8_0_1.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,8 +36,8 @@ msgid ""
 "7. If you are using Keycloak 7.0.0, 7.0.1 or 8.0.0 in production we strongly"
 " suggest that you upgrade immediately."
 msgstr ""
-"このリリースではKeycloak 7からのLDAPにおける致命的な脆弱性を修正しました。Keycloak 7.0.0、もしくは "
-"7.0.1、8.0.0を商用で利用している場合は、即座にアップグレードすることを強く推奨します。"
+"このリリースではKeycloak 7からのLDAPにおける致命的な脆弱性を修正しました。Keycloak "
+"7.0.0、もしくは7.0.1、8.0.0をプロダクション環境で利用している場合は、すぐにアップグレードすることを強く推奨します。"
 
 #. type: Title ==
 #, no-wrap
@@ -49,5 +49,5 @@ msgid ""
 "Upgrade to WildFly 18.0.1.Final which includes updates to a number of CVEs "
 "in third-party libraries."
 msgstr ""
-"WildFly 18.0.1.Finalにアップグレードしました。WildFly "
-"18.0.1.Finalには、サードパーティーライブラリにおけるいくつかのCVEに対する更新が含まれています。"
+"WildFly "
+"18.0.1.Finalにアップグレードしました。これにはサードパーティー・ライブラリーにおけるいくつかのCVEに対する更新が含まれています。"

--- a/i18n/po/ja_JP/release_notes/topics/8_0_1.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/8_0_1.ja_JP.po
@@ -1,0 +1,53 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Highlights"
+msgstr "ハイライト"
+
+#. type: Title ==
+#, no-wrap
+msgid "LDAP Issue"
+msgstr "LDAPの課題"
+
+#. type: Plain text
+msgid ""
+"This release fixes a critical vulnerability in LDAP introduced in Keycloak "
+"7. If you are using Keycloak 7.0.0, 7.0.1 or 8.0.0 in production we strongly"
+" suggest that you upgrade immediately."
+msgstr ""
+"このリリースではKeycloak 7からのLDAPにおける致命的な脆弱性を修正しました。Keycloak 7.0.0、もしくは "
+"7.0.1、8.0.0を商用で利用している場合は、即座にアップグレードすることを強く推奨します。"
+
+#. type: Title ==
+#, no-wrap
+msgid "WildFly 18.0.1.Final"
+msgstr "WildFly 18.0.1.Final"
+
+#. type: Plain text
+msgid ""
+"Upgrade to WildFly 18.0.1.Final which includes updates to a number of CVEs "
+"in third-party libraries."
+msgstr ""
+"WildFly 18.0.1.Finalにアップグレードしました。WildFly "
+"18.0.1.Finalには、サードパーティーライブラリにおけるいくつかのCVEに対する更新が含まれています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/8_0_1.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__8_0_1
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
