### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-configuring-remote-cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-configuring-remote-cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-configuring-remote-cache.ja_JP.po
@@ -102,13 +102,13 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"<subsystem xmlns=\"urn:jboss:domain:infinispan:11.0\">\n"
+"<subsystem xmlns=\"urn:jboss:domain:infinispan:12.0\">\n"
 "    <cache-container name=\"keycloak\"\n"
-"                     module=\"org.keycloak.keycloak-model-infinispan\"/>\n"
+"                     modules=\"org.keycloak.keycloak-model-infinispan\"/>\n"
 msgstr ""
-"<subsystem xmlns=\"urn:jboss:domain:infinispan:11.0\">\n"
+"<subsystem xmlns=\"urn:jboss:domain:infinispan:12.0\">\n"
 "    <cache-container name=\"keycloak\"\n"
-"                     module=\"org.keycloak.keycloak-model-infinispan\"/>\n"
+"                     modules=\"org.keycloak.keycloak-model-infinispan\"/>\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/proc-configuring-remote-cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc__proc-configuring-remote-cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
