### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,11 +23,6 @@ msgstr ""
 #, no-wrap
 msgid "Example using CURL"
 msgstr "CURLを使用した例"
-
-#. type: Title ====
-#, no-wrap
-msgid "Endpoints"
-msgstr "エンドポイント"
 
 #. type: Title ===
 #, no-wrap
@@ -50,6 +45,11 @@ msgstr ""
 "Party（RP）ライブラリーを使用することができます。この章では、{project_name}固有のことについて詳細に説明しますが、特定のプロトコルの詳細については言及しません。詳細については、"
 " https://openid.net/connect/[OpenID Connectの仕様] と "
 "https://tools.ietf.org/html/rfc6749[OAuth2の仕様] を参照してください。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Endpoints"
+msgstr "エンドポイント"
 
 #. type: Plain text
 msgid ""
@@ -298,6 +298,32 @@ msgstr ""
 "このエンドポイントで呼び出す方法の詳細については、 https://tools.ietf.org/html/rfc7009[OAuth 2.0 "
 "Token Revocationの仕様] を参照してください。"
 
+#. type: Title =====
+#, no-wrap
+msgid "Device Authorization Endpoint"
+msgstr "デバイス認可エンドポイント"
+
+#. type: delimited block .
+#, no-wrap
+msgid "/realms/{realm-name}/protocol/openid-connect/auth/device\n"
+msgstr "/realms/{realm-name}/protocol/openid-connect/auth/device\n"
+
+#. type: Plain text
+msgid ""
+"The device authorization endpoint is used to obtain a device code and a user"
+" code. It can only be invoked by confidential clients."
+msgstr ""
+"デバイス認可エンドポイントは、デバイスコードとユーザーコードを取得するために使用されます。コンフィデンシャル・クライアントのみが呼び出すことができます。"
+
+#. type: Plain text
+msgid ""
+"For more details on how to invoke on this endpoint, see "
+"https://tools.ietf.org/html/rfc8628[OAuth 2.0 Device Authorization Grant "
+"specification]."
+msgstr ""
+"このエンドポイントで呼び出す方法の詳細については、 https://tools.ietf.org/html/rfc8628[OAuth 2.0 "
+"Device Authorization Grantの仕様] を参照してください。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Validating Access Tokens"
@@ -312,20 +338,20 @@ msgid ""
 "server if you have too many validation requests going on at the same time.  "
 "{project_name} issued access tokens are "
 "https://tools.ietf.org/html/rfc7519[JSON Web Tokens (JWT)] digitally signed "
-"and encoded using https://www.rfc-editor.org/rfc/rfc7515.txt[JSON Web "
-"Signature (JWS)].  Because they are encoded in this way, this allows you to "
-"locally validate access tokens using the public key of the issuing realm.  "
-"You can either hard code the realm's public key in your validation code, or "
-"lookup and cache the public key using the <<_certificate_endpoint, "
-"certificate endpoint>> with the Key ID (KID) embedded within the JWS.  "
-"Depending what language you code in, there are a multitude of third party "
-"libraries out there that can help you with JWS validation."
+"and encoded using https://tools.ietf.org/html/rfc7515[JSON Web Signature "
+"(JWS)].  Because they are encoded in this way, this allows you to locally "
+"validate access tokens using the public key of the issuing realm.  You can "
+"either hard code the realm's public key in your validation code, or lookup "
+"and cache the public key using the <<_certificate_endpoint, certificate "
+"endpoint>> with the Key ID (KID) embedded within the JWS.  Depending what "
+"language you code in, there are a multitude of third party libraries out "
+"there that can help you with JWS validation."
 msgstr ""
 "{project_name}によって発行されたアクセストークンを手動で検証する必要がある場合は、<<_token_introspection_endpoint,"
 " "
 "イントロスペクション・エンドポイント>>を呼び出すことができます。このアプローチの欠点は、{project_name}サーバーへのネットワーク呼び出しが必要であることです。これは、同時に実行される検証リクエストが多すぎると、サーバーの速度を低下させ、過剰な負荷をかかる可能性があります。{project_name}が発行したアクセストークンは"
-" https://tools.ietf.org/html/rfc7519[JSON Web Tokens（JWT）] であり、 https://www"
-".rfc-editor.org/rfc/rfc7515.txt[JSON Web Signature（JWS）] "
+" https://tools.ietf.org/html/rfc7519[JSON Web Tokens（JWT）] であり、 "
+"https://tools.ietf.org/html/rfc7515[JSON Web Signature（JWS）] "
 "によりデジタル署名されています。このようにエンコードされているため、発行したレルムの公開鍵を使用してアクセストークンをローカルで検証できます。レルムの公開鍵を検証コードにハードコードするか、<<_certificate_endpoint,"
 " 証明書エンドポイント>>を使用してJWSに埋め込まれたKey "
 "ID（KID）を使用して公開鍵を検索してキャッシュすることができます。コーディングする言語に応じて、JWS検証の手助けをするサードパーティー・ライブラリーが多数あります。"
@@ -537,6 +563,36 @@ msgid ""
 msgstr ""
 "詳細については、OAuth 2.0仕様の https://tools.ietf.org/html/rfc6749#section-4.4[Client "
 "Credentials Grant] のセクションを参照してください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Device Authorization Grant"
+msgstr "デバイス認可グラント"
+
+#. type: Plain text
+msgid ""
+"Device Authorization Grant is used by clients running on internet-connected "
+"devices that have limited input capabilities or lack a suitable browser.  "
+"The application requests {project_name} a device code and a user code. "
+"{project_name} creates a device code and a user code.  {project_name} "
+"returns a response including the device code and the user code to the "
+"application.  Then the application provides the user with the user code and "
+"the verification URI. The user accesses a verification URI to be "
+"authenticated by using another browser.  The application repeatedly polls "
+"{project_name} until {project_name} completes the user authorization.  If "
+"user authentication is complete, the application obtains the device code. "
+"Then the application uses the device code along with its credentials to "
+"obtain an Access Token, Refresh Token and ID Token from {project_name}."
+msgstr ""
+"デバイス認可グラントは、入力機能が制限されているか、適切なブラウザーがない、インターネットに接続されたデバイスで実行されているクライアントによって使用されます。アプリケーションは{project_name}にデバイスコードとユーザーコードを要求します。{project_name}は、デバイスコードとユーザーコードを作成します。{project_name}は、デバイスコードとユーザーコードを含むレスポンスをアプリケーションに返します。次に、アプリケーションはユーザーにユーザーコードと検証URIを提供します。ユーザーは、別のブラウザーを使用して、認証を受けるための検証URIにアクセスします。アプリケーションは、{project_name}がユーザーの認可を完了するまで、繰り返し{project_name}をポーリングします。ユーザーの認可が完了すると、アプリケーションはデバイスコードを取得します。次に、アプリケーションはデバイスコードとそのクレデンシャルを使用して、{project_name}からアクセストークン、リフレッシュトークン、およびIDトークンを取得します。"
+
+#. type: Plain text
+msgid ""
+"For more details refer to the https://tools.ietf.org/html/rfc8628[OAuth 2.0 "
+"Device Authorization Grant specification]."
+msgstr ""
+"詳細については、https://tools.ietf.org/html/rfc8628 [OAuth 2.0 Device Authorization "
+"Grantの仕様] を参照してください。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
