### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,23 +19,38 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
-#: source/server_installation/topics/cache/clear.adoc:2
+#. type: Block title
 #, no-wrap
-msgid "Clearing Caches at Runtime"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title ===
+#, no-wrap
+msgid "Clearing cache at runtime"
 msgstr "実行時のキャッシュクリア"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/clear.adoc:6
 msgid ""
-"To clear the realm or user cache, go to the {project_name} admin console "
-"Realm Settings->Cache Config page.  On this page you can clear the realm "
-"cache, the user cache or cache of external public keys."
-msgstr ""
-"レルムキャッシュまたはユーザー・キャッシュをクリアするには、{project_name}の管理コンソールのRealm "
-"Settings->Cache設定ページへ移動します。このページでは、レルムキャッシュ、ユーザー・キャッシュ、外部の公開鍵キャッシュをクリアすることができます。"
+"You can clear the realm cache, user cache, or the external public keys."
+msgstr "レルムキャッシュ、ユーザーキャッシュ、外部の公開鍵のいずれかをクリアすることができます。"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/clear.adoc:7
+msgid "Log into the Admin Console."
+msgstr "管理コンソールへログインする。"
+
+#. type: Plain text
+msgid "Click *Realm Settings*."
+msgstr "*Realm Settings* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Cache* tab."
+msgstr "*Cache* タブをクリックします。"
+
+#. type: Plain text
+msgid ""
+"Clear the realm cache, the user cache or cache of external public keys."
+msgstr "レルムキャッシュ、ユーザーキャッシュ、外部の公開鍵のキャッシュをクリアします。"
+
+#. type: Plain text
 msgid "The cache will be cleared for all realms!"
 msgstr "すべてのレルムのキャッシュがクリアされます。"

--- a/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po
@@ -36,7 +36,7 @@ msgstr "レルムキャッシュ、ユーザーキャッシュ、外部の公開
 
 #. type: Plain text
 msgid "Log into the Admin Console."
-msgstr "管理コンソールへログインする。"
+msgstr "管理コンソールにログインします。"
 
 #. type: Plain text
 msgid "Click *Realm Settings*."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/clear.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__clear
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
