### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,37 +28,16 @@ msgstr "ロケール・セレクター"
 msgid ""
 "By default, the locale is selected using the `DefaultLocaleSelectorProvider`"
 " which implements the `LocaleSelectorProvider` interface. English is the "
-"default language when internationalization is disabled. With "
-"internationalization enabled, the locale is resolved in the following "
-"priority:"
+"default language when internationalization is disabled.  With "
+"internationalization enabled, the locale is resolved according to the logic "
+"described in the "
+"link:{adminguide_link}#_user_locale_selection[{adminguide_name}]."
 msgstr ""
 "デフォルトでは、ロケールは `LocaleSelectorProvider` インターフェイスを実装する "
 "`DefaultLocaleSelectorProvider` "
-"を使用して選択されます。国際化が無効の場合は、英語がデフォルトの言語です。国際化が有効になっている場合は、ロケールは次の優先順位で解決されます。"
-
-#. type: Plain text
-msgid "`kc_locale` query parameter"
-msgstr "`kc_locale` クエリー・パラメーター"
-
-#. type: Plain text
-msgid "`KEYCLOAK_LOCALE` cookie value"
-msgstr "`KEYCLOAK_LOCALE` Cookie値"
-
-#. type: Plain text
-msgid "User's preferred locale if a user instance is available"
-msgstr "ユーザー・インスタンスが利用可能な場合はユーザーの優先ロケール"
-
-#. type: Plain text
-msgid "`ui_locales` query parameter"
-msgstr "`ui_locales` クエリー・パラメーター"
-
-#. type: Plain text
-msgid "`Accept-Language` request header"
-msgstr "`Accept-Language` リクエスト・ヘッダー"
-
-#. type: Plain text
-msgid "Realm's default language"
-msgstr "レルムのデフォルトの言語"
+"を使用して選択されます。国際化が無効の場合は、英語がデフォルトの言語です。国際化を有効にすると、ロケールは "
+"link:{adminguide_link}#_user_locale_selection[{adminguide_name}] "
+"で説明されているロジックに従って解決されます。 "
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__locale-selector
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
