### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title ===
 #, no-wrap
 msgid "Password Policies"
 msgstr "パスワード・ポリシー"
@@ -128,7 +128,7 @@ msgstr "Hashing Iterations"
 #. type: Plain text
 msgid ""
 "This value specifies the number of times a password will be hashed before it"
-" is stored or verified. The default value is 20,000.  This hashing is done "
+" is stored or verified. The default value is 27,500.  This hashing is done "
 "in the rare case that a hacker gets access to your password database. Once "
 "they have access to the database, they can reverse engineer user passwords."
 "  The industry recommended value for this parameter changes every year as "
@@ -137,7 +137,7 @@ msgid ""
 "important to you: performance or protecting your passwords stores.  There "
 "may be more cost effective ways of protecting your password stores."
 msgstr ""
-"この値は、パスワードが保存または検証される前にハッシュされる回数を指定します。デフォルト値は20,000です。このハッシングは、ハッカーがパスワード・データベースにアクセスするまれなケースで行われます。データベースにアクセスすると、ユーザーのパスワードをリバース・エンジニアリングすることができます。このパラメーターの業界推奨値は、CPUパワーが向上するにつれて毎年変化します。ハッシュ反復の値が高いほど、ハッシュに必要なCPUパワーが増え、パフォーマンスに影響を与える可能性があります。パフォーマンスとパスワードストアの保護のどちらを重要視するかは、要件により異なります。もしくは、パスワードストアの保護よりも、費用対効果の高い方法があるかもしれません。"
+"この値は、パスワードが保存または検証される前にハッシュされる回数を指定します。デフォルト値は27,500です。このハッシングは、ハッカーがパスワード・データベースにアクセスするまれなケースで行われます。データベースにアクセスすると、ユーザーのパスワードをリバース・エンジニアリングすることができます。このパラメーターの業界推奨値は、CPUパワーが向上するにつれて毎年変化します。ハッシュ反復の値が高いほど、ハッシュに必要なCPUパワーが増え、パフォーマンスに影響を与える可能性があります。パフォーマンスとパスワードストアの保護のどちらを重要視するかは、要件により異なります。もしくは、パスワードストアの保護よりも、費用対効果の高い方法があるかもしれません。"
 
 #. type: Labeled list
 #, no-wrap
@@ -231,20 +231,21 @@ msgstr "パスワード・ブラックリスト"
 
 #. type: Plain text
 msgid ""
-"This policy checks if a given password is contained in a blacklist file, "
-"which is potentially a very large file.  Password blacklists are UTF-8 "
-"plain-text files with Unix line endings where every line represents a "
-"blacklisted password.  The file name of the blacklist file must be provided "
-"as the password policy value, e.g. "
+"This policy checks if a given password (converted to lowercase) is contained"
+" in a blacklist file, which is potentially a very large file.  Password "
+"blacklists are UTF-8 plain-text files with Unix line endings where every "
+"line represents a blacklisted password.  All passwords in the blacklist must"
+" be lowercased to facilitate case-insensitive comparison.  The file name of "
+"the blacklist file must be provided as the password policy value, e.g. "
 "`10_million_password_list_top_1000000.txt`.  Blacklist files are resolved "
 "against `${jboss.server.data.dir}/password-blacklists/` by default.  This "
 "path can be customized via the `keycloak.password.blacklists.path` system "
 "property, or the `blacklistsPath` property of the `passwordBlacklist` policy"
 " SPI configuration."
 msgstr ""
-"このポリシーは、特定のパスワードがブラックリスト・ファイル（非常に大きなファイルになる可能性があります）に含まれているかどうかをチェックします。パスワード"
+"このポリシーは、与えられたパスワード（小文字に変換されます）がブラックリスト・ファイル（非常に大きなファイルになる可能性があります）に含まれているかどうかをチェックします。パスワード"
 "・ブラックリストはUnixの改行コードを持つUTF-"
-"8プレーンテキスト・ファイルで、各行はブラックリストに載っているパスワードを表します。ブラックリスト・ファイルのファイル名は、パスワード・ポリシー値として提供されなければなりません。例えば、"
+"8プレーンテキスト・ファイルで、各行はブラックリストに載っているパスワードを表します。大文字と小文字を区別しない比較を容易にするために、ブラックリスト内のすべてのパスワードを小文字にする必要があります。ブラックリスト・ファイルのファイル名は、パスワード・ポリシー値として提供されなければなりません。例えば、"
 " `10_million_password_list_top_1000000.txt` です。ブラックリスト・ファイルはデフォルトで "
 "`${jboss.server.data.dir}/password-blacklists/` に対して解決されます。このパスは、 "
 "`keycloak.password.blacklists.path` システム・プロパティー、または `passwordBlacklist` "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__password-policies
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
