### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po
@@ -5,15 +5,15 @@
 # 
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -545,7 +545,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The Username form is similar to \"Browser\" flow's Username Password Form, "
-"but only asks for a username, allowing a user to do perform a password-less "
+"but only asks for a username, allowing a user to perform a password-less "
 "login.  However, note that this inevitably allows a user enumeration attack "
 "on your {project_name} server. This is an unavoidable security risk for the "
 "convenience, so the flow should make sure that an attacker cannot just have "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/flows.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__flows
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
