### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -4,20 +4,30 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Block title
 #, no-wrap
@@ -31,136 +41,157 @@ msgstr "Windows"
 
 #. type: delimited block -
 #, no-wrap
-msgid ""
-"$ cd bin\n"
-"$ ./standalone.sh\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./standalone.sh\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "> ...\\bin\\standalone.bat\n"
-msgstr "> ...\\bin\\standalone.bat\n"
+msgid "$ unzip <filename>.zip\n"
+msgstr "$ unzip <filename>.zip\n"
 
 #. type: Title ===
 #, no-wrap
-msgid "Installing the Client Adapter"
-msgstr "クライアント・アダプターのインストール"
+msgid "Installing the {appserver_name} client adapter"
+msgstr "{appserver_name}クライアント・アダプターのインストール"
 
 #. type: Plain text
 msgid ""
-"Download the {appserver_name} distribution and extract it from the "
-"compressed file into a directory on your machine."
-msgstr "{appserver_name}の配布物をダウンロードし、圧縮ファイルをマシンのディレクトリーに展開します。"
+"When {appserver_name} and {project_name} are installed on the same machine, "
+"{appserver_name} requires some modification. To make this modification, you "
+"install a {project_name} client adapter."
+msgstr ""
+"{appserver_name}と{project_name}が同じマシンにインストールされている場合、{appserver_name}にいくつかの変更が必要です。この変更を行うには、{project_name}クライアント・アダプターをインストールします。"
+
+#. type: Plain text
+msgid "{appserver_name} is installed."
+msgstr "{appserver_name}がインストールされていること"
 
 #. type: Plain text
 msgid ""
-"Download the WildFly OpenID Connect adapter distribution from "
+"You have a backup of the `../standalone/configuration/standalone.xml` file "
+"if you have customized this file."
+msgstr ""
+" `../standalone/configuration/standalone.xml` "
+"をカスタマイズしている場合は、このファイルのバックアップがあること"
+
+#. type: Plain text
+msgid ""
+"Download the *WildFly OpenID Connect Client Adapter* distribution from "
 "link:https://www.keycloak.org/downloads.html[keycloak.org]."
 msgstr ""
-"link:https://www.keycloak.org/downloads.html[keycloak.org]からWildFly OpenID "
-"Connectアダプターの配布物をダウンロードします。"
-
-#. type: Plain text
-msgid "Download the RH-SSO-{project_version}-eap7-adapter.zip distribution."
-msgstr "RH-SSO-{project_version}-eap7-adapter.zipの配布物をダウンロードします。"
+"link:https://www.keycloak.org/downloads.html[keycloak.org]から *WildFly OpenID"
+" Connect Client Adapter* のディストリビューションをダウンロードします。"
 
 #. type: Plain text
 msgid ""
-"Extract the contents of this file into the root directory of your "
-"{appserver_name} distribution."
-msgstr "{appserver_name}配布物のルートディレクトリーに、このファイルを解凍します。"
+"Download the *Client Adapter for EAP 7* from the "
+"https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=core.service.rhsso[Red"
+" Hat customer portal]."
+msgstr ""
+"https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=core.service.rhsso[Red"
+" Hatカスタマー・ポータル]から *Client Adapter for EAP 7* をダウンロードします。"
 
 #. type: Plain text
-msgid "Run the appropriate script for your platform:"
-msgstr "次のように、使用しているプラットフォームに適したスクリプトを実行します。"
-
-#. type: Block title
-#, no-wrap
-msgid "EAP 6.3 and Linux/Unix"
-msgstr "EAP 6.3 and Linux/Unix"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
-
-#. type: Block title
-#, no-wrap
-msgid "EAP 6.3 and Windows"
-msgstr "EAP 6.3 and Windows"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-install-offline.cli\n"
-msgstr ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-install-offline.cli\n"
-
-#. type: Block title
-#, no-wrap
-msgid "EAP 7.2.5 and Linux/Unix"
-msgstr "EAP 7.2.5 and Linux/Unix"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
-msgstr ""
-"$ cd bin\n"
-"$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
-
-#. type: Block title
-#, no-wrap
-msgid "EAP 7.2.5 and Windows"
-msgstr "EAP 7.2.5 and Windows"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
-msgstr ""
-"> cd bin\n"
-"> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
-
-#. type: Block title
-#, no-wrap
-msgid "WildFly 10 and Linux/Unix"
-msgstr "WildFly 10・Linux/Unix"
-
-#. type: Block title
-#, no-wrap
-msgid "WildFly 10 and Windows"
-msgstr "WildFly 10・Windows"
-
-#. type: Block title
-#, no-wrap
-msgid "Wildfly 11+ and Linux/Unix"
-msgstr "WildFly 11+・Linux/Unix"
-
-#. type: Block title
-#, no-wrap
-msgid "Wildfly 11+ and Windows"
-msgstr "WildFly 11+・Windows"
+msgid "Change to the root directory of {appserver_name}."
+msgstr "{appserver_name}のルート・ディレクトリーに移動します。"
 
 #. type: Plain text
+msgid "Unzip the downloaded client adapter in this directory."
+msgstr "ダウンロードしたクライアント・アダプターをこのディレクトリーに解凍します。"
+
+#. type: Plain text
+msgid "Change to the bin directory."
+msgstr "binディレクトリーに移動します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ cd bin\n"
+msgstr "$ cd bin\n"
+
+#. type: Plain text
+msgid "Run the appropriate script for your platform."
+msgstr "使用しているプラットフォームに適したスクリプトを実行します。"
+
+#. type: delimited block =
 msgid ""
-"This script will make the necessary edits to the "
-"`.../standalone/configuration/standalone.xml` file of your app server "
-"distribution and may take some time to complete."
+"If you receive a `file not found`, make sure that you used `unzip` in the "
+"previous step.  This method of extraction installs the files in the right "
+"place."
 msgstr ""
-"このスクリプトは、アプリケーション・サーバーの配布物の `.../standalone/configuration/standalone.xml` "
-"ファイルを必要に応じて編集します。また、完了するまでに時間がかかることがあります。"
+"`file not found` が出力された場合は、前の手順で `unzip` "
+"を使用したかどうかを確認してください。この解凍方法で、ファイルが適切な場所にインストールされます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+msgstr "$ ./jboss-cli.sh --file=adapter-elytron-install-offline.cli\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
+msgstr "> jboss-cli.bat --file=adapter-elytron-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "WildFly 10 on Linux/Unix"
+msgstr "Linux/Unix上のWildFly 10"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
+msgstr "$ ./jboss-cli.sh --file=adapter-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "WildFly 10 on Windows"
+msgstr "Windows上のWildFly 10"
+
+#. type: delimited block -
+#, no-wrap
+msgid "> jboss-cli.bat --file=adapter-install-offline.cli\n"
+msgstr "> jboss-cli.bat --file=adapter-install-offline.cli\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Wildfly 11 on Linux/Unix"
+msgstr "Linux/Unix上のWildFly 11"
+
+#. type: Block title
+#, no-wrap
+msgid "Wildfly 11 on Windows"
+msgstr "Windows上のWildFly 11"
+
+#. type: delimited block =
+msgid ""
+"This script makes the necessary edits to the "
+"`.../standalone/configuration/standalone.xml` file."
+msgstr ""
+"このスクリプトは、 `.../standalone/configuration/standalone.xml` ファイルを必要に応じて編集します。"
 
 #. type: Plain text
 msgid "Start the application server."
 msgstr "アプリケーション・サーバーを起動します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ ./standalone.sh\n"
+msgstr "$ ./standalone.sh\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "> ...\\standalone.bat\n"
+msgstr "> ...\\standalone.bat\n"
+
+#. type: delimited block =
+msgid ""
+"If you receive a `file not found`, make sure you used `unzip` in the "
+"previous step.  This method of extraction installs the files in the right "
+"place."
+msgstr ""
+"`file not found` が出力された場合は、前の手順で `unzip` "
+"を使用したかどうかを確認してください。この解凍方法で、ファイルが適切な場所にインストールされます。"
+
+#. type: Block title
+#, no-wrap
+msgid "EAP 7.3 on Linux/Unix"
+msgstr "Linux/Unix上のEAP 7.3"
+
+#. type: Block title
+#, no-wrap
+msgid "EAP 7.3 on Windows"
+msgstr "Windows上のEAP 7.3"

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -59,7 +59,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "{appserver_name} is installed."
-msgstr "{appserver_name}がインストールされていること"
+msgstr "{appserver_name}がインストールされていること。"
 
 #. type: Plain text
 msgid ""
@@ -67,7 +67,7 @@ msgid ""
 "if you have customized this file."
 msgstr ""
 " `../standalone/configuration/standalone.xml` "
-"をカスタマイズしている場合は、このファイルのバックアップがあること"
+"をカスタマイズしている場合は、このファイルのバックアップがあること。"
 
 #. type: Plain text
 msgid ""
@@ -75,7 +75,7 @@ msgid ""
 "link:https://www.keycloak.org/downloads.html[keycloak.org]."
 msgstr ""
 "link:https://www.keycloak.org/downloads.html[keycloak.org]から *WildFly OpenID"
-" Connect Client Adapter* のディストリビューションをダウンロードします。"
+" Connect Client Adapter* の配布物をダウンロードします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/install-client-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__install-client-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
