### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,7 +87,7 @@ msgstr ""
 msgid ""
 "The mapper will update user information when the user logs in repeatedly "
 "according to the `Sync Mode Override`:"
-msgstr "ユーザーが `Sync Mode Override` に従って繰り返しログインすると、マッパーはユーザー情報を更新します。"
+msgstr "以下の `Sync Mode Override` の設定により、ユーザーがログインするとマッパーはユーザー情報を更新します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -82,6 +82,38 @@ msgstr ""
 "`Mapper Type` "
 "のリストからマッパーを選択してください。ツールチップにカーソルを合わせると、マッパーの機能の説明が表示されます。ツールチップには、入力する必要がある設定情報も記載されています。"
 " `Save` ボタンをクリックすると、新しいマッパーが追加されます。"
+
+#. type: Plain text
+msgid ""
+"The mapper will update user information when the user logs in repeatedly "
+"according to the `Sync Mode Override`:"
+msgstr "ユーザーが `Sync Mode Override` に従って繰り返しログインすると、マッパーはユーザー情報を更新します。"
+
+#. type: Plain text
+msgid ""
+"Choose `legacy` to use the behavior in the previous {project_name} version."
+msgstr "以前のバージョンの{project_name}の動作を使用するには、 `legacy` を選択します。"
+
+#. type: Plain text
+msgid ""
+"Choose `import` to import only data from when the user was first created in "
+"{project_name} during the first login to {project_name} with a particular "
+"identity provider."
+msgstr ""
+"特定のアイデンティティー・プロバイダーを使用して{project_name}への初回ログイン中に、ユーザーが{project_name}で最初に作成されたときのデータのみをインポートするには、"
+" `import` を選択します。"
+
+#. type: Plain text
+msgid "Choose `force` to update user data at each user login."
+msgstr "ユーザーのログインごとにユーザーデータを更新するには、 `force` を選択します。"
+
+#. type: Plain text
+msgid ""
+"Choose `inherit` to use the sync mode configured in the identity provider, "
+"all other options will override this sync mode."
+msgstr ""
+"アイデンティティー・プロバイダーで設定された同期モードを使用するには、 `inherit` "
+"を選択します。他のすべてのオプションは、この同期モードをオーバーライドします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
