### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -6,20 +6,25 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Creating a user"
+msgstr "ユーザーの作成"
 
 #. type: Plain text
 msgid "For example, on:"
@@ -1823,6 +1828,32 @@ msgstr "$ kcadm.sh get clients/$CID/client-secret\n"
 
 #. type: Title ====
 #, no-wrap
+msgid "Generate a new secret for a specific client"
+msgstr "特定のクライアントの新しいシークレットを生成する"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ kcadm.sh create clients/$CID/client-secret\n"
+msgstr "$ kcadm.sh create clients/$CID/client-secret\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Updating the current secret for a specific client"
+msgstr "特定のクライアントの現在のシークレットを更新する"
+
+#. type: Plain text
+msgid ""
+"Use a client's ID to construct an endpoint URI, such as "
+"[filename]`clients/ID`."
+msgstr "クライアントのIDを使用して、 [filename]`clients/ID` のようなエンドポイントURIを構築します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ kcadm.sh update clients/$CID -s \"secret=newSecret\"\n"
+msgstr "$ kcadm.sh update clients/$CID -s \"secret=newSecret\"\n"
+
+#. type: Title ====
+#, no-wrap
 msgid ""
 "Getting an adapter configuration file (keycloak.json) for a specific client"
 msgstr "特定のクライアントのアダプター設定ファイル（keycloak.json）の取得"
@@ -1981,11 +2012,6 @@ msgstr ""
 #, no-wrap
 msgid "User operations"
 msgstr "ユーザー操作"
-
-#. type: Title ====
-#, no-wrap
-msgid "Creating a user"
-msgstr "ユーザーの作成"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
