### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -406,17 +406,17 @@ msgid ""
 "[filename]`users` as ENDPOINT results in the resource URL "
 "http://localhost:8080/auth/admin/realms/master/users."
 msgstr ""
-"たとえば、http://localhost:8080/authのサーバーに対して認証し、レルムが [filename]`master` "
-"の場合、エンドポイントとして [filename]`users` "
-"を使用すると、リソースURLはhttp://localhost:8080/auth/admin/realms/master/usersとなります。"
+"たとえば、 http://localhost:8080/auth のサーバーに対して認証し、レルムが [filename]`master` "
+"の場合、エンドポイントとして [filename]`users` を使用すると、リソースURLは "
+"http://localhost:8080/auth/admin/realms/master/users となります。"
 
 #. type: Plain text
 msgid ""
 "If you set ENDPOINT to [filename]`clients`, the effective resource URI would"
 " be http://localhost:8080/auth/admin/realms/master/clients."
 msgstr ""
-"エンドポイントに [filename]`clients` "
-"を設定すると、有効なリソースURIはhttp://localhost:8080/auth/admin/realms/master/clientsになります。"
+"エンドポイントに [filename]`clients` を設定すると、有効なリソースURIは "
+"http://localhost:8080/auth/admin/realms/master/clients になります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
