### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -4,20 +4,30 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ======
+#, no-wrap
+msgid "Example using CURL"
+msgstr "CURLを使用した例"
+
+#. type: Title ====
+#, no-wrap
+msgid "Endpoints"
+msgstr "エンドポイント"
 
 #. type: Title ===
 #, no-wrap
@@ -40,11 +50,6 @@ msgstr ""
 "Party（RP）ライブラリーを使用することができます。この章では、{project_name}固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。詳細については、"
 " https://openid.net/connect/[OpenID Connectの仕様] と "
 "https://tools.ietf.org/html/rfc6749[OAuth2の仕様] を参照してください。"
-
-#. type: Title ====
-#, no-wrap
-msgid "Endpoints"
-msgstr "エンドポイント"
 
 #. type: Plain text
 msgid ""
@@ -300,7 +305,7 @@ msgid ""
 "If you need to manually validate access tokens issued by {project_name} you "
 "can invoke the <<_token_introspection_endpoint,Introspection Endpoint>>.  "
 "The downside to this approach is that you have to make a network invocation "
-"to the {project_name} server.  This can be slow and possibily overload the "
+"to the {project_name} server.  This can be slow and possibly overload the "
 "server if you have too many validation requests going on at the same time.  "
 "{project_name} issued access tokens are "
 "https://tools.ietf.org/html/rfc7519[JSON Web Tokens (JWT)] digitally signed "
@@ -471,11 +476,6 @@ msgstr ""
 "詳細については、OAuth 2.0仕様の "
 "https://tools.ietf.org/html/rfc6749#section-4.3[Resource Owner Password "
 "Credentials Grant] のセクションを参照してください。"
-
-#. type: Title ===
-#, no-wrap
-msgid "Example using CURL"
-msgstr "CURLを使用した例"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
