### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/standalone/proc-creating-admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/standalone/proc-creating-admin.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/standalone/proc-creating-admin.ja_JP.po
@@ -1,0 +1,67 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title =
+#, no-wrap
+msgid "Creating the admin account"
+msgstr "管理者アカウントの作成"
+
+#. type: Plain text
+msgid ""
+"Before you can use {project_name}, you need to create an admin account which"
+" you use to log in to the {project_name} admin console."
+msgstr ""
+"{project_name}を使用する前に、{project_name}管理コンソールへのログインに使用する管理者アカウントを作成する必要があります。"
+
+#. type: Plain text
+msgid "You saw no errors when you started the {project_name} server."
+msgstr "{project_name}サーバー起動時にエラーが発生していないこと。"
+
+#. type: Plain text
+msgid "Open http://localhost:8080/auth in your web browser."
+msgstr "Webブラウザーで http://localhost:8080/auth を開きます。"
+
+#. type: Plain text
+msgid "The welcome page opens, confirming that the server is running."
+msgstr "ウェルカムページが開き、サーバーが実行中であることを確認します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Welcome page"
+msgstr "ウェルカムページ"
+
+#. type: Plain text
+msgid "image:images/welcome.png[Welcome page]"
+msgstr "image:images/welcome.png[Welcome page]"
+
+#. type: Plain text
+msgid "Enter a username and password to create an initial admin user."
+msgstr "ユーザー名とパスワードを入力して、最初の管理ユーザーを作成します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/standalone/proc-creating-admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__standalone__proc-creating-admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
