### PR TITLE
Translations for i18n/po/ja_JP/release_notes/topics/11_0_0.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/release_notes/topics/11_0_0.ja_JP.po
+++ b/i18n/po/ja_JP/release_notes/topics/11_0_0.ja_JP.po
@@ -76,6 +76,29 @@ msgstr ""
 "Keycloakサーバーは、WildFly 20.0.1.Finalを使用するようにアップグレードされました。詳細については、 "
 "link:{upgradingguide_link_latest}[{upgradingguide_name}] を参照してください。"
 
+#. type: Title ==
+#, no-wrap
+msgid "SAML POST binding is broken in the latest versions of browsers"
+msgstr "最新バージョンのブラウザーでは、SAML POSTバインディングが正常に動作しません"
+
+#. type: Plain text
+msgid ""
+"The `SameSite` value `None` for `JSESSIONID` cookie is necessary for correct"
+" behavior of the {project_name} SAML adapter.  Usage of a different value is"
+" causing resetting of the container's session with each request to "
+"{project_name}, when the SAML POST binging is used. Refer to the following "
+"steps for link:{adapterguide_link}#_saml-jboss-adapter-samesite-"
+"setting[Wildfly] and link:{adapterguide_link}#_saml-tomcat-adapter-samesite-"
+"setting[Tomcat] to keep the correct behavior. Notice, that this workaround "
+"should be working also with the previous versions of the adapter."
+msgstr ""
+"{project_name} SAMLアダプターが正しく動作するには、 `JSESSIONID` Cookieの `SameSite` 値を "
+"`None` にする必要があります。SAML "
+"POSTバインディングが使用されている場合、異なる値を使用すると、{project_name}へのリクエストごとにコンテナーのセッションがリセットされます。正しい動作を維持するように"
+" link:{adapterguide_link}#_saml-jboss-adapter-samesite-setting[Wildfly] と "
+"link:{adapterguide_link}#_saml-tomcat-adapter-samesite-setting[Tomcat] "
+"については、次の手順を参照してください。この回避策は、以前のバージョンのアダプターでも機能するはずであることに注意してください。"
+
 #. type: Plain text
 msgid ""
 "Support for client offline session lifespan. Thanks to "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/release_notes/topics/11_0_0.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/release_notes__topics__11_0_0
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
