### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -38,4 +38,4 @@ msgid ""
 " has its own dedicated namespace where roles can be defined."
 msgstr ""
 "ロールは、ユーザーのタイプまたはカテゴリを識別します。 `Admin` 、 `user` 、  `manager` 、 `employee` "
-"はすべて、組織内に存在する典型的なロールです。個々のユーザーを扱うことはきめ細かく管理が難しいため、アプリケーションは多くの場合、特定のロールにアクセスとパーミッションを割り当てます。たとえば、管理コンソールには、管理コンソールUIの一部にアクセスして特定の操作を実行するパーミッションをユーザーに与える特定のロールがあります。ロールにはグローバルな名前空間があり、各クライアントにも、ロールを定義できる専用の名前空間があります。"
+"はすべて、組織内に存在する典型的なロールです。個々のユーザーを扱うと細かすぎて管理が難しいため、アプリケーションは多くの場合、特定のロールにアクセスとパーミッションを割り当てます。たとえば、管理コンソールには、管理コンソールUIの一部にアクセスして特定の操作を実行するパーミッションをユーザーに与える特定のロールがあります。ロールにはグローバルな名前空間があり、各クライアントにも、ロールを定義できる専用の名前空間があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
