### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po
@@ -7,13 +7,13 @@
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -164,12 +164,12 @@ msgstr "OIDCユーザー・セッション・ノート・マッパー"
 
 #. type: Plain text
 msgid ""
-"User session details are via mappers and depend on various criteria. User "
-"session details are automatically included when you use or enable a feature "
-"on a client. You can also click the `Add builtin` button to include session "
-"details."
+"User session details are defined via mappers and depend on various criteria."
+" User session details are automatically included when you use or enable a "
+"feature on a client. You can also click the `Add builtin` button to include "
+"session details."
 msgstr ""
-"ユーザー・セッションの詳細は、マッパーを介し、さまざまな基準に依存します。クライアントである機能を使用または有効にすると、ユーザー・セッションの詳細が自動的に含まれます。セッションの詳細を含めるために、"
+"ユーザー・セッションの詳細は、マッパーを介して定義され、さまざまな基準に依存します。クライアントである機能を使用または有効にすると、ユーザー・セッションの詳細が自動的に含まれます。セッションの詳細を含めるために、"
 " `Add builtin` ボタンをクリックすることもできます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
