### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/command-options.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/command-options.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/command-options.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -33,13 +34,13 @@ msgstr "カスタム・リクエストを作成したら、 `{create_cmd_brief}`
 msgid ""
 "To edit a custom request, use this command: `{create_cmd_brief} edit <CR-"
 "name>`"
-msgstr "カスタム・リクエストを編集するには、次のコマンドを使用します。`{create_cmd_brief} edit <CR-name>`"
+msgstr "カスタム・リクエストを編集するには、次のコマンドを使用します。 `{create_cmd_brief} edit <CR-name>`"
 
 #. type: Plain text
 msgid ""
 "To delete a custom request, use this command: `{create_cmd_brief} delete "
 "<CR-name>`"
-msgstr "カスタム・リクエストを削除するには、次のコマンドを使用します。`{create_cmd_brief} delete <CR-name>`"
+msgstr "カスタム・リクエストを削除するには、次のコマンドを使用します。 `{create_cmd_brief} delete <CR-name>`"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operator/command-options.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/command-options.ja_JP.po
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Command options for managing custom resources"
+msgstr "カスタムリソースを管理するためのコマンド・オプション"
+
+#. type: Plain text
+msgid ""
+"After you create a custom request, you can edit it or delete using the "
+"`{create_cmd_brief}` command."
+msgstr "カスタム・リクエストを作成したら、 `{create_cmd_brief}` コマンドを使用して、それを編集または削除できます。"
+
+#. type: Plain text
+msgid ""
+"To edit a custom request, use this command: `{create_cmd_brief} edit <CR-"
+"name>`"
+msgstr "カスタム・リクエストを編集するには、次のコマンドを使用します。`{create_cmd_brief} edit <CR-name>`"
+
+#. type: Plain text
+msgid ""
+"To delete a custom request, use this command: `{create_cmd_brief} delete "
+"<CR-name>`"
+msgstr "カスタム・リクエストを削除するには、次のコマンドを使用します。`{create_cmd_brief} delete <CR-name>`"
+
+#. type: Plain text
+msgid ""
+"For example, to edit a realm custom request named `test-realm`, use this "
+"command:"
+msgstr "たとえば、 `test-realm` という名前のレルム・カスタム・リクエストを編集するには、次のコマンドを使用します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ {create_cmd_brief} edit test-realm\n"
+msgstr "$ {create_cmd_brief} edit test-realm\n"
+
+#. type: Plain text
+msgid "A window opens where you can make changes."
+msgstr "変更を加えることができるウィンドウが開きます。"
+
+#. type: delimited block =
+msgid ""
+"You can update the YAML file and changes appear in the {project_name} admin "
+"console, however changes to the admin console do not update the custom "
+"resource."
+msgstr ""
+"YAMLファイルを更新すると、{project_name}管理コンソールに変更が表示されますが、管理コンソールで変更しても、カスタムリソースは更新されません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/command-options.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__command-options
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
