### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,14 +30,19 @@ msgstr "Prompt"
 msgid "Client Authentication"
 msgstr "クライアント認証"
 
+#. type: Plain text
+msgid "Configuration|Description"
+msgstr "設定|説明"
+
+#. type: Plain text
+#, no-wrap
+msgid "Client ID"
+msgstr "Client ID"
+
 #. type: Block title
 #, no-wrap
 msgid "Add Identity Provider"
 msgstr "アイデンティティー・プロバイダーの追加"
-
-#. type: Plain text
-msgid "Configuration|Description"
-msgstr "設定|説明"
 
 #. type: Title ===
 #, no-wrap
@@ -143,11 +148,6 @@ msgstr ""
 " https://openid.net/specs/openid-connect-core-"
 "1_0.html#ClientAuthentication[クライアント認証の仕様] を参照してください。\n"
 
-#. type: Labeled list
-#, no-wrap
-msgid "Client ID"
-msgstr "Client ID"
-
 #. type: Plain text
 #, no-wrap
 msgid ""
@@ -168,6 +168,19 @@ msgid ""
 msgstr ""
 "このレルムには、認可コードフローを使用するときに使用するクライアント・シークレットが必要です。このフィールドの値は、外部<<_vault-"
 "administration,ボールト>>の値を参照できます。"
+
+#. type: Plain text
+msgid "Client Assertion Signature Algorithm"
+msgstr "Client Assertion Signature Algorithm"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Signature algorithm to create JWT assertion as client authentication.\n"
+"In the case of JWT signed with private key or Client secret as jwt, it is required. If no algorithm is specified, the following algorithm is adapted. `RS256` is adapted in the case of JWT signed with private key.  `HS256` is adapted in the case of Client secret as jwt.\n"
+msgstr ""
+"クライアント認証としてJWTアサーションを作成するための署名アルゴリズム。秘密鍵で署名したJWTまたはJWTとしてのクライアント・シークレットの場合は必須です。アルゴリズムが指定されていない場合は、次のアルゴリズムが適用されます。秘密鍵で署名されたJWTの場合は、"
+" `RS256` が適用されます。 JWTとしてのクライアント・シークレットの場合は、`HS256` が適用されます。\n"
 
 #. type: Plain text
 msgid "Issuer"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
