### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/external-database.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/external-database.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/external-database.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,7 +33,7 @@ msgstr "手順"
 msgid ""
 "You have cluster-admin permission or an equivalent level of permissions "
 "granted by an administrator."
-msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること"
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること。"
 
 #. type: Title ===
 #, no-wrap
@@ -114,7 +115,7 @@ msgstr "`POSTGRES_EXTERNAL_PORT` - （任意）データベースのポート。
 msgid ""
 "The other properties work in the same way for a hosted or external database."
 " Set them as follows:"
-msgstr "他のプロパティーは、ホストされたデータベースまたは外部データベースの場合と同じように機能します。 次のように設定します。"
+msgstr "他のプロパティーは、ホストされたデータベースまたは外部データベースの場合と同じように機能します。次のように設定します。"
 
 #. type: Plain text
 msgid "`POSTGRES_DATABASE` - Database name to be used."
@@ -195,7 +196,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "You have a YAML file for `keycloak-db-secret`."
-msgstr " `keycloak-db-secret` のYAMLファイルがあること"
+msgstr "`keycloak-db-secret` のYAMLファイルがあること。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operator/external-database.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/external-database.ja_JP.po
@@ -1,0 +1,354 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid ""
+"You have cluster-admin permission or an equivalent level of permissions "
+"granted by an administrator."
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること"
+
+#. type: Title ===
+#, no-wrap
+msgid "Connecting to an external database"
+msgstr "外部データベースへの接続"
+
+#. type: Plain text
+msgid ""
+"You can use the Operator to connect to an external PostgreSQL database by "
+"modifying the Keycloak custom resource and creating a `keycloak-db-secret` "
+"YAML file. Note that values are Base64 encoded."
+msgstr ""
+"Operatorを使用して、Keycloakカスタムリソースを変更し、 `keycloak-db-secret` "
+"YAMLファイルを作成することにより、外部PostgreSQLデータベースに接続できます。値はBase64でエンコードされていることに注意してください。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example YAML file for `keycloak-db-secret`"
+msgstr "`keycloak-db-secret` のYAMLファイルの例"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: v1\n"
+"kind: Secret\n"
+"metadata:\n"
+"    name: keycloak-db-secret\n"
+"    namespace: keycloak\n"
+"stringData:\n"
+"    POSTGRES_DATABASE: <Database Name>\n"
+"    POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>\n"
+"    POSTGRES_EXTERNAL_PORT: <External Database Port>\n"
+"    # Strongly recommended to use <'Keycloak CR-Name'-postgresql>\n"
+"    POSTGRES_HOST: <Database Service Name>\n"
+"    POSTGRES_PASSWORD: <Database Password>\n"
+"    # Required for AWS Backup functionality\n"
+"    POSTGRES_SUPERUSER: true\n"
+"    POSTGRES_USERNAME: <Database Username>\n"
+" type: Opaque\n"
+msgstr ""
+"apiVersion: v1\n"
+"kind: Secret\n"
+"metadata:\n"
+"    name: keycloak-db-secret\n"
+"    namespace: keycloak\n"
+"stringData:\n"
+"    POSTGRES_DATABASE: <Database Name>\n"
+"    POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>\n"
+"    POSTGRES_EXTERNAL_PORT: <External Database Port>\n"
+"    # Strongly recommended to use <'Keycloak CR-Name'-postgresql>\n"
+"    POSTGRES_HOST: <Database Service Name>\n"
+"    POSTGRES_PASSWORD: <Database Password>\n"
+"    # Required for AWS Backup functionality\n"
+"    POSTGRES_SUPERUSER: true\n"
+"    POSTGRES_USERNAME: <Database Username>\n"
+" type: Opaque\n"
+
+#. type: Plain text
+msgid ""
+"The following properties set the hostname or IP address and port of the "
+"database."
+msgstr "次のプロパティーには、データベースのホスト名またはIPアドレスとポートを設定します。"
+
+#. type: Plain text
+msgid ""
+"`POSTGRES_EXTERNAL_ADDRESS` - an IP address or a hostname of the external "
+"database."
+msgstr "`POSTGRES_EXTERNAL_ADDRESS` - 外部データベースのIPアドレスまたはホスト名。"
+
+#. type: Plain text
+msgid "This address needs be resolvable in a Kubernetes cluster."
+msgstr "このアドレスは、Kubernetesクラスターで解決可能である必要があります。"
+
+#. type: Plain text
+msgid "`POSTGRES_EXTERNAL_PORT` - (Optional) A database port."
+msgstr "`POSTGRES_EXTERNAL_PORT` - （任意）データベースのポート。"
+
+#. type: Plain text
+msgid ""
+"The other properties work in the same way for a hosted or external database."
+" Set them as follows:"
+msgstr "他のプロパティーは、ホストされたデータベースまたは外部データベースの場合と同じように機能します。 次のように設定します。"
+
+#. type: Plain text
+msgid "`POSTGRES_DATABASE` - Database name to be used."
+msgstr "`POSTGRES_DATABASE` - 使用するデータベース名。"
+
+#. type: Plain text
+msgid ""
+"`POSTGRES_HOST` - The name of the `Service` used to communicate with a "
+"database. Typically `keycloak-postgresql`."
+msgstr ""
+"`POSTGRES_HOST` - データベースとの通信に使用される `Service` の名前。通常は `keycloak-postgresql` "
+"です。"
+
+#. type: Plain text
+msgid "`POSTGRES_USERNAME` - Database username"
+msgstr "`POSTGRES_USERNAME` - データベースのユーザー名"
+
+#. type: Plain text
+msgid "`POSTGRES_PASSWORD` - Database password"
+msgstr "`POSTGRES_PASSWORD` - データベースのパスワード"
+
+#. type: Plain text
+msgid ""
+"`POSTGRES_SUPERUSER` - Indicates, whether backups should run as super user. "
+"Typically `true`."
+msgstr ""
+"`POSTGRES_SUPERUSER` - バックアップをスーパーユーザーとして実行する必要があるかどうかを示します。通常は `true` です。"
+
+#. type: Plain text
+msgid ""
+"The Keycloak custom resource requires updates to enable external database "
+"support."
+msgstr "Keycloakカスタムリソースは、外部データベースのサポートを有効にするために更新が必要です。"
+
+#. type: Block title
+#, no-wrap
+msgid ""
+"Example YAML file for `Keycloak` custom resource that supports an external "
+"database"
+msgstr "外部データベースをサポートする `Keycloak` カスタムリソースのYAMLファイルの例"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: Keycloak\n"
+"metadata:\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"      app: example-keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"      app: sso\n"
+"endif::[]  \n"
+"  name: example-keycloak\n"
+"  namespace: keycloak\n"
+"spec:\n"
+"  externalDatabase:\n"
+"    enabled: true\n"
+"  instances: 1\n"
+msgstr ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: Keycloak\n"
+"metadata:\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"      app: example-keycloak\n"
+"endif::[]  \n"
+"ifeval::[{project_product}==true]\n"
+"      app: sso\n"
+"endif::[]  \n"
+"  name: example-keycloak\n"
+"  namespace: keycloak\n"
+"spec:\n"
+"  externalDatabase:\n"
+"    enabled: true\n"
+"  instances: 1\n"
+
+#. type: Plain text
+msgid "You have a YAML file for `keycloak-db-secret`."
+msgstr " `keycloak-db-secret` のYAMLファイルがあること"
+
+#. type: Plain text
+msgid ""
+"You have modified the Keycloak custom resource to set `externalDatabase` to "
+"`true`."
+msgstr "Keycloakカスタムリソースを変更して、 `externalDatabase` を `true` に設定しました。"
+
+#. type: Plain text
+msgid ""
+"Locate the secret for your PostgreSQL database: `{create_cmd_brief} get "
+"secret <secret_for_db> -o yaml`. For example:"
+msgstr ""
+"`{create_cmd_brief} get secret <secret_for_db> -o yaml` "
+"のようにPostgreSQLデータベースのシークレットを見つけます。たとえば、"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd_brief} get secret keycloak-db-secret -o yaml\n"
+"apiVersion: v1\n"
+"data\n"
+"  POSTGRES_DATABASE: cm9vdA==\n"
+"  POSTGRES_EXTERNAL_ADDRESS: MTcyLjE3LjAuMw==\n"
+"  POSTGRES_EXTERNAL_PORT: NTQzMg==\n"
+msgstr ""
+"$ {create_cmd_brief} get secret keycloak-db-secret -o yaml\n"
+"apiVersion: v1\n"
+"data\n"
+"  POSTGRES_DATABASE: cm9vdA==\n"
+"  POSTGRES_EXTERNAL_ADDRESS: MTcyLjE3LjAuMw==\n"
+"  POSTGRES_EXTERNAL_PORT: NTQzMg==\n"
+
+#. type: Plain text
+msgid "The `POSTGRES_EXTERNAL_ADDRESS` is in Base64 format."
+msgstr "`POSTGRES_EXTERNAL_ADDRESS` はBase64形式です。"
+
+#. type: Plain text
+msgid ""
+"Decode the value for the secret: `echo \"<encoded_secret>\" | base64 "
+"-decode`. For example:"
+msgstr "`echo \"<encoded_secret>\" | base64 -decode` のようにシークレットの値をデコードします。たとえば、"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ echo \"MTcyLjE3LjAuMw==\" | base64 -decode\n"
+"192.0.2.3\n"
+msgstr ""
+"$ echo \"MTcyLjE3LjAuMw==\" | base64 -decode\n"
+"192.0.2.3\n"
+
+#. type: Plain text
+msgid ""
+"Confirm that the decoded value matches the IP address for your database:"
+msgstr "デコードされた値がデータベースのIPアドレスと一致することを確認します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd_brief} get pods -o wide\n"
+"NAME                        READY  STATUS    RESTARTS   AGE   IP\n"
+"keycloak-0                  1/1    Running   0          13m   192.0.2.0\n"
+"keycloak-postgresql-c8vv27m 1/1    Running   0          24m   192.0.2.3\n"
+msgstr ""
+"$ {create_cmd_brief} get pods -o wide\n"
+"NAME                        READY  STATUS    RESTARTS   AGE   IP\n"
+"keycloak-0                  1/1    Running   0          13m   192.0.2.0\n"
+"keycloak-postgresql-c8vv27m 1/1    Running   0          24m   192.0.2.3\n"
+
+#. type: Plain text
+msgid ""
+"Confirm that `keycloak-postgresql` appears in a list of running services:"
+msgstr "実行中のサービスのリストに `keycloak-postgresql` が表示されていることを確認します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd_brief} get svc\n"
+"NAME                 TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE\n"
+"keycloak             ClusterIP  203.0.113.0    <none>       8443/TCP  27m\n"
+"keycloak-discovery   ClusterIP  None           <none>       8080/TCP  27m\n"
+"keycloak-postgresql  ClusterIP  203.0.113.1    <none>       5432/TCP  27m\n"
+msgstr ""
+"$ {create_cmd_brief} get svc\n"
+"NAME                 TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE\n"
+"keycloak             ClusterIP  203.0.113.0    <none>       8443/TCP  27m\n"
+"keycloak-discovery   ClusterIP  None           <none>       8080/TCP  27m\n"
+"keycloak-postgresql  ClusterIP  203.0.113.1    <none>       5432/TCP  27m\n"
+
+#. type: Plain text
+msgid ""
+"The `keycloak-postgresql` service sends requests to a set of IP addresses in"
+" the backend.  These IP addresses are called endpoints."
+msgstr ""
+"`keycloak-postgresql` "
+"サービスは、バックエンドの一連のIPアドレスにリクエストを送信します。これらのIPアドレスはエンドポイントと呼ばれます。"
+
+#. type: Plain text
+msgid ""
+"View the endpoints used by the `keycloak-postgresql` service to confirm that"
+" they use the IP addresses for your database:"
+msgstr ""
+"`keycloak-postgresql` サービスで使用されるエンドポイントを表示して、データベースのIPアドレスを使用していることを確認します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd_brief} get endpoints keycloak-postgresql\n"
+"NAME                  ENDPOINTS         AGE\n"
+"keycloak-postgresql   192.0.2.3.5432    27m\n"
+msgstr ""
+"$ {create_cmd_brief} get endpoints keycloak-postgresql\n"
+"NAME                  ENDPOINTS         AGE\n"
+"keycloak-postgresql   192.0.2.3.5432    27m\n"
+
+#. type: Plain text
+msgid ""
+"Confirm that {project_name} is running with the external database. This "
+"example shows that everything is running:"
+msgstr "{project_name}が外部データベースとともに実行されていることを確認します。この例は、すべてが実行中であることを示しています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ {create_cmd_brief} get pods\n"
+"NAME                        READY  STATUS    RESTARTS   AGE   IP\n"
+"keycloak-0                  1/1    Running   0          26m   192.0.2.0\n"
+"keycloak-postgresql-c8vv27m 1/1    Running   0          36m   192.0.2.3\n"
+msgstr ""
+"$ {create_cmd_brief} get pods\n"
+"NAME                        READY  STATUS    RESTARTS   AGE   IP\n"
+"keycloak-0                  1/1    Running   0          26m   192.0.2.0\n"
+"keycloak-postgresql-c8vv27m 1/1    Running   0          36m   192.0.2.3\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional Resources"
+msgstr "追加のリソース"
+
+#. type: Plain text
+msgid ""
+"To back up your database using custom resources, see xref:_backup-"
+"cr[Scheduling database backups]."
+msgstr ""
+"カスタムリソースを使用してデータベースをバックアップするには、 xref:_backup-cr[データベースのバックアップをスケジュールする] "
+"を参照してください。"
+
+#. type: Plain text
+msgid ""
+"For more information on Base64 encoding, see the "
+"https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes Secrets"
+" manual]."
+msgstr ""
+"Base64エンコードの詳細については、 "
+"https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes Secrets"
+" manual] をご覧ください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/external-database.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__external-database
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
