### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/9_0_1.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/9_0_1.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/9_0_1.ja_JP.po
@@ -1,0 +1,86 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Yoshikazu Nojima <mail@ynojima.net>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Highlights"
+msgstr "ハイライト"
+
+#. type: Title ==
+#, no-wrap
+msgid "PromiseType removed from JavaScript adapter"
+msgstr "JavaScriptアダプターからPromiseTypeが削除されました"
+
+#. type: Plain text
+msgid ""
+"The promiseType init option has been removed from the JavaScript adapter. "
+"Instead a promise that supports both native promise API and legacy Keycloak "
+"promise API is returned. This allows gradually migration of applications "
+"from the legacy/deprecated API to the native promise API."
+msgstr ""
+"promiseTypeのinitオプションがJavaScriptアダプターから削除されました。代わりに、ネイティブpromise "
+"APIとレガシーKeycloak promise "
+"APIの両方をサポートするpromiseが返されます。これにより、レガシー/非推奨のAPIからネイティブのpromise "
+"APIへのアプリケーションの段階的な移行が可能になります。"
+
+#. type: Title =
+#, no-wrap
+msgid "Other improvements"
+msgstr "その他の改善"
+
+#. type: Title ==
+#, no-wrap
+msgid "Reverted breaking API changes to LocaleSelectorSPI"
+msgstr "LocaleSelectorSPIへの互換性のないAPIの変更を元に戻しました"
+
+#. type: Plain text
+msgid ""
+"In 9.0.0 a breaking API change was introduced to LocaleSelectorSPI. With "
+"9.0.1 the changes to this API is now reverted, and a new LocaleUpdatorSPI "
+"has been introduced."
+msgstr ""
+"9.0.0では、LocaleSelectorSPIに重大なAPI変更が導入されました。9.0.1では、このAPIへの変更が元に戻され、新しいLocaleUpdatorSPIが導入されました。"
+
+#. type: Title ==
+#, no-wrap
+msgid ""
+"Fixed the automatic resolution of `KeycloakConfigResolver` instances for "
+"Spring Boot Applications"
+msgstr "Spring Bootアプリケーションの `KeycloakConfigResolver`インスタンスの自動解決を修正しました"
+
+#. type: Plain text
+msgid ""
+"In previous releases, Spring Boot applications had to manually implement the"
+" `KeycloakConfigResolver` interface or extend the built-in "
+"`org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver`."
+msgstr ""
+"以前のリリースでは、Spring Bootアプリケーションは手動で `KeycloakConfigResolver` "
+"インターフェイスを実装するか、組み込みの "
+"`org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver` "
+"を拡張する必要がありました。"
+
+#. type: Plain text
+msgid ""
+"This release fixes the backward compatibility issue by resolving instances "
+"automatically in case none is provided. As well as still allowing "
+"applications to provide their own configuration resolver implementations."
+msgstr ""
+"このリリースでは、何も提供されない場合にインスタンスを自動的に解決することにより、下位互換性の問題が修正されています。さらに、アプリケーションが独自の設定リゾルバーの実装を提供できるようにします。"

--- a/i18n/po/ja_JP/release_notes/topics/9_0_1.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/9_0_1.ja_JP.po
@@ -6,12 +6,13 @@
 # Translators:
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,9 +37,9 @@ msgid ""
 "promise API is returned. This allows gradually migration of applications "
 "from the legacy/deprecated API to the native promise API."
 msgstr ""
-"promiseTypeのinitオプションがJavaScriptアダプターから削除されました。代わりに、ネイティブpromise "
-"APIとレガシーKeycloak promise "
-"APIの両方をサポートするpromiseが返されます。これにより、レガシー/非推奨のAPIからネイティブのpromise "
+"promiseTypeのinitオプションがJavaScriptアダプターから削除されました。代わりに、ネイティブPromise "
+"APIとレガシーKeycloak Promise "
+"APIの両方をサポートするPromiseが返されます。これにより、レガシー/非推奨のAPIからネイティブのPromise "
 "APIへのアプリケーションの段階的な移行が可能になります。"
 
 #. type: Title =
@@ -64,7 +65,7 @@ msgstr ""
 msgid ""
 "Fixed the automatic resolution of `KeycloakConfigResolver` instances for "
 "Spring Boot Applications"
-msgstr "Spring Bootアプリケーションの `KeycloakConfigResolver`インスタンスの自動解決を修正しました"
+msgstr "Spring Bootアプリケーションの `KeycloakConfigResolver` インスタンスの自動解決を修正しました"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/9_0_1.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__9_0_1
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
