### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -689,4 +689,4 @@ msgstr "$ domain.sh --host-config=host-slave.xml\n"
 
 #. type: Plain text
 msgid "To try it out, open your browser and go to http://localhost:8080/auth."
-msgstr "これを試すには、ブラウザーを開いてhttp://localhost:8080/authに移動してください。"
+msgstr "これを試すには、ブラウザーを開いて http://localhost:8080/auth に移動してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
