### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -183,8 +183,8 @@ msgid ""
 "Session Idle configuration."
 msgstr ""
 "<<_offline-access, "
-"オフラインアクセス>>において、ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、オフライントークン・リクエストはアイドル・タイムアウトになります。これにより、セッションのオフライン・アイドル・タイムアウトよりも短いオフライントークンのアイドル・タイムアウトを指定できます。ただし、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、Offline"
-" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
+"オフライン・アクセス>>において、ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、オフライントークン・リクエストはアイドル・タイムアウトになります。これにより、セッションのオフライン・アイドル・タイムアウトよりも短いオフライントークンのアイドル・タイムアウトを指定できます。ただし、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、Offline"
+" Session Maxで設定されたものと同じアイドル・タイムアウトを使用します。"
 
 #. type: Plain text
 msgid "Client Offline Session Max"
@@ -200,8 +200,8 @@ msgid ""
 "the Offline Session Max configuration."
 msgstr ""
 "<<_offline-access, "
-"オフラインアクセス>>において、オフライントークンが期限切れになり無効になるまでの最大時間。オフライン・セッション・タイムアウトよりも短いオフライントークンのタイムアウトを指定できます。ただし、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、Offline"
-" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
+"オフライン・アクセス>>において、オフライントークンが期限切れになり無効になるまでの最大時間。オフライン・セッション・タイムアウトよりも短いオフライントークンのタイムアウトを指定できます。ただし、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、Offline"
+" Session Maxで設定されたものと同じアイドル・タイムアウトを使用します。"
 
 #. type: Plain text
 msgid "Client Session Idle"
@@ -217,7 +217,7 @@ msgid ""
 "SSO Session Idle configuration."
 msgstr ""
 "ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、リフレッシュトークン・リクエストはアイドル・タイムアウトになります。これにより、セッションのアイドル・タイムアウトよりも短いリフレッシュトークンのアイドル・タイムアウトを指定できます。また、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
-" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
+" Session Maxで設定されたものと同じアイドル・タイムアウトを使用します。"
 
 #. type: Plain text
 msgid "Client Session Max"
@@ -232,7 +232,7 @@ msgid ""
 "same idle timeout set in the SSO Session Max configuration."
 msgstr ""
 "リフレッシュトークンが期限切れになり無効になるまでの最大時間。セッション・タイムアウトよりも短いリフレッシュトークンのタイムアウトを指定できます。また、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、SSO"
-" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
+" Session Maxで設定されたものと同じアイドル・タイムアウトを使用します。"
 
 #. type: Plain text
 msgid "Access Token Lifespan"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -148,10 +148,12 @@ msgstr "Offline Session Max Limited"
 msgid ""
 "For <<_offline-access, offline access>>, if this flag is on, Offline Session"
 " Max is enabled to control the maximum time the offline token can remain "
-"active, regardless of user activity."
+"active, regardless of user activity. Also Client Offline Session Idle and "
+"Client Offline Session Max are enabled."
 msgstr ""
 "<<_offline-access, オフライン・アクセス>>では、このフラグがオンの場合、Offline Session "
-"Maxを有効にして、ユーザー・アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。"
+"Maxを有効にして、ユーザー・アクティビティーに関係なくオフライントークンをアクティブなままにできる最大時間を制御します。また、Client "
+"Offline Session IdleおよびClient Offline Session Maxは有効になっています。"
 
 #. type: Plain text
 msgid "Offline Session Max"
@@ -165,6 +167,41 @@ msgid ""
 msgstr ""
 "<<_offline-access, "
 "オフライン・アクセス>>では、これは対応するオフライントークンが取り消されるまでの最大時間です。このオプションはユーザー・アクティビティーに関係なく、オフライントークンがアクティブのままになる最大時間を制御します。"
+
+#. type: Plain text
+msgid "Client Offline Session Idle"
+msgstr "Offline Session Idle"
+
+#. type: Plain text
+msgid ""
+"For <<_offline-access, offline access>>, if the user is not active for "
+"longer than this timeout, offline token requests will bump the idle timeout."
+" It allows for the specification of a shorter idle timeout of offline token "
+"than offline session idle timeout. However, it can be overridden on "
+"individual clients. It is an optional configuration and if not set to a "
+"value bigger than 0, it uses the same idle timeout set in the Offline "
+"Session Idle configuration."
+msgstr ""
+"<<_offline-access, "
+"オフラインアクセス>>において、ユーザーがこのタイムアウトよりも長くアクティブになっていない場合、オフライントークン・リクエストはアイドル・タイムアウトになります。これにより、セッションのオフライン・アイドル・タイムアウトよりも短いオフライントークンのアイドル・タイムアウトを指定できます。ただし、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、Offline"
+" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
+
+#. type: Plain text
+msgid "Client Offline Session Max"
+msgstr "Offline Session Idle"
+
+#. type: Plain text
+msgid ""
+"For <<_offline-access, offline access>>, the maximum time before a offline "
+"token is expired and invalidated. It allows for the specification of a "
+"shorter timeout of offline token than offline session timeout. However, it "
+"can be overridden on individual clients. It is an optional configuration and"
+" if not set to a value bigger than 0, it uses the same idle timeout set in "
+"the Offline Session Max configuration."
+msgstr ""
+"<<_offline-access, "
+"オフラインアクセス>>において、オフライントークンが期限切れになり無効になるまでの最大時間。オフライン・セッション・タイムアウトよりも短いオフライントークンのタイムアウトを指定できます。ただし、個々のクライアントでオーバーライドできます。これはオプションの設定であり、0より大きい値に設定されていない場合は、Offline"
+" Session Maxで設定されたものと同じアイドルタイムアウトを使用します。"
 
 #. type: Plain text
 msgid "Client Session Idle"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/timeouts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__timeouts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
