### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/installation.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/installation.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +38,7 @@ msgstr "手順"
 msgid ""
 "You have cluster-admin permission or an equivalent level of permissions "
 "granted by an administrator."
-msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること"
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること。"
 
 #. type: Title ===
 #, no-wrap
@@ -50,7 +51,7 @@ msgstr "{project_operator}をインストールするには、以下を使用で
 
 #. type: Plain text
 msgid "xref:_install_by_olm[The Operator Lifecycle Manager (OLM)]"
-msgstr "xref:_install_by_olm[Operator Lifecycle Manager (OLM)]"
+msgstr "xref:_install_by_olm[Operator Lifecycle Manager（OLM）]"
 
 #. type: Plain text
 msgid "xref:_install_by_command[Command line installation]"
@@ -179,8 +180,8 @@ msgid ""
 "Go to link:https://operatorhub.io/operator/keycloak-operator[Keycloak "
 "Operator on OperatorHub.io]."
 msgstr ""
-" link:https://operatorhub.io/operator/keycloak-operator[Keycloak Operator on"
-" OperatorHub.io] に移動します。"
+"link:https://operatorhub.io/operator/keycloak-operator[Keycloak Operator on "
+"OperatorHub.io] に移動します。"
 
 #. type: Plain text
 msgid "Follow the instructions on the screen."
@@ -245,7 +246,7 @@ msgstr "$ {create_cmd} -f deploy/crds/\n"
 msgid ""
 "Create a new namespace (or reuse an existing one) such as the namespace "
 "`myproject`:"
-msgstr "ネームスペース`myproject` などの新しいネームスペースを作成（または既存のネームスペースを再利用）します。"
+msgstr "ネームスペース `myproject` などの新しいネームスペースを作成（または既存のネームスペースを再利用）します。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/operator/installation.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/installation.ja_JP.po
@@ -1,0 +1,292 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid ""
+"You have cluster-admin permission or an equivalent level of permissions "
+"granted by an administrator."
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること"
+
+#. type: Title ===
+#, no-wrap
+msgid "Installing the {project_operator} on a cluster"
+msgstr "クラスターに{project_operator}をインストールする"
+
+#. type: Plain text
+msgid "To install the {project_operator}, you can use:"
+msgstr "{project_operator}をインストールするには、以下を使用できます。"
+
+#. type: Plain text
+msgid "xref:_install_by_olm[The Operator Lifecycle Manager (OLM)]"
+msgstr "xref:_install_by_olm[Operator Lifecycle Manager (OLM)]"
+
+#. type: Plain text
+msgid "xref:_install_by_command[Command line installation]"
+msgstr "xref:_install_by_command[コマンドライン・インストール]"
+
+#. type: Title ====
+#, no-wrap
+msgid "Installing using the Operator Lifecycle Manager"
+msgstr "Operator Lifecycle Managerを使用したインストール"
+
+#. type: Plain text
+msgid ""
+"You can install the Operator on an xref:_openshift-olm[OpenShift] or xref"
+":_kubernetes-olm[Kubernetes] cluster."
+msgstr ""
+"Operatorは、 xref:_openshift-olm[OpenShift] または xref:_kubernetes-"
+"olm[Kubernetes] クラスターにインストールできます。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Installation on an OpenShift cluster"
+msgstr "OpenShiftクラスターへのインストール"
+
+#. type: Plain text
+msgid "Perform this procedure on an OpenShift 4.4 cluster."
+msgstr "OpenShift 4.4クラスターでこの手順を実行します。"
+
+#. type: Plain text
+msgid "Open the OpenShift Container Platform web console."
+msgstr "OpenShift Container Platform Webコンソールを開きます。"
+
+#. type: Plain text
+msgid "In the left column, click `Operators, OperatorHub`."
+msgstr "左側の列で、 `Operators, OperatorHub` をクリックします。"
+
+#. type: Plain text
+msgid "Search for {project_name} Operator."
+msgstr "{project_name} Operatorを検索します。"
+
+#. type: Block title
+#, no-wrap
+msgid "OperatorHub tab in OpenShift"
+msgstr "OpenShiftのOperatorHubタブ"
+
+#. type: Plain text
+msgid "image:{project_images}/operator-openshift-operatorhub.png[]"
+msgstr "image:{project_images}/operator-openshift-operatorhub.png[]"
+
+#. type: Plain text
+msgid "Click the {project_name} Operator icon."
+msgstr "{project_name}オペレーター・アイコンをクリックします。"
+
+#. type: Plain text
+msgid "An Install page opens."
+msgstr "インストール・ページが開きます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Operator Install page on OpenShift"
+msgstr "OpenShiftのOperatorインストール・ページ"
+
+#. type: Plain text
+msgid "image:{project_images}/operator-olm-installation.png[]"
+msgstr "image:{project_images}/operator-olm-installation.png[]"
+
+#. type: Plain text
+msgid "Click `Install`."
+msgstr "`Install` をクリックします。"
+
+#. type: Plain text
+msgid "Select a namespace and click Subscribe."
+msgstr "ネームスペースを選択し、Subscribeをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Namespace selection in OpenShift"
+msgstr "OpenShiftでのネームスペースの選択"
+
+#. type: Plain text
+msgid "image:images/installed-namespace.png[]"
+msgstr "image:images/installed-namespace.png[]"
+
+#. type: Plain text
+msgid "The Operator starts installing."
+msgstr "Operatorがインストールを開始します。"
+
+#. type: Plain text
+msgid ""
+"When the Operator installation completes, you are ready to create your first"
+" custom resource. See xref:_keycloak_cr[{project_name} installation using a "
+"custom resource]."
+msgstr ""
+"Operatorのインストールが完了すると、最初のカスタムリソースを作成する準備が整います。 "
+"xref:_keycloak_cr[{project_name} カスタムリソースを使用したインストール] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"However, if you want to start tracking all Operator activities before "
+"creating custom resources, see the xref:_monitoring-operator[Application "
+"Monitoring Operator]."
+msgstr ""
+"ただし、カスタムリソースを作成する前にすべてのOperatorアクティビティーの追跡を開始する場合は、 xref:_monitoring-"
+"operator[Application Monitoring Operator] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"For more information on OpenShift Operators, see the "
+"link:https://docs.openshift.com/container-platform/4.4/operators/olm-what-"
+"operators-are.html[OpenShift Operators guide]."
+msgstr ""
+"OpenShiftオペレーターの詳細については、 link:https://docs.openshift.com/container-"
+"platform/4.4/operators/olm-what-operators-are.html[OpenShift Operators "
+"guide] を参照してください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Installation on a Kubernetes cluster"
+msgstr "Kubernetesクラスターへのインストール"
+
+#. type: Plain text
+msgid "For a Kubernetes cluster, perform these steps."
+msgstr "Kubernetesクラスターの場合、次の手順を実行します。"
+
+#. type: Plain text
+msgid ""
+"Go to link:https://operatorhub.io/operator/keycloak-operator[Keycloak "
+"Operator on OperatorHub.io]."
+msgstr ""
+" link:https://operatorhub.io/operator/keycloak-operator[Keycloak Operator on"
+" OperatorHub.io] に移動します。"
+
+#. type: Plain text
+msgid "Follow the instructions on the screen."
+msgstr "画面の指示に従ってください。"
+
+#. type: Block title
+#, no-wrap
+msgid "Operator Install page on Kubernetes"
+msgstr "KubernetesのOperatorインストール・ページ"
+
+#. type: Plain text
+msgid "image:{project_images}/operator-operatorhub-install.png[]"
+msgstr "image:{project_images}/operator-operatorhub-install.png[]"
+
+#. type: Plain text
+msgid ""
+"When the Operator installation completes, you are ready to create your first"
+" custom resource. See xref:_keycloak_cr[{project_name} installation using a "
+"custom resource]. However, if you want to start tracking all Operator "
+"activities before creating custom resources, see the xref:_monitoring-"
+"operator[Application Monitoring Operator]."
+msgstr ""
+"Operatorのインストールが完了すると、最初のカスタムリソースを作成する準備が整います。 "
+"xref:_keycloak_cr[{project_name} カスタムリソースを使用したインストール] "
+"を参照してください。ただし、カスタムリソースを作成する前にすべてのOperatorアクティビティーの追跡を開始する場合は、 xref"
+":_monitoring-operator[Application Monitoring Operator] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"For more information on a Kubernetes installation, see "
+"link:https://operatorhub.io/how-to-install-an-operator[How to install an "
+"Operator from OperatorHub.io]."
+msgstr ""
+"Kubernetesのインストールの詳細については、 link:https://operatorhub.io/how-to-install-an-"
+"operator[How to install an Operator from OperatorHub.io] を参照してください。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Installing from the command line"
+msgstr "コマンドラインからのインストール"
+
+#. type: Plain text
+msgid "You can install the {project_operator} from the command line."
+msgstr "コマンドラインから{project_operator}をインストールできます。"
+
+#. type: Plain text
+msgid ""
+"Obtain the software to install from this location: "
+"link:{operatorRepo_link}[Github repo]."
+msgstr "次の場所からインストールするソフトウェアを入手してください。link:{operatorRepo_link}[Github repo]"
+
+#. type: Plain text
+msgid "Install all required custom resource definitions:"
+msgstr "必要なすべてのカスタムリソース定義をインストールします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ {create_cmd} -f deploy/crds/\n"
+msgstr "$ {create_cmd} -f deploy/crds/\n"
+
+#. type: Plain text
+msgid ""
+"Create a new namespace (or reuse an existing one) such as the namespace "
+"`myproject`:"
+msgstr "ネームスペース`myproject` などの新しいネームスペースを作成（または既存のネームスペースを再利用）します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ {create_cmd} namespace myproject\n"
+msgstr "$ {create_cmd} namespace myproject\n"
+
+#. type: Plain text
+msgid "Deploy a role, role binding, and service account for the Operator:"
+msgstr "Operatorのロール、ロール・バインディング、およびサービス・アカウントをデプロイします。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd} -f deploy/role.yaml -n myproject\n"
+"$ {create_cmd} -f deploy/role_binding.yaml -n myproject\n"
+"$ {create_cmd} -f deploy/service_account.yaml -n myproject\n"
+msgstr ""
+"$ {create_cmd} -f deploy/role.yaml -n myproject\n"
+"$ {create_cmd} -f deploy/role_binding.yaml -n myproject\n"
+"$ {create_cmd} -f deploy/service_account.yaml -n myproject\n"
+
+#. type: Plain text
+msgid "Deploy the Operator:"
+msgstr "Operatorを配置します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ {create_cmd} -f deploy/operator.yaml -n myproject\n"
+msgstr "$ {create_cmd} -f deploy/operator.yaml -n myproject\n"
+
+#. type: Plain text
+msgid "Confirm that the Operator is running:"
+msgstr "Operatorが実行されていることを確認します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd_brief} get deployment keycloak-operator\n"
+"NAME                READY   UP-TO-DATE   AVAILABLE   AGE\n"
+"keycloak-operator   1/1     1            1           41s\n"
+msgstr ""
+"$ {create_cmd_brief} get deployment keycloak-operator\n"
+"NAME                READY   UP-TO-DATE   AVAILABLE   AGE\n"
+"keycloak-operator   1/1     1            1           41s\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
