### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -5,19 +5,29 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Enabled"
+msgstr "Enabled"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Identity Provider"
+msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ===
 #, no-wrap
@@ -57,11 +67,6 @@ msgid ""
 msgstr ""
 "ドロップ・ダウン・リスト・ボックスで、追加するアイデンティティー・プロバイダを選択します。 "
 "これにより、そのアイデンティティー・プロバイダー・タイプの設定ページが表示されます。"
-
-#. type: Block title
-#, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
 msgid "image:{project_images}/add-identity-provider.png[]"
@@ -141,7 +146,8 @@ msgstr "1,1"
 msgid "Configuration|Description"
 msgstr "設定|説明"
 
-#. type: Plain text
+#. type: Labeled list
+#, no-wrap
 msgid "Alias"
 msgstr "Alias"
 
@@ -157,11 +163,6 @@ msgstr ""
 "OpenID Connectなどの一部のプロトコルでは、アイデンティティー・プロバイダーと通信するために、リダイレクトURIまたはコールバックURLが必要です。\n"
 "この場合、エイリアスはリダイレクトURIを構築するために使用されます。\n"
 "すべてのアイデンティティー・プロバイダーにエイリアスが必要です。例としては、 `facebook` 、 `google` 、 `idp.acme.com` などです。\n"
-
-#. type: Labeled list
-#, no-wrap
-msgid "Enabled"
-msgstr "Enabled"
 
 #. type: Plain text
 msgid "Turn the provider on/off."
@@ -256,3 +257,17 @@ msgid ""
 "Authentication flow that is triggered after the user finishes logging in "
 "with the external identity provider."
 msgstr "ユーザーが外部アイデンティティー・プロバイダーへのログインを完了した後にトリガーされる認証フロー。"
+
+#. type: Plain text
+msgid "Sync Mode"
+msgstr "同期モード"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Strategy of how to update user information from the idp through mappers: When choosing `legacy`, the current behavior is kept, \n"
+" `import` will never update user data, while `force` will always update user data when possible. See also the documentation for <<_mappers, Identity Provider Mappers>> for more details.\n"
+msgstr ""
+"マッパーを通じてidpからユーザー情報を更新する方法の戦略： `legacy` を選択すると、現在の動作が維持されます。 `import` "
+"はユーザーデータを更新しませんが、 `force` は常にユーザーデータを更新します。 詳細については、<<_mappers, "
+"アイデンティティー・プロバイダー・マッパー>>のドキュメントも参照してください。\n"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -268,6 +268,6 @@ msgid ""
 "Strategy of how to update user information from the idp through mappers: When choosing `legacy`, the current behavior is kept, \n"
 " `import` will never update user data, while `force` will always update user data when possible. See also the documentation for <<_mappers, Identity Provider Mappers>> for more details.\n"
 msgstr ""
-"マッパーを通じてidpからユーザー情報を更新する方法の戦略： `legacy` を選択すると、現在の動作が維持されます。 `import` "
-"はユーザーデータを更新しませんが、 `force` は常にユーザーデータを更新します。 詳細については、<<_mappers, "
+"マッパーを通じてIdPからユーザー情報を更新する方法の戦略： `legacy` を選択すると、現在の動作が維持されます。 `import` "
+"はユーザーデータを更新しませんが、 `force` は常にユーザーデータを更新します。詳細については、<<_mappers, "
 "アイデンティティー・プロバイダー・マッパー>>のドキュメントも参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
