### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -294,7 +294,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Example configuration:"
-msgstr "設定例"
+msgstr "設定例："
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -274,6 +274,32 @@ msgstr "    var app = express();\n"
 #, no-wrap
 msgid "    app.use( keycloak.middleware() );\n"
 msgstr "    app.use( keycloak.middleware() );\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Configuration for Proxies"
+msgstr "プロキシーの設定"
+
+#. type: Plain text
+msgid ""
+"If the application is running behind a proxy that terminates an SSL "
+"connection Express must be configured per the "
+"link:https://expressjs.com/en/guide/behind-proxies.html[express behind "
+"proxies] guide.  Using an incorrect proxy configuration can result in "
+"invalid redirect URIs being generated."
+msgstr ""
+"SSL接続を終了するプロキシーの背後でアプリケーションが実行されている場合は、 link:https://expressjs.com/en/guide"
+"/behind-proxies.html[express behind proxies] "
+"ガイドに従ってExpressを設定する必要があります。不適切なプロキシー設定を使用すると、無効なリダイレクトURIが生成される可能性があります。"
+
+#. type: Plain text
+msgid "Example configuration:"
+msgstr "設定例"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    app.set( 'trust proxy', true );\n"
+msgstr "    app.set( 'trust proxy', true );\n"
 
 #. type: Title ====
 #, no-wrap
@@ -602,10 +628,31 @@ msgstr ""
 "の呼び出しをキャッチし、ユーザーに{project_name}中心のログアウト・ワークフローを経由させます。これは、 `logout` "
 "設定パラメーターを `middleware()` の呼び出しに指定することで変更できます。"
 
-#. type: Plain text
+#. type: delimited block -
 #, no-wrap
 msgid "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
 msgstr "    app.use( keycloak.middleware( { logout: '/logoff' } ));\n"
+
+#. type: Plain text
+msgid ""
+"When the user-triggered logout is invoked a query parameter `redirect_url` "
+"can be passed:"
+msgstr "ユーザートリガーのログアウトが呼び出されると、次のようにクエリー・パラメーター `redirect_url` を渡すことができます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"https://example.com/logoff?redirect_url=https%3A%2F%2Fexample.com%3A3000%2Flogged%2Fout\n"
+msgstr ""
+"https://example.com/logoff?redirect_url=https%3A%2F%2Fexample.com%3A3000%2Flogged%2Fout\n"
+
+#. type: Plain text
+msgid ""
+"This parameter is then used as the redirect url of the OIDC logout endpoint "
+"and the user will be redirected to `\\https://example.com/logged/out`."
+msgstr ""
+"このパラメーターはOIDCログアウト・エンドポイントのリダイレクトURLとして使用され、ユーザーは "
+"`\\https://example.com/logged/out` にリダイレクトされます。"
 
 #. type: Plain text
 msgid "{project_name} Admin Callbacks::"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/nodejs-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__nodejs-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
