### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po
@@ -4,20 +4,24 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
 
 #. type: Title ===
 #, no-wrap
@@ -26,13 +30,13 @@ msgstr "mod_auth_mellon Apache HTTPDモジュール"
 
 #. type: Plain text
 msgid ""
-"The https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] module is an"
-" Apache HTTPD plugin for SAML. If your language/environment supports using "
-"Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your web"
-" application with SAML. For more details on this module see the "
+"The https://github.com/latchset/mod_auth_mellon[mod_auth_mellon] module is "
+"an Apache HTTPD plugin for SAML. If your language/environment supports using"
+" Apache HTTPD as a proxy, then you can use mod_auth_mellon to secure your "
+"web application with SAML. For more details on this module see the "
 "_mod_auth_mellon_ GitHub repo."
 msgstr ""
-"https://github.com/UNINETT/mod_auth_mellon[mod_auth_mellon] "
+"https://github.com/latchset/mod_auth_mellon[mod_auth_mellon] "
 "モジュールは、SAML用のApache HTTPDプラグインです。使用している言語/環境がApache "
 "HTTPDをプロキシーとして使用することをサポートしている場合、mod_auth_mellonを使用してWebアプリケーションをSAMLでセキュリティー保護できます。このモジュールの詳細については、"
 " _mod_auth_mellon_ のGitHubリポジトリーを参照してください。"
@@ -285,6 +289,51 @@ msgid ""
 "Some of the files referenced in the code above are created in later steps."
 msgstr "上記のコードで参照されているファイルの一部は、後の手順で作成されます。"
 
+#. type: Title ====
+#, no-wrap
+msgid "Setting the SameSite value for the cookie used by mod_auth_mellon"
+msgstr "mod_auth_mellonが使用するCookieのSameSite値を設定する"
+
+#. type: Plain text
+msgid ""
+"Browsers are planning to set the default value for the `SameSite` attribute "
+"for cookies to `Lax`. This setting means that cookies will be sent to "
+"applications only if the request originates in the same domain. This "
+"behavior can affect the SAML POST binding which may become non-functional. "
+"To preserve full functionality of the _mod_auth_mellon_ module, we recommend"
+" setting the `SameSite` value to `None` for the cookie created by "
+"_mod_auth_mellon_. Not doing so may result in an inability to login using "
+"{project_name}."
+msgstr ""
+"ブラウザーは、Cookieの `SameSite` 属性のデフォルト値を `Lax` "
+"に設定することを計画しています。この設定は、リクエストが同じドメインで発生した場合にのみCookieがアプリケーションに送信されることを意味します。この動作はSAML"
+" POSTバインディングに影響を与え、機能しなくなる可能性があります。 _mod_auth_mellon_ モジュールの完全な機能を保持するために、 "
+"_mod_auth_mellon_ モジュールによって作成されたCookieの `SameSite` 値を `None` "
+"に設定することをお勧めします。そうしないと、{project_name}を使用してログインできなくなる場合があります。"
+
+#. type: Plain text
+msgid ""
+"To set the `SameSite` value to `None`, add the following configuration to "
+"`<Location / >` tag within your `mellon.conf` file."
+msgstr ""
+"`SameSite` の値を `None` に設定するには、次の設定を `mellon.conf` ファイル内の `<Location / >` "
+"タグに追加します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"MellonSecureCookie On\n"
+"MellonCookieSameSite none\n"
+msgstr ""
+"MellonSecureCookie On\n"
+"MellonCookieSameSite none\n"
+
+#. type: Plain text
+msgid ""
+"The support for this configuration is available in the _mod_auth_mellon_ "
+"module from version 0.16.0."
+msgstr "この設定のサポートは、バージョン0.16.0以降の _mod_auth_mellon_ モジュールで利用できます。"
+
 #. type: Title =====
 #, no-wrap
 msgid "Creating the Service Provider Metadata"
@@ -516,10 +565,6 @@ msgid ""
 msgstr ""
 "上記で作成したMellon "
 "SPメタデータ・ファイル（/etc/httpd/saml2/mellon_metadata.xml）を提供します。ブラウザーが実行されている場所によっては、$sp_hostからブラウザーが実行されているマシンにSPメタデータをコピーして、ブラウザーがそのファイルを見つけなければならない場合があります。"
-
-#. type: Plain text
-msgid "Click *Save*."
-msgstr "*Save* をクリックします。"
 
 #. type: Title ======
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/mod-auth-mellon.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__mod-auth-mellon
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
