### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -316,15 +316,17 @@ msgstr "OpenID Connect動的クライアント登録"
 msgid ""
 "{project_name} implements https://openid.net/specs/openid-connect-"
 "registration-1_0.html[OpenID Connect Dynamic Client Registration], which "
-"extends https://tools.ietf.org/html/rfc7591[OAuth 2.0 Dynamic Client "
-"Registration Protocol] and https://tools.ietf.org/html/rfc7592[OAuth 2.0 "
-"Dynamic Client Registration Management Protocol]."
+"extends https://datatracker.ietf.org/doc/html/rfc7591[OAuth 2.0 Dynamic "
+"Client Registration Protocol] and "
+"https://datatracker.ietf.org/doc/html/rfc7592[OAuth 2.0 Dynamic Client "
+"Registration Management Protocol]."
 msgstr ""
-"{project_name}は、 https://tools.ietf.org/html/rfc7591[OAuth 2.0 Dynamic "
-"Client Registration Protocol] と https://tools.ietf.org/html/rfc7592[OAuth "
-"2.0 Dynamic Client Registration Management Protocol] を拡張した "
-"https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect"
-" Dynamic Client Registration] を実装しています。"
+"{project_name}は、 https://datatracker.ietf.org/doc/html/rfc7591[OAuth 2.0 "
+"Dynamic Client Registration Protocol] と "
+"https://datatracker.ietf.org/doc/html/rfc7592[OAuth 2.0 Dynamic Client "
+"Registration Management Protocol] を拡張した https://openid.net/specs/openid-"
+"connect-registration-1_0.html[OpenID Connect Dynamic Client Registration] "
+"を実装しています。"
 
 #. type: Plain text
 msgid ""
@@ -468,6 +470,17 @@ msgstr "String registrationAccessToken = client.getRegistrationAccessToken();\n"
 #, no-wrap
 msgid "Client Registration Policies"
 msgstr "クライアント登録ポリシー"
+
+#. type: Plain text
+msgid ""
+"The current plans are for the Client Registration Policies to be removed in "
+"favor of the Client Policies described in the "
+"link:{adminguide_link}#_client_policies[{adminguide_name}].  Client Policies"
+" are more flexible and support more use cases."
+msgstr ""
+"現在の計画では、クライアント登録ポリシーは削除され、 "
+"link:{adminguide_link}#_client_policies[{adminguide_name}] "
+"に記載されているクライアント・ポリシーが採用される予定です。クライアント・ポリシーはより柔軟で、より多くのユースケースをサポートします。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/client-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__client-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
