### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,7 +43,7 @@ msgstr "サーバーの拡張"
 msgid ""
 "The {project_name} SPI framework offers the possibility to implement or "
 "override particular built-in providers. However {project_name} also provides"
-" capabilities to extend it's core functionalities and domain. This includes "
+" capabilities to extend its core functionalities and domain. This includes "
 "possibilities to:"
 msgstr ""
 "{project_name} "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/extensions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__extensions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
