### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po
@@ -5,86 +5,19 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Code block
-#, no-wrap
-msgid ""
-"curl -X POST \\\n"
-"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
-"  -H \"Authorization: Bearer ${access_token}\" \\\n"
-"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\" \\\n"
-"  --data \"ticket=${permission_ticket}\n"
-msgstr ""
-"curl -X POST \\\n"
-"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
-"  -H \"Authorization: Bearer ${access_token}\" \\\n"
-"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\" \\\n"
-"  --data \"ticket=${permission_ticket}\n"
-
-#. type: Plain text
-msgid ""
-"If {project_name} assessment process results in issuance of permissions, it "
-"issues the RPT with which it has associated the permissions:"
-msgstr "{project_name}の評価処理の結果、パーミッションが発行されると、そのパーミッションに関連付けられているRPTが発行されます。"
-
-#. type: Block title
-#, no-wrap
-msgid "{project_name} responds to the client with the RPT"
-msgstr "{project_name}はRPTを使用してクライアントに応答します"
-
-#. type: Code block
-#, no-wrap
-msgid ""
-"HTTP/1.1 200 OK\n"
-"Content-Type: application/json\n"
-"...\n"
-"{\n"
-"    \"access_token\": \"${rpt}\",\n"
-"}\n"
-msgstr ""
-"HTTP/1.1 200 OK\n"
-"Content-Type: application/json\n"
-"...\n"
-"{\n"
-"    \"access_token\": \"${rpt}\",\n"
-"}\n"
-
-#. type: Block title
-#, no-wrap
-msgid "{project_name} denies the authorization request"
-msgstr "{project_name}の認可リクエストの拒否"
-
-#. type: Code block
-#, no-wrap
-msgid ""
-"HTTP/1.1 403 Forbidden\n"
-"Content-Type: application/json\n"
-"...\n"
-"{\n"
-"    \"error\": \"access_denied\",\n"
-"    \"error_description\": \"request_denied\"\n"
-"}\n"
-msgstr ""
-"HTTP/1.1 403 Forbidden\n"
-"Content-Type: application/json\n"
-"...\n"
-"{\n"
-"    \"error\": \"access_denied\",\n"
-"    \"error_description\": \"request_denied\"\n"
-"}\n"
 
 #. type: Title =
 #, no-wrap
@@ -262,7 +195,7 @@ msgstr "**submit_request**\n"
 msgid ""
 "This parameter is *optional*. A boolean value indicating whether the server "
 "should create permission requests to the resources and scopes referenced by "
-"a permission ticket.  This parameter only have effect if used together with "
+"a permission ticket.  This parameter only has effect if used together with "
 "the `ticket` parameter as part of a UMA authorization process."
 msgstr ""
 "このパラメーターは *optional* "
@@ -400,6 +333,49 @@ msgid ""
 msgstr ""
 "認可プロセスの一環として、リソースサーバーからパーミッション・チケットを受け取った後で、クライアントがUMA保護リソースへのアクセスを求めている場合の認可リクエストの例です。"
 
+#. type: Code block
+#, no-wrap
+msgid ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  -H \"Authorization: Bearer ${access_token}\" \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\" \\\n"
+"  --data \"ticket=${permission_ticket}\n"
+msgstr ""
+"curl -X POST \\\n"
+"  http://${host}:${port}/auth/realms/${realm}/protocol/openid-connect/token \\\n"
+"  -H \"Authorization: Bearer ${access_token}\" \\\n"
+"  --data \"grant_type=urn:ietf:params:oauth:grant-type:uma-ticket\" \\\n"
+"  --data \"ticket=${permission_ticket}\n"
+
+#. type: Plain text
+msgid ""
+"If {project_name} assessment process results in issuance of permissions, it "
+"issues the RPT with which it has associated the permissions:"
+msgstr "{project_name}の評価処理の結果、パーミッションが発行されると、そのパーミッションに関連付けられているRPTが発行されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "{project_name} responds to the client with the RPT"
+msgstr "{project_name}はRPTを使用してクライアントに応答します"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"HTTP/1.1 200 OK\n"
+"Content-Type: application/json\n"
+"...\n"
+"{\n"
+"    \"access_token\": \"${rpt}\",\n"
+"}\n"
+msgstr ""
+"HTTP/1.1 200 OK\n"
+"Content-Type: application/json\n"
+"...\n"
+"{\n"
+"    \"access_token\": \"${rpt}\",\n"
+"}\n"
+
 #. type: Plain text
 msgid ""
 "The response from the server is just like any other response from the token "
@@ -410,3 +386,27 @@ msgstr ""
 "サーバーからのレスポンスは、他のグラントタイプを使用しているときのトークン・エンドポイントからの任意のレスポンスとまったく同じです。RPTは "
 "`access_token` レスポンス・パラメーターから取得できます。クライアントが認可されていない場合、{project_name}は次のように "
 "`403` HTTPステータスコードで応答します。"
+
+#. type: Block title
+#, no-wrap
+msgid "{project_name} denies the authorization request"
+msgstr "{project_name}の認可リクエストの拒否"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"HTTP/1.1 403 Forbidden\n"
+"Content-Type: application/json\n"
+"...\n"
+"{\n"
+"    \"error\": \"access_denied\",\n"
+"    \"error_description\": \"request_denied\"\n"
+"}\n"
+msgstr ""
+"HTTP/1.1 403 Forbidden\n"
+"Content-Type: application/json\n"
+"...\n"
+"{\n"
+"    \"error\": \"access_denied\",\n"
+"    \"error_description\": \"request_denied\"\n"
+"}\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-obtaining-permission.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-obtaining-permission
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
