### PR TITLE
Translations for i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
+++ b/i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,6 +42,13 @@ msgstr ""
 "アップグレードする前に、踏まなければならない手順がありますので、その順序に気をつけてください。また、アップグレードする過程で起こり得る問題についても注意してください。通常は、まず{project_name}サーバーをアップグレードしてから、アダプターをアップグレードする必要があります。"
 " "
 
+#. type: delimited block =
+msgid ""
+"In a minor upgrade of {project_name}, all user sessions are lost. After the "
+"upgrade, all users will have to log in again."
+msgstr ""
+"{project_name}のマイナー・アップグレードでは、すべてのユーザーセッションが失われます。アップグレード後は、すべてのユーザーが再度ログインする必要があります。"
+
 #. type: Plain text
 msgid "Back up the old installation (configuration, themes, and so on)."
 msgstr "古いインストール（設定、テーマなど）をバックアップします。"
@@ -51,7 +58,7 @@ msgid ""
 "Back up the database. For detailed information on how to back up the "
 "database, see the documentation for the relational database you are using."
 msgstr ""
-"データベースをバックアップします。データベースのバックアップの仕方について、詳しくは、使用しているデータベースの関連ドキュメントを参照してください。"
+"データベースをバックアップします。データベースのバックアップの仕方についての詳細は、使用しているデータベースの関連ドキュメントを参照してください。"
 
 #. type: Plain text
 msgid "Upgrade {project_name} server."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/upgrading/topics/prep_migration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/upgrading__topics__prep_migration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
