### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -4,20 +4,30 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Block title
 #, no-wrap
@@ -29,44 +39,75 @@ msgstr "Linux/Unix"
 msgid "Windows"
 msgstr "Windows"
 
-#. type: Title =
+#. type: Plain text
+msgid "You have an admin account for the admin console."
+msgstr "管理コンソールの管理者アカウントを持っていること"
+
+#. type: Title ===
 #, no-wrap
-msgid "Before You Start"
-msgstr "始める前に"
+msgid "Adjusting the port used by {project_name}"
+msgstr "{project_name}が使用するポートの調整"
 
 #. type: Plain text
 msgid ""
-"Before you can secure a Java servlet application, you must complete the "
-"installation of {project_name} and create the initial admin user as shown in"
-" <<_install-boot, Installing and Booting>>."
+"The instructions in this guide apply to running {appserver_name} on the same"
+" machine as the {project_name} server. In this situation, even though "
+"{appserver_name} is bundled with {project_name}, you cannot use "
+"{appserver_name} as an application container. You must run a separate "
+"{appserver_name} instance for your servlet application."
 msgstr ""
-"Javaサーブレット・アプリケーションをセキュリティー保護するには、まず{project_name}のインストールを完了し、<<_install-"
-"boot, インストールと起動>>に沿って初期管理者ユーザーを作成する必要があります。"
+"このガイドの手順は、{project_name}サーバーと同じマシンで{appserver_name}を実行する場合に適用されます。この状況では、{appserver_name}が{project_name}にバンドルされていても、{appserver_name}をアプリケーション・コンテナーとして使用することはできません。サーブレット・アプリケーション用に別の{appserver_name}インスタンスを実行する必要があります。"
 
 #. type: Plain text
 msgid ""
-"There is one caveat: Even though {appserver_name} is bundled with "
-"{project_name}, you cannot use this as an application container.  Instead, "
-"you must run a separate {appserver_name} instance on the same machine as the"
-" {project_name} server to run your Java servlet application. Run the "
-"{project_name} using a different port than the {appserver_name}, to avoid "
-"port conflicts."
-msgstr ""
-"1つの注意点があります。{appserver_name}は{project_name}にバンドルされていますが、これをアプリケーション・コンテナーとして使用することはできません。代わりに、Javaサーブレット・アプリケーションを実行するには、{project_name}サーバーと同じマシン上で別の{appserver_name}インスタンスを実行する必要があります。ポートの競合を避けるため、{appserver_name}とは異なるポートを使用して{project_name}を実行します。"
+"To avoid port conflicts, you need different ports to run {project_name} and "
+"{appserver_name}."
+msgstr "ポートの競合を回避するには、{project_name}と{appserver_name}を実行する異なるポートが必要です。"
+
+#. type: Plain text
+msgid "You created a demo realm."
+msgstr "demoレルムを作成していること"
+
+#. type: Plain text
+msgid "You created a user in the demo realm."
+msgstr "demoレルムにユーザーを作成していること"
+
+#. type: Plain text
+msgid "Download WildFly from link:https://wildfly.org[WildFly.org]."
+msgstr "link:https://wildfly.org[WildFly.org]からWildFlyをダウンロードします。"
 
 #. type: Plain text
 msgid ""
-"To adjust the port used, change the value of the `jboss.socket.binding.port-"
-"offset` system property when starting the server from the command line. The "
-"value of this property is a number that will be added to the base value of "
-"every port opened by the {project_name} server."
+"Download JBoss EAP 7.3 from the "
+"https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions[Red"
+" Hat customer portal]."
 msgstr ""
-"使用するポートを調整するには、コマンドラインからサーバーを起動する際に `jboss.socket.binding.port-offset` "
-"システム・プロパティーの値を変更します。このプロパティーの値は、{project_name}サーバーによって開かれたすべてのポートの基本値に追加される数値です。"
+"https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=appplatform&downloadType=distributions[Red"
+" Hatカスタマーポータル]からJBoss EAP 7.3をダウンロードします。"
 
 #. type: Plain text
-msgid "To start the {project_name} server while also adjusting the port:"
-msgstr "ポートを調整して{project_name}サーバーを起動するには、以下を実行します。"
+msgid "Unzip the downloaded {appserver_name}."
+msgstr "ダウンロードした{appserver_name}を解凍します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ unzip <filename>.zip\n"
+msgstr "$ unzip <filename>.zip\n"
+
+#. type: Plain text
+msgid "Change to the {project_name} root directory."
+msgstr "{project_name}のルート・ディレクトリーに移動します。"
+
+#. type: Plain text
+msgid ""
+"Start the {project_name} server by supplying a value for the "
+"`jboss.socket.binding.port-offset` system property. This value is added to "
+"the base value of every port opened by the {project_name} server. In this "
+"example, *100* is the value."
+msgstr ""
+"`jboss.socket.binding.port-offset` "
+"システム・プロパティーの値を指定して、{project_name}サーバーを起動します。この値は、{project_name}サーバーによって開かれたすべてのポートのベース値に追加されます。この例では、"
+" *100* です。"
 
 #. type: delimited block -
 #, no-wrap
@@ -84,8 +125,14 @@ msgstr "> ...\\bin\\standalone.bat -Djboss.socket.binding.port-offset=100\n"
 
 #. type: Plain text
 msgid ""
-"After starting {project_name}, go to http://localhost:8180/auth/admin/ to "
-"access the admin console."
+"Confirm that the {project_name} server is running. Go to "
+"http://localhost:8180/auth/admin/ ."
 msgstr ""
-"{project_name}を起動したら、管理コンソールにアクセスして、 http://localhost:8180/auth/admin/ "
-"に遷移します。"
+"{project_name}サーバーが実行されていることを確認します。http://localhost:8180/auth/admin/にアクセスします。"
+
+#. type: Plain text
+msgid ""
+"If the admin console opens, you are ready to install a client adapter that "
+"enables {appserver_name} to work with {project_name}."
+msgstr ""
+"管理コンソールが開いたら、{appserver_name}が{project_name}と連携できるようにするクライアント・アダプターをインストールする準備ができています。"

--- a/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,7 +41,7 @@ msgstr "Windows"
 
 #. type: Plain text
 msgid "You have an admin account for the admin console."
-msgstr "管理コンソールの管理者アカウントを持っていること"
+msgstr "管理コンソールの管理者アカウントを持っていること。"
 
 #. type: Title ===
 #, no-wrap
@@ -66,11 +66,11 @@ msgstr "ポートの競合を回避するには、{project_name}と{appserver_na
 
 #. type: Plain text
 msgid "You created a demo realm."
-msgstr "demoレルムを作成していること"
+msgstr "demoレルムを作成していること。"
 
 #. type: Plain text
 msgid "You created a user in the demo realm."
-msgstr "demoレルムにユーザーを作成していること"
+msgstr "demoレルムにユーザーを作成していること。"
 
 #. type: Plain text
 msgid "Download WildFly from link:https://wildfly.org[WildFly.org]."
@@ -128,7 +128,8 @@ msgid ""
 "Confirm that the {project_name} server is running. Go to "
 "http://localhost:8180/auth/admin/ ."
 msgstr ""
-"{project_name}サーバーが実行されていることを確認します。http://localhost:8180/auth/admin/にアクセスします。"
+"{project_name}サーバーが実行されていることを確認します。 http://localhost:8180/auth/admin/ "
+"にアクセスします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/secure-jboss-app/before.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__secure-jboss-app__before
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
