### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +31,7 @@ msgid ""
 "in the client's `Settings` tab, a new `Credentials` tab will show up. Note "
 "that the `Credentials` tab only shows up after you've clicked the `Save` "
 "button at the bottom of the settings screen with a `confidential` access "
-"type. As part of dealing with thistype of client you have to configure the "
+"type. As part of dealing with this type of client you have to configure the "
 "client's credentials."
 msgstr ""
 "クライアントの `Settings` タブでクライアントの<<_access-type, アクセスタイプ>>を `confidential` "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/confidential.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__confidential
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
