### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,16 +23,6 @@ msgstr ""
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
-
-#. type: Block title
-#, no-wrap
-msgid "Add a New App"
-msgstr "新しいアプリケーションの追加"
-
-#. type: Block title
-#, no-wrap
-msgid "Register App"
-msgstr "アプリケーションの登録"
 
 #. type: Title ====
 #, no-wrap
@@ -73,15 +63,20 @@ msgid ""
 msgstr ""
 "後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をBitbucketに提供します。"
 
+#. type: Block title
+#, no-wrap
+msgid "Add a New App"
+msgstr "新しいアプリケーションの追加"
+
 #. type: Plain text
 msgid ""
 "To enable login with Bitbucket you must first register an application "
-"project in https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-"
-"cloud-238027431.html[OAuth on Bitbucket Cloud]."
+"project in https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-"
+"bitbucket-cloud/[OAuth on Bitbucket Cloud]."
 msgstr ""
-"Bitbucketでログインできるようにするには、まずアプリケーション・プロジェクトを "
-"https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-"
-"cloud-238027431.html[OAuth on Bitbucket Cloud] に登録する必要があります。"
+"Bitbucketでログインできるようにするには、まずアプリケーション・プロジェクトを https://support.atlassian.com"
+"/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/[OAuth on Bitbucket "
+"Cloud] に登録する必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -98,6 +93,11 @@ msgstr "image:images/bitbucket-developer-applications.png[]"
 #. type: Plain text
 msgid "Click the `Add consumer` button."
 msgstr "`Add consumer` ボタンをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Register App"
+msgstr "アプリケーションの登録"
 
 #. type: Plain text
 msgid "image:images/bitbucket-register-app.png[]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__bitbucket
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
