### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -45,9 +45,9 @@ msgstr "ドメインモードとは、サーバーの設定を一元管理し、
 msgid ""
 "Running a cluster in standard mode can quickly become aggravating as the "
 "cluster grows in size.  Every time you need to make a configuration change, "
-"you have perform it on each node in the cluster.  Domain mode solves this "
-"problem by providing a central place to store and publish configuration.  It"
-" can be quite complex to set up, but it is worth it in the end.  This "
+"you have to perform it on each node in the cluster.  Domain mode solves this"
+" problem by providing a central place to store and publish configurations.  "
+"It can be quite complex to set up, but it is worth it in the end.  This "
 "capability is built into the {appserver_name} Application Server which "
 "{project_name} derives from."
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"This config defines the default port mappings for various connectors that "
-"are opened with each {project_name} server instance.  Any value that "
+"This configration defines the default port mappings for various connectors "
+"that are opened with each {project_name} server instance.  Any value that "
 "contains `${...}` is a value that can be overridden on the command line with"
 " the `-D` switch, i.e."
 msgstr ""
-"この設定では、各{project_name}サーバー・インスタンスによって開かれる、さまざまなコネクターのデフォルトのポートマッピングを定義します。 "
+"この設定では、各{project_name}サーバー・インスタンスによって開かれる、さまざまなコネクターのデフォルトポートマッピングを定義します。 "
 "`${...}` を含む値はコマンドラインの `-D` スイッチで上書きできる値です。すなわち、以下のように上書きできます。"
 
 #. type: delimited block -
@@ -476,9 +476,9 @@ msgstr "> ...\\bin\\domain.bat --host-config=host-master.xml\n"
 
 #. type: Plain text
 msgid ""
-"When running the boot script you will need pass in the host controlling "
+"When running the boot script you will need to pass in the host controlling "
 "configuration file you are going to use via the `--host-config` switch."
-msgstr "起動スクリプトを実行する場合、 `--host-config` スイッチ経由で、使用するホスト制御設定ファイルを渡す必要があります 。"
+msgstr "起動スクリプトを実行する場合、 `--host-config` スイッチ経由で、使用するホスト制御設定ファイルを渡す必要があります。"
 
 #. type: Title ====
 #, no-wrap
@@ -508,15 +508,15 @@ msgstr "2つの{project_name}サーバー・インスタンス"
 
 #. type: Plain text
 msgid ""
-"To simulate running a cluster on two machines, you'll run the `domain.sh` "
-"script twice to start two separate host controllers.  The first will be the "
-"master host controller which will start a domain controller, an HTTP load "
-"balancer, and one {project_name} authentication server instance.  The second"
-" will be a slave host controller that only starts up an authentication "
-"server instance."
+"To simulate running a cluster on two machines, you'll need to run the "
+"`domain.sh` script twice to start two separate host controllers.  The first "
+"will be the master host controller which will start a domain controller, an "
+"HTTP load balancer, and one {project_name} authentication server instance.  "
+"The second will be a slave host controller that only starts up an "
+"authentication server instance."
 msgstr ""
 "2台のマシンでのクラスターの実行をシミュレートするには、 `domain.sh` "
-"スクリプトを2回実行して2つの別々のホスト・コントローラーを起動させます。はじめに、ドメイン・コントローラー、HTTPロード・バランサー、および1つの{project_name}認証サーバー・インスタンスを起動するマスター・ホスト・コントローラーを起動させます。次に、認証サーバー・インスタンスを起動するだけのスレーブ・ホスト・コントローラーを起動させます。"
+"スクリプトを2回実行して2つの別々のホスト・コントローラーを起動させる必要があります。はじめに、ドメイン・コントローラー、HTTPロードバランサー、および1つの{project_name}認証サーバー・インスタンスを起動するマスター・ホスト・コントローラーを起動させます。次に、認証サーバー・インスタンスを起動するだけのスレーブ・ホスト・コントローラーを起動させます。"
 
 #. type: Title =====
 #, no-wrap
@@ -620,11 +620,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Now cut and paste the secret value into the _.../domain/configuration/host-"
-"slave.xml_ file as follows:"
+"Next, cut and paste the secret value into the _.../domain/configuration"
+"/host-slave.xml_ file as follows:"
 msgstr ""
-"_.../domain/configuration/host-slave.xml_ "
-"ファイルにシークレットの値をカット・アンド・ペーストすると、以下のようになります。"
+"次に、以下のようにシークレット値を _.../domain/configuration/host-slave.xml_ "
+"ファイルにカット・アンド・ペーストします。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
