### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/sample-app/proc-registering-app.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/sample-app/proc-registering-app.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/sample-app/proc-registering-app.ja_JP.po
@@ -1,0 +1,138 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Title =
+#, no-wrap
+msgid "Registering the {appserver_name} application"
+msgstr "{appserver_name}アプリケーションの登録"
+
+#. type: Plain text
+msgid ""
+"You can now define and register the client in the {project_name} admin "
+"console."
+msgstr "これで、{project_name}管理コンソールでクライアントを定義および登録できます。"
+
+#. type: Plain text
+msgid "You installed a client adapter to work with {appserver_name}."
+msgstr "{appserver_name}で動作するようにクライアント・アダプターをインストールしていること。"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure "
+msgstr "手順"
+
+#. type: Plain text
+msgid ""
+"Log in to the admin console with your admin account: "
+"http://localhost:8180/auth/admin/"
+msgstr "管理者アカウントで管理コンソールにログインします： http://localhost:8180/auth/admin/"
+
+#. type: Plain text
+msgid "In the top left drop-down list, select the `Demo` realm."
+msgstr "左上のドロップダウン・リストで `Demo` レルムを選択します。"
+
+#. type: Plain text
+msgid "Click `Clients` in the left side menu to open the Clients page."
+msgstr "左側のメニューの `Clients` をクリックして、クライアント・ページを開きます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Clients"
+msgstr "Clients"
+
+#. type: Plain text
+msgid "image:images/clients.png[Clients]"
+msgstr "image:images/clients.png[Clients]"
+
+#. type: Plain text
+msgid "On the right side, click *Create*."
+msgstr "右側にある *Create* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"On the Add Client dialog, create a client called *vanilla* by completing the"
+" fields as shown below:"
+msgstr "Add Clientダイアログで、次のようにフィールドに入力して、 *vanilla* というクライアントを作成します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Client"
+msgstr "Add Client"
+
+#. type: Plain text
+msgid "image:images/add-client.png[Add Client]"
+msgstr "image:images/add-client.png[Add Client]"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"On the *Vanilla* client page that appears, click the *Installation* tab."
+msgstr "表示される *Vanilla* クライアントページで、 *Installation* タブをクリックします。"
+
+#. type: Plain text
+msgid ""
+"Select *Keycloak OIDC JSON* to generate a file that you need in a later "
+"procedure."
+msgstr "*Keycloak OIDC JSON* を選択して、後の手順で必要なファイルを生成します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Keycloak.json file"
+msgstr "Keycloak.jsonファイル"
+
+#. type: Plain text
+msgid "image:images/keycloak-json.png[Keycloak.json file]"
+msgstr "image:images/keycloak-json.png[Keycloak.json file]"
+
+#. type: Plain text
+msgid ""
+"Click *Download* to save *Keycloak.json* in a location that you can find "
+"later."
+msgstr "*Download* をクリックして *Keycloak.json* を後で見つけられる場所に保存します。"
+
+#. type: Plain text
+msgid ""
+"Select *Keycloak OIDC JBoss Subsystem XML* to generate an XML template."
+msgstr "XMLテンプレートを生成するには、 *Keycloak OIDC JBoss Subsystem XML* を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Template XML"
+msgstr "XMLテンプレート"
+
+#. type: Plain text
+msgid "image:images/client-install-selected.png[Template XML]"
+msgstr "image:images/client-install-selected.png[Template XML]"
+
+#. type: Plain text
+msgid ""
+"Click *Download* to save a copy for use in the next procedure, which "
+"involves {appserver_name} configuration."
+msgstr "次の手順で使用するために、 *Download* をクリックして{appserver_name}の設定を含むコピーを保存します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/sample-app/proc-registering-app.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__sample-app__proc-registering-app
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
