### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -109,6 +109,18 @@ msgid ""
 "token and grants access to the requested resource (if appropriate)."
 msgstr ""
 "Dockerレジストリーが保護されたリソースへの新しいリクエストを{project_name}サーバーからのトークンとともに受信すると、Dockerレジストリーはトークンを検証し、必要に応じてリソースへのアクセスを許可します。"
+
+#. type: Plain text
+msgid ""
+"No user session is created on the {project_name} side after successful "
+"authentication with the Docker protocol. The Docker protocol is not used in "
+"case of browser SSO session and it does not have a way to refresh token or "
+"ask {project_name} server if a particular token/session is still valid. So "
+"creating the session is unnecessary overhead for this protocol. For more "
+"details, see the <<_transient-session, transient session>> section."
+msgstr ""
+"Dockerプロトコルによる認証が成功した後、{project_name}側にユーザー・セッションは作成されません。Dockerプロトコルは、ブラウザーSSOセッションの場合は使用されず、トークンを更新したり、特定のトークン/セッションがまだ有効かどうかを{project_name}サーバーに確認したりする方法がありません。したがって、セッションの作成は、このプロトコルにとって不要なオーバーヘッドです。詳細については、"
+" <<_transient-session, transient session>> のセクションを参照してください。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__docker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
