### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -148,10 +148,14 @@ msgstr "Principal Type"
 msgid ""
 "Specifies which part of the SAML assertion will be used to identify and "
 "track external user identities. Can be either Subject NameID or SAML "
-"attribute (either by name or by friendly name)."
+"attribute (either by name or by friendly name). Subject NameID value can not"
+" be set together with 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' "
+"NameID Policy Format value."
 msgstr ""
 "SAMLアサーションのどの部分を外部ユーザー・アイデンティティを一意に特定しトラックするのに使用するかを指定します。Subject "
-"NameID、SAML attributeのいずれか（名前もしくはフレンドリー名）です。"
+"NameID、SAML attributeのいずれか（名前もしくはフレンドリー名）です。Subject NameID値は、 "
+"'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' NameID Policy Format "
+"値とともに設定することはできません。"
 
 #. type: Plain text
 msgid "Principal Attribute"
@@ -165,6 +169,16 @@ msgid ""
 msgstr ""
 "プリンシパルが\"Attribute [Name]\"、もしくは\"Attribute [Friendly "
 "Name]\"に設定された場合、このフィールドには対応する識別する属性の名前もしくはフレンドリー名を指定します。"
+
+#. type: Plain text
+msgid "Allow create"
+msgstr "Allow create"
+
+#. type: Plain text
+msgid ""
+"Allow the external identity provider to create a new identifier to represent"
+" the principal."
+msgstr "外部アイデンティティー・プロバイダーがプリンシパルを表す新しい識別子を作成できるようにします。"
 
 #. type: Plain text
 msgid "HTTP-POST Binding Response"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
