### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-js-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-js-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-js-policy.ja_JP.po
@@ -8,13 +8,13 @@
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
 # KojiNose <knose.dev@gmail.com>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -38,10 +38,6 @@ msgid "*Description*\n"
 msgstr "*Description*\n"
 
 #. type: Plain text
-msgid "A string containing details about this policy."
-msgstr "このポリシーに関する詳細情報を含む文字列。"
-
-#. type: Plain text
 #, no-wrap
 msgid "*Logic*\n"
 msgstr "*Logic*\n"
@@ -52,10 +48,9 @@ msgid ""
 "conditions have been evaluated."
 msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
 
-#. type: Title ==
-#, no-wrap
-msgid "Examples"
-msgstr "サンプル"
+#. type: Plain text
+msgid "A string containing details about this policy."
+msgstr "このポリシーに関する詳細情報を含む文字列。"
 
 #. type: Plain text
 msgid ""
@@ -69,6 +64,18 @@ msgstr ""
 #, no-wrap
 msgid "JavaScript-Based Policy"
 msgstr "JavaScriptベースポリシー"
+
+#. type: Plain text
+msgid ""
+"If your policy implementation is using Attribute based access control (ABAC)"
+" as in the examples below, then please make sure that users are not able to "
+"edit the protected attributes and the corresponding attributes are read-"
+"only. See the details in the "
+"link:{adminguide_link}#_read_only_user_attributes[Threat model mitigation "
+"chapter]."
+msgstr ""
+"以下の例のように、ポリシーの実装で属性ベースのアクセス制御（ABAC）を使用している場合は、ユーザーが保護された属性を編集できず、対応する属性が読み取り専用であることを確認してください。詳細については"
+" link:{adminguide_link}#_read_only_user_attributes[脅威モデルの緩和の章] を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -136,6 +143,11 @@ msgid ""
 "Once you have your scripts deployed, you should be able to select the "
 "scripts you deployed from the list of available policy providers."
 msgstr "スクリプトをデプロイしたら、利用可能なポリシー・プロバイダーのリストからデプロイしたスクリプトを選択できるようになります。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Examples"
+msgstr "サンプル"
 
 #. type: Title ===
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/policy-js-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-js-policy.ja_JP.po
@@ -74,7 +74,7 @@ msgid ""
 "link:{adminguide_link}#_read_only_user_attributes[Threat model mitigation "
 "chapter]."
 msgstr ""
-"以下の例のように、ポリシーの実装で属性ベースのアクセス制御（ABAC）を使用している場合は、ユーザーが保護された属性を編集できず、対応する属性が読み取り専用であることを確認してください。詳細については"
+"以下の例のように、ポリシーの実装で属性ベースのアクセス・コントロール（ABAC）を使用している場合は、ユーザーが保護された属性を編集できず、対応する属性が読み取り専用であることを確認してください。詳細については"
 " link:{adminguide_link}#_read_only_user_attributes[脅威モデルの緩和の章] を参照してください。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-js-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-js-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
