### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -68,6 +68,18 @@ msgid ""
 "and plug in your own required actions."
 msgstr ""
 "{project_name}での必須アクションとは、認証後にユーザーが実行する必要のあるアクションのことです。アクションが実行された後、ユーザーはそのアクションを再実行する必要はありません。{project_name}には、\"パスワードリセット\"などの必須アクションがいくつか組み込まれています。たとえば、パスワードリセットは、ユーザーがログインした後にパスワードを変更するよう強制します。必須アクションを作成してプラグインすることができます。"
+
+#. type: Plain text
+msgid ""
+"If your authenticator or required action implementation is using some user "
+"attributes as the metadata attributes for linking/establishing the user "
+"identity, then please make sure that users are not able to edit the "
+"attributes and the corresponding attributes are read-only. See the details "
+"in the link:{adminguide_link}#_read_only_user_attributes[Threat model "
+"mitigation chapter]."
+msgstr ""
+"オーセンティケーターまたは必須アクションの実装で、ユーザーのアイデンティティーをリンク/確立するためのメタデータ属性として一部のユーザー属性を使用している場合は、ユーザーが属性を編集できず、対応する属性が読み取り専用であることを確認してください。詳細については"
+" link:{adminguide_link}#_read_only_user_attributes[脅威モデルの緩和の章] を参照してください。"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__auth-spi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
