### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po
@@ -32,12 +32,12 @@ msgstr "Clients"
 msgid "Add Client"
 msgstr "Add Client"
 
-#. type: Labeled list
+#. type: Plain text
 #, no-wrap
 msgid "Name"
 msgstr "Name"
 
-#. type: Labeled list
+#. type: Plain text
 #, no-wrap
 msgid "Description"
 msgstr "Description"
@@ -307,9 +307,9 @@ msgstr "Client Signature Required"
 msgid ""
 "Expect that documents coming from a client are signed.  {project_name} will "
 "validate this signature using the client public key or cert set up in the "
-"`SAML Keys` tab."
+"`Keys` tab."
 msgstr ""
-"クライアントからのドキュメントに署名があることを期待します。{project_name}は、 `SAML Keys` "
+"クライアントからのドキュメントに署名があることを期待します。{project_name}は、 `Keys` "
 "タブに設定されたクライアント公開鍵または証明書を使用して、この署名を検証します。"
 
 #. type: Labeled list


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/client-saml.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__client-saml
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
