### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy-required-client-scope.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy-required-client-scope.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy-required-client-scope.ja_JP.po
@@ -5,12 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,8 +31,9 @@ msgid ""
 " the client requesting access has been granted *all* the *required* client "
 "scopes."
 msgstr ""
-"クライアント・スコープ・ベースのポリシーを作成するときに、特定のクライアント・スコープを「必須」として指定できます。これを行うと、アクセスを要求しているクライアントに"
-" *すべての必要な* クライアント・スコープが付与されている場合にのみ、ポリシーはアクセスを許可します。"
+"クライアント・スコープ・ベースのポリシーを作成するときに、特定のクライアント・スコープを `Required` "
+"として指定できます。これを行うと、アクセスを要求しているクライアントに *全て* の *必須* "
+"クライアント・スコープが付与されている場合にのみ、ポリシーはアクセスを許可します。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy-required-client-scope.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy-required-client-scope.ja_JP.po
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Defining a Client Scope as Required"
+msgstr "必須としてクライアント・スコープを定義する"
+
+#. type: Plain text
+msgid ""
+"When creating a client scope-based policy, you can specify a specific client"
+" scope as `Required`. When you do that, the policy will grant access only if"
+" the client requesting access has been granted *all* the *required* client "
+"scopes."
+msgstr ""
+"クライアント・スコープ・ベースのポリシーを作成するときに、特定のクライアント・スコープを「必須」として指定できます。これを行うと、アクセスを要求しているクライアントに"
+" *すべての必要な* クライアント・スコープが付与されている場合にのみ、ポリシーはアクセスを許可します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example of Required Client Scope"
+msgstr "必須クライアント・スコープの例"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/policy/create-client-scope.png[alt=\"Example of "
+"Required Client Scope\"]"
+msgstr ""
+"image:{project_images}/policy/create-client-scope.png[alt=\"Example of "
+"Required Client Scope\"]"
+
+#. type: Plain text
+msgid ""
+"To specify a client scope as required, select the `Required` checkbox for "
+"the client scope you want to configure as required."
+msgstr "クライアント・スコープを必須と指定するには、そのクライアント・スコープの `Required` チェックボックスをチェックします。"
+
+#. type: Plain text
+msgid ""
+"Required client scopes can be useful when your policy defines multiple "
+"client scopes but only a subset of them are mandatory."
+msgstr ""
+"必須のクライアント・スコープは、ポリシーで複数のクライアント・スコープが定義されているが、それらのサブセットのみが必須である場合に役立ちます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy-required-client-scope.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-client-scope-policy-required-client-scope
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
