### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -707,11 +707,12 @@ msgid ""
 "For the details about FAPI CIBA compliance, please refer to the <<_fapi-"
 "support,FAPI section of this guide>>."
 msgstr ""
-"また、{project_name}のドキュメントにある<<_backchannel_authentication_endpoint,Backchannel"
-" Authentication Endpoint of this Guide>>や{adminguide_name}の "
+"また、<<_backchannel_authentication_endpoint,このガイドのBackchannel Authentication "
+"Endpoint>>や{adminguide_name}の "
 "link:{adminguide_link}#_client_initiated_backchannel_authentication_grant "
-"[Client Initiated Backchannel Authentication Grant section] "
-"など他の箇所にも参照してください。FAPI CIBA対応については、本ガイドの<<_fapi-support,FAPIセクション>>を参照してださい。"
+"[Client Initiated Backchannel Authentication Grantのセクション] "
+"など、{project_name}ドキュメントの他の箇所も参照してください。FAPI CIBA対応については、本ガイドの<<_fapi-"
+"support,FAPIセクション>>を参照してください。"
 
 #. type: Title ====
 #, no-wrap

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -107,12 +107,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details see the https://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[Authorization Endpoint] section in the OpenID"
-" Connect specification."
+"For more details see the https://openid.net/specs/openid-connect-"
+"core-1_0.html#AuthorizationEndpoint[Authorization Endpoint] section in the "
+"OpenID Connect specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
-"1_0.html#AuthorizationEndpoint[Authorization Endpoint] を参照してください。"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-"
+"core-1_0.html#AuthorizationEndpoint[Authorization Endpoint] を参照してください。"
 
 #. type: Title ===
 #, no-wrap
@@ -135,12 +135,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details see the https://openid.net/specs/openid-connect-core-"
-"1_0.html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
+"For more details see the https://openid.net/specs/openid-connect-"
+"core-1_0.html#TokenEndpoint[Token Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
-"1_0.html#TokenEndpoint[Token Endpoint] を参照してください。"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-"
+"core-1_0.html#TokenEndpoint[Token Endpoint] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -160,12 +160,12 @@ msgstr "UserInfoエンドポイントは、認証されたユーザーに関す�
 
 #. type: Plain text
 msgid ""
-"For more details see the https://openid.net/specs/openid-connect-core-"
-"1_0.html#UserInfo[Userinfo Endpoint] section in the OpenID Connect "
+"For more details see the https://openid.net/specs/openid-connect-"
+"core-1_0.html#UserInfo[Userinfo Endpoint] section in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
-"1_0.html#UserInfo[Userinfo Endpoint]を参照してください。"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-"
+"core-1_0.html#UserInfo[Userinfo Endpoint]を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -266,12 +266,13 @@ msgstr "動的クライアント登録エンドポイントを使用して、ク
 #. type: Plain text
 msgid ""
 "For more details see the <<_client_registration,Client Registration "
-"chapter>> and the https://openid.net/specs/openid-connect-registration-"
-"1_0.html[OpenID Connect Dynamic Client Registration specification]."
+"chapter>> and the https://openid.net/specs/openid-connect-"
+"registration-1_0.html[OpenID Connect Dynamic Client Registration "
+"specification]."
 msgstr ""
-"詳細については、<<_client_registration,クライアントの登録の章>>と https://openid.net/specs"
-"/openid-connect-registration-1_0.html[OpenID Connect Dynamic Client "
-"Registrationの仕様] を参照してください。"
+"詳細については、<<_client_registration,クライアントの登録の章>>と "
+"https://openid.net/specs/openid-connect-registration-1_0.html[OpenID Connect"
+" Dynamic Client Registrationの仕様] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -433,12 +434,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details refer to the https://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
+"For more details refer to the https://openid.net/specs/openid-connect-"
+"core-1_0.html#CodeFlowAuth[Authorization Code Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
-"1_0.html#CodeFlowAuth[Authorization Code Flow] を参照してください。"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-"
+"core-1_0.html#CodeFlowAuth[Authorization Code Flow] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -477,12 +478,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"For more details refer to the https://openid.net/specs/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
+"For more details refer to the https://openid.net/specs/openid-connect-"
+"core-1_0.html#ImplicitFlowAuth[Implicit Flow] in the OpenID Connect "
 "specification."
 msgstr ""
-"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-core-"
-"1_0.html#ImplicitFlowAuth[Implicit Flow] を参照してください。"
+"詳細については、OpenID Connectの仕様の https://openid.net/specs/openid-connect-"
+"core-1_0.html#ImplicitFlowAuth[Implicit Flow] を参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -676,6 +677,18 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"In case that client uses `ping` mode, it does not need to repeatedly poll "
+"the token endpoint, but it can wait for the notification sent by "
+"{project_name} to the specified Client Notification Endpoint.  The Client "
+"Notification Endpoint can be configured in the {project_name} Admin Console."
+" The details of the contract for Client Notification Endpoint are described "
+"in the CIBA specification."
+msgstr ""
+"`ping` "
+"モードを使用している場合、クライアントはトークン・エンドポイントを繰り返しポーリングする必要はありませんが、指定されたクライアント通知エンドポイントに{project_name}が通知が送信するのを待つことができます。クライアント通知エンドポイントは、{project_name}の管理コンソールで設定することができます。クライアント通知エンドポイントの決まりごとの詳細については、CIBA仕様書に記載されています。"
+
+#. type: Plain text
+msgid ""
 "For more details refer to https://openid.net/specs/openid-client-initiated-"
 "backchannel-authentication-core-1_0.html[OpenID Connect Client Initiated "
 "Backchannel Authentication Flow specification]."
@@ -690,9 +703,15 @@ msgid ""
 "<<_backchannel_authentication_endpoint,Backchannel Authentication Endpoint "
 "of this guide>> and "
 "link:{adminguide_link}#_client_initiated_backchannel_authentication_grant[Client"
-" Initiated Backchannel Authentication Grant section] of {adminguide_name}."
+" Initiated Backchannel Authentication Grant section] of {adminguide_name}.  "
+"For the details about FAPI CIBA compliance, please refer to the <<_fapi-"
+"support,FAPI section of this guide>>."
 msgstr ""
-"また、<<_backchannel_authentication_endpoint,このガイドのバックチャネル認証グラントのセクション>>などの{project_name}キュメントの他の場所と{adminguide_name}のlink:{adminguide_link}#_client_initiated_backchannel_authentication_grant[クライアント起点バックチャネル認証グラントのセクション]を参照してください。"
+"また、{project_name}のドキュメントにある<<_backchannel_authentication_endpoint,Backchannel"
+" Authentication Endpoint of this Guide>>や{adminguide_name}の "
+"link:{adminguide_link}#_client_initiated_backchannel_authentication_grant "
+"[Client Initiated Backchannel Authentication Grant section] "
+"など他の箇所にも参照してください。FAPI CIBA対応については、本ガイドの<<_fapi-support,FAPIセクション>>を参照してださい。"
 
 #. type: Title ====
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
