### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -459,7 +459,7 @@ msgid ""
 "configuration file at a default location, "
 "[filename]`./.keycloak/kcreg.config`, under the user's home directory. You "
 "can use the [command]`--config` option to point to a different file or "
-"location to mantain multiple authenticated sessions in parallel. It is the "
+"location to maintain multiple authenticated sessions in parallel. It is the "
 "safest way to perform operations tied to a single configuration file from a "
 "single thread."
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration/client-registration-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration__client-registration-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
