### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -1477,12 +1477,18 @@ msgstr "アカウント管理コンソールにリダイレクトします。"
 
 #. type: Title ======
 #, no-wrap
-msgid "createAccountUrl()"
-msgstr "createAccountUrl()"
+msgid "createAccountUrl(options)"
+msgstr "createAccountUrl(options)"
 
 #. type: Plain text
 msgid "Returns the URL to the Account Management Console."
 msgstr "アカウント管理コンソールのURLを返します。"
+
+#. type: Plain text
+msgid ""
+"redirectUri - Specifies the uri to redirect to when redirecting back to the "
+"application."
+msgstr "redirectUri - アプリケーションにリダイレクトで戻るときに、リダイレクトするURIを指定します。"
 
 #. type: Title ======
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
