### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -205,7 +205,7 @@ msgstr "requested_token_type"
 msgid ""
 "_OPTIONAL._ This parameter represents the type of token the client wants to "
 "exchange for.  Currently only oauth and OpenID Connect token types are "
-"supported.  The default value for this depends on whether the is "
+"supported.  The default value for this depends on whether it is "
 "`urn:ietf:params:oauth:token-type:refresh_token` in which case you will be "
 "returned both an access token and refresh token within the response.  Other "
 "appropriate values are `urn:ietf:params:oauth:token-type:access_token` and "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
