### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,7 +41,7 @@ msgid ""
 "example, the load balancer serves as a reverse proxy between three clients "
 "and a cluster of three {project_name} servers."
 msgstr ""
-"次の図は、ロードバランサーの使用法を示しています。この例では、ロードバランサーは、3つのクライアントと3つの{project_name}サーバーのクラスター間のリバースプロキシーとして機能します。"
+"次の図は、ロードバランサーの使用方法を示しています。この例では、ロードバランサーは、3つのクライアントと3つの{project_name}サーバーのクラスター間のリバースプロキシーとして機能します。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,6 +34,23 @@ msgid ""
 msgstr ""
 "このセクションでは、クラスター構成の{project_name}の前にリバース・プロキシーまたはロードバランサーを配置するにあたって、設定が必要な項目について説明します。また、組み込みのロードバランサーの設定についても説明します。これは"
 "<<_clustered-domain-example, クラスター構成ドメインのサンプル>>でも確認できます。"
+
+#. type: Plain text
+msgid ""
+"The following diagram illustrates the use of a load balancer. In this "
+"example, the load balancer serves as a reverse proxy between three clients "
+"and a cluster of three {project_name} servers."
+msgstr ""
+"次の図は、ロードバランサーの使用法を示しています。この例では、ロードバランサーは、3つのクライアントと3つの{project_name}サーバーのクラスター間のリバースプロキシーとして機能します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example Load Balancer Diagram"
+msgstr "ロードバランサーの例の図"
+
+#. type: Plain text
+msgid "image:{project_images}/load_balancer.png[]"
+msgstr "image:{project_images}/load_balancer.png[]"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/load-balancer.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__load-balancer
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
