### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -640,7 +640,7 @@ msgid ""
 "https://datatracker.ietf.org/doc/html/rfc8628[OAuth 2.0 Device Authorization"
 " Grant specification]."
 msgstr ""
-"詳細については、https://datatracker.ietf.org/doc/html/rfc8628[OAuth 2.0 Device "
+"詳細については、 https://datatracker.ietf.org/doc/html/rfc8628[OAuth 2.0 Device "
 "Authorization Grantの仕様] を参照してください。"
 
 #. type: Title =====

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
-# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -709,8 +709,8 @@ msgid ""
 msgstr ""
 "また、<<_backchannel_authentication_endpoint,このガイドのBackchannel Authentication "
 "Endpoint>>や{adminguide_name}の "
-"link:{adminguide_link}#_client_initiated_backchannel_authentication_grant "
-"[Client Initiated Backchannel Authentication Grantのセクション] "
+"link:{adminguide_link}#_client_initiated_backchannel_authentication_grant[Client"
+" Initiated Backchannel Authentication Grantのセクション] "
 "など、{project_name}ドキュメントの他の箇所も参照してください。FAPI CIBA対応については、本ガイドの<<_fapi-"
 "support,FAPIセクション>>を参照してください。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/oidc-generic.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__oidc-generic
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
