### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-creating-infinispan-caches.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-creating-infinispan-caches.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-creating-infinispan-caches.ja_JP.po
@@ -1,0 +1,139 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Title =
+#, no-wrap
+msgid "Creating Infinispan Caches"
+msgstr "Infinispanキャッシュの生成"
+
+#. type: Plain text
+msgid "Create the Infinispan caches that {project_name} requires."
+msgstr "{project_name}が必要とするInfinispanキャッシュを生成します。"
+
+#. type: Plain text
+msgid ""
+"We recommend that you create caches on {jdgserver_name} clusters at runtime "
+"rather than adding caches to `infinispan.xml`.  This strategy ensures that "
+"your caches are automatically synchronized across the cluster and "
+"permanently stored."
+msgstr ""
+"`infinispan.xml` "
+"にキャッシュを追加するのではなく、実行時に{jdgserver_name}クラスターにキャッシュを作成することをお勧めします。この戦略により、キャッシュがクラスター全体で自動的に同期され、永続的に保存されます。"
+
+#. type: Plain text
+msgid ""
+"The following procedure uses the {jdgserver_name} Command Line Interface "
+"(CLI) to create all the required caches in a single batch command."
+msgstr ""
+"次の手順では、{jdgserver_name}コマンドライン・インターフェイス（CLI）を使用して、必要なすべてのキャッシュを1つのバッチコマンドで作成します。"
+
+#. type: Plain text
+msgid "Configure your {jdgserver_name} clusters."
+msgstr "{jdgserver_name}クラスターを設定します。"
+
+#. type: Plain text
+msgid "Create a batch file that contains caches, for example:"
+msgstr "次に例を示すように、キャッシュを含むバッチファイルを作成します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"cat > /tmp/caches.batch<<EOF\n"
+"echo \"creating caches...\"\n"
+"create cache work --template=sessions-cfg\n"
+"create cache sessions --template=sessions-cfg\n"
+"create cache clientSessions --template=sessions-cfg\n"
+"create cache offlineSessions --template=sessions-cfg\n"
+"create cache offlineClientSessions --template=sessions-cfg\n"
+"create cache actionTokens --template=sessions-cfg\n"
+"create cache loginFailures --template=sessions-cfg\n"
+"echo \"verifying caches\"\n"
+"ls caches\n"
+"EOF\n"
+msgstr ""
+"cat > /tmp/caches.batch<<EOF\n"
+"echo \"creating caches...\"\n"
+"create cache work --template=sessions-cfg\n"
+"create cache sessions --template=sessions-cfg\n"
+"create cache clientSessions --template=sessions-cfg\n"
+"create cache offlineSessions --template=sessions-cfg\n"
+"create cache offlineClientSessions --template=sessions-cfg\n"
+"create cache actionTokens --template=sessions-cfg\n"
+"create cache loginFailures --template=sessions-cfg\n"
+"echo \"verifying caches\"\n"
+"ls caches\n"
+"EOF\n"
+
+#. type: Plain text
+msgid "Create the caches with the CLI."
+msgstr "CLIを使用してキャッシュを作成します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "$ bin/cli.sh -c https://server1:11222 --trustall -f /tmp/caches.batch\n"
+msgstr "$ bin/cli.sh -c https://server1:11222 --trustall -f /tmp/caches.batch\n"
+
+#. type: Plain text
+msgid ""
+"Instead of the `--trustall` argument you can specify the truststore with the"
+" `-t` argument and the truststore password with the `-s` argument."
+msgstr ""
+"引数 `--trustall` の代わりに、引数 `-t` でトラストストアを指定し、 `-s` 引数でトラストストア・パスワードを指定できます。"
+
+#. type: Plain text
+msgid "Create the caches on the other site."
+msgstr "他のサイトにキャッシュを作成します。"
+
+#. type: Plain text
+msgid ""
+"link:https://access.redhat.com/documentation/en-us/red_hat_data_grid/8.1"
+"/html-single/data_grid_server_guide/index#start_server[Getting Started with "
+"Data Grid Server] + link:https://access.redhat.com/documentation/en-"
+"us/red_hat_data_grid/8.1/html-"
+"single/data_grid_server_guide/index#create_remote_cache[Remotely Creating "
+"Caches on Data Grid Clusters] + link:https://access.redhat.com/documentation"
+"/en-us/red_hat_data_grid/8.1/html-"
+"single/data_grid_command_line_interface/index#batch_operations[Performing "
+"Batch Operations with the CLI]"
+msgstr ""
+"link:https://access.redhat.com/documentation/en-us/red_hat_data_grid/8.1"
+"/html-single/data_grid_server_guide/index#start_server[Getting Started with "
+"Data Grid Server] + link:https://access.redhat.com/documentation/en-"
+"us/red_hat_data_grid/8.1/html-"
+"single/data_grid_server_guide/index#create_remote_cache[Remotely Creating "
+"Caches on Data Grid Clusters] + link:https://access.redhat.com/documentation"
+"/en-us/red_hat_data_grid/8.1/html-"
+"single/data_grid_command_line_interface/index#batch_operations[Performing "
+"Batch Operations with the CLI]"

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-creating-infinispan-caches.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-creating-infinispan-caches.ja_JP.po
@@ -65,7 +65,7 @@ msgstr "{jdgserver_name}クラスターを設定します。"
 
 #. type: Plain text
 msgid "Create a batch file that contains caches, for example:"
-msgstr "次に例を示すように、キャッシュを含むバッチファイルを作成します。"
+msgstr "たとえば、次にようにキャッシュを含むバッチファイルを作成します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-creating-infinispan-caches.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc__proc-creating-infinispan-caches
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
