### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,12 +42,12 @@ msgstr "有効および無効にできる機能は、以下のとおりです。
 msgid "4*"
 msgstr "4*"
 
-#. type: Labeled list
+#. type: Plain text
 #, no-wrap
 msgid "Name"
 msgstr "名前"
 
-#. type: Labeled list
+#. type: Plain text
 #, no-wrap
 msgid "Description"
 msgstr "説明"
@@ -116,6 +116,14 @@ msgstr "client_policies"
 #. type: Plain text
 msgid "Add client configuration policies"
 msgstr "クライアント設定ポリシーの追加"
+
+#. type: Plain text
+msgid "declarative_user_profile"
+msgstr "declarative_user_profile"
+
+#. type: Plain text
+msgid "Configure user profiles using a declarative style"
+msgstr "宣言型スタイルによるユーザー・プロファイルの設定"
 
 #. type: Plain text
 msgid "docker"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/profiles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__profiles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
