### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -77,8 +77,8 @@ msgid ""
 "This contains configuration files and working directory when running "
 "{project_name} in <<_standalone-mode,standalone mode>>."
 msgstr ""
-"<<_standalone-"
-"mode,スタンドアローン・モード>>で{project_name}を実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
+"{project_name}を<<_standalone-"
+"mode,スタンドアローン・モード>>で実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -78,7 +78,7 @@ msgid ""
 "{project_name} in <<_standalone-mode,standalone mode>>."
 msgstr ""
 "<<_standalone-"
-"mode,スタンドアローン・モード>>で{project_name}を実行する場合、設定ファイルとワーキング・ディレクトリーは含まれません。"
+"mode,スタンドアローン・モード>>で{project_name}を実行する場合の、設定ファイルとワーキング・ディレクトリーが含まれています。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/installation/directory-structure.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__installation__directory-structure
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
