### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # KojiNose <knose.dev@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,16 +30,16 @@ msgstr "各設定オプションの説明は次のとおりです。"
 msgid "Configuration"
 msgstr "設定"
 
+#. type: Block title
+#, no-wrap
+msgid "keycloak.json"
+msgstr "keycloak.json"
+
 #. type: Plain text
 msgid ""
 "To enable policy enforcement for your application, add the following "
 "property to your *keycloak.json* file:"
 msgstr "アプリケーションのポリシー適用を有効にするには、 *keycloak.json* ファイルに次のプロパティーを追加します。"
-
-#. type: Block title
-#, no-wrap
-msgid "keycloak.json"
-msgstr "keycloak.json"
 
 #. type: Code block
 #, no-wrap
@@ -257,11 +257,12 @@ msgstr "*** *lifespan*\n"
 #. type: Plain text
 msgid ""
 "Defines the time in milliseconds when the entry should be expired. If not "
-"provided, default value is *3000*. A value less than or equal to 0 can be "
-"set to completely disable the cache."
+"provided, default value is *3000*. A value equal to 0 can be set to "
+"completely disable the cache. A value equal to -1 can be set to disable the "
+"expiry of the cache."
 msgstr ""
 "エントリーを期限切れにする時間をミリ秒単位で定義します。指定されていない場合、デフォルト値は *3000* "
-"です。0以下の値を設定すると、キャッシュを完全に無効にすることができます。"
+"です。0を設定してキャッシュを完全に無効にすることができます。または、-1を設定してキャッシュの有効期限を無効にすることもできます。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-keycloak-enforcement-filter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
