### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -1367,15 +1367,6 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"kcLocale - Specifies the desired Keycloak locale for the UI.  This differs "
-"from the locale param in that it tells the Keycloak server to set a cookie "
-"and update the user's profile to a new preferred locale."
-msgstr ""
-"kcLocale - "
-"UIに対するKeycloakロケールを指定します。これは、Cookieを設定し、ユーザーのプロファイルを新しい優先ロケールに更新するようにKeycloakサーバーに指示するという点で、ロケール・パラメーターとは異なります。"
-
-#. type: Plain text
-msgid ""
 "cordovaOptions - Specifies the arguments that are passed to the Cordova in-"
 "app-browser (if applicable). Options `hidden` and `location` are not "
 "affected by these arguments. All available options are defined at "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
