### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -106,29 +106,43 @@ msgstr "次の例は、JavaScriptアダプターを初期化する方法を示�
 #. type: delimited block -
 #, no-wrap
 msgid ""
+"<html>\n"
 "<head>\n"
 "    <script src=\"keycloak.js\"></script>\n"
 "    <script>\n"
-"        var keycloak = new Keycloak();\n"
-"        keycloak.init().then(function(authenticated) {\n"
-"            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
-"        }).catch(function() {\n"
-"            alert('failed to initialize');\n"
-"        });\n"
+"        function initKeycloak() {\n"
+"            var keycloak = new Keycloak();\n"
+"            keycloak.init().then(function(authenticated) {\n"
+"                alert(authenticated ? 'authenticated' : 'not authenticated');\n"
+"            }).catch(function() {\n"
+"                alert('failed to initialize');\n"
+"            });\n"
+"        }\n"
 "    </script>\n"
 "</head>\n"
+"<body onload=\"initKeycloak()\">\n"
+"    <!-- your page content goes here -->\n"
+"</body>\n"
+"</html>\n"
 msgstr ""
+"<html>\n"
 "<head>\n"
 "    <script src=\"keycloak.js\"></script>\n"
 "    <script>\n"
-"        var keycloak = new Keycloak();\n"
-"        keycloak.init().then(function(authenticated) {\n"
-"            alert(authenticated ? 'authenticated' : 'not authenticated');\n"
-"        }).catch(function() {\n"
-"            alert('failed to initialize');\n"
-"        });\n"
+"        function initKeycloak() {\n"
+"            var keycloak = new Keycloak();\n"
+"            keycloak.init().then(function(authenticated) {\n"
+"                alert(authenticated ? 'authenticated' : 'not authenticated');\n"
+"            }).catch(function() {\n"
+"                alert('failed to initialize');\n"
+"            });\n"
+"        }\n"
 "    </script>\n"
 "</head>\n"
+"<body onload=\"initKeycloak()\">\n"
+"    <!-- your page content goes here -->\n"
+"</body>\n"
+"</html>\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
