### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-realm.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-realm.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-realm.ja_JP.po
@@ -1,0 +1,107 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Title =
+#, no-wrap
+msgid "Creating a realm"
+msgstr "レルムの作成"
+
+#. type: Plain text
+msgid ""
+"As the admin in the master realm, you create the realms where administrators"
+" create users and applications."
+msgstr "masterレルムの管理者として、管理者がユーザーとアプリケーションを作成するレルムを作成します。"
+
+#. type: Plain text
+msgid "{project_name} is installed."
+msgstr "{project_name}がインストールされていること。"
+
+#. type: Plain text
+msgid "You have the initial admin account for the admin console."
+msgstr "管理コンソールの初期管理者アカウントを持っていること。"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid ""
+"Go to http://localhost:8080/auth/admin/ and log in to the {project_name} "
+"admin console using the admin account."
+msgstr ""
+"http://localhost:8080/auth/admin/ "
+"に移動し、adminアカウントを使用して{project_name}管理コンソールにログインします。"
+
+#. type: Plain text
+msgid ""
+"From the *Master* menu, click *Add Realm*. When you are logged in to the "
+"master realm, this menu lists all other realms."
+msgstr ""
+"*Master* のメニューから *Add Realm* "
+"を選択し、クリックします。masterレルムにログインすると、このメニューには他のすべてのレルムが一覧表示されます。"
+
+#. type: Plain text
+msgid "Type `demo` in the *Name* field."
+msgstr "*Name* フィールドに `demo` と入力します。"
+
+#. type: Block title
+#, no-wrap
+msgid "A new realm"
+msgstr "新規レルム"
+
+#. type: Plain text
+msgid "image:images/add-demo-realm.png[A new realm]"
+msgstr "image:images/add-demo-realm.png[A new realm]"
+
+#. type: Plain text
+msgid ""
+"The realm name is case-sensitive, so make note of the case that you use."
+msgstr "レルム名では大文字と小文字が区別されるため、使用する値をメモしてください。"
+
+#. type: Plain text
+msgid "Click *Create*."
+msgstr "*Create* をクリックします。"
+
+#. type: Plain text
+msgid "The main admin console page opens with realm set to `demo`."
+msgstr "メインの管理コンソールページが開き、レルムが `demo` に設定されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Demo realm"
+msgstr "Demoレルム"
+
+#. type: Plain text
+msgid "image:images/demo-realm.png[Demo realm]"
+msgstr "image:images/demo-realm.png[Demo realm]"
+
+#. type: Plain text
+msgid ""
+"Switch between managing the `master` realm and the realm you just created by"
+" clicking entries in the *Select realm* drop-down list."
+msgstr ""
+"*Select realm* ドロップダウン・リストのエントリーをクリックして、 `master` レルムと作成したレルムの管理を切り替えます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-realm.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-realm__proc-create-realm
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
