### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -206,5 +206,5 @@ msgid ""
 "Review` left menu item and then `Requests`. After that follow the "
 "instructions on screen."
 msgstr ""
-"この後、Instagramアプリを公開する必要があります。左側のメニュー項目の `App Review` lをクリックし、次に `Requests` "
+"この後、Instagramアプリを公開する必要があります。左側のメニュー項目の `App Review` をクリックし、次に `Requests` "
 "をクリックします。その後、画面の指示に従ってください。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
@@ -1,0 +1,210 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Identity Provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Block title
+#, no-wrap
+msgid "Add a New App"
+msgstr "新しいアプリケーションの追加"
+
+#. type: Title ====
+#, no-wrap
+msgid "Instagram"
+msgstr "Instagram"
+
+#. type: Plain text
+msgid ""
+"There are a number of steps you have to complete to be able to enable login "
+"with Instagram.  First, go to the `Identity Providers` left menu item and "
+"select `Instagram` from the `Add provider` drop down list.  This will bring "
+"you to the `Add identity provider` page."
+msgstr ""
+"Instagramでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
+"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Instagram` を選択します。これにより、 "
+"`Add identity provider` ページが表示されます。"
+
+#. type: Plain text
+msgid "image:{project_images}/instagram-add-identity-provider.png[]"
+msgstr "image:{project_images}/instagram-add-identity-provider.png[]"
+
+#. type: Plain text
+msgid ""
+"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
+" Secret` from Instagram.  One piece of data you'll need from this page is "
+"the `Redirect URI`.  You'll have to provide that to Instagram when you "
+"register {project_name} as a client there, so copy this URI to your "
+"clipboard."
+msgstr ""
+"Instagramから `Client ID` と `Client Secret` "
+"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
+"です。Instagramに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
+
+#. type: Plain text
+msgid ""
+"To enable login with Instagram you first have to create a project and a "
+"client. Instagram API is managed through the "
+"https://developers.facebook.com/[Facebook Developer Console]."
+msgstr ""
+"Instagramでのログインを可能にするには、まずプロジェクトとクライアントを作成する必要があります。Instagram APIは、 "
+"https://developers.facebook.com/[Facebook Developer Console] を通じて管理されます。"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Facebook often changes the look and feel of the Facebook Developer Console, so these directions might not always be up to date and the\n"
+"      configuration steps might be slightly different.\n"
+msgstr ""
+"FacebookはFacebook Developer "
+"Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
+
+#. type: Plain text
+msgid ""
+"Once you've logged into the console there is a menu in the top right corner "
+"of the screen that says `My Apps`.  Select the `Add a New App` menu item."
+msgstr ""
+"コンソールにログインすると、画面の右上に `My Apps` と表示されるメニューが表示されます。 `Add a New App` "
+"メニュー項目を選択します。"
+
+#. type: Plain text
+msgid "image:images/instagram-add-new-app.png[]"
+msgstr "image:images/instagram-add-new-app.png[]"
+
+#. type: Plain text
+msgid "Select `For Everything Else`."
+msgstr "`For Everything Else` を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Create a New App ID"
+msgstr "新しいApp IDの作成"
+
+#. type: Plain text
+msgid "image:images/instagram-create-app-id.png[]"
+msgstr "image:images/instagram-create-app-id.png[]"
+
+#. type: Plain text
+msgid ""
+"Fill all required fields. Once you're done with that, you will be brought to"
+" the dashboard for the application. In the menu in the left navigation panel"
+" select `Basic` under `Settings`."
+msgstr ""
+"すべての必須フィールドに入力します。これを完了すると、アプリケーションのダッシュボードが表示されます。左側のナビゲーション・パネルのメニューで、 "
+"`Settings` の下の `Basic` を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Platform"
+msgstr "プラットフォームの追加"
+
+#. type: Plain text
+msgid "image:images/instagram-add-platform.png[]"
+msgstr "image:images/instagram-add-platform.png[]"
+
+#. type: Plain text
+msgid ""
+"Select `+ Add Platform` at the bottom and then click `[Website]` with the "
+"globe icon. Specify URL of your site."
+msgstr ""
+"下部にある `+ Add Platform` を選択し、地球のアイコンの付いた `[Website]` をクリックします。サイトのURLを指定します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add a Product"
+msgstr "プロダクトの追加"
+
+#. type: Plain text
+msgid "image:images/instagram-add-product.png[]"
+msgstr "image:images/instagram-add-product.png[]"
+
+#. type: Plain text
+msgid ""
+"Select `Dashboard` from the left menu and click `Set Up` in the Instagram "
+"box. In the left menu then select `Basic Display` under `Instagram` and "
+"click `Create New App`."
+msgstr ""
+"左側のメニューから `Dashboard` を選択し、Instagramボックスの `Set Up` をクリックします。左側のメニューで、 "
+"`Instagram` の下の `Basic Display` を選択し、 `Create New App` をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Create a New Instagram App ID"
+msgstr "新しいInstagram App IDの作成"
+
+#. type: Plain text
+msgid "image:images/instagram-create-instagram-app-id.png[]"
+msgstr "image:images/instagram-create-instagram-app-id.png[]"
+
+#. type: Plain text
+msgid "Specify `Display Name`."
+msgstr "`Display Name` を指定します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Setup the App"
+msgstr "アプリのセットアップ"
+
+#. type: Plain text
+msgid "image:images/instagram-app-settings.png[]"
+msgstr "image:images/instagram-app-settings.png[]"
+
+#. type: Plain text
+msgid ""
+"Copy and paste the `Redirect URI` from the {project_name} `Add identity "
+"provider` page into the `Valid OAuth Redirect URIs` of the Instagram `Client"
+" OAuth Settings` settings block."
+msgstr ""
+"{project_name}の `Add identity provider` ページから取得した `Redirect URI` をInstagramの"
+" `Client OAuth Settings` 設定ブロックの `Valid OAuth Redirect URIs` "
+"にコピー・アンド・ペーストします。"
+
+#. type: Plain text
+msgid ""
+"You can use this URL also for `Deauthorize Callback URL` and `Data Deletion "
+"Request URL`. {project_name} currently doesn't support either of them, but "
+"the Facebook Developer Console requires both of them to be filled."
+msgstr ""
+"このURLは、 `Deauthorize Callback URL` にも `Data Deletion Request URL` "
+"にも使用できます。{project_name}は現在どちらもサポートしていませんが、Facebook Developer "
+"Consoleでは両方に入力する必要があります。"
+
+#. type: Plain text
+msgid ""
+"You will need also to obtain the App ID and App Secret from this page so you"
+" can enter them into the {project_name} `Add identity provider` page.  To "
+"obtain this click on `Show` under `App Secret`. Go back to {project_name} "
+"and specify those items and finally save your Instagram Identity Provider."
+msgstr ""
+"このページからApp IDとApp Secretを取得して、{project_name}の `Add identity provider` "
+"ページに入力する必要があります。これを取得するには、 `App Secret` の下の `Show` "
+"をクリックします。{project_name}に戻り、これらの項目を指定し、最後にInstagramアイデンティティー・プロバイダーを保存します。"
+
+#. type: Plain text
+msgid ""
+"After this it is necessary to make the Instagram app public. Click `App "
+"Review` left menu item and then `Requests`. After that follow the "
+"instructions on screen."
+msgstr ""
+"この後、Instagramアプリを公開する必要があります。左側のメニュー項目の `App Review` lをクリックし、次に `Requests` "
+"をクリックします。その後、画面の指示に従ってください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__instagram
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
