### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -392,7 +392,7 @@ msgstr "キーストアを開くためのパスワード。"
 #. type: Labeled list
 #, no-wrap
 msgid "`ssl/keystore/alias` (optional)"
-msgstr "`ssl/keystore/alias` (optional)"
+msgstr "`ssl/keystore/alias` （オプション）"
 
 #. type: Plain text
 msgid ""
@@ -956,12 +956,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Consult the link:http://www.haproxy.org/#docs[HAProxy documentation] for the"
-" details of how the HTTP Headers for the client certificate and client "
-"certificate chain can be configured and their proper names."
+"Consult the HAProxy documentation for the details of how the HTTP Headers "
+"for the client certificate and client certificate chain can be configured "
+"and their proper names."
 msgstr ""
-"クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの構成方法と固有名詞の詳細については、 "
-"link:http://www.haproxy.org/#docs[HAProxyのドキュメント] を参照してください。"
+"クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの構成方法と固有名詞の詳細については、HAProxyのドキュメントを参照してください。"
 
 #. type: Title =====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
