### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,9 +19,24 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Declare Your JDBC Drivers"
+msgstr "JDBCドライバーの宣言"
+
 #. type: Title ===
 #, no-wrap
-msgid "Package the JDBC Driver"
+msgid "Packaging the JDBC driver"
 msgstr "JDBCドライバーのパッケージ化"
 
 #. type: Plain text
@@ -29,24 +44,32 @@ msgid ""
 "Find and download the JDBC driver JAR for your RDBMS. Before you can use "
 "this driver, you must package it up into a module and install it into the "
 "server. Modules define JARs that are loaded into the {project_name} "
-"classpath and the dependencies those JARs have on other modules. They are "
-"pretty simple to set up."
+"classpath and the dependencies those JARs have on other modules."
 msgstr ""
-"RDBMS用のJDBCドライバーのJARを検索してダウンロードします。このドライバーを使用する前に、モジュールにパッケージ化してサーバーにインストールする必要があります。モジュールによって、{project_name}のクラスパスにロードされるJAR、およびこれらのJARが他のモジュールに持つ依存関係が定義されます。設定は非常に簡単です。"
+"RDBMS用のJDBCドライバーのJARを検索してダウンロードします。このドライバーを使用する前に、モジュールにパッケージ化してサーバーにインストールする必要があります。モジュールによって、{project_name}のクラスパスにロードされるJAR、およびこれらのJARが他のモジュールに持つ依存関係が定義されます。"
 
 #. type: Plain text
 msgid ""
-"Within the _.../modules/_ directory of your {project_name} distribution, you"
-" need to create a directory structure to hold your module definition.  The "
-"convention is use the Java package name of the JDBC driver for the name of "
-"the directory structure. For PostgreSQL, create the directory "
-"_org/postgresql/main_. Copy your database driver JAR into this directory and"
-" create an empty _module.xml_ file within it too."
+"Create a directory structure to hold your module definition within the "
+"_.../modules/_ directory of your {project_name} distribution."
 msgstr ""
-"{project_name}の配布物の _.../modules/_ "
-"ディレクトリー内で、モジュール定義を保持するディレクトリー構造を作成する必要があります。規約では、ディレクトリー構造の名前にJDBCドライバーのJavaパッケージ名を使用します。PostgreSQLの場合、"
-" _org/postgresql/main_ ディレクトリーを作成します。このディレクトリーにデータベース・ドライバーのJARをコピーし、その中に空の "
-"_module.xml_ ファイルも作成します。"
+" {project_name}配布ファイルの _.../modules/_ "
+"ディレクトリー内に、モジュールの定義を格納するディレクトリー構造を作成してください。"
+
+#. type: Plain text
+msgid ""
+"The convention is use the Java package name of the JDBC driver for the name "
+"of the directory structure. For PostgreSQL, create the directory "
+"_org/postgresql/main_."
+msgstr ""
+"ディレクトリー構造の名前には、JDBCドライバーのJavaパッケージ名を使うのが一般的です。PostgreSQLの場合は、 "
+"_org/postgresql/main_ というディレクトリーを作成します。"
+
+#. type: Plain text
+msgid ""
+"Copy your database driver JAR into this directory and create an empty "
+"_module.xml_ file within it too."
+msgstr "データベース・ドライバーのJARをこのディレクトリーにコピーし、その中に空の _module.xml_ ファイルを作成します。"
 
 #. type: Block title
 #, no-wrap
@@ -54,14 +77,12 @@ msgid "Module Directory"
 msgstr "モジュール・ディレクトリー"
 
 #. type: Plain text
-msgid "image:{project_images}/db-module.png[]"
-msgstr "image:{project_images}/db-module.png[]"
+msgid "image:{project_images}/db-module.png[Module Directory]"
+msgstr "image:{project_images}/db-module.png[Module Directory]"
 
 #. type: Plain text
-msgid ""
-"After you have done this, open up the _module.xml_ file and create the "
-"following XML:"
-msgstr "これを行った後、 _module.xml_ ファイルを開き、以下のXMLを作成します。"
+msgid "Open up the _module.xml_ file and create the following XML:"
+msgstr "_module.xml_ ファイルを開き、以下のようなXMLを作成します。"
 
 #. type: Block title
 #, no-wrap
@@ -71,21 +92,21 @@ msgstr "モジュールXML"
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"<?xml version=\"1.0\" ?>\n"
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 "<module xmlns=\"urn:jboss:module:1.3\" name=\"org.postgresql\">\n"
 msgstr ""
-"<?xml version=\"1.0\" ?>\n"
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 "<module xmlns=\"urn:jboss:module:1.3\" name=\"org.postgresql\">\n"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
 "    <resources>\n"
-"        <resource-root path=\"postgresql-9.4.1212.jar\"/>\n"
+"        <resource-root path=\"postgresql-VERSION.jar\"/>\n"
 "    </resources>\n"
 msgstr ""
 "    <resources>\n"
-"        <resource-root path=\"postgresql-9.4.1212.jar\"/>\n"
+"        <resource-root path=\"postgresql-VERSION.jar\"/>\n"
 "    </resources>\n"
 
 #. type: delimited block -
@@ -106,47 +127,80 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The module name should match the directory structure of your module. So, "
-"_org/postgresql_ maps to `org.postgresql`. The `resource-root path` "
-"attribute should specify the JAR filename of the driver.  The rest are just "
-"the normal dependencies that any JDBC driver JAR would have."
+"_org/postgresql_ maps to `org.postgresql`."
 msgstr ""
-"モジュール名は、モジュールのディレクトリー構造と一致する必要があります。したがって、 _org/postgresql_ は "
-"`org.postgresql` にマッピングされます。ドライバーのJARファイル名は、 `resource-root` の `path` "
-"の属性によって指定される必要があります。残りの部分は、JDBCドライバーのJARが持つ通常の依存関係になります。"
+"モジュール名は、モジュールのディレクトリー構造と一致していなければなりません。例えば、 _org/postgresql_ は "
+"`org.postgresql` に対応します。"
+
+#. type: Plain text
+msgid ""
+"The `resource-root path` attribute should specify the JAR filename of the "
+"driver."
+msgstr "`resource-root path` 属性は、ドライバーのJARファイル名を指定します。"
+
+#. type: Plain text
+msgid ""
+"The rest are just the normal dependencies that any JDBC driver JAR would "
+"have."
+msgstr "残りの部分は、JDBCドライバーのJARが持っている通常の依存関係です。"
 
 #. type: Title ===
 #, no-wrap
-msgid "Declare and Load JDBC Driver"
+msgid "Declaring and loading the JDBC driver"
 msgstr "JDBCドライバーの宣言とロード"
 
 #. type: Plain text
 msgid ""
-"The next thing you have to do is declare your newly packaged JDBC driver "
-"into your deployment profile so that it loads and becomes available when the"
-" server boots up. Where you perform this action depends on your "
-"<<_operating-mode, operating mode>>. If you're deploying in standard mode, "
-"edit _.../standalone/configuration/standalone.xml_.  If you're deploying in "
-"standard clustering mode, edit _.../standalone/configuration/standalone-"
-"ha.xml_.  If you're deploying in domain mode, edit "
-"_.../domain/configuration/domain.xml_. In domain mode, you'll need to make "
-"sure you edit the profile you are using: either `auth-server-standalone` or "
-"`auth-server-clustered`"
+"You declare your JDBC into your deployment profile so that it loads and "
+"becomes available when the server boots up."
+msgstr "JDBCをデプロイメント・プロファイルに宣言し、サーバー起動時にロードして利用できるようにします。"
+
+#. type: Plain text
+msgid "You have packaged the JDBC driver."
+msgstr "JDBCドライバーをパッケージ化しました。"
+
+#. type: Plain text
+msgid ""
+"Declare your JDBC driver by editing one of these files based on your "
+"deployment mode:"
+msgstr "デプロイメント・モードに応じて、これらのファイルのいずれかを編集し、JDBCドライバーを宣言します。"
+
+#. type: Plain text
+msgid "For standard mode, edit _.../standalone/configuration/standalone.xml_."
 msgstr ""
-"次に、新しくパッケージ化されたJDBCドライバーをデプロイメント・プロファイルに宣言して、ロードし、サーバーの起動時に使用できるようにする必要があります。この操作を行う場所は"
-"、<<_operating-mode, 動作モード>>によって異なります。標準モードでデプロイしている場合は、 "
-"_.../standalone/configuration/standalone.xml_ を編集します。ドメインモードでデプロイしている場合は、 "
-"_.../domain/configuration/domain.xml_ を編集します。ドメインモードでは、 `auth-server-"
-"standalone` または `auth-server-clustered` のどちらか使用している方のプロファイルを必ず編集する必要があります。"
+"スタンドアローン・モードでは、  _.../standalone/configuration/standalone.xml_ を編集します。"
+
+#. type: Plain text
+msgid ""
+"For standard clustering mode, edit _.../standalone/configuration/standalone-"
+"ha.xml_."
+msgstr ""
+"スタンドアローン・クラスタリング・モードの場合は、 _.../standalone/configuration/standalone-ha.xml_ "
+"を編集してください。"
+
+#. type: Plain text
+msgid "For domain mode, edit _.../domain/configuration/domain.xml_."
+msgstr "ドメインモードの場合は、 _.../domain/configuration/domain.xml_ を編集します。"
+
+#. type: Plain text
+msgid ""
+"In domain mode, make sure you edit the profile you are using: either `auth-"
+"server-standalone` or `auth-server-clustered`"
+msgstr ""
+"ドメインモードでは、使用しているプロファイル（ `auth-server-standalone` または `auth-server-clustered`"
+" のいずれか）を編集することを確認してください。"
 
 #. type: Plain text
 msgid ""
 "Within the profile, search for the `drivers` XML block within the "
-"`datasources` subsystem. You should see a pre-defined driver declared for "
-"the H2 JDBC driver. This is where you'll declare the JDBC driver for your "
-"external database."
-msgstr ""
-"プロファイル内で、 `datasources` サブシステム内の `drivers` のXMLブロックを検索すると、H2 "
-"JDBCドライバー用に宣言された定義済みのドライバーが見つかります。ここで、外部データベース用のJDBCドライバーを宣言します。"
+"`datasources` subsystem."
+msgstr "プロファイル内で、 `datasources` サブシステム内の `drivers` XMLブロックを検索します。"
+
+#. type: Plain text
+msgid ""
+"You should see a pre-defined driver declared for the H2 JDBC driver. This is"
+" where you'll declare the JDBC driver for your external database."
+msgstr "H2 JDBCドライバーの定義済みのドライバーが宣言されているはずです。ここでは、外部データベースのJDBCドライバーを宣言します。"
 
 #. type: Block title
 #, no-wrap
@@ -179,22 +233,28 @@ msgstr ""
 "  </subsystem>\n"
 
 #. type: Plain text
-msgid ""
-"Within the `drivers` XML block you'll need to declare an additional JDBC "
-"driver.  It needs to have a `name` which you can choose to be anything you "
-"want.  You specify the `module` attribute which points to the `module` "
-"package you created earlier for the driver JAR.  Finally you have to specify"
-" the driver's Java class.  Here's an example of installing PostgreSQL driver"
-" that lives in the module example defined earlier in this chapter."
-msgstr ""
-"`drivers` のXMLブロック内で、追加のJDBCドライバーを宣言する必要があります。それに `name` "
-"を付けて、必要時に選択できるようにします。ドライバーのJAR用に以前作成した `module` パッケージを指す、 `module` "
-"属性を指定します。最後に、ドライバーのJavaクラスを指定します。サンプルとして、この章で以前定義したモジュールのサンプル内にある、PostgreSQLドライバーをインストールすると下記のとおりになります。"
+msgid "Within the `drivers` XML block, declare an additional JDBC driver."
+msgstr "`drivers` のXMLブロック内で、追加のJDBCドライバーを宣言します。"
 
-#. type: Block title
-#, no-wrap
-msgid "Declare Your JDBC Drivers"
-msgstr "JDBCドライバーの宣言"
+#. type: Plain text
+msgid "Assign any `name` to this driver."
+msgstr "このドライバーに任意の `name` を付けます。"
+
+#. type: Plain text
+msgid ""
+"Specify the `module` attribute which points to the `module` package that you"
+" created earlier for the driver JAR."
+msgstr "`module` 属性を指定します。この属性は、ドライバーJAR用に以前作成した `module` パッケージを指します。"
+
+#. type: Plain text
+msgid "Specify the driver's Java class."
+msgstr "ドライバーのJavaクラスを指定します。"
+
+#. type: Plain text
+msgid ""
+"Here's an example of installing a PostgreSQL driver that lives in the module"
+" example defined earlier in this chapter."
+msgstr "ここでは、本章の前半で定義したモジュールのサンプルに含まれるPostgreSQLドライバーをインストールする例を紹介します。"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/jdbc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__jdbc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
