### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -324,6 +324,48 @@ msgstr ""
 "このエンドポイントで呼び出す方法の詳細については、 https://tools.ietf.org/html/rfc8628[OAuth 2.0 "
 "Device Authorization Grantの仕様] を参照してください。"
 
+#. type: Title =====
+#, no-wrap
+msgid "Backchannel Authentication Endpoint"
+msgstr "バックチャネル認証エンドポイント"
+
+#. type: delimited block .
+#, no-wrap
+msgid "/realms/{realm-name}/protocol/openid-connect/ext/ciba/auth\n"
+msgstr "/realms/{realm-name}/protocol/openid-connect/ext/ciba/auth\n"
+
+#. type: Plain text
+msgid ""
+"The backchannel authentication endpoint is used to obtain an auth_req_id "
+"that identifies the authentication request made by the client. It can only "
+"be invoked by confidential clients."
+msgstr ""
+"バックチャネル認証エンドポイントは、クライアントによって行われた認証リクエストを識別するauth_req_idを取得するために使用されます。コンフィデンシャル・クライアントのみが呼び出すことができます。"
+
+#. type: Plain text
+msgid ""
+"For more details on how to invoke on this endpoint, see "
+"https://openid.net/specs/openid-client-initiated-backchannel-authentication-"
+"core-1_0.html[OpenID Connect Client Initiated Backchannel Authentication "
+"Flow specification]."
+msgstr ""
+"このエンドポイントで呼び出す方法の詳細については、 https://openid.net/specs/openid-client-initiated-"
+"backchannel-authentication-core-1_0.html[OpenID Connect Client Initiated "
+"Backchannel Authentication Flow specification] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Also please refer to other places of {project_name} documentation like "
+"<<_client_initiated_backchannel_authentication_grant,Client Initiated "
+"Backchannel Authentication Grant section of this guide>> and "
+"link:{adminguide_link}#_client_initiated_backchannel_authentication_grant[Client"
+" Initiated Backchannel Authentication Grant section] of {adminguide_name}."
+msgstr ""
+"また、<<_client_initiated_backchannel_authentication_grant,このガイドのClient "
+"Initiated Backchannel Authentication "
+"Grantセクション>>などの{project_name}キュメントの他の場所と{adminguide_name}のlink:{adminguide_link}#_client_initiated_backchannel_authentication_grant[Client"
+" Initiated Backchannel Authentication Grantのセクション]を参照してください。"
+
 #. type: Title ====
 #, no-wrap
 msgid "Validating Access Tokens"
@@ -593,6 +635,58 @@ msgid ""
 msgstr ""
 "詳細については、https://tools.ietf.org/html/rfc8628 [OAuth 2.0 Device Authorization "
 "Grantの仕様] を参照してください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Client Initiated Backchannel Authentication Grant"
+msgstr "Client Initiated Backchannel Authentication Grant"
+
+#. type: Plain text
+msgid ""
+"Client Initiated Backchannel Authentication Grant is used by clients who "
+"want to initiate the authentication flow by communicating with the OpenID "
+"Provider directly without redirect through the user's browser like OAuth "
+"2.0's authorization code grant."
+msgstr ""
+"クライアント起点バックチャネル認証グラントは、OAuth "
+"2.0の認証コードグラントのように、ユーザーのブラウザーを介してリダイレクトせずに、OpenIDプロバイダーと直接通信することによって認証フローを開始したいクライアントによって使用されます。"
+
+#. type: Plain text
+msgid ""
+"The client requests {project_name} an auth_req_id that identifies the "
+"authentication request made by the client. {project_name} creates the "
+"auth_req_id."
+msgstr ""
+"クライアントは、クライアントによって行われた認証リクエストを識別するauth_req_idを{project_name}に要求します。{project_name}はauth_req_idを作成します。"
+
+#. type: Plain text
+msgid ""
+"After receiving this auth_req_id, this client repeatedly needs to poll "
+"{project_name} to obtain an Access Token, Refresh Token and ID Token from "
+"{project_name} in return for the auth_req_id until the user is "
+"authenticated."
+msgstr ""
+"このauth_req_idを受信した後、このクライアントは{project_name}を繰り返しポーリングして、ユーザーが認証されるまでauth_req_idと引き換えに{project_name}からアクセストークン、リフレッシュトークン、IDトークンを取得する必要があります。"
+
+#. type: Plain text
+msgid ""
+"For more details refer to https://openid.net/specs/openid-client-initiated-"
+"backchannel-authentication-core-1_0.html[OpenID Connect Client Initiated "
+"Backchannel Authentication Flow specification]."
+msgstr ""
+"詳細については、 https://openid.net/specs/openid-client-initiated-backchannel-"
+"authentication-core-1_0.html[OpenID Connect Client Initiated Backchannel "
+"Authentication Flow specification] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Also please refer to other places of {project_name} documentation like "
+"<<_backchannel_authentication_endpoint,Backchannel Authentication Endpoint "
+"of this guide>> and "
+"link:{adminguide_link}#_client_initiated_backchannel_authentication_grant[Client"
+" Initiated Backchannel Authentication Grant section] of {adminguide_name}."
+msgstr ""
+"また、<<_backchannel_authentication_endpoint,このガイドのバックチャネル認証グラントのセクション>>などの{project_name}キュメントの他の場所と{adminguide_name}のlink:{adminguide_link}#_client_initiated_backchannel_authentication_grant[クライアント起点バックチャネル認証グラントのセクション]を参照してください。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
