### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -299,7 +299,7 @@ msgstr ""
 "/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
 "  これは、OIDC仕様で説明されているUserInfoサービスのURLエンドポイントです。\n"
 "/realms/{realm-name}/protocol/openid-connect/revoke::\n"
-" これは、 https://tools.ietf.org/html/rfc7009[RFC7009] で説明されているOAuth 2.0トークン無効化のURLエンドポイントです。\n"
+"  これは、 https://tools.ietf.org/html/rfc7009[RFC7009] で説明されているOAuth 2.0トークン無効化のURLエンドポイントです。\n"
 
 #. type: Plain text
 msgid "In all of these replace _{realm-name}_ with the name of the realm."

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -287,6 +287,8 @@ msgid ""
 "  This is the URL endpoint for performing logouts.\n"
 "/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
 "  This is the URL endpoint for the User Info service described in the OIDC specification.\n"
+"/realms/{realm-name}/protocol/openid-connect/revoke::\n"
+"  This is the URL endpoint for OAuth 2.0 Token Revocation described in https://tools.ietf.org/html/rfc7009[RFC7009].\n"
 msgstr ""
 "/realms/{realm-name}/protocol/openid-connect/auth::\n"
 "  これは、認可コード・フローで一時コードを取得するため、またはインプリシット・フロー、ダイレクト・グラント、またはクライアント・グラントを使用してトークンを取得するためのURLエンドポイントです。\n"
@@ -296,6 +298,8 @@ msgstr ""
 "  これは、ログアウトを実行するためのURLエンドポイントです。\n"
 "/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
 "  これは、OIDC仕様で説明されているUserInfoサービスのURLエンドポイントです。\n"
+"/realms/{realm-name}/protocol/openid-connect/revoke::\n"
+" これは、 https://tools.ietf.org/html/rfc7009[RFC7009] で説明されているOAuth 2.0トークン無効化のURLエンドポイントです。\n"
 
 #. type: Plain text
 msgid "In all of these replace _{realm-name}_ with the name of the realm."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
