### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -372,7 +372,7 @@ msgstr ""
 "クライアントを作成するには、SAMLエンティティー記述子を使用して `/auth/realms/<realm>/clients-"
 "registrations/saml2-entity-descriptor` にHTTP POSTリクエストを送信します。"
 
-#. type: Title ===
+#. type: Title ======
 #, no-wrap
 msgid "Example using CURL"
 msgstr "CURLを使用した例"
@@ -471,8 +471,8 @@ msgstr "クライアント登録ポリシー"
 
 #. type: Plain text
 msgid ""
-"{project_name} currently supports 2 ways how can be new clients registered "
-"through Client Registration Service."
+"{project_name} currently supports two ways how new clients can be registered"
+" through Client Registration Service."
 msgstr "{project_name}は現在、クライアント登録サービスを介して新しいクライアントを登録できる2つの方法をサポートしています。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
