### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -181,7 +181,7 @@ msgid ""
 "backend requests to the application for various tasks, like logout users or "
 "push revocation policies."
 msgstr ""
-"特定のクライアント用の管理者URLは、{project_name}管理コンソールで設定できます。これは、{project_name}サーバーによって、ユーザーのログアウトや取消しポリシーのプッシュなどのさまざまなタスクのバックエンド・リクエストをアプリケーションに送信するために使用されます。"
+"特定のクライアント用の管理URLは、{project_name}管理コンソールで設定できます。これは、{project_name}サーバーによって、ユーザーのログアウトや取消しポリシーのプッシュなどのさまざまなタスクのバックエンド・リクエストをアプリケーションに送信するために使用されます。"
 
 #. type: Plain text
 msgid "For example the way backchannel logout works is:"
@@ -203,7 +203,7 @@ msgstr "{project_name}サーバーはユーザー・セッションを無効に�
 msgid ""
 "The {project_name} server then sends a backchannel request to application "
 "with an admin url that are associated with the session"
-msgstr "{project_name}サーバーは、セッションに関連付けられた管理者URLでバックチャネル・リクエストをアプリケーションに送信します"
+msgstr "{project_name}サーバーは、セッションに関連付けられた管理URLでバックチャネル・リクエストをアプリケーションに送信します"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -172,7 +172,7 @@ msgstr ""
 #. type: Title =====
 #, no-wrap
 msgid "Admin URL configuration"
-msgstr "管理者URLの設定"
+msgstr "管理URLの設定"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -216,7 +216,7 @@ msgid ""
 "If admin URL contains `${application.session.host}` it will be replaced with"
 " the URL to the node associated with the HTTP session."
 msgstr ""
-"管理者URLに `${application.session.host}` "
+"管理URLに `${application.session.host}` "
 "が含まれていると、HTTPセッションに関連付けられたノードのURLに置き換えられます。"
 
 #. type: Title =====


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/application-clustering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__application-clustering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
