### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -270,11 +270,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "_Silent_ `check-sso` functionality is limited in some modern browsers. "
-"Please see link:#_modern_browsers[Modern Browsers with Tracking Protection "
-"Section]."
+"Please see the <<_modern_browsers,Modern Browsers with Tracking Protection "
+"Section>>."
 msgstr ""
-"_Silent_ `check-sso` 機能は、一部の最新ブラウザーで制限されています。 "
-"link:#_modern_browsers[トラッキング防止機能を備えた最新のブラウザー] を参照してください。"
+"_Silent_ `check-sso` "
+"機能は、一部の最新ブラウザーで制限されています。<<_modern_browsers,トラッキング防止機能を備えた最新のブラウザーのセクション>>を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -418,11 +418,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Session Status iframe functionality is limited in some modern browsers. "
-"Please see link:#_modern_browsers[Modern Browsers with Tracking Protection "
-"Section]."
+"Please see <<_modern_browsers,Modern Browsers with Tracking Protection "
+"Section>>."
 msgstr ""
-"Session Status iframe機能は、一部の最新ブラウザーで制限されています。 "
-"link:#_modern_browsers[トラッキング防止機能を備えた最新のブラウザー] を参照してください。"
+"Session Status "
+"iframe機能は、一部の最新ブラウザーで制限されています。<<_modern_browsers,トラッキング防止機能を備えた最新のブラウザーのセクション>>を参照してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -1311,13 +1311,13 @@ msgstr "redirectUri - ログイン後にリダイレクトするURIを指定し�
 msgid ""
 "prompt - This parameter allows to slightly customize the login flow on the "
 "{project_name} server side.  For example enforce displaying the login screen"
-" in case of value `login`. See link:#_params_forwarding[Parameters "
-"Forwarding Section] for the details and all the possible values of the "
-"`prompt` parameter."
+" in case of value `login`. See "
+"link:{adapterguide_link}#_params_forwarding[Parameters Forwarding Section] "
+"for the details and all the possible values of the `prompt` parameter."
 msgstr ""
 "prompt - このパラメーターを使用すると、{project_name}サーバー側のログインフローを少しだけカスタマイズできます。たとえば、値が "
 "`login` の場合は、ログイン画面を表示するようにします。 `prompt` パラメーターの詳細とすべての値については、 "
-"link:#_params_forwarding[パラメーター転送のセクション] を参照してください。"
+"link:{adapterguide_link}#_params_forwarding[パラメーター転送のセクション] を参照してください。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
