### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -121,7 +121,8 @@ msgid ""
 "brackets to access array fields by index.  For example "
 "'contact.address[0].country'."
 msgstr ""
-"JSONベースのクレームでは、ネストと角括弧にドット表記を使用して、インデックスで配列フィールドにアクセスできます。たとえば、'contact.address[0].country'です。"
+"JSONベースのクレームでは、ネストと角括弧にドット表記を使用して、インデックスで配列フィールドにアクセスできます。たとえば、'contact.address[0].country'"
+" です。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
