### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/hawtio.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/hawtio.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/hawtio.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,23 +32,6 @@ msgstr "{project_name}を使用して、Hawtio管理コンソールをセキュ�
 
 #. type: Plain text
 msgid ""
-"Create a client in the {project_name} administration console in your realm. "
-"For example, in the {project_name} `demo` realm, create a client `hawtio-"
-"client`, specify `public` as the Access Type, and specify a redirect URI "
-"pointing to Hawtio: \\http://localhost:8181/hawtio/*. Configure "
-"corresponding Web Origin (in this case, \\http://localhost:8181). Setup "
-"client scope mapping to include _view-profile_ client role of _account_ "
-"client in _Scope_ tab in `hawtio-client` client detail."
-msgstr ""
-"利用レルムの{project_name}管理コンソールにクライアントを作成します。たとえば、{project_name}の `demo` "
-"レルムでクライアント `hawtio-client` を作成し、アクセスタイプとして `public` を指定し、Hawtio: "
-"\\http://localhost:8181/hawtio/* を指すリダイレクトURIを指定します。対応するWeb "
-"Origin（この場合は、\\http://localhost:8181）を設定します。 `hawtio-client` クライアント詳細の "
-"_Scope_ タブにある _account_ クライアントの _view-profile_ "
-"クライアントロールを含むようにクライアント・スコープ・マッピングを設定します。"
-
-#. type: Plain text
-msgid ""
 "Create the `keycloak-hawtio-client.json` file in the `$FUSE_HOME/etc` "
 "directory using content similar to that shown in the example below. Change "
 "the `realm`, `resource`, and `auth-server-url` properties according to your "
@@ -61,6 +44,72 @@ msgstr ""
 "`resource` 、 `auth-server-url` の各プロパティーを変更してください。 `resource` "
 "プロパティーは前のステップで作成されたクライアントを指し示さなければなりません。このファイルは、クライアント（Hawtio "
 "JavaScriptアプリケーション）側で使用されます。"
+
+#. type: Plain text
+msgid ""
+"Create the `keycloak-hawtio.json` file in the `$FUSE_HOME/etc` dicrectory "
+"using content similar to that shown in the example below. Change the `realm`"
+" and `auth-server-url` properties according to your {project_name} "
+"environment. This file is used by the adapters on the server (JAAS Login "
+"module) side."
+msgstr ""
+"`$FUSE_HOME/etc` ディレクトリーに `keycloak-hawtio.json` "
+"ファイルを作成します。このファイルは、以下の例のような内容です。{project_name}の環境に応じて `realm` と `auth-"
+"server-url` プロパティーを変更してください。このファイルは、サーバー（JAASログイン・モジュール）側のアダプターによって使用されます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"{\n"
+"  \"realm\" : \"demo\",\n"
+"  \"resource\" : \"jaas\",\n"
+"  \"bearer-only\" : true,\n"
+"  \"auth-server-url\" : \"http://localhost:8080/auth\",\n"
+"  \"ssl-required\" : \"external\",\n"
+"  \"use-resource-role-mappings\": false,\n"
+"  \"principal-attribute\": \"preferred_username\"\n"
+"}\n"
+msgstr ""
+"{\n"
+"  \"realm\" : \"demo\",\n"
+"  \"resource\" : \"jaas\",\n"
+"  \"bearer-only\" : true,\n"
+"  \"auth-server-url\" : \"http://localhost:8080/auth\",\n"
+"  \"ssl-required\" : \"external\",\n"
+"  \"use-resource-role-mappings\": false,\n"
+"  \"principal-attribute\": \"preferred_username\"\n"
+"}\n"
+
+#. type: Plain text
+msgid ""
+"Go to http://localhost:8181/hawtio and log in as a user from your "
+"{project_name} realm."
+msgstr "http://localhost:8181/hawtio に移動し、{project_name}のレルムからユーザーとしてログインします。"
+
+#. type: Plain text
+msgid ""
+"Note that the user needs to have the proper realm role to successfully "
+"authenticate to Hawtio. The available roles are configured in the "
+"`$FUSE_HOME/etc/system.properties` file in `hawtio.roles`."
+msgstr ""
+"Hawtioに対して正常に認証するには、ユーザーが適切なレルムロールを持っている必要があることに注意してください。利用可能なロールは、 "
+"`hawtio.roles` の `$FUSE_HOME/etc/system.properties` ファイルで設定されます。"
+
+#. type: Plain text
+msgid ""
+"Create a client in the {project_name} administration console in your realm. "
+"For example, in the {project_name} `demo` realm, create a client `hawtio-"
+"client`, specify `public` as the Access Type, and specify a redirect URI "
+"pointing to Hawtio: \\http://localhost:8181/hawtio/*. Configure "
+"corresponding Web Origin (in this case, \\http://localhost:8181). Setup "
+"client scope mapping to include _view-profile_ client role of _account_ "
+"client in _Scope_ tab in `hawtio-client` client detail."
+msgstr ""
+"利用レルムの{project_name}管理コンソールにクライアントを作成します。たとえば、{project_name}の `demo` "
+"レルムでクライアント `hawtio-client` を作成し、アクセスタイプとして `public` を指定し、Hawtio: "
+"\\http://localhost:8181/hawtio/* を指すリダイレクトURIを指定します。対応するWeb Origin（この場合は、 "
+"\\http://localhost:8181）を設定します。 `hawtio-client` クライアント詳細の _Scope_ タブにある "
+"_account_ クライアントの _view-profile_ クライアントロールを含むようにクライアント・スコープ・マッピングを設定します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -117,41 +166,6 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Create the `keycloak-hawtio.json` file in the `$FUSE_HOME/etc` dicrectory "
-"using content similar to that shown in the example below. Change the `realm`"
-" and `auth-server-url` properties according to your {project_name} "
-"environment. This file is used by the adapters on the server (JAAS Login "
-"module) side."
-msgstr ""
-"`$FUSE_HOME/etc` ディレクトリーに `keycloak-hawtio.json` "
-"ファイルを作成します。このファイルは、以下の例のような内容です。{project_name}の環境に応じて `realm` と `auth-"
-"server-url` プロパティーを変更してください。このファイルは、サーバー（JAASログイン・モジュール）側のアダプターによって使用されます。"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"{\n"
-"  \"realm\" : \"demo\",\n"
-"  \"resource\" : \"jaas\",\n"
-"  \"bearer-only\" : true,\n"
-"  \"auth-server-url\" : \"http://localhost:8080/auth\",\n"
-"  \"ssl-required\" : \"external\",\n"
-"  \"use-resource-role-mappings\": false,\n"
-"  \"principal-attribute\": \"preferred_username\"\n"
-"}\n"
-msgstr ""
-"{\n"
-"  \"realm\" : \"demo\",\n"
-"  \"resource\" : \"jaas\",\n"
-"  \"bearer-only\" : true,\n"
-"  \"auth-server-url\" : \"http://localhost:8080/auth\",\n"
-"  \"ssl-required\" : \"external\",\n"
-"  \"use-resource-role-mappings\": false,\n"
-"  \"principal-attribute\": \"preferred_username\"\n"
-"}\n"
-
-#. type: Plain text
-msgid ""
 "Start {fuse7Version}, <<_fuse7_install_feature,install the Keycloak "
 "feature>>. Then type in the Karaf terminal:"
 msgstr ""
@@ -172,18 +186,3 @@ msgstr ""
 "system:property -p hawtio.keycloakClientConfig file://\\${karaf.base}/etc/keycloak-hawtio-client.json\n"
 "system:property -p hawtio.rolePrincipalClasses org.keycloak.adapters.jaas.RolePrincipal,org.apache.karaf.jaas.boot.principal.RolePrincipal\n"
 "restart io.hawt.hawtio-war \n"
-
-#. type: Plain text
-msgid ""
-"Go to http://localhost:8181/hawtio and log in as a user from your "
-"{project_name} realm."
-msgstr "http://localhost:8181/hawtio に移動し、{project_name}のレルムからユーザーとしてログインします。"
-
-#. type: Plain text
-msgid ""
-"Note that the user needs to have the proper realm role to successfully "
-"authenticate to Hawtio. The available roles are configured in the "
-"`$FUSE_HOME/etc/system.properties` file in `hawtio.roles`."
-msgstr ""
-"Hawtioに対して正常に認証するには、ユーザーが適切なレルムロールを持っている必要があることに注意してください。利用可能なロールは、 "
-"`hawtio.roles` の `$FUSE_HOME/etc/system.properties` ファイルで設定されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/hawtio.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__hawtio
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
