### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Shinsuke UEDA, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -111,12 +111,12 @@ msgstr "grant_type=client_credentials\n"
 #. type: Plain text
 msgid ""
 "The response would be this "
-"https://tools.ietf.org/html/rfc6749#section-4.4.3[standard JSON document] "
-"from the OAuth 2.0 specification."
+"https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3[standard JSON "
+"document] from the OAuth 2.0 specification."
 msgstr ""
 "このレスポンスは、OAuth 2.0仕様の "
-"https://tools.ietf.org/html/rfc6749#section-4.4.3[standard JSON document] "
-"になります。"
+"https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3[standard JSON "
+"document] になります。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/service-accounts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__service-accounts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
