### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/host.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/host.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/host.ja_JP.po
@@ -130,10 +130,10 @@ msgstr "jboss-cliで `frontendUrl` を更新するには、次のコマンドを
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"/subsystem=keycloak-server/spi=hostname/provider=fixed:write-"
+"/subsystem=keycloak-server/spi=hostname/provider=default:write-"
 "attribute(name=properties.frontendUrl,value=\"https://auth.example.com\")\n"
 msgstr ""
-"/subsystem=keycloak-server/spi=hostname/provider=fixed:write-"
+"/subsystem=keycloak-server/spi=hostname/provider=default:write-"
 "attribute(name=properties.frontendUrl,value=\"https://auth.example.com\")\n"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/host.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__host
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
