### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -78,7 +78,7 @@ msgid ""
 "you configure an IDP, it will appear on the {project_name} login page as an "
 "option."
 msgstr ""
-"上記は、Facebookのソーシャル・ログイン・プロバイダーを設定する例です。IDPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
+"上記は、Facebookのソーシャル・ログイン・プロバイダーを設定する例です。IdPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -74,11 +74,11 @@ msgstr "image:{project_images}/add-identity-provider.png[]"
 
 #. type: Plain text
 msgid ""
-"Above is an example of configuring a Google social login provider.  Once you"
-" configure an IDP, it will appear on the {project_name} login page as an "
+"Above is an example of configuring a Facebook social login provider.  Once "
+"you configure an IDP, it will appear on the {project_name} login page as an "
 "option."
 msgstr ""
-"上記は、Googleのソーシャル・ログイン・プロバイダーを設定する例です。IDPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
+"上記は、Facebookのソーシャル・ログイン・プロバイダーを設定する例です。IDPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
