### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/keycloak-client-cr.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/keycloak-client-cr.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/keycloak-client-cr.ja_JP.po
@@ -1,0 +1,275 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "You have a YAML file for this custom resource."
+msgstr "このカスタムリソース用のYAMLファイルがあること。"
+
+#. type: Plain text
+msgid ""
+"You have cluster-admin permission or an equivalent level of permissions "
+"granted by an administrator."
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ {create_cmd_brief} describe keycloak <CR-name>\n"
+msgstr "$ {create_cmd_brief} describe keycloak <CR-name>\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Results"
+msgstr "結果"
+
+#. type: Plain text
+msgid ""
+"After the Operator processes the custom resource, view the status with this "
+"command:"
+msgstr "Operatorがカスタムリソースを処理したら、次のコマンドでステータスを表示します。"
+
+#. type: delimited block =
+msgid ""
+"You can update the YAML file and changes appear in the {project_name} admin "
+"console, however changes to the admin console do not update the custom "
+"resource."
+msgstr ""
+"YAMLファイルを更新すると、{project_name}管理コンソールに変更が表示されますが、管理コンソールで変更しても、カスタムリソースは更新されません。"
+
+#. type: Title ===
+#, no-wrap
+msgid "Creating a client custom resource"
+msgstr "クライアント・カスタム・リソースの作成"
+
+#. type: Plain text
+msgid ""
+"You can use the Operator to create clients in {project_name} as defined by a"
+" custom resource.  You define the properties of the realm in a YAML file."
+msgstr ""
+"Operatorを使用して、カスタムリソースで定義されているように{project_name}にクライアントを作成できます。レルムのプロパティーをYAMLファイルで定義します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example YAML file for a Client custom resource"
+msgstr "クライアント・カスタム・リソースのYAMLファイルの例"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: KeycloakClient\n"
+"metadata:\n"
+"  name: example-client\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"    app: app=example-keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"    app: sso\n"
+"endif::[]  \n"
+"spec:\n"
+"  realmSelector:\n"
+"     matchLabels:\n"
+"      app: <matching labels for KeycloakRealm custom resource>\n"
+"  client:\n"
+"    # auto-generated if not supplied\n"
+"    #id: 123\n"
+"    clientId: client-secret\n"
+"    secret: client-secret\n"
+"    # ...\n"
+"    # other properties of Keycloak Client\n"
+msgstr ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: KeycloakClient\n"
+"metadata:\n"
+"  name: example-client\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"    app: app=example-keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"    app: sso\n"
+"endif::[]  \n"
+"spec:\n"
+"  realmSelector:\n"
+"     matchLabels:\n"
+"      app: <matching labels for KeycloakRealm custom resource>\n"
+"  client:\n"
+"    # auto-generated if not supplied\n"
+"    #id: 123\n"
+"    clientId: client-secret\n"
+"    secret: client-secret\n"
+"    # ...\n"
+"    # other properties of Keycloak Client\n"
+
+#. type: Plain text
+msgid ""
+"Use this command on the YAML file that you created: `{create_cmd} -f "
+"<client-name>.yaml`. For example:"
+msgstr "作成したYAMLファイルで `{create_cmd} -f <client-name>.yaml` のコマンドを使用します。例えば、"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd} -f initial_client.yaml\n"
+"keycloak.keycloak.org/example-client created\n"
+msgstr ""
+"$ {create_cmd} -f initial_client.yaml\n"
+"keycloak.keycloak.org/example-client created\n"
+
+#. type: Plain text
+msgid ""
+"Log into the {project_name} admin console for the related instance of "
+"{project_name}."
+msgstr "{project_name}の関連インスタンスの{project_name}管理コンソールにログインします。"
+
+#. type: Plain text
+msgid "Click Clients."
+msgstr "Clientsをクリックします。"
+
+#. type: Plain text
+msgid "The new client appears in the list of clients."
+msgstr "新しいクライアントがクライアントの一覧に表示されます。"
+
+#. type: Plain text
+msgid "image:images/clients.png[]"
+msgstr "image:images/clients.png[]"
+
+#. type: Plain text
+msgid ""
+"After a client is created, the Operator creates a Secret containing the "
+"`Client ID` and the client's secret using the following naming pattern: "
+"`keycloak-client-secret-<custom resource name>`. For example:"
+msgstr ""
+"クライアントが作成された後、オペレーターは `keycloak-client-secret-<custom resource name>` "
+"の命名パターンを使用して `Client ID` とクライアントのシークレットを含むシークレットを作成します。次に例を示します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Client's Secret"
+msgstr "クライアントのシークレット"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: v1\n"
+"data:\n"
+"  CLIENT_ID: <base64 encoded Client ID>\n"
+"  CLIENT_SECRET: <base64 encoded Client Secret>\n"
+"kind: Secret\n"
+msgstr ""
+"apiVersion: v1\n"
+"data:\n"
+"  CLIENT_ID: <base64 encoded Client ID>\n"
+"  CLIENT_SECRET: <base64 encoded Client Secret>\n"
+"kind: Secret\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Client custom resource Status"
+msgstr "クライアント・カスタム・リソースのステータス"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"Name:         client-secret\n"
+"Namespace:    keycloak\n"
+"ifeval::[{project_community}==true]\n"
+"Labels:       app=example-keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"Labels:       app=sso\n"
+"endif::[]  \n"
+"API Version:  keycloak.org/v1alpha1\n"
+"Kind:         KeycloakClient\n"
+"Spec:\n"
+"  Client:\n"
+"    Client Authenticator Type:     client-secret\n"
+"    Client Id:                     client-secret\n"
+"    Id:                            keycloak-client-secret\n"
+"  Realm Selector:\n"
+"    Match Labels:\n"
+"ifeval::[{project_community}==true]\n"
+"      App:  keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"      App:  sso\n"
+"endif::[]  \n"
+"Status:\n"
+"  Message:\n"
+"  Phase:    reconciling\n"
+"  Ready:    true\n"
+"  Secondary Resources:\n"
+"    Secret:\n"
+"      keycloak-client-secret-client-secret\n"
+"Events:  <none>\n"
+msgstr ""
+"Name:         client-secret\n"
+"Namespace:    keycloak\n"
+"ifeval::[{project_community}==true]\n"
+"Labels:       app=example-keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"Labels:       app=sso\n"
+"endif::[]  \n"
+"API Version:  keycloak.org/v1alpha1\n"
+"Kind:         KeycloakClient\n"
+"Spec:\n"
+"  Client:\n"
+"    Client Authenticator Type:     client-secret\n"
+"    Client Id:                     client-secret\n"
+"    Id:                            keycloak-client-secret\n"
+"  Realm Selector:\n"
+"    Match Labels:\n"
+"ifeval::[{project_community}==true]\n"
+"      App:  keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"      App:  sso\n"
+"endif::[]  \n"
+"Status:\n"
+"  Message:\n"
+"  Phase:    reconciling\n"
+"  Ready:    true\n"
+"  Secondary Resources:\n"
+"    Secret:\n"
+"      keycloak-client-secret-client-secret\n"
+"Events:  <none>\n"
+
+#. type: Plain text
+msgid ""
+"When the client creation completes, you are ready to xref:_user-cr[create a "
+"user custom resource]."
+msgstr "クライアントの作成が完了すると、 xref:_user-cr[ユーザーカスタムリソースの作成] の準備が整います。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/keycloak-client-cr.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__keycloak-client-cr
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
