### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2020
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -410,8 +410,8 @@ msgid ""
 "factory implementation.  In the code, you can obtain the provider such as "
 "`keycloakSession.getProvider(HostnameProvider.class)`"
 msgstr ""
-" `default-provider` の値として使用される `default` の値は、特定のプロバイダー・ファクトリーの実装の "
-"`ProviderFactory.getId()` によって返されるIDと一致する必要があります。 コードでは、 "
+"`default-provider` の値として使用される `default` の値は、特定のプロバイダー・ファクトリーの実装の "
+"`ProviderFactory.getId()` によって返されるIDと一致する必要があります。コードでは、 "
 "`keycloakSession.getProvider(HostnameProvider.class)` などのプロバイダーを取得できます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
