### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/external-keycloak.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/external-keycloak.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/external-keycloak.ja_JP.po
@@ -29,20 +29,20 @@ msgid ""
 "{project_name} instance.  In it's current state, it will only be able to "
 "create clients."
 msgstr ""
-"このオペレーターは、外部の {project_name} インスタンスを部分的に管理するためにも使用できます。  "
-"現在の状態では、クライアントを作成することしかできません。"
+"このオペレーターは、外部の{project_name}インスタンスを部分的に管理するためにも使用できます。現在の状態では、クライアントを作成することしかできません。"
 
 #. type: Plain text
 msgid ""
 "To do this, you'll need to create unmanaged versions of the `Keycloak` and "
 "`KeycloakRealm` CRDs to use for targeting and configuration."
 msgstr ""
-"そのためには、ターゲット設定や構成に使用するアンマネージド版の`Keycloak`と`KeycloakRealm`のCRDを作成する必要があります。"
+"そのためには、ターゲティングや設定に使用するアンマネージド版の `Keycloak` と `KeycloakRealm` "
+"のCRDを作成する必要があります。"
 
 #. type: Block title
 #, no-wrap
 msgid "Example YAML file for `external-keycloak`"
-msgstr "external-keycloak`のYAMLファイルの例"
+msgstr "`external-keycloak` のYAMLファイルの例"
 
 #. type: Code block
 #, no-wrap
@@ -86,12 +86,13 @@ msgid ""
 "In order to authenticate against this keycloak, the operator infers the "
 "secret name from the CRD by prefixing the CRD name with `credential-`."
 msgstr ""
-"このkeycloakに対して認証を行うために、オペレータはCRD名の前に`credential-`を付けることで、CRDから秘密の名前を推測します。"
+"このKeycloakに対して認証を行うために、オペレーターはCRD名の前に `credential-` "
+"を付けることで、CRDからシークレット名を推測します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Example YAML file for `credential-external-ref`"
-msgstr "credential-external-ref`のYAMLファイルの例"
+msgstr "`credential-external-ref` のYAMLファイルの例"
 
 #. type: Code block
 #, no-wrap
@@ -117,7 +118,7 @@ msgstr ""
 #. type: Block title
 #, no-wrap
 msgid "Example YAML file for `external-realm`"
-msgstr "EXTERNAL-REALM`のYAMLファイルの例"
+msgstr "`EXTERNAL-REALM` のYAMLファイルの例"
 
 #. type: Code block
 #, no-wrap
@@ -177,4 +178,4 @@ msgid ""
 "You can now use the realm reference in your client as usual, and it will "
 "create the client on the external {project_name} instance."
 msgstr ""
-"これで、通常通りクライアントでrealmの参照を使用することができ、外部の {project_name} インスタンスにクライアントが作成されます。"
+"これで、通常通りクライアントでレルムの参照を使用することができ、外部の{project_name}インスタンスにクライアントが作成されます。"

--- a/i18n/po/ja_JP/server_installation/topics/operator/external-keycloak.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/external-keycloak.ja_JP.po
@@ -1,0 +1,180 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Connecting to an external {project_name}"
+msgstr "外部{project_name}への接続"
+
+#. type: Plain text
+msgid ""
+"This operator can also be used to partially manage an external "
+"{project_name} instance.  In it's current state, it will only be able to "
+"create clients."
+msgstr ""
+"このオペレーターは、外部の {project_name} インスタンスを部分的に管理するためにも使用できます。  "
+"現在の状態では、クライアントを作成することしかできません。"
+
+#. type: Plain text
+msgid ""
+"To do this, you'll need to create unmanaged versions of the `Keycloak` and "
+"`KeycloakRealm` CRDs to use for targeting and configuration."
+msgstr ""
+"そのためには、ターゲット設定や構成に使用するアンマネージド版の`Keycloak`と`KeycloakRealm`のCRDを作成する必要があります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example YAML file for `external-keycloak`"
+msgstr "external-keycloak`のYAMLファイルの例"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: Keycloak\n"
+"metadata:\n"
+"  name: external-ref\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"    app: external-keycloak\n"
+"endif::[]\n"
+"ifeval::[{project_product}==true]\n"
+"    app: external-sso\n"
+"endif::[]\n"
+"spec:\n"
+"  unmanaged: true\n"
+"  external:\n"
+"    enabled: true\n"
+"    url: https://some.external.url\n"
+msgstr ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: Keycloak\n"
+"metadata:\n"
+"  name: external-ref\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"    app: external-keycloak\n"
+"endif::[]\n"
+"ifeval::[{project_product}==true]\n"
+"    app: external-sso\n"
+"endif::[]\n"
+"spec:\n"
+"  unmanaged: true\n"
+"  external:\n"
+"    enabled: true\n"
+"    url: https://some.external.url\n"
+
+#. type: Plain text
+msgid ""
+"In order to authenticate against this keycloak, the operator infers the "
+"secret name from the CRD by prefixing the CRD name with `credential-`."
+msgstr ""
+"このkeycloakに対して認証を行うために、オペレータはCRD名の前に`credential-`を付けることで、CRDから秘密の名前を推測します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Example YAML file for `credential-external-ref`"
+msgstr "credential-external-ref`のYAMLファイルの例"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: v1\n"
+"kind: Secret\n"
+"metadata:\n"
+"  name: credential-external-ref\n"
+"type: Opaque\n"
+"data:\n"
+"  ADMIN_USERNAME: YWRtaW4=\n"
+"  ADMIN_PASSWORD: cGFzcw==\n"
+msgstr ""
+"apiVersion: v1\n"
+"kind: Secret\n"
+"metadata:\n"
+"  name: credential-external-ref\n"
+"type: Opaque\n"
+"data:\n"
+"  ADMIN_USERNAME: YWRtaW4=\n"
+"  ADMIN_PASSWORD: cGFzcw==\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Example YAML file for `external-realm`"
+msgstr "EXTERNAL-REALM`のYAMLファイルの例"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: KeycloakRealm\n"
+"metadata:\n"
+"  name: external-realm\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"    app: external-keycloak\n"
+"endif::[]\n"
+"ifeval::[{project_product}==true]\n"
+"    app: external-sso\n"
+"endif::[]\n"
+"spec:\n"
+"  unmanaged: true\n"
+"  realm:\n"
+"    id: \"basic\"\n"
+"    realm: \"basic\"\n"
+"  instanceSelector:\n"
+"    matchLabels:\n"
+"ifeval::[{project_community}==true]\n"
+"      app: external-keycloak\n"
+"endif::[]\n"
+"ifeval::[{project_product}==true]\n"
+"      app: external-sso\n"
+"endif::[]\n"
+msgstr ""
+"apiVersion: keycloak.org/v1alpha1\n"
+"kind: KeycloakRealm\n"
+"metadata:\n"
+"  name: external-realm\n"
+"  labels:\n"
+"ifeval::[{project_community}==true]\n"
+"    app: external-keycloak\n"
+"endif::[]\n"
+"ifeval::[{project_product}==true]\n"
+"    app: external-sso\n"
+"endif::[]\n"
+"spec:\n"
+"  unmanaged: true\n"
+"  realm:\n"
+"    id: \"basic\"\n"
+"    realm: \"basic\"\n"
+"  instanceSelector:\n"
+"    matchLabels:\n"
+"ifeval::[{project_community}==true]\n"
+"      app: external-keycloak\n"
+"endif::[]\n"
+"ifeval::[{project_product}==true]\n"
+"      app: external-sso\n"
+"endif::[]\n"
+
+#. type: Plain text
+msgid ""
+"You can now use the realm reference in your client as usual, and it will "
+"create the client on the external {project_name} instance."
+msgstr ""
+"これで、通常通りクライアントでrealmの参照を使用することができ、外部の {project_name} インスタンスにクライアントが作成されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/external-keycloak.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__external-keycloak
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
