### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -248,11 +248,91 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The Email Event Listener sends an email to the user's account when an event "
-"occurs.  The Email Event Listener only supports the following events at the "
-"moment:"
+"The Logging Event Listener logs events to the `org.keycloak.events` logger "
+"category. By default debug log events are not included in server logs."
 msgstr ""
-"電子メール・イベントリスナーは、イベントが発生したときにユーザーのアカウントに電子メールを送信します。電子メール・イベントリスナーは、現時点で次のイベントのみをサポートしています。"
+"ロギング・イベントリスナーは、イベントを `org.keycloak.events` "
+"ロガーカテゴリーに記録します。デフォルトでは、デバッグログ・イベントはサーバーログに含まれません。"
+
+#. type: Plain text
+msgid ""
+"To include debug log events in server logs, edit the `standalone.xml` file "
+"and change the log level used by the Logging Event listener. Alternately, "
+"you can configure the log level for `org.keycloak.events`."
+msgstr ""
+"サーバーログにデバッグログ・イベントを含めるには、 `standalone.xml` "
+"ファイルを編集し、ロギング・イベントリスナーで使用されるログレベルを変更します。または、 `org.keycloak.events` "
+"のログレベルを設定できます。"
+
+#. type: Plain text
+msgid "For example, to change the log level add the following:"
+msgstr "たとえば、ログレベルを変更するには、以下を追加します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<subsystem xmlns=\"urn:jboss:domain:logging:...\">\n"
+"    ...\n"
+"    <logger category=\"org.keycloak.events\">\n"
+"        <level name=\"DEBUG\"/>\n"
+"    </logger>\n"
+"</subsystem>\n"
+msgstr ""
+"<subsystem xmlns=\"urn:jboss:domain:logging:...\">\n"
+"    ...\n"
+"    <logger category=\"org.keycloak.events\">\n"
+"        <level name=\"DEBUG\"/>\n"
+"    </logger>\n"
+"</subsystem>\n"
+
+#. type: Plain text
+msgid ""
+"To change the log level used by the Logging Event listener, add the "
+"following:"
+msgstr "ロギング・イベントリスナーが使用するログレベルを変更するには、以下を追加します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<subsystem xmlns=\"urn:jboss:domain:keycloak-server:...\">\n"
+"    ...\n"
+"    <spi name=\"eventsListener\">\n"
+"      <provider name=\"jboss-logging\" enabled=\"true\">\n"
+"        <properties>\n"
+"          <property name=\"success-level\" value=\"info\"/>\n"
+"          <property name=\"error-level\" value=\"error\"/>\n"
+"        </properties>\n"
+"      </provider>\n"
+"    </spi>\n"
+"</subsystem>\n"
+msgstr ""
+"<subsystem xmlns=\"urn:jboss:domain:keycloak-server:...\">\n"
+"    ...\n"
+"    <spi name=\"eventsListener\">\n"
+"      <provider name=\"jboss-logging\" enabled=\"true\">\n"
+"        <properties>\n"
+"          <property name=\"success-level\" value=\"info\"/>\n"
+"          <property name=\"error-level\" value=\"error\"/>\n"
+"        </properties>\n"
+"      </provider>\n"
+"    </spi>\n"
+"</subsystem>\n"
+
+#. type: Plain text
+msgid ""
+"Valid values for the log levels are `debug`, `info`, `warn`, `error`, and "
+"`fatal`."
+msgstr "ログレベルの有効な値は、 `debug` 、`info` 、 `warn` 、` error` 、および `fatal` です。"
+
+#. type: Plain text
+msgid ""
+"The Email Event Listener sends an email to the user's account when an event "
+"occurs."
+msgstr "電子メール・イベントリスナーは、イベントが発生したときにユーザーのアカウントに電子メールを送信します。"
+
+#. type: Plain text
+msgid "Currently, the Email Event Listener supports the following events:"
+msgstr "現在、電子メール・イベントリスナーは次のイベントをサポートしています。"
 
 #. type: Plain text
 msgid "Login Error"
@@ -301,6 +381,35 @@ msgstr ""
 " <property name=\"exclude-events\" value=\"[&quot;UPDATE_TOTP&quot;,&quot;REMOVE_TOTP&quot;]\"/>\n"
 " </properties>\n"
 " </provider>\n"
+"</spi>\n"
+
+#. type: Plain text
+msgid ""
+"You can also set up a maximum length of the Event detail stored in the "
+"database by editing `standalone.xml`, `standalone-ha.xml`, or `domain.xml`. "
+"This setting can be useful in case some field (e.g. redirect_uri) is very "
+"long. Here is an example of defining the maximum length.:"
+msgstr ""
+"また、 `standalone.xml` 、`standalone-ha.xml` 、または `domain.xml` "
+"を編集して、データベースに保存されるイベントの詳細の最大長を設定することもできます。この設定は、一部のフィールド（redirect_uriなど）が非常に長い場合に役立ちます。以下に、最大長を定義する例を示します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<spi name=\"eventsStore\">\n"
+"    <provider name=\"jpa\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"max-detail-length\" value=\"1000\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+msgstr ""
+"<spi name=\"eventsStore\">\n"
+"    <provider name=\"jpa\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"max-detail-length\" value=\"1000\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
 "</spi>\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
