### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po
@@ -404,19 +404,41 @@ msgstr ""
 
 #. type: Title =====
 #, no-wrap
-msgid "Generating Example Tokens"
-msgstr "サンプルトークンの生成"
+msgid "Generating Example Tokens and User Info"
+msgstr "サンプルトークンとユーザー情報の生成"
 
 #. type: Plain text
 msgid ""
-"To see an example of a real access token, generated for the particular user "
-"and issued for the particular client, with the specified value of `scope` "
-"parameter, select the user from the `Evaluate` screen. This will generate an"
-" example token that includes all of the claims and role mappings used."
+"If you select a user in the `Evaluate` screen, the following example data is"
+" generated:"
+msgstr "`Evaluate` 画面でユーザーを選択すると、次のサンプルデータが生成されます。"
+
+#. type: Plain text
+msgid ""
+"Generated Access Token: An access token that will be generated and sent to "
+"the client when the selected user is authenticated."
+msgstr "Generated Access Token: 選択されたユーザーが認証されたときに生成され、クライアントに送信されるアクセストークン。"
+
+#. type: Plain text
+msgid ""
+"Generated ID Token: An ID Token that will be generated and sent to the "
+"client when the selected user is authenticated."
+msgstr "Generated ID Token: 選択されたユーザーが認証されたときに生成され、クライアントに送信されるIDトークン。"
+
+#. type: Plain text
+msgid ""
+"Generated User Info: The information about the user that is returned by the "
+"UserInfo Endpoint."
+msgstr "Generated User Info: UserInfoエンドポイントによって返されるユーザーに関する情報。"
+
+#. type: Plain text
+msgid ""
+"All examples are generated for the particular user and issued for the "
+"particular client, with the specified value of `scope` parameter. The "
+"examples include all of the claims and role mappings used."
 msgstr ""
-"特定のユーザーに対して生成され、特定のクライアントに対して発行された `scope` "
-"パラメーターの指定された値を持つ実際のアクセストークンのサンプルを見るには、 `Evaluate` "
-"画面からユーザーを選択してください。これにより、使用されているすべてのクレームおよびロールマッピングが含まれているトークンのサンプルが生成されます。"
+"すべての例は、特定のユーザー向けに生成され、特定のクライアント向けに発行されます（指定された `scope` "
+"パラメーターの値を使用して）。例には、使用されているすべてのクレームとロールマッピングが含まれています。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
