### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,25 +23,6 @@ msgstr ""
 #, no-wrap
 msgid "</blueprint>\n"
 msgstr "</blueprint>\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
-"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
-"           xsi:schemaLocation=\"\n"
-"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
-"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
-msgstr ""
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
-"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
-"           xsi:schemaLocation=\"\n"
-"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
-"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
 
 #. type: Title =====
 #, no-wrap
@@ -57,8 +38,8 @@ msgid ""
 "undeploys a built-in servlet at startup, enabling you to redeploy it on a "
 "context secured by {project_name}."
 msgstr ""
-"いくつかのサービスは、起動時にデプロイされたサーブレットを自動的に提供します。そのようなサービスの1つは、$$http://localhost:8181/cxf$$"
-" "
+"いくつかのサービスは、起動時にデプロイされたサーブレットを自動的に提供します。そのようなサービスの1つは、 "
+"$$http://localhost:8181/cxf$$ "
 "コンテキストで実行されているCXFサーブレットです。そのようなエンドポイントを保護することは複雑になる可能性があります。{project_name}が現在使用しているアプローチの1つは"
 " `ServletReregistrationService` "
 "で、これは組み込みのサーブレットを起動時にアンデプロイし、{project_name}によってセキュリティー保護されたコンテキストに再デプロイできるようにします。"
@@ -73,6 +54,25 @@ msgstr ""
 "アプリケーション内の設定ファイル `OSGI-INF/blueprint/blueprint.xml` は、以下のようになります。JAX-RSの "
 "`customerservice` エンドポイント（アプリケーション固有のエンドポイント）を追加しますが、もっと重要なのは、 `/cxf` "
 "コンテキスト全体をセキュリティー保護することです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
+"           xsi:schemaLocation=\"\n"
+"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
+"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
+msgstr ""
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+"<blueprint xmlns=\"http://www.osgi.org/xmlns/blueprint/v1.0.0\"\n"
+"           xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+"           xmlns:jaxrs=\"http://cxf.apache.org/blueprint/jaxrs\"\n"
+"           xsi:schemaLocation=\"\n"
+"\t\thttp://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd\n"
+"\t\thttp://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd\">\n"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/cxf-builtin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__cxf-builtin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
