### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -93,8 +93,7 @@ msgid ""
 "See {developerguide_deploying_themes}[Deploying Themes] manual entry for "
 "more information."
 msgstr ""
-"他の拡張機能と同じ方法でテーマをパッケージ化してデプロイできます。詳細については、{developerguide_deploying_themes} "
-"[テーマのデプロイ]のマニュアル・エントリーを参照してください。"
+"他の拡張機能と同じ方法でテーマをパッケージ化してデプロイできます。詳細については、{developerguide_deploying_themes}[テーマのデプロイ]のマニュアル・エントリーを参照してください。"
 
 #. type: Plain text
 msgid "You have a YAML file for the Keycloak custom resource."

--- a/i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
+#. type: Title ==
 #, no-wrap
 msgid "Prerequisites"
 msgstr "前提条件"
@@ -28,17 +28,6 @@ msgstr "前提条件"
 #, no-wrap
 msgid "Procedure"
 msgstr "手順"
-
-#. type: Block title
-#, no-wrap
-msgid "Example YAML file for a Keycloak custom resource"
-msgstr "Keycloakカスタム・リソースのYAMLファイルの例"
-
-#. type: Plain text
-msgid ""
-"You have cluster-admin permission or an equivalent level of permissions "
-"granted by an administrator."
-msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること。"
 
 #. type: Title ===
 #, no-wrap
@@ -53,6 +42,11 @@ msgid ""
 "You add the extension or theme to the Keycloak custom resource."
 msgstr ""
 "Operatorを使用して、会社または組織に必要な拡張機能とテーマをインストールできます。拡張機能またはテーマは、{project_name}が使用できるものであれば何でもかまいません。たとえば、メトリクス拡張を追加できます。Keycloakカスタムリソースに拡張機能またはテーマを追加します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example YAML file for a Keycloak custom resource"
+msgstr "Keycloakカスタム・リソースのYAMLファイルの例"
 
 #. type: Code block
 #, no-wrap
@@ -94,8 +88,23 @@ msgstr ""
 "    enabled: True\n"
 
 #. type: Plain text
+msgid ""
+"You can package and deploy themes in the same way as any other extensions. "
+"See {developerguide_deploying_themes}[Deploying Themes] manual entry for "
+"more information."
+msgstr ""
+"他の拡張機能と同じ方法でテーマをパッケージ化してデプロイできます。詳細については、{developerguide_deploying_themes} "
+"[テーマのデプロイ]のマニュアル・エントリーを参照してください。"
+
+#. type: Plain text
 msgid "You have a YAML file for the Keycloak custom resource."
 msgstr "Keycloakカスタムリソース用のYAMLファイルがあること。"
+
+#. type: Plain text
+msgid ""
+"You have cluster-admin permission or an equivalent level of permissions "
+"granted by an administrator."
+msgstr "cluster-adminパーミッションまたは同等のレベルのパーミッションが管理者によって付与されていること。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
