### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,8 +30,8 @@ msgid ""
 "`admin_fine_grained_authz` feature. Please, take a look at "
 "link:{installguide_profile_link}[{installguide_profile_name}]."
 msgstr ""
-"トークン交換を使用するには、 `admin_fine_grained_authz` "
-"機能も有効にする必要があります。link:{installguide_profile_link}[{installguide_profile_name}]を参照してください。"
+"Token Exchangeを使用するには、 `admin_fine_grained_authz` 機能も有効にする必要があります。 "
+"link:{installguide_profile_link}[{installguide_profile_name}] を参照してください。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,6 +23,15 @@ msgstr ""
 #, no-wrap
 msgid "Token Exchange"
 msgstr "Token Exchange"
+
+#. type: delimited block =
+msgid ""
+"In order to use token exchange you should also enable the "
+"`admin_fine_grained_authz` feature. Please, take a look at "
+"link:{installguide_profile_link}[{installguide_profile_name}]."
+msgstr ""
+"トークン交換を使用するには、 `admin_fine_grained_authz` "
+"機能も有効にする必要があります。link:{installguide_profile_link}[{installguide_profile_name}]を参照してください。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
