### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/create-client.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/create-client.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/create-client.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,28 +19,44 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
 #. type: Title ===
 #, no-wrap
-msgid "Creating and Registering the Client"
-msgstr "クライアントの作成と登録"
+msgid "Registering the {appserver_name} application"
+msgstr "{appserver_name}アプリケーションの登録"
 
 #. type: Plain text
 msgid ""
-"To define and register the client in the {project_name} admin console, "
-"complete the following steps:"
-msgstr "{project_name}管理コンソールでクライアントを定義して登録するには、次の手順を実行します。"
+"You can now define and register the client in the {project_name} admin "
+"console."
+msgstr "これで、{project_name}管理コンソールでクライアントを定義および登録できます。"
 
 #. type: Plain text
-msgid "Log in to the admin console with your admin account."
-msgstr "管理者アカウントで管理コンソールにログインします。"
+msgid "You installed a client adapter to work with {appserver_name}."
+msgstr "{appserver_name}で動作するようにクライアント・アダプターをインストールしていること"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure "
+msgstr "手順"
 
 #. type: Plain text
 msgid ""
-"In the top left drop-down menu select and manage the `Demo` realm. Click "
-"`Clients` in the left side menu to open the Clients page."
-msgstr ""
-"左上のドロップダウン・メニューで、`Demo` レルムを選択して管理します。左側のメニューで `Clients` "
-"をクリックして、クライアントページを開きます。"
+"Log in to the admin console with your admin account: "
+"http://localhost:8180/auth/admin/"
+msgstr "管理者アカウントで管理コンソールにログインします。: http://localhost:8180/auth/admin/"
+
+#. type: Plain text
+msgid "In the top left drop-down list, select the `Demo` realm."
+msgstr "左上のドロップダウン・リストで `Demo` レルムを選択します。"
+
+#. type: Plain text
+msgid "Click `Clients` in the left side menu to open the Clients page."
+msgstr "左側のメニューの `Clients` をクリックして、クライアント・ページを開きます。"
 
 #. type: Block title
 #, no-wrap
@@ -52,8 +72,10 @@ msgid "On the right side, click *Create*."
 msgstr "右側にある *Create* をクリックします。"
 
 #. type: Plain text
-msgid "Complete the fields as shown here:"
-msgstr "下記のとおり、空欄に入力します。"
+msgid ""
+"On the Add Client dialog, create a client called *vanilla* by completing the"
+" fields as shown below:"
+msgstr "Add Clientダイアログで、次のようにフィールドに入力して、 *vanilla* というクライアントを作成します。"
 
 #. type: Block title
 #, no-wrap
@@ -65,22 +87,39 @@ msgid "image:{project_images}/add-client.png[]"
 msgstr "image:{project_images}/add-client.png[]"
 
 #. type: Plain text
-msgid "Click *Save* to create the client application entry."
-msgstr "クライアント・アプリケーション・エントリーを作成するには、 *Save* をクリックします。"
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
 
 #. type: Plain text
 msgid ""
-"Click the *Installation* tab in the {project_name} admin console to obtain a"
-" configuration template."
-msgstr "{project_name}管理コンソールの *Installation* タブをクリックして、設定テンプレートを取得します。"
+"On the *Vanilla* client page that appears, click the *Installation* tab."
+msgstr "表示される *Vanilla* クライアントページで、 *Installation* タブをクリックします。"
 
 #. type: Plain text
 msgid ""
-"Select *Keycloak OIDC JBoss Subsystem XML* to generate an XML template. Copy"
-" the contents for use in the next section."
-msgstr ""
-"*Keycloak OIDC JBoss Subsystem XML* "
-"を選択して、XMLテンプレートを生成します。次のセクションで使用するために、内容をコピーします。"
+"Select *Keycloak OIDC JSON* to generate a file that you need in a later "
+"procedure."
+msgstr "*Keycloak OIDC JSON* を選択して、後の手順で必要なファイルを生成します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Keycloak.json file"
+msgstr "Keycloak.jsonファイル"
+
+#. type: Plain text
+msgid "image:{project_images}/client-install-selected.png[]"
+msgstr "image:{project_images}/client-install-selected.png[]"
+
+#. type: Plain text
+msgid ""
+"Click *Download* to save *Keycloak.json* in a location that you can find "
+"later."
+msgstr "*Download* をクリックして *Keycloak.json* を後で見つけられる場所に保存します。"
+
+#. type: Plain text
+msgid ""
+"Select *Keycloak OIDC JBoss Subsystem XML* to generate an XML template."
+msgstr "XMLテンプレートを生成するには、 *Keycloak OIDC JBoss Subsystem XML* を選択します。"
 
 #. type: Block title
 #, no-wrap
@@ -88,5 +127,7 @@ msgid "Template XML"
 msgstr "XMLテンプレート"
 
 #. type: Plain text
-msgid "image:{project_images}/client-install-selected.png[]"
-msgstr "image:{project_images}/client-install-selected.png[]"
+msgid ""
+"Click *Download* to save a copy for use in the next procedure, which "
+"involves {appserver_name} configuration."
+msgstr "次の手順で使用するために、 *Download* をクリックして{appserver_name}の設定を含むコピーを保存します。"

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/create-client.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/create-client.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +37,7 @@ msgstr "これで、{project_name}管理コンソールでクライアントを�
 
 #. type: Plain text
 msgid "You installed a client adapter to work with {appserver_name}."
-msgstr "{appserver_name}で動作するようにクライアント・アダプターをインストールしていること"
+msgstr "{appserver_name}で動作するようにクライアント・アダプターをインストールしていること。"
 
 #. type: Block title
 #, no-wrap
@@ -48,7 +48,7 @@ msgstr "手順"
 msgid ""
 "Log in to the admin console with your admin account: "
 "http://localhost:8180/auth/admin/"
-msgstr "管理者アカウントで管理コンソールにログインします。: http://localhost:8180/auth/admin/"
+msgstr "管理者アカウントで管理コンソールにログインします： http://localhost:8180/auth/admin/"
 
 #. type: Plain text
 msgid "In the top left drop-down list, select the `Demo` realm."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/create-client.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__create-client
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
