### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,12 +80,11 @@ msgstr "<<_jboss_adapter,JBoss EAP 7アダプター>>"
 
 #. type: Plain text
 msgid ""
-"as {fuse7Version} is bundled with https://undertow.io/[Undertow HTTP engine]"
-" under the covers and Undertow is used for running various kinds of web "
-"applications."
+"as {fuse7Version} is bundled with the Undertow HTTP engine under the covers "
+"and Undertow is used for running various kinds of web applications."
 msgstr ""
-"{fuse7Version}は https://undertow.io/[Undertow HTTP engine] "
-"にバンドルされており、Undertowはさまざまな種類のWebアプリケーションの実行に使用されています。"
+"{fuse7Version}はUndertow HTTP "
+"engineにバンドルされており、Undertowはさまざまな種類のWebアプリケーションの実行に使用されています。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
