### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
@@ -53,7 +53,7 @@ msgstr "`**` = `/profile=auth-server-clustered/subsystem=keycloak-server`"
 #. type: Title ====
 #, no-wrap
 msgid "Changing the web context of the server"
-msgstr "サーバーのウェブコンテキストの変更"
+msgstr "サーバーのwebコンテキストの変更"
 
 #. type: delimited block -
 #, no-wrap
@@ -115,7 +115,7 @@ msgstr "**/spi=mySPI/:write-attribute(name=default-provider,value=myProvider)\n"
 #. type: Title ====
 #, no-wrap
 msgid "Configuring the dblock SPI"
-msgstr "dblockのSPIを設定する"
+msgstr "dblock SPIの設定"
 
 #. type: delimited block -
 #, no-wrap
@@ -129,7 +129,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Adding or changing a single property value for a provider"
-msgstr "プロバイダの単一のプロパティ値を追加または変更する"
+msgstr "プロバイダーのシングル・プロパティー値の追加または変更"
 
 #. type: delimited block -
 #, no-wrap
@@ -157,7 +157,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Setting values on a provider property of type `List`"
-msgstr "List`型のプロバイダプロパティに値を設定する"
+msgstr "`List` 型のプロバイダー・プロパティー値の設定"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +22,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "CLI Recipes"
+msgid "CLI recipes"
 msgstr "CLIレシピ"
 
 #. type: Plain text
@@ -47,8 +52,8 @@ msgstr "`**` = `/profile=auth-server-clustered/subsystem=keycloak-server`"
 
 #. type: Title ====
 #, no-wrap
-msgid "Change the web context of the server"
-msgstr "サーバーのwebコンテキストの変更"
+msgid "Changing the web context of the server"
+msgstr "サーバーのウェブコンテキストの変更"
 
 #. type: delimited block -
 #, no-wrap
@@ -61,7 +66,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Set the global default theme"
+msgid "Setting the global default theme"
 msgstr "グローバルなデフォルトテーマの設定"
 
 #. type: delimited block -
@@ -71,7 +76,7 @@ msgstr "**/theme=defaults/:write-attribute(name=default,value=myTheme)\n"
 
 #. type: Title ====
 #, no-wrap
-msgid "Add a new SPI and a provider"
+msgid "Adding a new SPI and a provider"
 msgstr "新しいSPIとプロバイダーの追加"
 
 #. type: delimited block -
@@ -85,7 +90,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Disable a provider"
+msgid "Disabling a provider"
 msgstr "プロバイダーの無効化"
 
 #. type: delimited block -
@@ -99,7 +104,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Change the default provider for an SPI"
+msgid "Changing the default provider for an SPI"
 msgstr "SPIのデフォルトプロバイダーの変更"
 
 #. type: delimited block -
@@ -109,8 +114,8 @@ msgstr "**/spi=mySPI/:write-attribute(name=default-provider,value=myProvider)\n"
 
 #. type: Title ====
 #, no-wrap
-msgid "Configure the dblock SPI"
-msgstr "dblock SPIの設定"
+msgid "Configuring the dblock SPI"
+msgstr "dblockのSPIを設定する"
 
 #. type: delimited block -
 #, no-wrap
@@ -123,8 +128,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Add or change a single property value for a provider"
-msgstr "プロバイダーのシングル・プロパティー値の追加または変更"
+msgid "Adding or changing a single property value for a provider"
+msgstr "プロバイダの単一のプロパティ値を追加または変更する"
 
 #. type: delimited block -
 #, no-wrap
@@ -151,8 +156,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Set values on a provider property of type `List`"
-msgstr " `List` 型のプロバイダー・プロパティー値の設定"
+msgid "Setting values on a provider property of type `List`"
+msgstr "List`型のプロバイダプロパティに値を設定する"
 
 #. type: delimited block -
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/cli-recipes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__cli-recipes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
