### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat-adapter-samesite-setting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat-adapter-samesite-setting.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat-adapter-samesite-setting.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -34,9 +35,9 @@ msgid ""
 "container. Not doing so may result in resetting the container's session with"
 " each request to {project_name}."
 msgstr ""
-"ブラウザーは、Cookieの `SameSite` 属性のデフォルト値を `Lax` "
+"各ブラウザーは、Cookieの `SameSite` 属性のデフォルト値を `Lax` "
 "に設定することを計画しています。この設定は、リクエストが同じドメインで発生した場合にのみCookieがアプリケーションに送信されることを意味します。この動作はSAML"
-" POSTバインディングに影響を与え、機能しなくなる可能性があります。SAMLアダプターの完全な機能を保持するために、 コンテナーによって作成された "
+" POSTバインディングに影響を与え、機能しなくなる可能性があります。SAMLアダプターの完全な機能を保持するために、コンテナーによって作成された "
 "`JSESSIONID` Cookieの `SameSite` 値を `None` "
 "に設定することをお勧めします。そうしないと、{project_name}へのリクエストごとにコンテナーのセッションがリセットされる可能性があります。"
 

--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat-adapter-samesite-setting.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat-adapter-samesite-setting.ja_JP.po
@@ -1,0 +1,82 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =====
+#, no-wrap
+msgid "Setting SameSite value for JSESSIONID cookie"
+msgstr "JSESSIONID CookieにSameSite値を設定する"
+
+#. type: Plain text
+msgid ""
+"Browsers are planning to set the default value for the `SameSite` attribute "
+"for cookies to `Lax`. This setting means that cookies will be sent to "
+"applications only if the request originates in the same domain. This "
+"behavior can affect the SAML POST binding which may become non-functional. "
+"To preserve full functionality of the SAML adapter, we recommend setting the"
+" `SameSite` value to `None` for the `JSESSIONID` cookie created by your "
+"container. Not doing so may result in resetting the container's session with"
+" each request to {project_name}."
+msgstr ""
+"ブラウザーは、Cookieの `SameSite` 属性のデフォルト値を `Lax` "
+"に設定することを計画しています。この設定は、リクエストが同じドメインで発生した場合にのみCookieがアプリケーションに送信されることを意味します。この動作はSAML"
+" POSTバインディングに影響を与え、機能しなくなる可能性があります。SAMLアダプターの完全な機能を保持するために、 コンテナーによって作成された "
+"`JSESSIONID` Cookieの `SameSite` 値を `None` "
+"に設定することをお勧めします。そうしないと、{project_name}へのリクエストごとにコンテナーのセッションがリセットされる可能性があります。"
+
+#. type: Plain text
+msgid ""
+"To avoid setting the `SameSite` attribute to `None`, consider switching to "
+"the REDIRECT binding if it is acceptable, or to OIDC protocol where this "
+"workaround is not necessary."
+msgstr ""
+"`SameSite` 属性が `None` "
+"に設定されないようにするには、許容できる場合はREDIRECTバインディングに切り替えるか、この回避策が不要な場合はOIDCプロトコルに切り替えることを検討してください。"
+
+#. type: Plain text
+msgid ""
+"To set the `SameSite` value to `None` for `JSESSIONID` cookie in Tomcat add "
+"following configuration to the`context.xml` of your application. Note, this "
+"will set the `SameSite` value to `None` for all cookies created by Tomcat "
+"container."
+msgstr ""
+"Tomcatの `JSESSIONID` Cookieの `SameSite` 値を `None` に設定するには、アプリケーションの "
+"`context.xml` に次の設定を追加します。これにより、Tomcatコンテナーによって作成されたすべてのCookieの `SameSite` "
+"値が `None` に設定されることに注意してください。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "<CookieProcessor sameSiteCookies=\"None\" />\n"
+msgstr "<CookieProcessor sameSiteCookies=\"None\" />\n"
+
+#. type: Plain text
+msgid ""
+"It is not possible to set the `SameSite` attribute only to a subset of "
+"cookies, therefore all cookies created for your application will have this "
+"attribute set to `None`."
+msgstr ""
+"`SameSite` "
+"属性をCookieのサブセットのみに設定することはできません。そのため、アプリケーション用に作成されたすべてのCookieでは、この属性が `None`"
+" に設定されます。"
+
+#. type: Plain text
+msgid ""
+"The support for this feature is available in Tomcat from versions 9.0.29 and"
+" 8.5.49."
+msgstr "この機能のサポートは、バージョン9.0.29および8.5.49のTomcatで利用できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/tomcat-adapter/tomcat-adapter-samesite-setting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__tomcat-adapter__tomcat-adapter-samesite-setting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
