### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title =
+#. type: Attribute :authorizationguide_name_short:
 #, no-wrap
 msgid "Authorization Services"
 msgstr "認可サービス"
@@ -37,7 +37,7 @@ msgid ""
 "In {project_name} Authorization Services the access token with permissions "
 "is called a Requesting Party Token or RPT for short."
 msgstr ""
-"OAuth2クライアント（フロントエンド・アプリケーションなど）は、トークン・エンドポイントを使用して{project_name}サーバーからアクセストークンを取得し、それらのトークンを使用してリソースサーバーによって保護されたリソース（バックエンド・サービスなど）にアクセスできます。同様に、{project_name}認可サービスは、要求されているリソースやスコープに関係付けられたすべてのポリシーの処理に基づいてアクセストークンを発行できるように、OAuth2の拡張機能を提供します。つまり、リソースサーバーは、サーバーによって付与され、アクセストークンによって保持されているパーミッションに基づいて、保護されたリソースへのアクセスを実施できます。{project_name}認可サービスでは、パーミッションを持つアクセストークンはリクエスティング・パーティー・トークンまたはRPTと呼ばれます。"
+"OAuth2クライアント（フロントエンド・アプリケーションなど）は、トークン・エンドポイントを使用してサーバーからアクセストークンを取得し、これらのトークンを使用してリソースサーバーによって保護されたリソース（バックエンド・サービスなど）にアクセスできます。同様に、{project_name}認可サービスは、要求されているリソースまたはスコープに関連するすべてのポリシーの処理に基づいてアクセストークンを発行できるように、OAuth2の拡張機能を提供します。つまり、リソースサーバーは、サーバーによって付与され、アクセストークンによって保持されているアクセス許可に基づいて、保護されたリソースへのアクセスを強制できます。{project_name}認可サービスでは、アクセス権を持つアクセストークンはリクエスティング・パーティー・トークンまたはRPTと呼ばれます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
