### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po
@@ -5,20 +5,25 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Block title
 #, no-wrap
@@ -32,8 +37,8 @@ msgstr "Windows"
 
 #. type: Title ===
 #, no-wrap
-msgid "Domain Clustered Mode"
-msgstr "ドメイン・クラスター・モード"
+msgid "Using domain clustered mode"
+msgstr "ドメイン・クラスター・モードの使用"
 
 #. type: Plain text
 msgid ""
@@ -45,13 +50,13 @@ msgstr "ドメインモードとは、サーバーの設定を一元管理し、
 msgid ""
 "Running a cluster in standard mode can quickly become aggravating as the "
 "cluster grows in size.  Every time you need to make a configuration change, "
-"you have to perform it on each node in the cluster.  Domain mode solves this"
-" problem by providing a central place to store and publish configurations.  "
-"It can be quite complex to set up, but it is worth it in the end.  This "
-"capability is built into the {appserver_name} Application Server which "
-"{project_name} derives from."
+"you perform it on each node in the cluster.  Domain mode solves this problem"
+" by providing a central place to store and publish configurations.  It can "
+"be quite complex to set up, but it is worth it in the end.  This capability "
+"is built into the {appserver_name} Application Server which {project_name} "
+"derives from."
 msgstr ""
-"標準モードでクラスターを実行すると、クラスターが大きくなり、煩雑化する可能性があります。クラスター内の各ノードにおいて、都度設定を変更する必要がでてきてしまいます。一方、ドメインモードの場合は、設定を保存しパブリッシュするために一元管理する場所を提供することで、この問題を解決できます。セットアップにはかなり手間がかかりますが、最終的にはその工数は見合うことになります。この機能は{project_name}が構成される{appserver_name}アプリケーション・サーバーに組み込まれています。"
+"標準モードでクラスターを実行すると、クラスターが大きくなり、煩雑化する可能性があります。設定を変更する必要があるたびに、クラスター内の各ノードでそれを実行します。一方、ドメインモードの場合は、設定を保存しパブリッシュするために一元管理する場所を提供することで、この問題を解決できます。セットアップにはかなり手間がかかりますが、最終的にはその工数は見合うことになります。この機能は{project_name}が構成される{appserver_name}アプリケーション・サーバーに組み込まれています。"
 
 #. type: Plain text
 #, no-wrap
@@ -141,7 +146,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Domain Configuration"
+msgid "Domain configuration"
 msgstr "ドメイン設定"
 
 #. type: Plain text
@@ -325,7 +330,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Host Controller Configuration"
+msgid "Host controller configuration"
 msgstr "ホスト・コントローラー設定"
 
 #. type: Plain text
@@ -390,13 +395,14 @@ msgid ""
 "authentication server instance.  It has a `port-offset` setting.  Any "
 "network port defined in the _domain.xml_ `socket-binding-group` or the "
 "server group will have the value of `port-offset` added to it.  For this "
-"example domain setup we do this so that ports opened by the load balancer "
+"sample domain setup, we do this so that ports opened by the load balancer "
 "server don't conflict with the authentication server instance that is "
 "started."
 msgstr ""
-"このファイルに関してもう1つ興味深い点は、認証サーバー・インスタンスの宣言です。これには `port-offset` が設定されています。 "
-"_domain.xml_ の `socket-binding-group` またはサーバーグループで定義されたネットワークポートには、port-"
-"offsetの値が加算されます。このサンプルでは、ロードバランサー・サーバーによって開かれたポートが、起動中の認証サーバー・インスタンスと競合しないように設定しています。"
+"このファイルのもう一つの興味深い点は、認証サーバー・インスタンスの宣言です。これには、 `port-offset` という設定があります。 "
+"_domain.xml_  の `socket-binding-group` やサーバーグループで定義されたネットワークポートには、 `port-"
+"offset` "
+"の値が追加されます。このサンプルドメインの設定では、ロードバランサー・サーバーが開くポートが、起動している認証サーバー・インスタンスと衝突しないように、このようにしています。"
 
 #. type: delimited block -
 #, no-wrap
@@ -417,7 +423,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Server Instance Working Directories"
+msgid "Server instance working directories"
 msgstr "サーバー・インスタンス・ワーキング・ディレクトリー"
 
 #. type: Plain text
@@ -442,10 +448,10 @@ msgstr "ワーキング・ディレクトリー"
 msgid "image:{project_images}/domain-server-dir.png[]"
 msgstr "image:{project_images}/domain-server-dir.png[]"
 
-#. type: Block title
+#. type: Title ====
 #, no-wrap
-msgid "Domain Boot Script"
-msgstr "ドメイン起動スクリプト"
+msgid "Booting in domain clustered mode"
+msgstr "ドメイン・クラスター・モードでの起動"
 
 #. type: Plain text
 msgid ""
@@ -455,6 +461,11 @@ msgid ""
 msgstr ""
 "ドメインモードでサーバーを実行する場合、オペレーティング・システム固有の起動スクリプトを実行する必要があります。これらのスクリプトは、サーバー配布物の "
 "_bin/_ ディレクトリーにあります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Domain Boot Script"
+msgstr "ドメイン起動スクリプト"
 
 #. type: Plain text
 msgid "image:{project_images}/domain-boot-files.png[]"
@@ -482,17 +493,15 @@ msgstr "起動スクリプトを実行する場合、 `--host-config` スイッ�
 
 #. type: Title ====
 #, no-wrap
-msgid "Clustered Domain Example"
-msgstr "クラスター構成ドメインのサンプル"
+msgid "Testing with a sample clustered domain"
+msgstr "クラスター化されたドメインのサンプルを使ったテスト"
 
 #. type: Plain text
 msgid ""
-"You can test drive clustering using the out-of-the-box _domain.xml_ "
-"configuration.  This example domain is meant to run on one machine and boots"
-" up:"
+"You can test drive clustering using the sample _domain.xml_ configuration.  "
+"This sample domain is meant to run on one machine and boots up:"
 msgstr ""
-"そのまま利用可能な _domain.xml_ "
-"設定を使用してクラスタリングをテストできます。このサンプルドメインは、1台のマシンで実行され、以下を起動します。"
+"サンプルの _domain.xml_ 設定を使用してクラスタリングをテストできます。このサンプルドメインは、1台のマシンで実行され、以下を起動します。"
 
 #. type: Plain text
 msgid "a domain controller"
@@ -503,50 +512,57 @@ msgid "an HTTP load balancer"
 msgstr "HTTPロードバランサー"
 
 #. type: Plain text
-msgid "2 {project_name} server instances"
+msgid "two {project_name} server instances"
 msgstr "2つの{project_name}サーバー・インスタンス"
 
 #. type: Plain text
 msgid ""
-"To simulate running a cluster on two machines, you'll need to run the "
-"`domain.sh` script twice to start two separate host controllers.  The first "
-"will be the master host controller which will start a domain controller, an "
-"HTTP load balancer, and one {project_name} authentication server instance.  "
-"The second will be a slave host controller that only starts up an "
+"Run the `domain.sh` script twice to start two separate host controllers."
+msgstr "2つのホスト・コントローラーを起動するために、`domain.sh` スクリプトを2回実行します。"
+
+#. type: Plain text
+msgid ""
+"The first one is the master host controller that starts a domain controller,"
+" an HTTP load balancer, and one {project_name} authentication server "
+"instance.  The second one is a slave host controller that starts up only an "
 "authentication server instance."
 msgstr ""
-"2台のマシンでのクラスターの実行をシミュレートするには、 `domain.sh` "
-"スクリプトを2回実行して2つの別々のホスト・コントローラーを起動させる必要があります。はじめに、ドメイン・コントローラー、HTTPロードバランサー、および1つの{project_name}認証サーバー・インスタンスを起動するマスター・ホスト・コントローラーを起動させます。次に、認証サーバー・インスタンスを起動するだけのスレーブ・ホスト・コントローラーを起動させます。"
-
-#. type: Title =====
-#, no-wrap
-msgid "Setup Slave Connection to Domain Controller"
-msgstr "ドメイン・コントローラーへのスレーブ接続セットアップ"
+"1つ目はマスター・ホスト・コントローラーで、ドメイン・コントローラー、HTTPロードバランサー、1つの{project_name}認証サーバー・インスタンスを起動します。2つ目はスレーブ・ホスト・コントローラーで、認証サーバーのインスタンスのみを起動します。"
 
 #. type: Plain text
 msgid ""
-"Before you can boot things up though, you have to configure the slave host "
-"controller so that it can talk securely to the domain controller.  If you do"
-" not do this, then the slave host will not be able to obtain the centralized"
-" configuration from the domain controller.  To set up a secure connection, "
-"you have to create a server admin user and a secret that will be shared "
-"between the master and the slave.  You do this by running the `.../bin/add-"
-"user.sh` script."
-msgstr ""
-"ホスト・コントローラーを起動する前に、スレーブ・ホスト・コントローラーをドメイン・コントローラーと安全に通信できるように設定する必要があります。これを設定しなかった場合、スレーブホストはドメイン・コントローラーから一元管理された設定を取得できなくなります。安全な接続をセットアップするには、マスターとスレーブの間で共有されるサーバー管理ユーザーとシークレットを作成する必要があります。これを作成するには、"
-" `.../bin/add-user.sh` スクリプトを実行します。"
+"Configure the slave host controller so that it can talk securely to the "
+"domain controller. Perform these steps:"
+msgstr "スレーブ・ホスト・コントローラーがドメイン・コントローラーと安全に通信できるように設定します。以下の手順を実行してください。"
 
 #. type: Plain text
 msgid ""
-"When you run the script select `Management User` and answer `yes` when it "
-"asks you if the new user is going to be used for one AS process to connect "
-"to another.  This will generate a secret that you'll need to cut and paste "
-"into the _.../domain/configuration/host-slave.xml_ file."
+"If you omit these steps, the slave host cannot obtain the centralized "
+"configuration from the domain controller."
+msgstr "これらの手順を省略すると、スレーブホストはドメイン・コントローラーから集中管理された設定を取得できません。"
+
+#. type: Plain text
+msgid ""
+"Set up a secure connection by creating a server admin user and a secret that"
+" are shared between the master and the slave."
+msgstr "マスターとスレーブの間で共有されるサーバー管理者のユーザーとシークレットを作成し、安全な接続を設定します。"
+
+#. type: Plain text
+msgid "Run the `.../bin/add-user.sh` script."
+msgstr "`.../bin/add-user.sh`スクリプトを実行してください。"
+
+#. type: Plain text
+msgid ""
+"Select `Management User` when the script asks about the type of user to add."
+msgstr "スクリプトで追加するユーザーの種類を尋ねられたら、 `Management User` を選択します。"
+
+#. type: Plain text
+msgid ""
+"This choice generates a secret that you cut and paste into the "
+"_.../domain/configuration/host-slave.xml_ file."
 msgstr ""
-"スクリプトを実行する場合は `Management User` "
-"を選び、新規ユーザーがASプロセスを別のプロセスに接続するかどうかを尋ねるメッセージが表示された場合は `yes` と回答します。これにより、 "
-"_.../domain/configuration/host-slave.xml_ "
-"ファイルにカット・アンド・ペーストする必要があるシークレットが生成されます。"
+"この選択により、 _.../domain/configuration/host-slave.xml_ "
+"ファイルにカット＆ペーストするシークレットが生成されます。"
 
 #. type: Block title
 #, no-wrap
@@ -610,21 +626,22 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The add-user.sh does not add user to {project_name} server but to the "
-"underlying JBoss Enterprise Application Platform. The credentials used and "
-"generated in the above script are only for example purpose. Please use the "
-"ones generated on your system."
+"The add-user.sh script does not add the user to the {project_name} server "
+"but to the underlying JBoss Enterprise Application Platform. The credentials"
+" used and generated in this script are only for demonstration purposes. "
+"Please use the ones generated on your system."
 msgstr ""
-"add-user.shにより、{project_name}サーバーにではなく、基盤となるJBoss Enterprise Application "
-"Platformにユーザーが追加されます。上記のスクリプトで使用、生成された証明書は、あくまでサンプルです。お使いのシステムで生成されたものを使用してください。"
+"add-user.sh スクリプトは、ユーザーを {project_name} サーバーに追加するのではなく、基盤となるJBoss Enterprise"
+" Application "
+"Platformに追加します。このスクリプトで使用および生成されるクレデンシャルは、デモ目的でのみ使用されます。お使いのシステムで生成されたものを使用してください。"
 
 #. type: Plain text
 msgid ""
-"Next, cut and paste the secret value into the _.../domain/configuration"
-"/host-slave.xml_ file as follows:"
+"Cut and paste the secret value into the _.../domain/configuration/host-"
+"slave.xml_ file as follows:"
 msgstr ""
-"次に、以下のようにシークレット値を _.../domain/configuration/host-slave.xml_ "
-"ファイルにカット・アンド・ペーストします。"
+"_.../domain/configuration/host-slave.xml_ "
+"ファイルにシークレットの値をカット・アンド・ペーストすると、以下のようになります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -645,27 +662,21 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"You will also need to add the _username_ of the created user in the "
+"Add the _username_ of the created user in the "
 "_.../domain/configuration/host-slave.xml_ file:"
 msgstr ""
-"作成したユーザーの _username_ も _.../domain/configuration/host-slave.xml_ "
-"ファイルに追加する必要があります。"
+"作成したユーザーの _username_ も _.../domain/configuration/host-slave.xml_ ファイルに追加します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid "     <remote security-realm=\"ManagementRealm\" username=\"admin\">\n"
 msgstr "     <remote security-realm=\"ManagementRealm\" username=\"admin\">\n"
 
-#. type: Title =====
-#, no-wrap
-msgid "Run the Boot Scripts"
-msgstr "起動スクリプトの実行"
-
 #. type: Plain text
 msgid ""
-"Since we're simulating a two node cluster on one development machine, you'll"
-" run the boot script twice:"
-msgstr "1つの開発マシンで2つのノードクラスターをシミュレートするので、以下のとおり、起動スクリプトを2回実行します。"
+"Run the boot script twice to simulate a two node cluster on one development "
+"machine."
+msgstr "ブートスクリプトを2回実行して、1台の開発マシンで2つのノードクラスターをシミュレートします。"
 
 #. type: Block title
 #, no-wrap
@@ -688,5 +699,5 @@ msgid "$ domain.sh --host-config=host-slave.xml\n"
 msgstr "$ domain.sh --host-config=host-slave.xml\n"
 
 #. type: Plain text
-msgid "To try it out, open your browser and go to http://localhost:8080/auth."
-msgstr "これを試すには、ブラウザーを開いて http://localhost:8080/auth に移動してください。"
+msgid "Open your browser and go to http://localhost:8080/auth to try it out."
+msgstr "ブラウザーを開いてhttp://localhost:8080/authにアクセスし、試してみてください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/domain.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__domain
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
