### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po
@@ -38,7 +38,7 @@ msgstr "Keycloakカスタム・リソースのYAMLファイルの例"
 msgid ""
 "You have cluster-admin permission or an equivalent level of permissions "
 "granted by an administrator."
-msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること"
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること。"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
