### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,12 +69,12 @@ msgid "New Account Management Console"
 msgstr "新しいアカウント管理コンソール"
 
 #. type: Plain text
-msgid "No"
-msgstr "No"
+msgid "Yes"
+msgstr "Yes"
 
 #. type: Plain text
-msgid "Preview"
-msgstr "Preview"
+msgid "Supported"
+msgstr "Supported"
 
 #. type: Plain text
 msgid "account_api"
@@ -93,6 +93,31 @@ msgid "Fine-Grained Admin Permissions"
 msgstr "きめ細かい管理権限"
 
 #. type: Plain text
+msgid "No"
+msgstr "No"
+
+#. type: Plain text
+msgid "Preview"
+msgstr "Preview"
+
+#. type: Plain text
+msgid "ciba"
+msgstr "ciba"
+
+#. type: Title ==
+#, no-wrap
+msgid "OpenID Connect Client Initiated Backchannel Authentication (CIBA)"
+msgstr "OpenID Connect Client Initiated Backchannel Authentication (CIBA)"
+
+#. type: Plain text
+msgid "client_policies"
+msgstr "client_policies"
+
+#. type: Plain text
+msgid "Add client configuration policies"
+msgstr "クライアント設定ポリシーの追加"
+
+#. type: Plain text
 msgid "docker"
 msgstr "docker"
 
@@ -101,20 +126,12 @@ msgid "Docker Registry protocol"
 msgstr "Dockerレジストリーのプロトコル"
 
 #. type: Plain text
-msgid "Supported"
-msgstr "Supported"
-
-#. type: Plain text
 msgid "impersonation"
 msgstr "impersonation"
 
 #. type: Plain text
 msgid "Ability for admins to impersonate users"
 msgstr "管理者がユーザーに成り代わる機能"
-
-#. type: Plain text
-msgid "Yes"
-msgstr "Yes"
 
 #. type: Plain text
 msgid "openshift_integration"
@@ -168,24 +185,15 @@ msgstr "ifeval::[{project_community}==true]"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"Experimental\n"
+"Preview\n"
 "endif::[]\n"
 msgstr ""
-"Experimental\n"
+"Preview\n"
 "endif::[]\n"
 
 #. type: Plain text
 msgid "ifeval::[{project_product}==true]"
 msgstr "ifeval::[{project_product}==true]"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Preview\n"
-"endif::[]\n"
-msgstr ""
-"Preview\n"
-"endif::[]\n"
 
 #. type: Plain text
 msgid "To enable all preview features start the server with:"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
