### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator.ja_JP.po
@@ -1,0 +1,95 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "{project_operator}"
+msgstr "{project_operator}"
+
+#. type: Plain text
+msgid "The {project_operator} automates {project_name} administration in"
+msgstr "{project_operator}は{project_name}の管理を自動化します"
+
+#. type: Plain text
+msgid "Kubernetes or"
+msgstr "Kubernetesまたは"
+
+#. type: Plain text
+msgid ""
+"Openshift. You use this Operator to create custom resources (CRs), which "
+"automate administrative tasks. For example, instead of creating a client or "
+"a user in the {project_name} admin console, you can create custom resources "
+"to perform those tasks. A custom resource is a YAML file that defines the "
+"parameters for the administrative task."
+msgstr ""
+"Openshift。このオペレーターを使用して、管理タスクを自動化するカスタムリソース（CR）を作成します。たとえば、{project_name}管理コンソールでクライアントまたはユーザーを作成する代わりに、これらのタスクを実行するカスタムリソースを作成できます。カスタムリソースは、管理タスクのパラメーターを定義するYAMLファイルです。"
+
+#. type: Plain text
+msgid "You can create custom resources to perform the following tasks:"
+msgstr "カスタムリソースを作成して、次のタスクを実行できます。"
+
+#. type: Plain text
+msgid "xref:_keycloak_cr[Install {project_name}]"
+msgstr "xref:_keycloak_cr[Install {project_name}]"
+
+#. type: Plain text
+msgid "xref:_realm-cr[Create realms]"
+msgstr "xref:_realm-cr[Create realms]"
+
+#. type: Plain text
+msgid "xref:_client-cr[Create clients]"
+msgstr "xref:_client-cr[Create clients]"
+
+#. type: Plain text
+msgid "xref:_user-cr[Create users]"
+msgstr "xref:_user-cr[Create users]"
+
+#. type: Plain text
+msgid "xref:_external_database[Connect to an external database]"
+msgstr "xref:_external_database[Connect to an external database]"
+
+#. type: Plain text
+msgid "xref:_backup-cr[Schedule database backups]"
+msgstr "xref:_backup-cr[Schedule database backups]"
+
+#. type: Plain text
+msgid "xref:_operator-extensions[Install extensions and themes]"
+msgstr "xref:_operator-extensions[Install extensions and themes]"
+
+#. type: Plain text
+msgid ""
+"After you create custom resources for realms, clients, and users, you can "
+"manage them by using the {project_name} admin console or as custom resources"
+" using the `{create_cmd_brief}` command.  However, you cannot use both "
+"methods, because the Operator performs a one way sync for custom resources "
+"that you modify.  For example, if you modify a realm custom resource, the "
+"changes show up in the admin console. However, if you modify the realm using"
+" the admin console, those changes have no effect on the custom resource."
+msgstr ""
+"レルム、クライアント、ユーザーのカスタムリソースを作成したら、{project_name}管理コンソールを使用するか、 "
+"`{create_cmd_brief}` "
+"コマンドを使用してカスタムリソースとして管理できます。ただし、オペレーターは変更したカスタムリソースに対して一方向の同期を実行するため、両方の方法を使用することはできません。たとえば、レルムのカスタムリソースを変更すると、その変更が管理コンソールに表示されます。ただし、管理コンソールを使用してレルムを変更した場合、それらの変更はカスタムリソースには影響しません。"
+
+#. type: Plain text
+msgid ""
+"Begin using the Operator by xref:_installing-operator[Installing the "
+"{project_operator} on a cluster]."
+msgstr ""
+" xref:_installing-operator[{project_operator} のインストール] でオペレーターの使用を開始します。"

--- a/i18n/po/ja_JP/server_installation/topics/operator.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -92,4 +93,4 @@ msgid ""
 "Begin using the Operator by xref:_installing-operator[Installing the "
 "{project_operator} on a cluster]."
 msgstr ""
-" xref:_installing-operator[{project_operator} のインストール] でオペレーターの使用を開始します。"
+"xref:_installing-operator[{project_operator}のインストール] でオペレーターの使用を開始します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
