### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -79,12 +79,6 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"You must subscribe to the JBoss EAP 7 repository before you can install the "
-"EAP 7 adapters from an RPM."
-msgstr "RPMからEAP 7アダプターをインストールする前に、JBoss EAP 7リポジトリーにサブスクライブする必要があります。"
-
-#. type: Plain text
-msgid ""
 "If you are already subscribed to another JBoss EAP repository, you must "
 "unsubscribe from that repository first."
 msgstr "すでに別のJBoss EAPリポジトリーに登録している場合は、まずそのリポジトリーから登録を解除する必要があります。"
@@ -110,22 +104,13 @@ msgstr ""
 "-for-x86_64-appstream-rpms\n"
 
 #. type: Plain text
-msgid "Install the EAP 7 adapters for SAML using the following command:"
-msgstr "次のコマンドを使用して、SAML用のEAP 7アダプターをインストールします。"
-
-#. type: delimited block -
-#, no-wrap
-msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_3\n"
-msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_3\n"
-
-#. type: Plain text
 msgid "or use following one for Red Hat Enterprise Linux 8:"
 msgstr "または、次のいずれかをRed Hat Enterprise Linux 8に使用します。"
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ sudo dnf install eap7-keycloak-adapter-sso7_3\n"
-msgstr "$ sudo dnf install eap7-keycloak-adapter-sso7_3\n"
+msgid "$ sudo dnf install eap7-keycloak-adapter-sso7_4\n"
+msgstr "$ sudo dnf install eap7-keycloak-adapter-sso7_4\n"
 
 #. type: Plain text
 msgid ""
@@ -136,19 +121,6 @@ msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/
 #. type: Plain text
 msgid "Run the appropriate module installation script."
 msgstr "適切なモジュール・インストール・スクリプトを実行します。"
-
-#. type: Plain text
-msgid "For the SAML module, enter the following command:"
-msgstr "SAMLモジュールの場合は、次のコマンドを実行します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install-"
-"saml.cli\n"
-msgstr ""
-"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install-"
-"saml.cli\n"
 
 #. type: Plain text
 msgid "Your installation is complete."
@@ -184,16 +156,44 @@ msgstr ""
 ">-server-rpms\n"
 
 #. type: Plain text
+msgid ""
+"The default EAP_HOME path for the RPM installation is "
+"/opt/rh/eap6/root/usr/share/wildfly."
+msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"
+
+#. type: Plain text
+msgid ""
+"You must subscribe to the JBoss EAP 7 repository before you can install the "
+"EAP 7 adapters from an RPM."
+msgstr "RPMからEAP 7アダプターをインストールする前に、JBoss EAP 7リポジトリーにサブスクライブする必要があります。"
+
+#. type: Plain text
+msgid "Install the EAP 7 adapters for SAML using the following command:"
+msgstr "次のコマンドを使用して、SAML用のEAP 7アダプターをインストールします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ sudo yum install eap7-keycloak-saml-adapter-sso7_4\n"
+msgstr "$ sudo yum install eap7-keycloak-saml-adapter-sso7_4\n"
+
+#. type: Plain text
+msgid "For the SAML module, enter the following command:"
+msgstr "SAMLモジュールの場合は、次のコマンドを実行します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install-"
+"saml.cli\n"
+msgstr ""
+"$ $EAP_HOME/bin/jboss-cli.sh -c --file=$EAP_HOME/bin/adapter-install-"
+"saml.cli\n"
+
+#. type: Plain text
 msgid "Install the EAP 6 adapters for SAML using the following command:"
 msgstr "次のコマンドを使用して、SAML用のEAP 6アダプターをインストールします。"
 
 #. type: delimited block -
 #, no-wrap
-msgid "$ sudo yum install keycloak-saml-adapter-sso7_3-eap6\n"
-msgstr "$ sudo yum install keycloak-saml-adapter-sso7_3-eap6\n"
-
-#. type: Plain text
-msgid ""
-"The default EAP_HOME path for the RPM installation is "
-"/opt/rh/eap6/root/usr/share/wildfly."
-msgstr "RPMインストールのためのデフォルトのEAP_HOMEパスは、/opt/rh/eap6/root/usr/share/wildflyです。"
+msgid "$ sudo yum install keycloak-saml-adapter-sso7_4-eap6\n"
+msgstr "$ sudo yum install keycloak-saml-adapter-sso7_4-eap6\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss-adapter-rpms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss-adapter-rpms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
