### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po
@@ -6,19 +6,25 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid ""
+"When querying the server for permissions use parameters `first` and `max` "
+"results to limit the result."
+msgstr "サーバーにパーミッションを問い合わせる際に、結果を制限するためにパラメーター `first` と `max` を使用します。"
 
 #. type: Title =
 #, no-wrap
@@ -285,6 +291,23 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"By default, the `name` filter will match any resource with the given "
+"pattern. To restrict the query to only return resources with an exact match,"
+" use:"
+msgstr ""
+"デフォルトでは、 `name` "
+"フィルターは指定されたパターンのすべてのリソースと一致します。完全に一致するリソースのみを返すようにクエリーを制限するには、次を使用します。"
+
+#. type: Code block
+msgid ""
+"http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set?name=Alice"
+" Resource&exactName=true"
+msgstr ""
+"http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set?name=Alice"
+" Resource&exactName=true"
+
+#. type: Plain text
+msgid ""
 "To query resources given an `uri`, send an HTTP GET request as follows:"
 msgstr "`uri` を指定してリソースを照会するには、次のようにHTTP GETリクエストを送信します。"
 
@@ -326,9 +349,3 @@ msgid ""
 "http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set?scope=read"
 msgstr ""
 "http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set?scope=read"
-
-#. type: Plain text
-msgid ""
-"When querying the server for permissions use parameters `first` and `max` "
-"results to limit the result."
-msgstr "サーバーにパーミッションを問い合わせる際に、結果を制限するためにパラメーター `first` と `max` を使用します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-protection-resources-api-papi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-protection-resources-api-papi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
