### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,11 +30,11 @@ msgid ""
 "through the Account Console. The functionality is not enabled by default. To"
 " enable it, the following steps needs be taken:"
 msgstr ""
-"{project_name}を使用すると、アプリケーションのエンドユーザーはアカウント・コンソールからアカウントを削除できます。この機能はデフォルトでは有効になっていません。これを有効にするには、次の手順を実行する必要があります。"
+"{project_name}では、アプリケーションのエンドユーザーはアカウント・コンソールからアカウントを削除できます。この機能はデフォルトでは有効になっていません。これを有効にするには、次の手順を実行する必要があります。"
 
 #. type: Plain text
 msgid "Enabling the \"Delete Account\" Required Action"
-msgstr "「Delete Account」必須アクションを有効にする"
+msgstr "\"Delete Account\" 必須アクションを有効にする"
 
 #. type: Plain text
 msgid ""
@@ -44,8 +44,8 @@ msgid ""
 "Actions tab and tick the enabled checkbox for the \"Delete Account\" action."
 msgstr ""
 "ユーザーが自分のアカウントを削除できるようにすることは、AIA（Application Initiated "
-"Action）を介して行われます必須アクション。まず、管理コンソールからアクションを有効にする必要があります。Authenticationメニューで、Required"
-" Actionsタブに移動し、「Delete Account」アクションの有効なチェックボックスをオンにします。"
+"Action）を介して行われます。まず、管理コンソールからアクションを有効にする必要があります。Authenticationメニューで、Required"
+" Actionsタブに移動し、 \"Delete Account\" アクションの有効なチェックボックスをオンにします。"
 
 #. type: Plain text
 msgid "image:{project_images}/enable-delete-account-action.png[]"
@@ -53,7 +53,7 @@ msgstr "image:{project_images}/enable-delete-account-action.png[]"
 
 #. type: Plain text
 msgid "Making sure the user has the \"delete-account\" as a client role:"
-msgstr "ユーザーがクライアントロールとして「delete-account」を持っていることを確認します。"
+msgstr "ユーザーがクライアントロールとして \"delete-account\" を持っていることを確認します。"
 
 #. type: Plain text
 msgid ""
@@ -71,12 +71,12 @@ msgid ""
 "the \"Role Mappings\" Tab, select the \"account\" client from \"Clients "
 "Role\" list."
 msgstr ""
-"ユーザーのアカウント削除ロールを有効にするには、Usersメニューに移動し、アカウント削除機能を有効にするユーザーを見つけます。「Role "
-"Mappings」タブで、「Clients Role」の一覧から「account」クライアントを選択します。"
+"ユーザーのアカウント削除ロールを有効にするには、Usersメニューに移動し、アカウント削除機能を有効にするユーザーを見つけます。 \"Role "
+"Mappings\" タブで、 \"Clients Role\" の一覧から \"account\" クライアントを選択します。"
 
 #. type: Plain text
 msgid "Finally, select `delete-account` and click on add selected."
-msgstr "最後に、 `delete-account` を選択し、選択したものの追加をクリックします。"
+msgstr "最後に、 `delete-account` を選択し、 \"Add selected\" をクリックします。"
 
 #. type: Plain text
 msgid "image:{project_images}/delete-account-client-role.png[]"
@@ -85,14 +85,15 @@ msgstr "image:{project_images}/delete-account-client-role.png[]"
 #. type: Title ===
 #, no-wrap
 msgid "Deleting a user in action"
-msgstr "実行中のユーザーの削除"
+msgstr "アクションによるユーザーの削除"
 
 #. type: Plain text
 msgid ""
 "Once the functionlity is enabled, the user will see a new section named "
 "\"Delete Account\" appear in the bottom of the \"Personal Info\" page"
 msgstr ""
-"機能を有効にすると、「\"Personal Info」ページの下部に「Delete Account」という名前の新しいセクションが表示されます。"
+"機能を有効にすると、 \"Personal Info\" ページの下部に \"Delete Account\" "
+"という名前の新しいセクションが表示されます。"
 
 #. type: Plain text
 msgid "image:{project_images}/delete-account-landing-screen.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Enabling account deletion by users"
+msgstr "ユーザーによるアカウント削除の有効化"
+
+#. type: Plain text
+msgid ""
+"{project_name} can allow applications end users to delete their account "
+"through the Account Console. The functionality is not enabled by default. To"
+" enable it, the following steps needs be taken:"
+msgstr ""
+"{project_name}を使用すると、アプリケーションのエンドユーザーはアカウント・コンソールからアカウントを削除できます。この機能はデフォルトでは有効になっていません。これを有効にするには、次の手順を実行する必要があります。"
+
+#. type: Plain text
+msgid "Enabling the \"Delete Account\" Required Action"
+msgstr "「Delete Account」必須アクションを有効にする"
+
+#. type: Plain text
+msgid ""
+"Allowing the user to delete their account is done through an AIA "
+"(Application Initiated Action). You need first of all to enable the action "
+"from the admin console. In the Authentication menu, go to the Required "
+"Actions tab and tick the enabled checkbox for the \"Delete Account\" action."
+msgstr ""
+"ユーザーが自分のアカウントを削除できるようにすることは、AIA（Application Initiated "
+"Action）を介して行われます必須アクション。まず、管理コンソールからアクションを有効にする必要があります。Authenticationメニューで、Required"
+" Actionsタブに移動し、「Delete Account」アクションの有効なチェックボックスをオンにします。"
+
+#. type: Plain text
+msgid "image:{project_images}/enable-delete-account-action.png[]"
+msgstr "image:{project_images}/enable-delete-account-action.png[]"
+
+#. type: Plain text
+msgid "Making sure the user has the \"delete-account\" as a client role:"
+msgstr "ユーザーがクライアントロールとして「delete-account」を持っていることを確認します。"
+
+#. type: Plain text
+msgid ""
+"The delete account functionality is enabled on a per user basis. The second "
+"requirement to enable the delete account functionality is to make sure the "
+"user has the `delete-account` as a client role."
+msgstr ""
+"アカウントの削除機能は、ユーザーごとに有効になります。アカウントの削除機能を有効にするための2番目の要件は、ユーザーがクライアントロールとして "
+"`delete-account` を持っていることを確認することです。"
+
+#. type: Plain text
+msgid ""
+"To enable the delete account role for a user, go to the Users menu, and find"
+" the user for which the delete account functionality is to be enabled. In "
+"the \"Role Mappings\" Tab, select the \"account\" client from \"Clients "
+"Role\" list."
+msgstr ""
+"ユーザーのアカウント削除ロールを有効にするには、Usersメニューに移動し、アカウント削除機能を有効にするユーザーを見つけます。「Role "
+"Mappings」タブで、「Clients Role」の一覧から「account」クライアントを選択します。"
+
+#. type: Plain text
+msgid "Finally, select `delete-account` and click on add selected."
+msgstr "最後に、 `delete-account` を選択し、選択したものの追加をクリックします。"
+
+#. type: Plain text
+msgid "image:{project_images}/delete-account-client-role.png[]"
+msgstr "image:{project_images}/delete-account-client-role.png[]"
+
+#. type: Title ===
+#, no-wrap
+msgid "Deleting a user in action"
+msgstr "実行中のユーザーの削除"
+
+#. type: Plain text
+msgid ""
+"Once the functionlity is enabled, the user will see a new section named "
+"\"Delete Account\" appear in the bottom of the \"Personal Info\" page"
+msgstr ""
+"機能を有効にすると、「\"Personal Info」ページの下部に「Delete Account」という名前の新しいセクションが表示されます。"
+
+#. type: Plain text
+msgid "image:{project_images}/delete-account-landing-screen.png[]"
+msgstr "image:{project_images}/delete-account-landing-screen.png[]"
+
+#. type: Plain text
+msgid "image:{project_images}/delete-account-page.png[]"
+msgstr "image:{project_images}/delete-account-page.png[]"
+
+#. type: Plain text
+msgid ""
+"As stated by the warning message, this action is irreversible, and it "
+"implies the deletion of all the user's data in Keycloak."
+msgstr ""
+"警告メッセージに記載されているように、このアクションは元に戻せません。これは、Keycloak内のすべてのユーザーのデータが削除されることを意味します。"
+
+#. type: Plain text
+msgid ""
+"Once the user clicks on Delete, he will be prompted to enter his credentials"
+" again and redirected to the final confirmation step:"
+msgstr "ユーザーがDeleteをクリックすると、クレデンシャルを再度入力するように求められ、最後の確認手順にリダイレクトされます。"
+
+#. type: Plain text
+msgid "image:{project_images}/delete-account-confirm.png[]"
+msgstr "image:{project_images}/delete-account-confirm.png[]"
+
+#. type: Plain text
+msgid "After confirming, the user's account will be deleted."
+msgstr "確認後、ユーザーのアカウントは削除されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__allow-user-to-delete-account
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
