### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/themes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/themes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/themes.ja_JP.po
@@ -7,13 +7,13 @@
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -180,3 +180,14 @@ msgid ""
 "is also updated at this point."
 msgstr ""
 "ユーザーが認証されると、前述の永続化されたCookieのロケールを更新するアクションがトリガーされます。ユーザーがログインページのロケール・セレクターを介してアクティブにロケールを切り替えた場合、ユーザーロケールもこの時点で更新されます。"
+
+#. type: Plain text
+msgid ""
+"If you want to change the logic for selecting the locale, you have an option"
+" to create custom `LocaleSelectorProvider`. For details, please refer to the"
+" link:{developerguide_link}#_locale_selector[{developerguide_name}]."
+msgstr ""
+"ロケールを選択するためのロジックを変更する場合は、カスタムの `LocaleSelectorProvider` "
+"を作成するオプションがあります。詳細については、 "
+"link:{developerguide_link}#_locale_selector[{developerguide_name}] "
+"を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/themes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__themes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
