### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -8,13 +8,13 @@
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,10 +26,6 @@ msgstr ""
 #, no-wrap
 msgid "Clients"
 msgstr "Clients"
-
-#. type: Plain text
-msgid "image:{project_images}/clients.png[]"
-msgstr "image:{project_images}/clients.png[]"
 
 #. type: Block title
 #, no-wrap
@@ -46,25 +42,55 @@ msgstr "Name"
 msgid "Description"
 msgstr "Description"
 
-#. type: Labeled list
-#, no-wrap
-msgid "Enabled"
-msgstr "Enabled"
+#. type: Plain text
+msgid "image:{project_images}/clients.png[]"
+msgstr "image:{project_images}/clients.png[]"
 
-#. type: Labeled list
-#, no-wrap
-msgid "Client ID"
-msgstr "Client ID"
+#. type: Plain text
+msgid "This will bring you to the `Add Client` page."
+msgstr "これにより、 `Add Client` ページが表示されます。"
 
-#. type: Labeled list
+#. type: Block title
 #, no-wrap
-msgid "Signature Algorithm"
-msgstr "Signature Algorithm"
+msgid "Client Settings"
+msgstr "クライアントの設定"
 
-#. type: Labeled list
-#, no-wrap
-msgid "SAML Signature Key Name"
-msgstr "SAML Signature Key Name"
+#. type: Plain text
+msgid ""
+"This is the display name for the client whenever it is displayed in a "
+"{project_name} UI screen.  You can localize the value of this field by "
+"setting up a replacement string value i.e. $\\{myapp}.  See the "
+"link:{developerguide_link}[{developerguide_name}] for more information."
+msgstr ""
+"これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+
+#. type: Plain text
+msgid ""
+"This specifies the description of the client.  This can also be localized."
+msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
+
+#. type: Plain text
+msgid ""
+"If this is turned off, the client will not be allowed to request "
+"authentication."
+msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
+
+#. type: Plain text
+msgid ""
+"If this is on, then users will get a consent page which asks the user if "
+"they grant access to that application.  It will also display the metadata "
+"that the client is interested in so that the user knows exactly what "
+"information the client is getting access to.  If you've ever done a social "
+"login to Google, you'll often see a similar page.  {project_name} provides "
+"the same functionality."
+msgstr ""
+"これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
+
+#. type: Plain text
+msgid ""
+"If {project_name} uses any configured relative URLs, this value is prepended"
+" to them."
+msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
 
 #. type: Title ===
 #, no-wrap
@@ -89,10 +115,6 @@ msgstr ""
 "SAMLクライアントを作成するには、左側メニューの項目 `Clients` に移動します。このページには右側に `Create` ボタンがあります。"
 
 #. type: Plain text
-msgid "This will bring you to the `Add Client` page."
-msgstr "これにより、 `Add Client` ページが表示されます。"
-
-#. type: Plain text
 msgid "image:{project_images}/add-client-saml.png[]"
 msgstr "image:{project_images}/add-client-saml.png[]"
 
@@ -115,14 +137,14 @@ msgstr ""
 " `Settings` タブでこれを修正できます。 `Save` をクリックすると、クライアントが作成され、クライアントの `Settings` "
 "タブに移動します。"
 
-#. type: Block title
-#, no-wrap
-msgid "Client Settings"
-msgstr "クライアントの設定"
-
 #. type: Plain text
 msgid "image:{project_images}/client-settings-saml.png[]"
 msgstr "image:{project_images}/client-settings-saml.png[]"
+
+#. type: Plain text
+#, no-wrap
+msgid "Client ID"
+msgstr "Client ID"
 
 #. type: Plain text
 msgid ""
@@ -133,40 +155,14 @@ msgstr ""
 "この値は、AuthNRequestとともに送信されたissuer値と一致する必要があります。{project_name}はissuerを認証SAMLリクエストから取得し、この値でクライアントと照合します。"
 
 #. type: Plain text
-msgid ""
-"This is the display name for the client whenever it is displayed in a "
-"{project_name} UI screen.  You can localize the value of this field by "
-"setting up a replacement string value i.e. $\\{myapp}.  See the "
-"link:{developerguide_link}[{developerguide_name}] for more information."
-msgstr ""
-"これは{project_name}のUI画面に表示されるクライアントの表示名です。置換文字列値の$\\{myapp}を設定して、このフィールドの値をローカライズすることができます。詳細については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
-
-#. type: Plain text
-msgid ""
-"This specifies the description of the client.  This can also be localized."
-msgstr "これは、クライアントの説明を指定します。これはローカライズすることもできます。"
-
-#. type: Plain text
-msgid ""
-"If this is turned off, the client will not be allowed to request "
-"authentication."
-msgstr "これをオフにすると、クライアントは認証を要求できなくなります。"
+#, no-wrap
+msgid "Enabled"
+msgstr "Enabled"
 
 #. type: Labeled list
 #, no-wrap
 msgid "Consent Required"
 msgstr "Consent Required"
-
-#. type: Plain text
-msgid ""
-"If this is on, then users will get a consent page which asks the user if "
-"they grant access to that application.  It will also display the metadata "
-"that the client is interested in so that the user knows exactly what "
-"information the client is getting access to.  If you've ever done a social "
-"login to Google, you'll often see a similar page.  {project_name} provides "
-"the same functionality."
-msgstr ""
-"これがオンになっている場合、ユーザーに同意ページが表示され、そのアプリケーションへのアクセスを許可するかどうかが尋ねられます。また、クライアントがアクセスする情報をユーザーが正確に把握できるように、クライアントが関心を持つメタデータも表示されます。Googleにソーシャル・ログインしたことがある場合は、よく似たようなページを見ているでしょう。{project_name}は同じ機能を提供します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -185,6 +181,25 @@ msgstr ""
 "SAMLログイン・レスポンスでは、使用される認証方法（パスワードなど）、ログインのタイムスタンプ、およびセッションの有効期限を指定できます。これはデフォルトで有効になっています。つまり、"
 " `AuthStatement` "
 "要素がログイン・レスポンスに含まれます。これをオフに設定すると、クライアントは最大セッション長を決定できなくなり、クライアント・セッションが期限切れにならないことに注意してください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Force Artifact Binding"
+msgstr "Force Artifact Binding"
+
+#. type: Plain text
+msgid ""
+"When turned on, this will force {project_name} to send artifact messages "
+"instead of SAML messages via _POST_ and _Redirect_, even when the client has"
+" not asked for the binding during login. This must be set if _Artifact_ "
+"binding is to be used with Idp-initiated login. To use artifact messages "
+"also during logout, it is necessary to also configure `Logout Service "
+"Redirect Binding URL`."
+msgstr ""
+"オンにすると、クライアントがログイン中にバインディングを要求していなくても、{project_name}はSAMLメッセージではなくアーティファクト・メッセージを"
+" _POST_ および _Redirect_ 経由で送信するように強制されます。 _Artifact_ "
+"バインディングをIdP起点ログインで使用する場合は、これを設定する必要があります。ログアウト時にもアーティファクト・メッセージを使用するには、 "
+"`Logout Service Redirect Binding URL` も設定する必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -232,8 +247,18 @@ msgstr ""
 "XML認証レスポンスに埋め込まれます。"
 
 #. type: Plain text
+#, no-wrap
+msgid "Signature Algorithm"
+msgstr "Signature Algorithm"
+
+#. type: Plain text
 msgid "Choose between a variety of algorithms for signing SAML documents."
 msgstr "SAMLドキュメントに署名するためのアルゴリズムを選択します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "SAML Signature Key Name"
+msgstr "SAML Signature Key Name"
 
 #. type: Plain text
 msgid ""
@@ -339,20 +364,69 @@ msgid ""
 "Name ID Format for the subject.  If no name ID policy is specified in the "
 "request or if the Force Name ID Format attribute is true, this value is "
 "used.  Properties used for each of the respective formats are defined below."
+"  You can change the attribute used by the NameID Mapper."
 msgstr ""
 "subjectのName ID Format。リクエストにName IDポリシーが指定されていない場合、または `Force Name ID "
-"Format` 属性がtrueの場合、この値が使用されます。フォーマットとして使用されるプロパティーが定義されています。"
+"Format` "
+"属性がtrueの場合、この値が使用されます。フォーマットとして使用されるプロパティーが定義されています。NameIDマッパーで使用される属性を変更できます。"
+
+#. type: Plain text
+msgid "Name ID Format|Properties/Attributes Used|Example"
+msgstr "NameIDの形式|プロパティー/使用される属性|例"
+
+#. type: Plain text
+msgid "username (unspecified)"
+msgstr "username (不特定)"
+
+#. type: Plain text
+#, no-wrap
+msgid "Username Property     \n"
+msgstr "Username Property     \n"
+
+#. type: Plain text
+msgid "example_user"
+msgstr "example_user"
+
+#. type: Plain text
+msgid "email"
+msgstr "email"
+
+#. type: Plain text
+msgid "Email Property"
+msgstr "Email Property"
+
+#. type: Plain text
+msgid "example_user@example.com"
+msgstr "example_user@example.com"
+
+#. type: Plain text
+msgid "persistent"
+msgstr "persistent"
+
+#. type: Plain text
+msgid "saml.persistent.name.id.for.$clientId Attribute"
+msgstr "saml.persistent.name.id.for.$clientId Attribute"
+
+#. type: Plain text
+msgid "G-6e2a1050-0fc0-479b-bf6e-29cd3ccb373b"
+msgstr "G-6e2a1050-0fc0-479b-bf6e-29cd3ccb373b"
+
+#. type: Plain text
+msgid "transient"
+msgstr "transient"
+
+#. type: Plain text
+msgid "property and attribute values are not used"
+msgstr "property and attribute values are not used"
+
+#. type: Plain text
+msgid "G-bfb85c10-57d7-4331-81bc-52f104599d79"
+msgstr "G-bfb85c10-57d7-4331-81bc-52f104599d79"
 
 #. type: Labeled list
 #, no-wrap
 msgid "Root URL"
 msgstr "Root URL"
-
-#. type: Plain text
-msgid ""
-"If {project_name} uses any configured relative URLs, this value is prepended"
-" to them."
-msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -432,6 +506,42 @@ msgid "Logout Service Redirect Binding URL"
 msgstr "Logout Service Redirect Binding URL"
 
 #. type: Plain text
+msgid "Redirect Binding URL for the Logout Service."
+msgstr "ログアウト・サービスのREDIRECTバインディングURL。"
+
+#. type: Labeled list
 #, no-wrap
-msgid "Redirect Binding URL for the Logout Service.     \n"
-msgstr "ログアウト・サービスのREDIRECTバインディングURL。\n"
+msgid "Logout Service Artifact Binding URL"
+msgstr "Logout Service Artifact Binding URL"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"_Artifact_ Binding URL for the Logout Service. When set together with the "
+"`Force Artifact Binding` option, _Artifact_ binding is forced for both login"
+" and logout flows. _Artifact_ binding is not used for logout unless this "
+"property is set.\n"
+msgstr ""
+"_Artifact_ ログアウト・サービスのバインディングURL。 `Force Artifact Binding` "
+"オプションと一緒に設定すると、ログインフローとログアウトフローの両方で _Artifact_ "
+"バインディングが強制されます。このプロパティーが設定されていない限り、 _Artifact_ バインディングはログアウトに使用されません。\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Artifact Binding URL"
+msgstr "Artifact Binding URL"
+
+#. type: Plain text
+msgid "URL to send the HTTP artifact messages to."
+msgstr "HTTPアーティファクト・メッセージの送信先のURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Artifact Resolution Service"
+msgstr "Artifact Resolution Service"
+
+#. type: Plain text
+msgid ""
+"URL of the client SOAP endpoint where to send the `ArtifactResolve` messages"
+" to."
+msgstr "`ArtifactResolve` メッセージの送信先となるクライアントSOAPエンドポイントのURL。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -7,14 +7,14 @@
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -376,7 +376,7 @@ msgstr "NameIDの形式|プロパティー/使用される属性|例"
 
 #. type: Plain text
 msgid "username (unspecified)"
-msgstr "username (不特定)"
+msgstr "username（不特定）"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
