### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -183,6 +183,33 @@ msgid ""
 msgstr ""
 "ECPは、Webブラウザーのコンテキスト外でSAML属性を交換できるようにするSAML v.2.0プロファイルの\"Enhanced Client or"
 " Proxy\"の略です。これは、RESTまたはSOAPベースのクライアントで最も頻繁に使用されます。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Artifact Binding"
+msgstr "Artifact Binding"
+
+#. type: Plain text
+msgid ""
+"The SAML _Artifact_ binding works alongside the standard _Redirect_ or "
+"_POST_ bindings. The purpose of this binding is to prevent SAML messages "
+"from passing by the browser. When a SAML message would be sent to the "
+"application or the {project_name}, it is instead saved and in its place a "
+"Redirect or a POST is sent containing an unique identifier (this is the "
+"artifact).  The contacted party uses SOAP to send a message containing the "
+"artifact directly to the originator, which in turn replies via SOAP with the"
+" saved SAML message."
+msgstr ""
+"SAML _Artifact_ バインディングは、標準の _Redirect_ または _POST_ "
+"バインディングと一緒に機能します。このバインディングの目的は、SAMLメッセージがブラウザーを経由するのを防ぐことです。SAMLメッセージがアプリケーションまたは{project_name}に送信されると、代わりにそれが保存され、一意の識別子（これはアーティファクトです）を含むリダイレクトまたはPOSTが送信されます。連携先はSOAPを使用して、アーティファクトを含むメッセージを発信者に直接送信します。そして、発信者は保存されたSAMLメッセージをSOAP経由で返信します。"
+
+#. type: Plain text
+msgid ""
+"This binding can have some security benefits, for example when the user is "
+"not trusted with the contents of a SAML assertion. Instead, they are "
+"exchanged between the application and {project_name} via SOAP."
+msgstr ""
+"このバインディングには、たとえば、ユーザーがSAMLアサーションの内容で信頼されていない場合などで、セキュリティー上の利点がいくつかあります。代わりに、SOAPを介してアプリケーションと{project_name}の間で交換されます。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
