### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -82,10 +82,10 @@ msgid ""
 "The Docker client will construct an authentication request based on the 401 "
 "response from the Docker registry.  The client will then use the locally "
 "cached credentials (from a previously run `docker login` command) as part of"
-" a link:https://tools.ietf.org/html/rfc2617[HTTP Basic Authentication] "
-"request to the {project_name} authentication server."
+" a link:https://datatracker.ietf.org/doc/html/rfc2617[HTTP Basic "
+"Authentication] request to the {project_name} authentication server."
 msgstr ""
-"Dockerクライアントは、Dockerレジストリーからの401レスポンスに基づいて認証リクエストを作成します。クライアントは、{project_name}認証サーバーへのlink:https://tools.ietf.org/html/rfc2617[HTTP"
+"Dockerクライアントは、Dockerレジストリーからの401レスポンスに基づいて認証リクエストを作成します。クライアントは、{project_name}認証サーバーへのlink:https://datatracker.ietf.org/doc/html/rfc2617[HTTP"
 " Basic Authentication]リクエストの一部として、（以前に実行された `docker login` "
 "コマンドから）ローカルにキャッシュされたクレデンシャルを使用します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/docker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__docker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
