### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2019
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -338,14 +338,14 @@ msgstr "Signature Algorithms"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"It tells the WebAuthn authenticator which signature algorithms to use for the https://www.w3.org/TR/webauthn/#public-key-credential[Public Key Credential] that can be used for signing and verifying the https://www.w3.org/TR/webauthn/#authentication-assertion[Authentication Assertion]. Multiple algorithms can be specified. If no algorithm is specified, https://tools.ietf.org/html/rfc8152#section-8.1[ES256] is adapted. The default setting is ES256. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator.\n"
+"It tells the WebAuthn authenticator which signature algorithms to use for the https://www.w3.org/TR/webauthn/#public-key-credential[Public Key Credential] that can be used for signing and verifying the https://www.w3.org/TR/webauthn/#authentication-assertion[Authentication Assertion]. Multiple algorithms can be specified. If no algorithm is specified, https://datatracker.ietf.org/doc/html/rfc8152#section-8.1[ES256] is adapted. The default setting is ES256. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator.\n"
 " For more details, see https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialparameters[WebAuthn Specification].\n"
 msgstr ""
 "これは、 https://www.w3.org/TR/webauthn/#authentication-assertion[認証アサーション] "
 "の署名と検証に使用される https://www.w3.org/TR/webauthn/#public-key-"
 "credential[公開鍵クレデンシャル] "
 "に使用する署名アルゴリズムをWebAuthnオーセンティケーターに伝えます。複数のアルゴリズムを指定できます。アルゴリズムが指定されていない場合、 "
-"https://tools.ietf.org/html/rfc8152#section-8.1[ES256] "
+"https://datatracker.ietf.org/doc/html/rfc8152#section-8.1[ES256] "
 "が適応されます。デフォルト設定はES256です。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。詳細については、"
 " https://www.w3.org/TR/webauthn/#dictdef-"
 "publickeycredentialparameters[WebAuthn Specification] を参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__webauthn
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
