### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,13 +21,17 @@ msgstr ""
 
 #. type: Plain text
 #, no-wrap
+msgid "Alias"
+msgstr "Alias"
+
+#. type: Plain text
+msgid "Configuration|Description"
+msgstr "設定|説明"
+
+#. type: Plain text
+#, no-wrap
 msgid "Enabled"
 msgstr "Enabled"
-
-#. type: Block title
-#, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ===
 #, no-wrap
@@ -68,6 +72,11 @@ msgstr ""
 "ドロップ・ダウン・リスト・ボックスで、追加するアイデンティティー・プロバイダを選択します。 "
 "これにより、そのアイデンティティー・プロバイダー・タイプの設定ページが表示されます。"
 
+#. type: Block title
+#, no-wrap
+msgid "Add Identity Provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
 #. type: Plain text
 msgid "image:{project_images}/add-identity-provider.png[]"
 msgstr "image:{project_images}/add-identity-provider.png[]"
@@ -76,9 +85,13 @@ msgstr "image:{project_images}/add-identity-provider.png[]"
 msgid ""
 "Above is an example of configuring a Facebook social login provider.  Once "
 "you configure an IDP, it will appear on the {project_name} login page as an "
-"option."
+"option. It's possible to have custom icons on login screen for each identity"
+" provider.  For more details, please refer to the link:{developerguide_link"
+"}#custom-identity-providers-icons[custom icons]."
 msgstr ""
-"上記は、Facebookのソーシャル・ログイン・プロバイダーを設定する例です。IdPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。"
+"上記は、Facebookのソーシャル・ログイン・プロバイダーを設定する例です。IdPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。アイデンティティー・プロバイダーごとにログイン画面にカスタムアイコンを表示することができます。詳細については、"
+" link:{developerguide_link}#custom-identity-providers-icons[カスタムアイコン] "
+"を参照してください。"
 
 #. type: Block title
 #, no-wrap
@@ -141,15 +154,6 @@ msgstr "共通の設定"
 #, no-wrap
 msgid "1,1"
 msgstr "1,1"
-
-#. type: Plain text
-msgid "Configuration|Description"
-msgstr "設定|説明"
-
-#. type: Labeled list
-#, no-wrap
-msgid "Alias"
-msgstr "Alias"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
