### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po
@@ -5,19 +5,24 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Block title
 #, no-wrap
@@ -31,8 +36,8 @@ msgstr "Windows"
 
 #. type: Title ===
 #, no-wrap
-msgid "Start the {appserver_name} CLI"
-msgstr "{appserver_name}CLIの起動"
+msgid "Starting the {appserver_name} CLI"
+msgstr "{appserver_name} CLIの起動"
 
 #. type: Plain text
 msgid ""
@@ -109,7 +114,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "CLI Embedded Mode"
+msgid "CLI embedded mode"
 msgstr "CLI組み込みモード"
 
 #. type: Plain text
@@ -139,8 +144,8 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "CLI GUI Mode"
-msgstr "CLI GUIモード "
+msgid "Using CLI GUI mode"
+msgstr "CLI GUIモードの使用"
 
 #. type: Plain text
 msgid ""
@@ -152,10 +157,9 @@ msgid ""
 msgstr ""
 "CLIはGUIモードでも実行できます。GUIモードでは、実行中のサーバーの管理モデル全体をグラフィカルに表示および編集できるSwingアプリケーションが起動します。GUIモードは、CLIコマンドの書式を設定したり、オプションを調べる際のヘルプとして特に便利です。GUIは、ローカルまたはリモートサーバーからサーバーログを取得することもできます。"
 
-#. type: Block title
-#, no-wrap
-msgid "Start in GUI mode"
-msgstr "GUIモードの起動"
+#. type: Plain text
+msgid "Start the CLI in GUI mode"
+msgstr "GUIモードでのCLIの起動"
 
 #. type: delimited block -
 #, no-wrap
@@ -164,30 +168,36 @@ msgstr "$ .../bin/jboss-cli.sh --gui\n"
 
 #. type: Plain text
 msgid ""
-"_Note: to connect to a remote server, you pass the `--connect` option as "
-"well.  Use the --help option for more details._"
+"Note: to connect to a remote server, you pass the `--connect` option as "
+"well.  Use the --help option for more details."
 msgstr ""
-"_注意: リモートサーバーに接続するには、 `--connect` オプションも渡します。詳しくは、 --helpオプションを参照してください。_"
+"注意: リモートサーバーに接続するには、 `--connect` オプションも渡します。詳しくは、 --helpオプションを参照してください。"
 
 #. type: Plain text
-msgid ""
-"After launching GUI mode, you will probably want to scroll down to find the "
-"node, `subsystem=keycloak-server`.  If you right-click on the node and click"
-" `Explore subsystem=keycloak-server`, you will get a new tab that shows only"
-" the keycloak-server subsystem."
-msgstr ""
-"GUIモードを起動したら、スクロールダウンすると `subsystem=keycloak-server` ノードが見つかります。ノードを右クリックして "
-"`Explore subsystem=keycloak-server` をクリックすると、keycloak-"
-"serverサブシステムのみを表示する新しいタブが表示されます。"
+msgid "Scroll down to find the node `subsystem=keycloak-server`."
+msgstr "スクロールダウンして、 `subsystem=keycloak-server` というノードを見つけます。"
 
 #. type: Plain text
-msgid "image:images/cli-gui.png[]"
-msgstr "image:images/cli-gui.png[]"
+msgid "Right-click the node and select `Explore subsystem=keycloak-server`."
+msgstr "ノードを右クリックして、 `Explore subsystem=keycloak-server` を選択します。"
+
+#. type: Plain text
+msgid "A new tab displays only the keycloak-server subsystem."
+msgstr "新しいタブには、keycloak-serverサブシステムのみが表示されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "keycloak-server subsystem"
+msgstr "keycloak-serverサブシステム"
+
+#. type: Plain text
+msgid "image:images/cli-gui.png[keycloak-server subsystem]"
+msgstr "image:images/cli-gui.png[keycloak-server subsystem]"
 
 #. type: Title ===
 #, no-wrap
-msgid "CLI Scripting"
-msgstr "CLIスクリプト"
+msgid "CLI scripting"
+msgstr "CLIスクリプティング"
 
 #. type: Plain text
 msgid ""
@@ -213,7 +223,7 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"To execute the script, I can follow the `Scripts` menu in CLI GUI, or "
+"To execute the script, you can follow the `Scripts` menu in CLI GUI, or "
 "execute the script from the command line as follows:"
 msgstr ""
 "スクリプトを実行するには、CLI GUIの `Scripts` メニューに従うか、または以下のようにコマンドラインからスクリプトを実行します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/start-cli.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__start-cli
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
