### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
@@ -5,15 +5,15 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,25 +26,17 @@ msgstr ""
 msgid "W3C Web Authentication (WebAuthn)"
 msgstr "W3C Web Authentication（WebAuthn）"
 
-#. type: Title =====
-#, no-wrap
-msgid "Setup"
-msgstr "セットアップ"
-
-#. type: Plain text
-msgid "Configuration|Description"
-msgstr "設定|説明"
-
 #. type: Plain text
 msgid ""
 "{project_name} provides the limited support for "
 "https://www.w3.org/TR/webauthn/[W3C Web Authentication (WebAuthn)]. "
-"{project_name} works as a WebAuthn's https://www.w3.org/TR/webauthn/#rp-"
-"operations[Relying Party (RP)]."
+"{project_name} works as a WebAuthn's https://www.w3.org/TR/webauthn/#sctn-"
+"rp-operations[Relying Party (RP)]."
 msgstr ""
 "{project_name}は、 https://www.w3.org/TR/webauthn/[W3C Web "
 "Authentication（WebAuthn）] の限定的なサポートを提供します。{project_name}はWebAuthnの "
-"https://www.w3.org/TR/webauthn/#rp-operations[Relying Party（RP）] として機能します。"
+"https://www.w3.org/TR/webauthn/#sctn-rp-operations[Relying Party（RP）] "
+"として機能します。"
 
 #. type: Plain text
 msgid ""
@@ -62,6 +54,11 @@ msgid ""
 "specification."
 msgstr ""
 "WebAuthnの操作が成功するかどうかは、オーセンティケーター、ブラウザー、およびプラットフォームをサポートするユーザーのWebAuthnに依存します。このWebAuthnサポートを使用する場合は、それらのエンティティーがWebAuthn仕様をサポートする範囲を明確にしてください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Setup"
+msgstr "セットアップ"
 
 #. type: Plain text
 msgid "The setup procedure of WebAuthn support for 2FA is the following :"
@@ -316,6 +313,10 @@ msgid "The configurable items and their description follow."
 msgstr "設定可能な項目とその説明は次のとおりです。"
 
 #. type: Plain text
+msgid "Configuration|Description"
+msgstr "設定|説明"
+
+#. type: Plain text
 msgid "Relying Party Entity Name"
 msgstr "Relying Party Entity Name"
 
@@ -370,13 +371,13 @@ msgstr "Attestation Conveyance Preference"
 #, no-wrap
 msgid ""
 "It tells the WebAuthn API implementation on the browser (https://www.w3.org/TR/webauthn/#webauthn-client[WebAuthn Client]) the preference of how to generate an Attestation Statement. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no option is selected, its behavior is the same as selecting \"none\".\n"
-" For more details, see https://www.w3.org/TR/webauthn/#attestation-convey[WebAuthn Specification].\n"
+" For more details, see https://www.w3.org/TR/webauthn/#attestation-conveyance[WebAuthn Specification].\n"
 msgstr ""
 "ブラウザーのWebAuthn API実装（ https://www.w3.org/TR/webauthn/#webauthn-"
 "client[WebAuthnクライアント] "
 "）に、認証ステートメントの生成方法の設定を伝えます。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。オプションが選択されていない場合、その動作は\"none\"を選択した場合と同じです。詳細については、"
-" https://www.w3.org/TR/webauthn/#attestation-convey[WebAuthn Specification] "
-"を参照してください。\n"
+" https://www.w3.org/TR/webauthn/#attestation-conveyance[WebAuthn "
+"Specification] を参照してください。\n"
 
 #. type: Plain text
 msgid "Authenticator Attachment"
@@ -399,11 +400,11 @@ msgstr "Require Resident Key"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"It tells the WebAuthn authenticator to generate the Public Key Credential as https://www.w3.org/TR/webauthn/#client-side-resident-public-key-credential-source[Client-side-resident Public Key Credential Source]. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no option is selected, its behavior is the same as selecting \"No\".\n"
+"It tells the WebAuthn authenticator to generate the Public Key Credential as https://www.w3.org/TR/webauthn/#client-side-discoverable-public-key-credential-source[Client-side-resident Public Key Credential Source]. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no option is selected, its behavior is the same as selecting \"No\".\n"
 " For more details, see https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-requireresidentkey[WebAuthn Specification].\n"
 msgstr ""
-"https://www.w3.org/TR/webauthn/#client-side-resident-public-key-credential-"
-"source[Client-side-resident Public Key Credential Source] "
+"https://www.w3.org/TR/webauthn/#client-side-discoverable-public-key-"
+"credential-source[Client-side-resident Public Key Credential Source] "
 "として公開鍵クレデンシャルを生成するようにWebAuthnオーセンティケーターに指示します。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。オプションが選択されていない場合、その動作は\"No\"を選択した場合と同じです。詳細については、"
 " https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-"
 "requireresidentkey[WebAuthn Specification] を参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__webauthn
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
