### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/standalone/proc-logging-in-admin-console.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/standalone/proc-logging-in-admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/standalone/proc-logging-in-admin-console.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # n.watanabe <nwatanabe.ase@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -103,5 +103,5 @@ msgid ""
 "For more details, see xref:creating-first-realm_{context}[Creating a realm "
 "and a user]."
 msgstr ""
-"管理コンソールにログインできるようになったので、管理者がユーザーを作成してアプリケーションへのアクセス権を付与できるレルムの作成を開始できます。詳細については、xref"
-":creating-first-realm_{context}[レルムとユーザーの作成]を参照してください。"
+"管理コンソールにログインできるようになったので、管理者がユーザーを作成してアプリケーションへのアクセス権を付与できるレルムの作成を開始できます。詳細については、"
+" xref:creating-first-realm_{context}[レルムとユーザーの作成] を参照してください。"

--- a/i18n/po/ja_JP/getting_started/topics/standalone/proc-logging-in-admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/standalone/proc-logging-in-admin-console.ja_JP.po
@@ -1,0 +1,107 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# n.watanabe <nwatanabe.ase@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title ===
+#, no-wrap
+msgid "Next steps"
+msgstr "次のステップ"
+
+#. type: Plain text
+msgid "You have an admin account for the admin console."
+msgstr "管理コンソールの管理者アカウントを持っていること。"
+
+#. type: Title =
+#, no-wrap
+msgid "Logging into the admin console"
+msgstr "管理コンソールへのログイン"
+
+#. type: Plain text
+msgid ""
+"After you create the initial admin account, you can log in to the admin "
+"console.  In this console, you add users and register applications to be "
+"secured by {project_name}."
+msgstr ""
+"初期管理者アカウントを作成したら、管理コンソールにログインできます。このコンソールで、ユーザーを追加し、{project_name}によってセキュリティー保護されるアプリケーションを登録します。"
+
+#. type: Plain text
+msgid ""
+"Click the *Administration Console* link on the *Welcome* page or go directly"
+" to http://localhost:8080/auth/admin/ (the console URL)."
+msgstr ""
+"*Welcome* ページの *Administration Console* リンクをクリックするか、 "
+"http://localhost:8080/auth/admin/ （コンソールURL）に直接アクセスします。"
+
+#. type: delimited block =
+msgid ""
+"The Administration Console is generally referred to as the admin console for"
+" short in {project_name} documentation."
+msgstr ""
+"Administration Consoleは、一般的に{project_name}のドキュメントでは管理コンソール（admin "
+"console）と呼ばれています。"
+
+#. type: Plain text
+msgid ""
+"Enter the username and password you created on the *Welcome* page to open "
+"the *admin console*."
+msgstr "*Welcome* ページで作成したユーザー名とパスワードを入力して、 *admin console* を開きます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Admin console login screen"
+msgstr "管理コンソールのログイン画面"
+
+#. type: Plain text
+msgid "image:images/admin-login.png[Admin console login screen]"
+msgstr "image:images/admin-login.png[Admin console login screen]"
+
+#. type: Plain text
+msgid "The initial screen for the admin console appears."
+msgstr "管理コンソールの初期画面が表示されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Admin console"
+msgstr "管理コンソール"
+
+#. type: Plain text
+msgid "image:images/admin-console.png[Admin console]"
+msgstr "image:images/admin-console.png[Admin console]"
+
+#. type: Plain text
+msgid ""
+"Now that you can log into the admin console, you can begin creating realms "
+"where administrators can create users and give them access to applications. "
+"For more details, see xref:creating-first-realm_{context}[Creating a realm "
+"and a user]."
+msgstr ""
+"管理コンソールにログインできるようになったので、管理者がユーザーを作成してアプリケーションへのアクセス権を付与できるレルムの作成を開始できます。詳細については、xref"
+":creating-first-realm_{context}[レルムとユーザーの作成]を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/standalone/proc-logging-in-admin-console.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__standalone__proc-logging-in-admin-console
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
