### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,11 +19,121 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Title ====
+#, no-wrap
+msgid "Tomcat 7, 8 and 9 Adapters"
+msgstr "Tomcat 7、8、9アダプター"
+
+#. type: Plain text
+msgid ""
+"To be able to secure WAR apps deployed on Tomcat 7, 8 and 9 you must install"
+" the Keycloak Tomcat 7 adapter or Keycloak Tomcat adapter into your Tomcat "
+"installation.  You then have to provide some extra configuration in each WAR"
+" you deploy to Tomcat.  Let's go over these steps."
+msgstr ""
+"Tomcat 7、8、9にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 7アダプターまたはKeycloak "
+"TomcatアダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Adapter Installation"
+msgstr "アダプターのインストール"
+
+#. type: Plain text
+msgid ""
+"Adapters are no longer included with the appliance or war distribution.  "
+"Each adapter is a separate download on the Keycloak download site.  They are"
+" also available as a maven artifact."
+msgstr ""
+"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
+
+#. type: Plain text
+msgid ""
+"You must unzip the adapter distro into Tomcat's `lib/` directory.  Including"
+" adapter's jars within your WEB-INF/lib directory will not work! The "
+"Keycloak adapter is implemented as a Valve and valve code must reside in "
+"Tomcat's main lib/ directory."
+msgstr ""
+"アダプターの配布物をTomcatの `lib/` ディレクトリーに解凍する必要があります。WEB-"
+"INF/libディレクトリー内にアダプターのjarを含めても動作しません！KeycloakアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリーに存在する必要があります。"
+
+#. type: Plain text
+msgid "Install on Tomcat 7:"
+msgstr "Tomcat 7へのインストールは次のとおりです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat7-adapter-dist.zip\n"
+msgstr ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat7-adapter-dist.zip\n"
+
+#. type: Plain text
+msgid "Install on Tomcat 8 or 9:"
+msgstr "Tomcat 8、9へのインストールは次のとおりです。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat-adapter-dist.zip\n"
+msgstr ""
+"$ cd $TOMCAT_HOME/lib\n"
+"$ unzip keycloak-tomcat-adapter-dist.zip\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "Required Per WAR Configuration"
+msgstr "WARごとに必要な設定"
+
 #. type: Plain text
 msgid ""
 "This section describes how to secure a WAR directly by adding config and "
 "editing files within your WAR package."
 msgstr "このセクションでは、直接WARパッケージ内に設定を追加し、ファイルを編集することで、WARをセキュリティー保護する方法について説明します。"
+
+#. type: Plain text
+msgid ""
+"The first thing you must do is create a `META-INF/context.xml` file in your "
+"WAR package.  This is a Tomcat specific config file and you must define a "
+"Keycloak specific Valve."
+msgstr ""
+"まず、WARパッケージに `META-INF/context.xml` ファイルを作成します。 "
+"これはTomcat固有の設定ファイルであり、Keycloak固有のValveを定義する必要があります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<Context path=\"/your-context-path\">\n"
+"    <Valve className=\"org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve\"/>\n"
+"</Context>\n"
+msgstr ""
+"<Context path=\"/your-context-path\">\n"
+"    <Valve className=\"org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve\"/>\n"
+"</Context>\n"
+
+#. type: Plain text
+msgid ""
+"Next you must create a `keycloak.json` adapter config file within the `WEB-"
+"INF` directory of your WAR."
+msgstr "次に、WARの `WEB-INF` ディレクトリーに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"The format of this config file is described in the "
+"<<_java_adapter_config,Java adapter configuration>>           \n"
+msgstr "この設定ファイルの形式は<<_java_adapter_config,Javaアダプターの設定>>で説明しています。\n"
+
+#. type: Plain text
+msgid ""
+"Finally you must specify both a `login-config` and use standard servlet "
+"security to specify role-base constraints on your URLs.  Here's an example:"
+msgstr ""
+"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
+"と標準のサーブレット・セキュリティーの両方を指定する必要があります。例を次に示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -46,47 +156,6 @@ msgstr "\t<module-name>customer-portal</module-name>\n"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
-msgstr ""
-"    <security-role>\n"
-"        <role-name>admin</role-name>\n"
-"    </security-role>\n"
-"    <security-role>\n"
-"        <role-name>user</role-name>\n"
-"    </security-role>\n"
-"</web-app>\n"
-
-#. type: Title =====
-#, no-wrap
-msgid "Adapter Installation"
-msgstr "アダプターのインストール"
-
-#. type: Plain text
-msgid ""
-"The first thing you must do is create a `META-INF/context.xml` file in your "
-"WAR package.  This is a Tomcat specific config file and you must define a "
-"Keycloak specific Valve."
-msgstr ""
-"まず、WARパッケージに `META-INF/context.xml` ファイルを作成します。 "
-"これはTomcat固有の設定ファイルであり、Keycloak固有のValveを定義する必要があります。"
-
-#. type: Plain text
-msgid ""
-"Finally you must specify both a `login-config` and use standard servlet "
-"security to specify role-base constraints on your URLs.  Here's an example:"
-msgstr ""
-"最後に、URLに対してロールベース制約を指定するために、 `login-config` "
-"と標準のサーブレット・セキュリティーの両方を指定する必要があります。例を次に示します。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
 "    <security-constraint>\n"
 "        <web-resource-collection>\n"
 "            <web-resource-name>Customers</web-resource-name>\n"
@@ -120,90 +189,21 @@ msgstr ""
 "        <realm-name>this is ignored currently</realm-name>\n"
 "    </login-config>\n"
 
-#. type: Plain text
-msgid ""
-"Adapters are no longer included with the appliance or war distribution.  "
-"Each adapter is a separate download on the Keycloak download site.  They are"
-" also available as a maven artifact."
-msgstr ""
-"アダプターはアプライアンスやwarには含まれていません。各アダプターは、Keycloakのダウンロード・サイトで個別にダウンロードできます。これらは、mavenのアーティファクトとしても利用できます。"
-
-#. type: Plain text
-msgid "Install on Tomcat 7:"
-msgstr "Tomcat 7へのインストールは次のとおりです。"
-
-#. type: Plain text
-msgid "Install on Tomcat 8 or 9:"
-msgstr "Tomcat 8、9へのインストールは次のとおりです。"
-
-#. type: Title =====
-#, no-wrap
-msgid "Required Per WAR Configuration"
-msgstr "WARごとに必要な設定"
-
-#. type: Plain text
-msgid ""
-"Next you must create a `keycloak.json` adapter config file within the `WEB-"
-"INF` directory of your WAR."
-msgstr "次に、WARの `WEB-INF` ディレクトリーに `keycloak.json` アダプター設定ファイルを作成しておく必要があります。"
-
-#. type: Title ====
-#, no-wrap
-msgid "Tomcat 7 and 8 Adapters"
-msgstr "Tomcat 7、8アダプター"
-
-#. type: Plain text
-msgid ""
-"To be able to secure WAR apps deployed on Tomcat 7, 8 and 9 you must install"
-" the Keycloak Tomcat 7 adapter or Keycloak Tomcat adapter into your Tomcat "
-"installation.  You then have to provide some extra configuration in each WAR"
-" you deploy to Tomcat.  Let's go over these steps."
-msgstr ""
-"Tomcat 7、8、9にデプロイされたWARアプリケーションを保護するには、Keycloak Tomcat 7アダプターまたはKeycloak "
-"TomcatアダプターをTomcatにインストールする必要があります。その後、TomcatにデプロイするWARにもいくつかの設定を行う必要があります。これらの手順について説明します。"
-
-#. type: Plain text
-msgid ""
-"You must unzip the adapter distro into Tomcat's `lib/` directory.  Including"
-" adapter's jars within your WEB-INF/lib directory will not work! The "
-"Keycloak adapter is implemented as a Valve and valve code must reside in "
-"Tomcat's main lib/ directory."
-msgstr ""
-"アダプターの配布物をTomcatの `lib/` ディレクトリーに解凍する必要があります。WEB-"
-"INF/libディレクトリー内にアダプターのjarを含めても動作しません！KeycloakアダプターはValveとして実装され、ValveのコードはTomcatのメインのlib/ディレクトリーに存在する必要があります。"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-tomcat7-adapter-dist.zip\n"
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"
 msgstr ""
-"$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-tomcat7-adapter-dist.zip\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-tomcat-adapter-dist.zip\n"
-msgstr ""
-"$ cd $TOMCAT_HOME/lib\n"
-"$ unzip keycloak-tomcat-adapter-dist.zip\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"<Context path=\"/your-context-path\">\n"
-"    <Valve className=\"org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve\"/>\n"
-"</Context>\n"
-msgstr ""
-"<Context path=\"/your-context-path\">\n"
-"    <Valve className=\"org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve\"/>\n"
-"</Context>\n"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"The format of this config file is described in the "
-"<<_java_adapter_config,Java adapter configuration>>           \n"
-msgstr "この設定ファイルの形式は<<_java_adapter_config,Javaアダプターの設定>>で説明しています。\n"
+"    <security-role>\n"
+"        <role-name>admin</role-name>\n"
+"    </security-role>\n"
+"    <security-role>\n"
+"        <role-name>user</role-name>\n"
+"    </security-role>\n"
+"</web-app>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/tomcat-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__tomcat-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
