### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -139,3 +144,12 @@ msgstr ""
 "_EVENT1_ と _EVENT2_ "
 "のリストはシステムからプロバイダーに渡されます。リストに値を追加するには、各リスト要素をカンマで区切ります。残念ながら、各リスト要素を囲む引用符を "
 "`\\&quot;` にエスケープする必要があります。"
+
+#. type: Plain text
+msgid ""
+"Follow the steps in "
+"link:{developerguide_link}#_providers[{developerguide_name}] for more "
+"details on custom providers and the configuration of providers."
+msgstr ""
+"カスタム・プロバイダーとプロバイダーの設定の詳細については、link:{developerguide_link}#_providers[{developerguide_name}]"
+" の手順に従ってください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__configure-spi-providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
