### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -218,6 +218,19 @@ msgstr ""
 "`roleZ` になります。 `roleA` は `roleX` と `roleY` の両方にマップされ、 `roleB` "
 "は空のロールにマップされているので破棄され、 `roleC` はそのまま使用され、最後に追加のロールが `kc_user` プリンシパル（ "
 "`roleZ` ）に追加されるためです。"
+
+#. type: Plain text
+msgid ""
+"Note: to use spaces in role names for mappings, use unicode replacements for"
+" space. For example, incoming 'role A' would appear as:"
+msgstr ""
+"注意：マッピングのロール名にスペースを使用する場合は、スペースの代わりにUnicodeを使用してください。たとえば、受信した 'role A' "
+"は次のように表示されます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "role\\u0020A=roleX,roleY\n"
+msgstr "role\\u0020A=roleX,roleY\n"
 
 #. type: Title ======
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/sp_role_mappings_provider_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__sp_role_mappings_provider_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
