### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -595,7 +595,7 @@ msgstr "クライアント証明書からユーザー・アイデンティティ
 #. type: Labeled list
 #, no-wrap
 msgid "`Canonical DN representation enabled` (optional)"
-msgstr "`Canonical DN representation enabled` (optional)"
+msgstr "`Canonical DN representation enabled` （オプション）"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -619,7 +619,7 @@ msgstr ""
 #. type: Labeled list
 #, no-wrap
 msgid "`Enable Serial Number hexadecimal representation` (optional)"
-msgstr "`Enable Serial Number hexadecimal representation` (optional)"
+msgstr "`Enable Serial Number hexadecimal representation` （オプション）"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
