### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po
@@ -1,0 +1,125 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid "Equivalent configuration using CLI commands:"
+msgstr "CLIコマンドを使用した同等の設定は以下になります。"
+
+#. type: Title ===
+#, no-wrap
+msgid "Limit Authentication Sessions"
+msgstr "Limit Authentication Sessions"
+
+#. type: Plain text
+msgid ""
+"{project_name} creates an authentication session for each authentication "
+"request within a realm. This session is internally represented by "
+"`RootAuthenticationSession`. Each `RootAuthenticationSession` can have "
+"multiple authentication sessions for a given client. In a browser "
+"authentication flow, the browser session translates to "
+"`RootAuthenticationSession` while browser tabs translate to a collection of "
+"authentication sessions within the `RootAuthenticationSession`."
+msgstr ""
+"{project_name}は、レルム内の認証リクストごとに認証セッションを作成します。このセッションは、内部的には "
+"`RootAuthenticationSession` で表されます。各 `RootAuthenticationSession` "
+"は、特定のクライアントに対して複数の認証セッションを持つことができます。ブラウザー認証フローでは、ブラウザー・セッションは "
+"`RootAuthenticationSession` に変換され、ブラウザータブは `RootAuthenticationSession` "
+"内の認証セッションのコレクションに変換されます。"
+
+#. type: Plain text
+msgid ""
+"This section describes deployments that use the {jdgserver_name} provider "
+"for authentication sessions."
+msgstr "このセクションでは、認証セッションに{jdgserver_name}プロバイダーを使用するデプロイメントについて説明します。"
+
+#. type: Plain text
+msgid ""
+"Higher memory usage and a network overload in a cluster may occur for "
+"deployments where there are many active `RootAuthenticationSession` with a "
+"lot of authentication sessions."
+msgstr ""
+"多くの認証セッションを持つアクティブな `RootAuthenticationSession` "
+"が多数あるデプロイメントでは、クラスター内のメモリー使用量が高くなり、ネットワークの過負荷が発生する可能性があります。"
+
+#. type: Plain text
+msgid ""
+"There is a possibility to mitigate the aforementioned threats. The maximum "
+"allowed number of `RootAuthenticationSession` should be addressed by "
+"limiting the request rate per time on the proxy or load balancer in front of"
+" {project_name}. The maximum number of authentication sessions per "
+"`RootAuthenticationSession` can be configured in `authenticationSessions` "
+"SPI by setting property `authSessionsLimit`. The default value is set to 300"
+" authentication sessions per a `RootAuthenticationSession`. When this limit "
+"is reached, the oldest authentication session will be removed after a new "
+"authentication session request."
+msgstr ""
+"前述の脅威を軽減する可能性があります。 `RootAuthenticationSession` "
+"の最大許容数は、{project_name}の前にあるプロキシーまたはロードバランサーでの1回あたりのリクエストレートを制限することで対処する必要があります。"
+" `RootAuthenticationSession` ごとの認証セッションの最大数は、プロパティー `authSessionsLimit` "
+"を設定することで  `authenticationSessions` SPIで設定できます。デフォルト値は、 "
+"`RootAuthenticationSession` "
+"ごとに300認証セッションに設定されています。この制限に達すると、新しい認証セッション・リクストの後に最も古い認証セッションが削除されます。"
+
+#. type: Plain text
+msgid ""
+"The following example shows how to limit the number of active authentication"
+" sessions per a `RootAuthenticationSession` to 100."
+msgstr ""
+"次の例は、 `RootAuthenticationSession` ごとのアクティブな認証セッションの数を100に制限する方法を示しています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<subsystem xmlns=\"urn:jboss:domain:keycloak-server:1.1\">\n"
+"    ...\n"
+"    <spi name=\"authenticationSessions\">\n"
+"        <default-provider>infinispan</default-provider>\n"
+"        <provider name=\"infinispan\" enabled=\"true\">\n"
+"            <properties>\n"
+"                <property name=\"authSessionsLimit\" value=\"100\"/>\n"
+"            </properties>\n"
+"        </provider>\n"
+"    </spi>\n"
+"    ...\n"
+"</subsystem>\n"
+msgstr ""
+"<subsystem xmlns=\"urn:jboss:domain:keycloak-server:1.1\">\n"
+"    ...\n"
+"    <spi name=\"authenticationSessions\">\n"
+"        <default-provider>infinispan</default-provider>\n"
+"        <provider name=\"infinispan\" enabled=\"true\">\n"
+"            <properties>\n"
+"                <property name=\"authSessionsLimit\" value=\"100\"/>\n"
+"            </properties>\n"
+"        </provider>\n"
+"    </spi>\n"
+"    ...\n"
+"</subsystem>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"/subsystem=keycloak-server/spi=authenticationSessions:add(default-provider=infinispan)\n"
+"/subsystem=keycloak-server/spi=authenticationSessions/provider=infinispan:add(properties={authSessionsLimit => \"100\"},enabled=true)\n"
+msgstr ""
+"/subsystem=keycloak-server/spi=authenticationSessions:add(default-provider=infinispan)\n"
+"/subsystem=keycloak-server/spi=authenticationSessions/provider=infinispan:add(properties={authSessionsLimit => \"100\"},enabled=true)\n"

--- a/i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2021
-# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,17 +39,17 @@ msgid ""
 "`RootAuthenticationSession` while browser tabs translate to a collection of "
 "authentication sessions within the `RootAuthenticationSession`."
 msgstr ""
-"{project_name}は、レルム内の認証リクストごとに認証セッションを作成します。このセッションは、内部的には "
+"{project_name}は、レルム内の認証リクストごとに認証中セッションを作成します。このセッションは、内部的には "
 "`RootAuthenticationSession` で表されます。各 `RootAuthenticationSession` "
-"は、特定のクライアントに対して複数の認証セッションを持つことができます。ブラウザー認証フローでは、ブラウザー・セッションは "
+"は、特定のクライアントに対して複数の認証中セッションを持つことができます。ブラウザー認証フローでは、ブラウザー・セッションは "
 "`RootAuthenticationSession` に変換され、ブラウザータブは `RootAuthenticationSession` "
-"内の認証セッションのコレクションに変換されます。"
+"内の認証中セッションのコレクションに変換されます。"
 
 #. type: Plain text
 msgid ""
 "This section describes deployments that use the {jdgserver_name} provider "
 "for authentication sessions."
-msgstr "このセクションでは、認証セッションに{jdgserver_name}プロバイダーを使用するデプロイメントについて説明します。"
+msgstr "このセクションでは、認証中セッションに{jdgserver_name}プロバイダーを使用するデプロイメントについて説明します。"
 
 #. type: Plain text
 msgid ""
@@ -57,7 +57,7 @@ msgid ""
 "deployments where there are many active `RootAuthenticationSession` with a "
 "lot of authentication sessions."
 msgstr ""
-"多くの認証セッションを持つアクティブな `RootAuthenticationSession` "
+"多くの認証中セッションを持つアクティブな `RootAuthenticationSession` "
 "が多数あるデプロイメントでは、クラスター内のメモリー使用量が高くなり、ネットワークの過負荷が発生する可能性があります。"
 
 #. type: Plain text
@@ -84,7 +84,7 @@ msgid ""
 "The following example shows how to limit the number of active authentication"
 " sessions per a `RootAuthenticationSession` to 100."
 msgstr ""
-"次の例は、 `RootAuthenticationSession` ごとのアクティブな認証セッションの数を100に制限する方法を示しています。"
+"次の例は、 `RootAuthenticationSession` ごとのアクティブな認証中セッションの数を100に制限する方法を示しています。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__auth-sessions-limit
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
