### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -85,10 +85,10 @@ msgid ""
 "the link:https://docs.docker.com/registry/configuration/[registry config "
 "file specification] for more information on how the file should be set up, "
 "or start with "
-"link:https://github.com/docker/distribution/blob/master/cmd/registry/config-"
-"example.yml[a basic example]."
+"link:https://github.com/distribution/distribution/blob/main/cmd/registry"
+"/config-example.yml[a basic example]."
 msgstr ""
-"この出力は、既存のレジストリー設定ファイルにコピーできます。ファイルの設定方法の詳細については、link:https://docs.docker.com/registry/configuration/[レジストリー設定ファイルの仕様]を参照してください。または、link:https://github.com/docker/distribution/blob/master/cmd/registry"
+"この出力は、既存のレジストリー設定ファイルにコピーできます。ファイルの設定方法の詳細については、link:https://docs.docker.com/registry/configuration/[レジストリー設定ファイルの仕様]を参照してください。または、link:https://github.com/distribution/distribution/blob/main/cmd/registry"
 "/config-example.yml[基本的な例]から始めてください。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
