### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,7 +40,7 @@ msgstr ""
 "セキュリティー保護して、登録する必要があるアプリケーションが組織内に多数存在する場合、これらのクライアントごとに<<_protocol-mappers,"
 " プロトコル・マッパー>>や<<_role_scope_mappings, "
 "ロール・スコープ・マッピング>>を設定するのは面倒です。{project_name}を使用すると、 _クライアント・スコープ_ "
-"というエンティティーで共通クライアント設定を定義できます。"
+"というエンティティーで共通のクライアント設定を定義できます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
