### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,11 +38,23 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "If you want to enable authentication and encryption for clustering "
-"communication see link:https://access.redhat.com/documentation/en-"
-"us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/configuring_high_availability#securing_cluster[Securing"
-" a Cluster] in the _JBoss EAP Configuration Guide_."
+"communication, see link:https://access.redhat.com/documentation/en-"
+"us/red_hat_jboss_enterprise_application_platform/{appserver_version}/html-"
+"single/configuration_guide/configuring_high_availability#securing_cluster[Securing"
+" a Cluster] in the _{appserver_name} Configuration Guide_."
 msgstr ""
-"クラスタリング通信の認証と暗号化を有効にする場合は、 _JBoss EAP Configuration Guide_  "
-"のlink:https://access.redhat.com/documentation/en-"
-"us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/configuring_high_availability#securing_cluster[Securing"
-" a Cluster]を参照してください。"
+"クラスタリング通信の認証と暗号化を有効にする場合は、 _{appserver_name} Configuration Guide_ の "
+"link:https://access.redhat.com/documentation/en-"
+"us/red_hat_jboss_enterprise_application_platform/{appserver_version}/html-"
+"single/configuration_guide/configuring_high_availability#securing_cluster[Securing"
+" a Cluster] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"If you want to enable authentication and encryption for clustering "
+"communication, see the 'High Availability Guide' in the "
+"link:{appserver_doc_base_url}/High_Availability_Guide.html[WildFly "
+"documentation]."
+msgstr ""
+"クラスタリング通信の認証と暗号化を有効にする場合は、link:{appserver_doc_base_url}/High_Availability_Guide.html[WildFly"
+" documentation]にある'High Availability Guide'を参照してください。"

--- a/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,5 +56,6 @@ msgid ""
 "link:{appserver_doc_base_url}/High_Availability_Guide.html[WildFly "
 "documentation]."
 msgstr ""
-"クラスタリング通信の認証と暗号化を有効にする場合は、link:{appserver_doc_base_url}/High_Availability_Guide.html[WildFly"
-" documentation]にある'High Availability Guide'を参照してください。"
+"クラスタリング通信の認証と暗号化を有効にする場合は、 "
+"link:{appserver_doc_base_url}/High_Availability_Guide.html[WildFly "
+"documentation] にある'High Availability Guide'を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__securing-cluster-comm
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
