### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/8_0_2.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/8_0_2.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/8_0_2.ja_JP.po
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Highlights"
+msgstr "ハイライト"
+
+#. type: Title ==
+#, no-wrap
+msgid "SameSite cookie changes with upcoming Google Chrome update"
+msgstr "SameSite Cookieは、Google Chromeの今後のアップデートで変更されます"
+
+#. type: Plain text
+msgid ""
+"Starting with version 80, Google Chrome will change the default value for "
+"the `SameSite` cookie parameter to `Lax`.  Therefore, changes were required "
+"to several {project_name} cookies (especially those which are used within "
+"the Javascript adapter for checking the session status using the iframe) to "
+"set `SameSite` parameter to `None`. Please note that this settings also "
+"requires setting the `Secure` parameter, hence starting with this version, "
+"the Javascript adapter will only be fully functional when using the SSL / "
+"TLS connection on the {project_name} side."
+msgstr ""
+"バージョン80以降、Google Chromeは `SameSite` Cookieパラメータ－のデフォルト値を `Lax` "
+"に変更しています。したがって、 `SameSite` パラメーターを `None` に設定するには、いくつかの{project_name} "
+"Cookie（特にJavaScriptアダプター内でiframeを使用してセッション・ステータスをチェックするために使用されるCookie）を変更する必要がありました。この設定では"
+" `Secure` "
+"パラメーターも設定する必要があることに注意してください。このバージョン以降、JavaScriptアダプターは{project_name}側でSSL / "
+"TLS接続を使用する場合にのみ完全に機能します。"

--- a/i18n/po/ja_JP/release_notes/topics/8_0_2.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/8_0_2.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +27,7 @@ msgstr "ハイライト"
 #. type: Title ==
 #, no-wrap
 msgid "SameSite cookie changes with upcoming Google Chrome update"
-msgstr "SameSite Cookieは、Google Chromeの今後のアップデートで変更されます"
+msgstr "Google Chromeの今後のアップデートによるSameSite Cookieの変更"
 
 #. type: Plain text
 msgid ""
@@ -39,8 +40,8 @@ msgid ""
 "the Javascript adapter will only be fully functional when using the SSL / "
 "TLS connection on the {project_name} side."
 msgstr ""
-"バージョン80以降、Google Chromeは `SameSite` Cookieパラメータ－のデフォルト値を `Lax` "
-"に変更しています。したがって、 `SameSite` パラメーターを `None` に設定するには、いくつかの{project_name} "
+"バージョン80以降、Google Chromeは `SameSite` Cookieパラメータ－のデフォルト値を `Lax` に変更します。したがって、"
+" `SameSite` パラメーターを `None` に設定するために、いくつかの{project_name} "
 "Cookie（特にJavaScriptアダプター内でiframeを使用してセッション・ステータスをチェックするために使用されるCookie）を変更する必要がありました。この設定では"
 " `Secure` "
 "パラメーターも設定する必要があることに注意してください。このバージョン以降、JavaScriptアダプターは{project_name}側でSSL / "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/8_0_2.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__8_0_2
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
