### PR TITLE
Translations for i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-user.ja_JP.po
+++ b/i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-user.ja_JP.po
@@ -1,0 +1,104 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Shinsuke UEDA, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title ====
+#, no-wrap
+msgid "Creating a user"
+msgstr "ユーザーの作成"
+
+#. type: Plain text
+msgid ""
+"In the `demo` realm, you create a new user and a temporary password for that"
+" new user."
+msgstr "`demo` レルムで、新しいユーザーとその新しいユーザーの一時的なパスワードを作成します。"
+
+#. type: Plain text
+msgid "From the menu, click *Users* to open the user list page."
+msgstr "メニューから *Users* をクリックして、ユーザー一覧ページを開きます。"
+
+#. type: Plain text
+msgid ""
+"On the right side of the empty user list, click *Add User* to open the Add "
+"user page."
+msgstr "ユーザー追加ページを開くには、空のユーザーリストの右側にある *Add User* をクリックします。"
+
+#. type: Plain text
+msgid "Enter a name in the `Username` field."
+msgstr "`Username` フィールドに名前を入力します。"
+
+#. type: Plain text
+msgid "This is the only required field."
+msgstr "これは唯一の必須フィールドです。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add user page"
+msgstr "ユーザー追加ページ"
+
+#. type: Plain text
+msgid "image:images/add-user.png[Add user page]"
+msgstr "image:images/add-user.png[Add user page]"
+
+#. type: Plain text
+msgid "Flip the *Email Verified* switch to *On* and click *Save*."
+msgstr "*Email Verified* スイッチを *On* に切り替え、 *Save* をクリックします。"
+
+#. type: Plain text
+msgid "The management page for the new user opens."
+msgstr "新しいユーザーの管理ページが開きます。"
+
+#. type: Plain text
+msgid ""
+"Click the *Credentials* tab to set a temporary password for the new user."
+msgstr "*Credentials* タブをクリックして、新しいユーザーの仮パスワードを設定します。"
+
+#. type: Plain text
+msgid "Type a new password and confirm it."
+msgstr "新しいパスワードを入力して確認します。"
+
+#. type: Plain text
+msgid ""
+"Click *Set Password* to set the user password to the new one you specified."
+msgstr "ユーザーのパスワードを指定した新しいパスワードにするには、*Set Password* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Manage Credentials page"
+msgstr "クレデンシャルの管理ページ"
+
+#. type: Plain text
+msgid "image:images/user-credentials.png[Manage Credentials page]"
+msgstr "image:images/user-credentials.png[Manage Credentials page]"
+
+#. type: delimited block =
+msgid ""
+"This password is temporary and the user will be required to change it at the"
+" first login. If you prefer to create a password that is persistent, flip "
+"the *Temporary* switch to *Off* and click *Set Password*."
+msgstr ""
+"このパスワードは一時的なもので、最初のログイン時に変更する必要があります。永続的なパスワードを作成する場合は、 *Temporary* スイッチを "
+"*Off* に切り替えて、 *Set Password* をクリックします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/getting_started/topics/first-realm/proc-create-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/getting_started__topics__first-realm__proc-create-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
