### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -21,7 +21,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Title ====
 #, no-wrap
 msgid "Password Policies"
 msgstr "パスワード・ポリシー"
@@ -187,6 +187,16 @@ msgstr "Not Username"
 #. type: Plain text
 msgid "When set, the password is not allowed to be the same as the username."
 msgstr "設定すると、パスワードをユーザー名と同じにすることはできません。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Not Email"
+msgstr "Not Email"
+
+#. type: Plain text
+msgid ""
+"When set, the password is not allowed to be the same as the email address."
+msgstr "設定すると、パスワードを電子メールアドレスと同じにすることができなくなります。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -196,7 +196,7 @@ msgstr "Not Email"
 #. type: Plain text
 msgid ""
 "When set, the password is not allowed to be the same as the email address."
-msgstr "設定すると、パスワードを電子メールアドレスと同じにすることができなくなります。"
+msgstr "設定すると、パスワードをメールアドレスと同じにすることができなくなります。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__password-policies
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
