### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,3 +74,18 @@ msgstr ""
 "ユーザー・ストレージSPIプロバイダーの実装は、Java EEコンポーネントと同様にパッケージ化され、デプロイされます（しばしばJava "
 "EEコンポーネントです）。デフォルトでは有効になっていませんが、管理コンソールの `User Federation` "
 "タブでレルムごとに有効にして設定する必要があります。"
+
+#. type: Plain text
+msgid ""
+"If your user provider implementation is using some user attributes as the "
+"metadata attributes for linking/establishing the user identity, then please "
+"make sure that users are not able to edit the attributes and the "
+"corresponding attributes are read-only. The example is the `LDAP_ID` "
+"attribute, which the built-in {project_name} LDAP provider is using for to "
+"store the ID of the user on the LDAP server side. See the details in the "
+"link:{adminguide_link}#_read_only_user_attributes[Threat model mitigation "
+"chapter]."
+msgstr ""
+"ユーザー・プロバイダーの実装で、ユーザーのアイデンティティーをリンク/確立するためのメタデータ属性として一部のユーザー属性を使用している場合は、ユーザーが属性を編集できず、対応する属性が読み取り専用であることを確認してください。この例は、組み込みの{project_name}"
+" LDAPプロバイダーがLDAPサーバー側でユーザーのIDを保存するために使用している `LDAP_ID` 属性です。詳細については "
+"link:{adminguide_link}#_read_only_user_attributes[脅威モデルの緩和の章] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
