### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Hisanobu Okuda <hisanobu.okuda@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,14 +28,14 @@ msgstr "リクエスティング・パーティ・トークン"
 #. type: Plain text
 msgid ""
 "A requesting party token (RPT) is a https://tools.ietf.org/html/rfc7519[JSON"
-" web token (JWT)] digitally signed using https://www.rfc-"
-"editor.org/rfc/rfc7515.txt[JSON web signature (JWS)]. The token is built "
-"based on the OAuth2 access token previously issued by {project_name} to a "
-"specific client acting on behalf of a user or on its own behalf."
+" web token (JWT)] digitally signed using "
+"https://tools.ietf.org/html/rfc7515[JSON web signature (JWS)]. The token is "
+"built based on the OAuth2 access token previously issued by {project_name} "
+"to a specific client acting on behalf of a user or on its own behalf."
 msgstr ""
-"Requesting party token（RPT）は https://www.rfc-editor.org/rfc/rfc7515.txt[JSON"
-" web signature（JWS）] でデジタル署名された https://tools.ietf.org/html/rfc7519[JSON web"
-" token（JWT）] "
+"Requesting party token（RPT）は https://tools.ietf.org/html/rfc7515[JSON web "
+"signature（JWS）] でデジタル署名された https://tools.ietf.org/html/rfc7519[JSON web "
+"token（JWT）] "
 "です。RPTは、{project_name}によって発行されたOAuth2アクセストークンをベースとして、ユーザーの代わりに動作する特定のクライアントに組み込まれます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-rpt-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-rpt-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
