### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -234,15 +234,16 @@ msgid ""
 "HS512. For details, please refer to "
 "https://tools.ietf.org/html/rfc7518#section-3.2[JSON Web Algorithms (JWA)]."
 msgstr ""
-"「algorithm」フィールドには、クライアント・シークレットを使用した署名付きJWTのアルゴリズムを指定します。HS256、HS384、HS512のいずれかの値である必要があります。詳細については、https://tools.ietf.org/html/rfc7518#section-3.2[JSON"
-" Web Algorithms (JWA)]を参照してください。"
+"\"algorithm\"フィールドには、クライアント・シークレットを使用した署名付きJWTのアルゴリズムを指定します。HS256、HS384、HS512のいずれかの値である必要があります。詳細については、"
+" https://tools.ietf.org/html/rfc7518#section-3.2[JSON Web Algorithms（JWA）] "
+"を参照してください。"
 
 #. type: Plain text
 msgid ""
 "This \"algorithm\" field is optional so that HS256 is applied automatically "
 "if the \"algorithm\" field does not exist on the `keycloak.json` file."
 msgstr ""
-"この「algorithm」フィールドはオプションであり、「algorithm」フィールドが `keycloak.json` "
+"この\"algorithm\"フィールドはオプションであり、\"algorithm\"フィールドが `keycloak.json` "
 "ファイルに存在しない場合はHS256が自動的に適用されます。"
 
 #. type: Title =====

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,7 +19,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Plain text
 #, no-wrap
 msgid "Client Authentication"
 msgstr "クライアント認証"
@@ -211,15 +215,35 @@ msgstr ""
 msgid ""
 "\"credentials\": {\n"
 "  \"secret-jwt\": {\n"
-"    \"secret\": \"19666a4f-32dd-4049-b082-684c74115f28\"\n"
+"    \"secret\": \"19666a4f-32dd-4049-b082-684c74115f28\",\n"
+"    \"algorithm\": \"HS512\"\n"
 "  }\n"
 "}\n"
 msgstr ""
 "\"credentials\": {\n"
 "  \"secret-jwt\": {\n"
-"    \"secret\": \"19666a4f-32dd-4049-b082-684c74115f28\"\n"
+"    \"secret\": \"19666a4f-32dd-4049-b082-684c74115f28\",\n"
+"    \"algorithm\": \"HS512\"\n"
 "  }\n"
 "}\n"
+
+#. type: Plain text
+msgid ""
+"The \"algorithm\" field specifies the algorithm for Signed JWT using Client "
+"Secret. It needs to be one of the following values : HS256, HS384, and "
+"HS512. For details, please refer to "
+"https://tools.ietf.org/html/rfc7518#section-3.2[JSON Web Algorithms (JWA)]."
+msgstr ""
+"「algorithm」フィールドには、クライアント・シークレットを使用した署名付きJWTのアルゴリズムを指定します。HS256、HS384、HS512のいずれかの値である必要があります。詳細については、https://tools.ietf.org/html/rfc7518#section-3.2[JSON"
+" Web Algorithms (JWA)]を参照してください。"
+
+#. type: Plain text
+msgid ""
+"This \"algorithm\" field is optional so that HS256 is applied automatically "
+"if the \"algorithm\" field does not exist on the `keycloak.json` file."
+msgstr ""
+"この「algorithm」フィールドはオプションであり、「algorithm」フィールドが `keycloak.json` "
+"ファイルに存在しない場合はHS256が自動的に適用されます。"
 
 #. type: Title =====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/client-authentication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__client-authentication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
