### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2641,22 +2641,22 @@ msgstr "実際、{project_name}には、以下の2つのクライアント認証
 #, no-wrap
 msgid ""
 "Traditional authentication with client_id and client_secret::\n"
-"  This is default mechanism mentioned in the https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect]                                or https://tools.ietf.org/html/rfc6749[OAuth2] specification and {project_name} supports it since it's early days.\n"
+"  This is default mechanism mentioned in the https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect]                                or https://datatracker.ietf.org/doc/html/rfc6749[OAuth2] specification and {project_name} supports it since it's early days.\n"
 "  The public client needs to include `client_id` parameter with its ID in the POST request (so it's defacto not authenticated) and the confidential client needs to include `Authorization: Basic` header with the clientId and clientSecret used as username and password.\n"
 msgstr ""
 "client_idおよびclient_secretを使用した従来の認証::\n"
-"これは、 https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect] または https://tools.ietf.org/html/rfc6749[OAuth2] の仕様で記載されているデフォルトのメカニズムであり、{project_name}は初期段階からサポートしています。パブリック・クライアントは、POSTリクエストに自身のIDを指定した `client_id` パラメーターが含まれている必要があり（実際は認証されていません）、コンフィデンシャル・クライアントは、 `Authorization: Basic` ヘッダーとともに、ユーザー名とパスワードとして使用されるクライアントIDとクライアント・シークレットが含まれている必要があります。\n"
+"これは、 https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect] または https://datatracker.ietf.org/doc/html/rfc6749[OAuth2] の仕様で記載されているデフォルトのメカニズムであり、{project_name}は初期段階からサポートしています。パブリック・クライアントは、POSTリクエストに自身のIDを指定した `client_id` パラメーターが含まれている必要があり（実際は認証されていません）、コンフィデンシャル・クライアントは、 `Authorization: Basic` ヘッダーとともに、ユーザー名とパスワードとして使用されるクライアントIDとクライアント・シークレットが含まれている必要があります。\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
 "Authentication with signed JWT::\n"
-"  This is based on the https://tools.ietf.org/html/rfc7523[JWT Bearer Token Profiles for OAuth 2.0] specification.\n"
-"  The client/adapter generates the https://tools.ietf.org/html/rfc7519[JWT] and signs it with his private key.\n"
+"  This is based on the https://datatracker.ietf.org/doc/html/rfc7523[JWT Bearer Token Profiles for OAuth 2.0] specification.\n"
+"  The client/adapter generates the https://datatracker.ietf.org/doc/html/rfc7519[JWT] and signs it with his private key.\n"
 "  The {project_name} then verifies the signed JWT with the client's public key and authenticates client based on it.\n"
 msgstr ""
 "署名付きJWTによる認証:: \n"
-"これは、 https://tools.ietf.org/html/rfc7523[JWT Bearer Token Profiles for OAuth 2.0] 仕様に基づいています。クライアントまたはアダプターは、 https://tools.ietf.org/html/rfc7519[JWT] を生成し、秘密鍵で署名します。{project_name}は、署名されたJWTをクライアントの公開鍵で検証し、それに基づいてクライアントを認証します。\n"
+"これは、 https://datatracker.ietf.org/doc/html/rfc7523[JWT Bearer Token Profiles for OAuth 2.0] 仕様に基づいています。クライアントまたはアダプターは、 https://datatracker.ietf.org/doc/html/rfc7519[JWT] を生成し、秘密鍵で署名します。{project_name}は、署名されたJWTをクライアントの公開鍵で検証し、それに基づいてクライアントを認証します。\n"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/auth-spi.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__auth-spi
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
