### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po
@@ -1,0 +1,98 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Setting Up Cross DC with {jdgserver_name} {jdgserver_version_latest}"
+msgstr "{jdgserver_name} {jdgserver_version_latest}を使用したクロスDCの設定"
+
+#. type: Plain text
+msgid ""
+"Use the following procedures for {jdgserver_name} {jdgserver_version_latest}"
+" to perform a basic setup of Cross-Datacenter replication."
+msgstr ""
+"{jdgserver_name} "
+"{jdgserver_version_latest}に対して次の手順を使用して、データセンター間レプリケーションの基本的なセットアップを実行します。"
+
+#. type: Plain text
+msgid ""
+"This example for {jdgserver_name} {jdgserver_version_latest} involves two "
+"data centers, `site1` and `site2`. Each data center consists of 1 "
+"{jdgserver_name} server and 2 {project_name} servers. We will end up with 2 "
+"{jdgserver_name} servers and 4 {project_name} servers in total."
+msgstr ""
+"{jdgserver_name} {jdgserver_version_latest}のこの例には、 `site1` と `site2` "
+"の2つのデータセンターが含まれます。各データセンターは、1つの{jdgserver_name}サーバーと2つの{project_name}サーバーで構成されています。合計すると、2つの{jdgserver_name}サーバーと4つの{project_name}サーバーになります。"
+
+#. type: Plain text
+msgid ""
+"`Site1` consists of {jdgserver_name} server, `server1`, and 2 {project_name}"
+" servers, `node11` and `node12` ."
+msgstr ""
+"`Site1` は、{jdgserver_name}サーバーの `server1` と2つの{project_name}サーバーの `node11` "
+"および `node12` で構成されています。"
+
+#. type: Plain text
+msgid ""
+"`Site2` consists of {jdgserver_name} server, `server2`, and 2 {project_name}"
+" servers, `node21` and `node22` ."
+msgstr ""
+"`Site2` は、{jdgserver_name}サーバーの `server2` と2つの{project_name}サーバーの `node21` "
+"および `node22` で構成されています。"
+
+#. type: Plain text
+msgid ""
+"{jdgserver_name} servers `server1` and `server2` are connected to each other"
+" through the RELAY2 protocol and `backup` based {jdgserver_name} caches in a"
+" similar way as described in the "
+"link:{jdgserver_crossdcdocs_link}[{jdgserver_name} documentation]."
+msgstr ""
+"{jdgserver_name}サーバーである `server1` と `server2` は、 "
+"link:{jdgserver_crossdcdocs_link}[ {jdgserver_name} のドキュメント] "
+"で記載されているのと同様の方法で、RELAY2プロトコルと `backup` "
+"ベースの{jdgserver_name}キャッシュを介して相互に接続されています。"
+
+#. type: Plain text
+msgid ""
+"{project_name} servers `node11` and `node12` form a cluster with each other,"
+" but they do not communicate directly with any server in `site2`.  They "
+"communicate with the Infinispan server `server1` using the Hot Rod protocol "
+"(Remote cache). See <<communication>> for more information."
+msgstr ""
+"{project_name}サーバーである `node11` と `node12` は、お互いにクラスターを形成しますが、 `site2` "
+"内のサーバーとは直接通信はしません。それらはHot Rodプロトコル （リモート・キャッシュ）を使用して、Infinispanサーバー "
+"`server1` と通信します。詳細については、<<communication>>を参照してください。"
+
+#. type: Plain text
+msgid ""
+"The same details apply for `node21` and `node22`. They cluster with each "
+"other and communicate only with `server2` server using the Hot Rod protocol."
+msgstr ""
+"同じ説明が `node21` と `node22` にも当てはまります。それらはお互いにクラスター化し、Hot Rodプロトコルを使用して、 "
+"`server2` サーバーとのみ通信します。"
+
+#. type: Plain text
+msgid ""
+"Our example setup assumes that the four {project_name} servers talk to the "
+"same database. In production, we recommend that you use separate "
+"synchronously replicated databases across data centers as described in "
+"<<database>>."
+msgstr ""
+"この設定の例では、4つの{project_name}サーバーすべてが同じデータベースと通信することを前提としています。プロダクション環境では、<<database>>で説明されているとおり、データセンター間で別々の同期レプリケートされたデータベースを使用することをお勧めします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc__assembly-setting-up-crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
