### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po
@@ -1,0 +1,111 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# KojiNose <knose.dev@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Configuration"
+msgstr "設定"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Name*\n"
+msgstr "*Name*\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Description*\n"
+msgstr "*Description*\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Logic*\n"
+msgstr "*Logic*\n"
+
+#. type: Plain text
+msgid ""
+"The <<_policy_logic, Logic>> of this policy to apply after the other "
+"conditions have been evaluated."
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
+
+#. type: Plain text
+msgid "A string containing details about this policy."
+msgstr "このポリシーに関する詳細情報を含む文字列。"
+
+#. type: Title =
+#, no-wrap
+msgid "Client Scope-Based Policy"
+msgstr "クライアント・スコープ・ベース・ポリシー"
+
+#. type: Plain text
+msgid ""
+"You can use this type of policy to define conditions for your permissions "
+"where a set of one or more client scopes is permitted to access an object."
+msgstr "このポリシーは、1つ以上のクライアント・スコープが、ある対象へアクセスすることを可能にする条件を定義するために使うことができます。"
+
+#. type: Plain text
+msgid ""
+"By default, client scopes added to this policy are not specified as required"
+" and the policy will grant access if the client requesting access has been "
+"granted any of these client scopes. However, you can specify a specific "
+"client scope as <<_policy_client_scope_required, required>> if you want to "
+"enforce a specific client scope."
+msgstr ""
+"デフォルトでは、このポリシーに追加されたクライアント・スコープは必要に応じて指定されておらず、アクセスを要求しているクライアントにこれらのクライアントスコープのいずれかが許可されている場合、ポリシーはアクセスを許可します。ただし、特定のクライアントスコープを適用する場合は、特定のクライアントスコープを<<_policy_client_scope_required,"
+" required>>として指定できます。"
+
+#. type: Plain text
+msgid ""
+"To create a new client scope-based policy, select *Client Scope* in the "
+"dropdown list in the upper right corner of the policy listing."
+msgstr ""
+"新しいクライアント・スコープ・ベース・ポリシーを作成するには、ポリシー・リストの右上隅にあるドロップダウン・リストから *Client Acope* "
+"を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Client Scope-Based Policy"
+msgstr "クライアント・スコープ・ベース・ポリシーの追加"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/policy/create-client-scope.png[alt=\"Add Client "
+"Scope-Based Policy\"]"
+msgstr ""
+"image:{project_images}/policy/create-client-scope.png[alt=\"Add Client "
+"Scope-Based Policy\"]"
+
+#. type: Plain text
+msgid ""
+"A human-readable and unique string describing the policy. A best practice is"
+" to use names that are closely related to your business and security "
+"requirements, so you can identify them more easily."
+msgstr ""
+"ポリシーを説明する、人が判読可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Client Scopes*\n"
+msgstr "*Client Scopes*\n"
+
+#. type: Plain text
+msgid "Specifies which client scopes are permitted by this policy."
+msgstr "このポリシーによって、どのクライアント・スコープが許可されるかを指定します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-client-scope-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
