### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # KojiNose <knose.dev@gmail.com>, 2021
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,11 +87,11 @@ msgstr "クライアント・スコープ・ベース・ポリシーの追加"
 
 #. type: Plain text
 msgid ""
-"image:{project_images}/policy/create-client-scope.png[alt=\"Add Client "
-"Scope-Based Policy\"]"
+"image:images/policy/create-client-scope.png[alt=\"Add Client Scope-Based "
+"Policy\"]"
 msgstr ""
-"image:{project_images}/policy/create-client-scope.png[alt=\"Add Client "
-"Scope-Based Policy\"]"
+"image:images/policy/create-client-scope.png[alt=\"Add Client Scope-Based "
+"Policy\"]"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-client-scope-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-client-scope-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
