### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -426,7 +426,7 @@ msgid ""
 "            <property name=\"file\" value=\"path to your .jks file containing public certificates\"/>\n"
 "            <property name=\"password\" value=\"password\"/>\n"
 "            <property name=\"hostname-verification-policy\" value=\"WILDCARD\"/>\n"
-"            <property name=\"disabled\" value=\"false\"/>\n"
+"            <property name=\"enabled\" value=\"true\"/>\n"
 "        </properties>\n"
 "    </provider>\n"
 "</spi>\n"
@@ -437,7 +437,7 @@ msgstr ""
 "            <property name=\"file\" value=\"path to your .jks file containing public certificates\"/>\n"
 "            <property name=\"password\" value=\"password\"/>\n"
 "            <property name=\"hostname-verification-policy\" value=\"WILDCARD\"/>\n"
-"            <property name=\"disabled\" value=\"false\"/>\n"
+"            <property name=\"enabled\" value=\"true\"/>\n"
 "        </properties>\n"
 "    </provider>\n"
 "</spi>\n"
@@ -457,10 +457,10 @@ msgid ""
 "host of the server they are talking to.  This is what the trustore does.  "
 "The keystore contains one or more trusted host certificates or certificate "
 "authorities.  This truststore file should only contain public certificates "
-"of your secured hosts.  This is _REQUIRED_ if `disabled` is not true."
+"of your secured hosts.  This is _REQUIRED_ if `enabled` is true."
 msgstr ""
 "Javaキーストア・ファイルへのパスです。HTTPSリクエストでは、通信を行うサーバーのホストを検証する必要があります。これはトラストストアの役割です。キーストアには、1つ以上の信頼できるホスト証明書または認証局が含まれています。このトラストストア・ファイルには、セキュリティー保護されたホストのパブリック証明書のみを含めるべきです。"
-" `disabled` がtrueでない場合、これは _REQUIRED_ です。"
+" `enabled` がtrueの場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -468,9 +468,8 @@ msgid "password"
 msgstr "password"
 
 #. type: Plain text
-msgid ""
-"Password for the truststore.  This is _REQUIRED_ if `disabled` is not true."
-msgstr "トラストストア用のパスワードです。 `disabled` がtrueでない場合、これは _REQUIRED_ です。"
+msgid "Password for the truststore.  This is _REQUIRED_ if `enabled` is true."
+msgstr "トラストストア用のパスワードです。 `enabled` がtrueの場合、これは _REQUIRED_ です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -499,14 +498,14 @@ msgstr "*.foo.comです。 `STRICT` の場合、CNはホスト名と正確に一
 
 #. type: Labeled list
 #, no-wrap
-msgid "disabled"
-msgstr "disabled"
+msgid "enabled"
+msgstr "enabled"
 
 #. type: Plain text
 msgid ""
-"If true (default value), truststore configuration will be ignored, and "
+"If false (default value), truststore configuration will be ignored, and "
 "certificate checking will fall back to JSSE configuration as described.  If "
-"set to false, you must configure `file`, and `password` for the truststore."
+"set to true, you must configure `file`, and `password` for the truststore."
 msgstr ""
-"true（デフォルト値）の場合、トラストストアの設定は無視され、証明書チェックは前述のJSSE設定にフォールバックします。falseに設定されている場合は、トラストストア用に"
+"false（デフォルト値）の場合、トラストストアの設定は無視され、証明書チェックは前述のJSSE設定にフォールバックします。trueに設定されている場合は、トラストストア用に"
 " `file` と `password` を設定する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/outgoing.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__outgoing
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
