### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
@@ -7,13 +7,13 @@
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # KojiNose <knose.dev@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,7 +64,7 @@ msgid ""
 "{\n"
 "  \"policy-enforcer\": {\n"
 "    \"user-managed-access\" : {},\n"
-"    \"enforcement-mode\" : \"ENFORCING\"\n"
+"    \"enforcement-mode\" : \"ENFORCING\",\n"
 "    \"paths\": [\n"
 "      {\n"
 "        \"path\" : \"/someUri/*\",\n"
@@ -103,7 +103,7 @@ msgstr ""
 "{\n"
 "  \"policy-enforcer\": {\n"
 "    \"user-managed-access\" : {},\n"
-"    \"enforcement-mode\" : \"ENFORCING\"\n"
+"    \"enforcement-mode\" : \"ENFORCING\",\n"
 "    \"paths\": [\n"
 "      {\n"
 "        \"path\" : \"/someUri/*\",\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-keycloak-enforcement-filter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
