### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,8 +57,8 @@ msgid ""
 msgstr ""
 "利用レルムの{project_name}管理コンソールにクライアントを作成します。たとえば、{project_name}の `demo` "
 "レルムでクライアント `hawtio-client` を作成し、アクセス・タイプとして `public` を指定し、Hawtio: "
-"\\http://localhost:8181/hawtio/*を指すリダイレクトURIを指定します。また、対応するWeb "
-"Origin（この場合は、\\http://localhost:8181）も設定する必要があります。"
+"\\http://localhost:8181/hawtio/* を指すリダイレクトURIを指定します。また、対応するWeb Origin（この場合は、"
+" \\http://localhost:8181）も設定する必要があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse/hawtio.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse__hawtio
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
