### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/host.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/host.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/host.ja_JP.po
@@ -71,11 +71,10 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "This makes it possible to have user-agents (browsers) send requests to "
-"${project.name} through the public domain name, while internal clients can "
+"{project_name} through the public domain name, while internal clients can "
 "use an internal domain name or IP address."
 msgstr ""
-"これにより、ユーザー・エージェント（ブラウザー）がパブリック・ドメイン名を介して ${project.name} "
-"にリクエストを送信し、内部クライアントが内部ドメイン名またはIPアドレスを使用できるようになります。"
+"これにより、ユーザー・エージェント（ブラウザー）がパブリック・ドメイン名を介して{project_name}にリクエストを送信し、内部クライアントが内部ドメイン名またはIPアドレスを使用できるようになります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/host.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__host
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
