### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2021
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
-# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -66,7 +66,7 @@ msgstr ""
 "`RootAuthenticationSessionEntity` には、複数の認証中サブセッションを "
 "`AuthenticationSessionEntity` "
 "オブジェクトの集合として格納することができます。{project_name}は、認証中セッションを専用の{jdgserver_name}キャッシュに保存します。"
-" RootAuthenticationSessionEntity` に含まれる `AuthenticationSessionEntity` "
+" `RootAuthenticationSessionEntity` に含まれる `AuthenticationSessionEntity` "
 "の数は、各キャッシュ・エントリーのサイズに影響します。認証中セッション・キャッシュの総メモリー使用量は、保存された "
 "`RootAuthenticationSessionEntity` の数と、各 `RootAuthenticationSessionEntity` 内の"
 " `AuthenticationSessionEntity` の数によって決定されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/auth-sessions-limit.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__auth-sessions-limit
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
