### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/standalone/proc-starting-server.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/standalone/proc-starting-server.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/standalone/proc-starting-server.ja_JP.po
@@ -1,0 +1,75 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Linux/Unix"
+msgstr "Linux/Unix"
+
+#. type: Block title
+#, no-wrap
+msgid "Windows"
+msgstr "Windows"
+
+#. type: Title =
+#, no-wrap
+msgid "Starting the {project_name} server"
+msgstr "{project_name}サーバーの起動"
+
+#. type: Plain text
+msgid "You start the server on the system where you installed it."
+msgstr "インストールしたシステムでサーバーを起動します。"
+
+#. type: Plain text
+msgid "You saw no errors during the {project_name} server installation."
+msgstr "{project_name}サーバーのインストール中にエラーが発生していないこと"
+
+#. type: Plain text
+msgid "Go to the `bin` directory of the server distribution."
+msgstr "サーバー配布物の `bin` ディレクトリーに移動します。"
+
+#. type: Plain text
+msgid "Run the `standalone` boot script."
+msgstr "`standalone` 起動スクリプトを実行します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"$ cd bin\n"
+"$ ./standalone.sh\n"
+msgstr ""
+"$ cd bin\n"
+"$ ./standalone.sh\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "> ...\\bin\\standalone.bat\n"
+msgstr "> ...\\bin\\standalone.bat\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/standalone/proc-starting-server.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__standalone__proc-starting-server
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
