### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -5,24 +5,19 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Title ===
-#, no-wrap
-msgid "Example using CURL"
-msgstr "CURLを使用した例"
 
 #. type: Title ===
 #, no-wrap
@@ -272,6 +267,29 @@ msgstr ""
 "/openid-connect-registration-1_0.html[OpenID Connect Dynamic Client "
 "Registrationの仕様] を参照してください。"
 
+#. type: Title =====
+#, no-wrap
+msgid "Token Revocation Endpoint"
+msgstr "トークン無効化エンドポイント"
+
+#. type: delimited block .
+#, no-wrap
+msgid "/realms/{realm-name}/protocol/openid-connect/revoke\n"
+msgstr "/realms/{realm-name}/protocol/openid-connect/revoke\n"
+
+#. type: Plain text
+msgid "The token revocation endpoint is used to revoke tokens."
+msgstr "トークン無効化エンドポイントは、トークンを無効化するために使用されます。"
+
+#. type: Plain text
+msgid ""
+"For more details on how to invoke on this endpoint, see "
+"https://tools.ietf.org/html/rfc7009[OAuth 2.0 Token Revocation "
+"specification]."
+msgstr ""
+"このエンドポイントで呼び出す方法の詳細については、 https://tools.ietf.org/html/rfc7009[OAuth 2.0 "
+"Token Revocationの仕様] を参照してください。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Validating Access Tokens"
@@ -453,6 +471,11 @@ msgstr ""
 "詳細については、OAuth 2.0仕様の "
 "https://tools.ietf.org/html/rfc6749#section-4.3[Resource Owner Password "
 "Credentials Grant] のセクションを参照してください。"
+
+#. type: Title ===
+#, no-wrap
+msgid "Example using CURL"
+msgstr "CURLを使用した例"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
