### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1276,11 +1276,11 @@ msgstr "enableLogging - Keycloakからコンソールへのメッセージのロ
 #. type: Plain text
 msgid ""
 "pkceMethod - The method for Proof Key Code Exchange "
-"(https://tools.ietf.org/html/rfc7636[PKCE]) to use. Configuring this value "
-"enables the PKCE mechanism. Available options:"
+"(https://datatracker.ietf.org/doc/html/rfc7636[PKCE]) to use. Configuring "
+"this value enables the PKCE mechanism. Available options:"
 msgstr ""
 "pkceMethod - Proof Key Code Exchange（ "
-"https://tools.ietf.org/html/rfc7636[PKCE] "
+"https://datatracker.ietf.org/doc/html/rfc7636[PKCE] "
 "）が使用するメソッド。この値を設定すると、PKCEメカニズムが有効になります。利用可能なオプションは、以下の通りです。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
