### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po
@@ -7,13 +7,13 @@
 # KojiNose <knose.dev@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -119,7 +119,8 @@ msgid ""
 "https://host:port/auth."
 msgstr ""
 "{project_name}サーバーのベースURL。 "
-"他のすべての{project_name}ページとRESTサービス・エンドポイントは、これから派生しています。通常、https://host:port/authという形式です。"
+"他のすべての{project_name}ページとRESTサービス・エンドポイントは、これから派生しています。通常、 "
+"https://host:port/auth という形式です。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-client-api.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-client-api
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
