### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -252,8 +252,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For instance,to allow access to a group of resources only for users granted "
-"with a role \"User Premium\", you can use RBAC (Role-based Access Control)."
+"For instance, to allow access to a group of resources only for users granted"
+" with a role \"User Premium\", you can use RBAC (Role-based Access Control)."
 msgstr ""
 "例えば、ロール \"User Premium\" "
 "が付与されたユーザーに対してのみリソースのグループへのアクセスを許可するために、RBAC（ロールベースのアクセス・コントロール）を使用できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-architecture.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-architecture
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
