### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -35,7 +35,7 @@ msgid ""
 "to the `Realm Settings` left menu item and the `Cache` tab.\n"
 msgstr ""
 "{project_name}は、JVMの制限および/または設定した制限の範囲内で、できる限りすべてをメモリーにキャッシュします。サーバーのREST "
-"APIや管理コンソール以外（即ちDBA）の第三者によって{project_name}データベースが変更された場合、インメモリー・キャッシュの一部が失効する可能性があります。管理コンソール左側メニュー項目"
+"APIや管理コンソール以外の第三者（即ちDBA）によって{project_name}データベースが変更された場合、インメモリー・キャッシュの一部が失効する可能性があります。管理コンソール左側メニュー項目"
 " `Realm Settings` の `Cache` "
 "タブから、レルムキャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントやアイデンティティー・プロバイダーの公開鍵など、{project_name}が外部エンティティーの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
