### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po
@@ -48,15 +48,6 @@ msgstr ""
 "のバリアントをサポートしています。デスクトップ・バリアントは、システム・クレデンシャルを収集するためにシステム・ブラウザーを使用します。手動バリアントは、ユーザー・クレデンシャルを"
 " `STDIN` から読み込みます。"
 
-#. type: Plain text
-msgid ""
-"Tip: Google provides some more information about this approach on at "
-"https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]."
-msgstr ""
-"Tip：Googleは "
-"https://developers.google.com/identity/protocols/OAuth2InstalledApp[OAuth2InstalledApp]"
-" で、このアプローチに関する情報を提供しています。"
-
 #. type: Title =====
 #, no-wrap
 msgid "How it works"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/installed-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__installed-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
