### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,8 +48,8 @@ msgstr ""
 " Actionsタブに移動し、 \"Delete Account\" アクションの有効なチェックボックスをオンにします。"
 
 #. type: Plain text
-msgid "image:{project_images}/enable-delete-account-action.png[]"
-msgstr "image:{project_images}/enable-delete-account-action.png[]"
+msgid "image:images/enable-delete-account-action.png[]"
+msgstr "image:images/enable-delete-account-action.png[]"
 
 #. type: Plain text
 msgid "Making sure the user has the \"delete-account\" as a client role:"
@@ -79,8 +79,8 @@ msgid "Finally, select `delete-account` and click on add selected."
 msgstr "最後に、 `delete-account` を選択し、 \"Add selected\" をクリックします。"
 
 #. type: Plain text
-msgid "image:{project_images}/delete-account-client-role.png[]"
-msgstr "image:{project_images}/delete-account-client-role.png[]"
+msgid "image:images/delete-account-client-role.png[]"
+msgstr "image:images/delete-account-client-role.png[]"
 
 #. type: Title ===
 #, no-wrap
@@ -89,19 +89,15 @@ msgstr "アクションによるユーザーの削除"
 
 #. type: Plain text
 msgid ""
-"Once the functionlity is enabled, the user will see a new section named "
+"Once the functionality is enabled, the user will see a new section named "
 "\"Delete Account\" appear in the bottom of the \"Personal Info\" page"
 msgstr ""
 "機能を有効にすると、 \"Personal Info\" ページの下部に \"Delete Account\" "
 "という名前の新しいセクションが表示されます。"
 
 #. type: Plain text
-msgid "image:{project_images}/delete-account-landing-screen.png[]"
-msgstr "image:{project_images}/delete-account-landing-screen.png[]"
-
-#. type: Plain text
-msgid "image:{project_images}/delete-account-page.png[]"
-msgstr "image:{project_images}/delete-account-page.png[]"
+msgid "image:images/delete-account-page.png[]"
+msgstr "image:images/delete-account-page.png[]"
 
 #. type: Plain text
 msgid ""
@@ -117,8 +113,8 @@ msgid ""
 msgstr "ユーザーがDeleteをクリックすると、クレデンシャルを再度入力するように求められ、最後の確認手順にリダイレクトされます。"
 
 #. type: Plain text
-msgid "image:{project_images}/delete-account-confirm.png[]"
-msgstr "image:{project_images}/delete-account-confirm.png[]"
+msgid "image:images/delete-account-confirm.png[]"
+msgstr "image:images/delete-account-confirm.png[]"
 
 #. type: Plain text
 msgid "After confirming, the user's account will be deleted."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__allow-user-to-delete-account
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
