### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -833,7 +833,7 @@ msgid ""
 " -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
 "'config.keystore=[\"/opt/keycloak/keystore.jks\"]' -s "
 "'config.keystorePassword=[\"secret\"]' -s 'config.keyPassword=[\"secret\"]' "
-"-s 'config.alias=[\"localhost\"]'\n"
+"-s 'config.keyAlias=[\"localhost\"]'\n"
 msgstr ""
 "$ kcadm.sh create components -r demorealm -s name=java-keystore -s "
 "providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
@@ -841,7 +841,7 @@ msgstr ""
 " -s 'config.enabled=[\"true\"]' -s 'config.active=[\"true\"]' -s "
 "'config.keystore=[\"/opt/keycloak/keystore.jks\"]' -s "
 "'config.keystorePassword=[\"secret\"]' -s 'config.keyPassword=[\"secret\"]' "
-"-s 'config.alias=[\"localhost\"]'\n"
+"-s 'config.keyAlias=[\"localhost\"]'\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -854,7 +854,7 @@ msgid ""
 "\"config.keystore=[\\\"/opt/keycloak/keystore.jks\\\"]\" -s "
 "\"config.keystorePassword=[\\\"secret\\\"]\" -s "
 "\"config.keyPassword=[\\\"secret\\\"]\" -s "
-"\"config.alias=[\\\"localhost\\\"]\"\n"
+"\"config.keyAlias=[\\\"localhost\\\"]\"\n"
 msgstr ""
 "c:\\> kcadm create components -r demorealm -s name=java-keystore -s "
 "providerId=java-keystore -s providerType=org.keycloak.keys.KeyProvider -s "
@@ -864,7 +864,7 @@ msgstr ""
 "\"config.keystore=[\\\"/opt/keycloak/keystore.jks\\\"]\" -s "
 "\"config.keystorePassword=[\\\"secret\\\"]\" -s "
 "\"config.keyPassword=[\\\"secret\\\"]\" -s "
-"\"config.alias=[\\\"localhost\\\"]\"\n"
+"\"config.keyAlias=[\\\"localhost\\\"]\"\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
