### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -434,8 +434,8 @@ msgid ""
 "By default, the JavaScript adapter uses the https://openid.net/specs/openid-"
 "connect-core-1_0.html#CodeFlowAuth[Authorization Code] flow."
 msgstr ""
-"デフォルトで、JavaScriptアダプターは https://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[認可コード] フローを使用します。"
+"デフォルトで、JavaScriptアダプターは https://openid.net/specs/openid-connect-"
+"core-1_0.html#CodeFlowAuth[認可コード] フローを使用します。"
 
 #. type: Plain text
 msgid ""
@@ -457,8 +457,8 @@ msgid ""
 "access token expires."
 msgstr ""
 "{project_name}は、{project_name}での認証が成功した直後にアクセス・トークンが送信される "
-"https://openid.net/specs/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[インプリシット・フロー] "
+"https://openid.net/specs/openid-connect-"
+"core-1_0.html#ImplicitFlowAuth[インプリシット・フロー] "
 "もサポートしています。これは、トークンに対してコードを交換する追加のリクエストが無いので、標準フローよりもパフォーマンスに優れる可能性がありますが、アクセス・トークンの有効期限が切れたときに影響があります。"
 
 #. type: Plain text
@@ -503,8 +503,8 @@ msgid ""
 "{project_name} also supports the https://openid.net/specs/openid-connect-"
 "core-1_0.html#HybridFlowAuth[Hybrid] flow."
 msgstr ""
-"{project_name}は https://openid.net/specs/openid-connect-core-"
-"1_0.html#HybridFlowAuth[ハイブリッド・フロー] もサポートしています。"
+"{project_name}は https://openid.net/specs/openid-connect-"
+"core-1_0.html#HybridFlowAuth[ハイブリッド・フロー] もサポートしています。"
 
 #. type: Plain text
 msgid ""
@@ -691,8 +691,8 @@ msgstr ""
 "app://com.example.myapp/https/example.com/login` ）と "
 "https://developer.apple.com/ios/universal-links/[ユニバーサル・リンク（iOS）]）/ "
 "https://developer.android.com/training/app-links/deep-"
-"linking[ディープリンク（Android）]をクリックします。前者は設定が容易で、より確実に動作する傾向がありますが、後者はセキュリティーが強化され、ドメインの所有者のみが登録できます。カスタムURLはiOSでは推奨されていません。最良の信頼性を得るために、ユニバーサル"
-"・リンクとそれにcustom-urlリンクを持つ代替サイトを組み合わせて使用することをお勧めします。"
+"linking[ディープリンク（Android）]をクリックします。前者は設定が容易で、より確実に動作する傾向がありますが、後者はセキュリティーが強化され、ドメインの所有者のみが登録できます。カスタムURLはiOSでは推奨されていません。最良の信頼性を得るために、ユニバーサル・リンクとそれにcustom-"
+"urlリンクを持つ代替サイトを組み合わせて使用することをお勧めします。"
 
 #. type: Plain text
 msgid ""
@@ -1140,8 +1140,8 @@ msgid ""
 "apps-with-cordova>>)."
 msgstr ""
 "\"cordova-native\" - ライブラリーはBrowserTabs "
-"cordovaプラグインを使用して、電話のシステム・ブラウザーを使用してログインページと登録ページを開こうとします。これには、アプリケーションにリダイレクトするための特別な設定が必要です"
-"（<<hybrid-apps-with-cordova>>を参照してください）。"
+"cordovaプラグインを使用して、電話のシステム・ブラウザーを使用してログインページと登録ページを開こうとします。これには、アプリケーションにリダイレクトするための特別な設定が必要です（<<hybrid-"
+"apps-with-cordova>>を参照してください）。"
 
 #. type: Plain text
 msgid ""
@@ -1288,6 +1288,16 @@ msgid "\"S256\" - The SHA256 based PKCE method"
 msgstr "\"S256\" - SHA256ベースのPKCEメソッド"
 
 #. type: Plain text
+msgid ""
+"messageReceiveTimeout - Set a timeout in milliseconds for waiting for "
+"message responses from the Keycloak server. This is used, for example, when "
+"waiting for a message during 3rd party cookies check. The default value is "
+"10000."
+msgstr ""
+"messageReceiveTimeout - "
+"Keycloakサーバーからのメッセージ応答を待つためのタイムアウトをミリ秒単位で設定します。これは、例えば、サードパーティーのCookieチェック中にメッセージを待つときに使用されます。デフォルト値は10000です。"
+
+#. type: Plain text
 msgid "Returns a promise that resolves when initialization completes."
 msgstr "初期化が完了すると解決するPromiseを返します。"
 
@@ -1375,8 +1385,8 @@ msgid ""
 "https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[section "
 "3.1.2.1 of the OIDC 1.0 specification]."
 msgstr ""
-"locale - https://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthRequest[OIDC 1.0仕様のセクション3.1.2.1] に準拠した 'ui_locales' "
+"locale - https://openid.net/specs/openid-connect-"
+"core-1_0.html#AuthRequest[OIDC 1.0仕様のセクション3.1.2.1] に準拠した 'ui_locales' "
 "クエリー・パラメーターを設定します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
