### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,7 +36,7 @@ msgid ""
 "hardcoded to a property file that is embedded in the jar of the provider, "
 "which is not terribly useful. We might want to make the location of this "
 "file configurable per instance of the provider. In other words, we might "
-"want to reuse this provider mulitple times in multiple different realms and "
+"want to reuse this provider multiple times in multiple different realms and "
 "point to completely different user property files. We'll also want to "
 "perform this configuration within the administration console UI."
 msgstr ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
