### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -72,13 +72,13 @@ msgstr "クライアントは、ユーザーに成り代わることができま
 #. type: Plain text
 msgid ""
 "Token exchange in {project_name} is a very loose implementation of the "
-"link:https://tools.ietf.org/html/rfc8693[OAuth Token Exchange] specification"
-" at the IETF.  We have extended it a little, ignored some of it, and loosely"
-" interpreted other parts of the specification.  It is a simple grant type "
-"invocation on a realm's OpenID Connect token endpoint."
+"link:https://datatracker.ietf.org/doc/html/rfc8693[OAuth Token Exchange] "
+"specification at the IETF.  We have extended it a little, ignored some of "
+"it, and loosely interpreted other parts of the specification.  It is a "
+"simple grant type invocation on a realm's OpenID Connect token endpoint."
 msgstr ""
 "{project_name}のToken Exchangeは、 "
-"link:https://tools.ietf.org/html/rfc8693[OAuth Token Exchange] "
+"link:https://datatracker.ietf.org/doc/html/rfc8693[OAuth Token Exchange] "
 "の仕様の非常にルーズな実装です。Keycloakでは、それを少し拡張し、一部を無視し、仕様の他の部分をルーズに解釈しました。これは、あるレルムのOpenID"
 " Connectトークン・エンドポイントでの単純なグラントタイプの呼び出しです。"
 
@@ -285,14 +285,14 @@ msgid ""
 "response code with a content type that depends on the `requested-token-type`"
 " and `requested_issuer` the client asks for.  OAuth requested token types "
 "will return a JSON document as described in the "
-"link:https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16[OAuth "
-"Token Exchange] specification."
+"link:https://datatracker.ietf.org/doc/html/draft-ietf-oauth-token-"
+"exchange-16[OAuth Token Exchange] specification."
 msgstr ""
 "トークン交換の呼び出しの成功レスポンスは、クライアントがリクエストする `requested-token-type` と "
 "`requested_issuer` に依存したコンテンツタイプとともにHTTP "
-"200レスポンスコードを返します。OAuthでリクエストされたトークンタイプの場合は、 link:https://tools.ietf.org/html"
-"/draft-ietf-oauth-token-exchange-16[OAuth Token Exchange] "
-"の仕様に記載されているJSONドキュメントを返します。"
+"200レスポンスコードを返します。OAuthでリクエストされたトークンタイプの場合は、 "
+"link:https://datatracker.ietf.org/doc/html/draft-ietf-oauth-token-"
+"exchange-16[OAuth Token Exchange] の仕様に記載されているJSONドキュメントを返します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
