### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,6 +29,20 @@ msgstr "アイデンティティー・プロバイダーの追加"
 #, no-wrap
 msgid "Add a New App"
 msgstr "新しいアプリケーションの追加"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Facebook often changes the look and feel of the Facebook Developer Console, so these directions might not always be up to date and the\n"
+"      configuration steps might be slightly different.\n"
+msgstr ""
+"FacebookはFacebook Developer "
+"Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Create a New App ID"
+msgstr "新しいApp IDの作成"
 
 #. type: Title ====
 #, no-wrap
@@ -70,15 +84,6 @@ msgstr ""
 "Developer Console] でプロジェクトとクライアントを作成する必要があります。"
 
 #. type: Plain text
-#, no-wrap
-msgid ""
-"Facebook often changes the look and feel of the Facebook Developer Console, so these directions might not always be up to date and the\n"
-"      configuration steps might be slightly different.\n"
-msgstr ""
-"FacebookはFacebook Developer "
-"Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
-
-#. type: Plain text
 msgid ""
 "Once you've logged into the console there is a pull down menu in the top "
 "right corner of the screen that says `My Apps`.  Select the `Add a New App` "
@@ -94,11 +99,6 @@ msgstr "image:images/facebook-add-new-app.png[]"
 #. type: Plain text
 msgid "Select the `Website` icon.  Click the `Skip and Create App ID` button."
 msgstr "`Website` アイコンを選択します。 `Skip and Create App ID` ボタンをクリックします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Create a New App ID"
-msgstr "新しいApp IDの作成"
 
 #. type: Plain text
 msgid "image:images/facebook-create-app-id.png[]"
@@ -171,3 +171,23 @@ msgstr ""
 "このフィールドでは、このプロバイダーで認証するときに、ユーザーが承認する必要があるスコープを手動で指定できます。スコープの完全なリストについては、 "
 "https://developers.facebook.com/docs/graph-api "
 "を参照してください。デフォルトでは、{project_name}は `email` のスコープを使用します。"
+
+#. type: Plain text
+msgid ""
+"Another thing to note is that {project_name} sends a profile request to "
+"`graph.facebook.com/me?fields=id,name,email,first_name,last_name` by "
+"default, and the response only contains the specified fields.  If you want "
+"to fetch additional fields (e.g. birthday) from the Facebook profile then "
+"you have to add a corresponding scope as described in a paragraph above and "
+"add the field name in `Additional user's profile fields` configuration "
+"option field.  You can discover available field names and corresponding "
+"scopes by exploring the "
+"https://developers.facebook.com/tools/explorer[Facebook GraphQL API "
+"Explorer]."
+msgstr ""
+"注意すべきもう1つの点は、{project_name}がデフォルトでプロファイル・リクエストを "
+"`graph.facebook.com/me?fields=id,name,email,first_name,last_name` "
+"に送信し、レスポンスには指定されたフィールドのみが含まれることです。Facebookプロファイルから追加のフィールド（誕生日など）を取得する場合は、上記の段落で説明したように対応するスコープを追加し、"
+" `Additional user's profile fields` の設定オプション・フィールドにフィールド名を追加する必要があります。 "
+"https://developers.facebook.com/tools/explorer[Facebook GraphQL API "
+"Explorer] を調べると、使用可能なフィールド名と対応するスコープを見つけることができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/facebook.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__facebook
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
