### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -5,15 +5,15 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Yoshikazu Nojima <mail@ynojima.net>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -165,6 +165,37 @@ msgid ""
 msgstr ""
 "<<_offline-access, "
 "オフライン・アクセス>>では、これは対応するオフライントークンが取り消されるまでの最大時間です。このオプションはユーザー・アクティビティーに関係なく、オフライントークンがアクティブのままになる最大時間を制御します。"
+
+#. type: Plain text
+msgid "Client Session Idle"
+msgstr "Client Session Idle"
+
+#. type: Plain text
+msgid ""
+"If the user is not active for longer than this timeout, refresh token "
+"requests will bump the idle timeout. It allows for the specification of a "
+"shorter idle timeout of refresh token than session idle timeout. And it can "
+"be overridden on individual clients. It is an optional configuration and if "
+"not set to a value bigger than 0 it uses the same idle timeout set in the "
+"SSO Session Idle configuration."
+msgstr ""
+"ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、リフレッシュトークン・リクエストによりアイドル・タイムアウトがバンプされます。これにより、セッションのアイドル・タイムアウトよりも短いリフレッシュトークンのアイドル・タイムアウトを指定できます。また、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
+" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
+
+#. type: Plain text
+msgid "Client Session Max"
+msgstr "Client Session Max"
+
+#. type: Plain text
+msgid ""
+"The maximum time before a refresh token is expired and invalidated. It "
+"allows for the specification of a shorter timeout of refresh token than "
+"session timeout. And it can be overridden on individual clients. It is an "
+"optional configuration and if not set to a value bigger than 0 it uses the "
+"same idle timeout set in the SSO Session Max configuration."
+msgstr ""
+"リフレッシュトークンが期限切れになり無効になるまでの最大時間。セッション・タイムアウトよりも短いリフレッシュトークンのタイムアウトを指定できます。また、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
+" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
 
 #. type: Plain text
 msgid "Access Token Lifespan"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -179,7 +179,7 @@ msgid ""
 "not set to a value bigger than 0 it uses the same idle timeout set in the "
 "SSO Session Idle configuration."
 msgstr ""
-"ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、リフレッシュトークン・リクエストによりアイドル・タイムアウトがバンプされます。これにより、セッションのアイドル・タイムアウトよりも短いリフレッシュトークンのアイドル・タイムアウトを指定できます。また、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
+"ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、リフレッシュトークン・リクエストはアイドル・タイムアウトになります。これにより、セッションのアイドル・タイムアウトよりも短いリフレッシュトークンのアイドル・タイムアウトを指定できます。また、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
 " Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__timeouts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
