### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -45,9 +49,9 @@ msgstr "<subsystem xmlns=\"urn:jboss:domain:keycloak:1.1\"/>\n"
 #. type: Plain text
 msgid ""
 "Modify this text to prepare the file for pasting in contents from the "
-"*Keycloak OIDC JBoss Subsystem XML* template we obtained {project_name} "
-"admin console *Installation* tab by changing the XML entry from self-closing"
-" to using a pair of opening and closing tags:"
+"*Keycloak OIDC JBoss Subsystem XML* template we obtained from {project_name}"
+" admin console *Installation* tab by changing the XML entry from self-"
+"closing to using a pair of opening and closing tags:"
 msgstr ""
 "このテキストを変更して、{project_name}管理コンソールの *Installation* タブで取得した *Keycloak OIDC "
 "JBoss Subsystem XML* テンプレートの内容をファイルにペーストする準備をします。XMLエントリーを自己クローズ（self-"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/subsystem.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__subsystem
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
