### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # KojiNose <knose.dev@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -257,11 +257,11 @@ msgstr "*** *lifespan*\n"
 #. type: Plain text
 msgid ""
 "Defines the time in milliseconds when the entry should be expired. If not "
-"provided, default value is *3000*. A value equal to 0 can be set to "
+"provided, default value is *30000*. A value equal to 0 can be set to "
 "completely disable the cache. A value equal to -1 can be set to disable the "
 "expiry of the cache."
 msgstr ""
-"エントリーを期限切れにする時間をミリ秒単位で定義します。指定されていない場合、デフォルト値は *3000* "
+"エントリーを期限切れにする時間をミリ秒単位で定義します。指定されていない場合、デフォルト値は *30000* "
 "です。0を設定してキャッシュを完全に無効にすることができます。または、-1を設定してキャッシュの有効期限を無効にすることもできます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-keycloak-enforcement-filter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-keycloak-enforcement-filter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
