### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/database/unicode-considerations.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/database/unicode-considerations.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/unicode-considerations.ja_JP.po
@@ -35,7 +35,7 @@ msgstr "{project_name}のデータベース・スキーマは、以下の特別�
 msgid ""
 "Realms: display name, HTML display name, localization texts (keys and "
 "values)"
-msgstr "領域：表示名、HTML表示名、ローカライズテキスト（キーと値）"
+msgstr "レルム：表示名、HTML表示名、ローカライズテキスト（キーと値）"
 
 #. type: Plain text
 msgid "Federation Providers: display name"
@@ -96,7 +96,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Oracle database"
-msgstr "オラクルデータベース"
+msgstr "Oracleデータベース"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/database/unicode-considerations.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/database/unicode-considerations.ja_JP.po
@@ -4,16 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,7 +22,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Unicode Considerations for Databases"
+msgid "Unicode considerations for databases"
 msgstr "データベースのユニコードに関する考慮事項"
 
 #. type: Plain text
@@ -33,8 +32,10 @@ msgid ""
 msgstr "{project_name}のデータベース・スキーマは、以下の特別なフィールドにだけユニコード文字列の使用を許可します。"
 
 #. type: Plain text
-msgid "Realms: display name, HTML display name"
-msgstr "レルム：表示名、HTML表示名"
+msgid ""
+"Realms: display name, HTML display name, localization texts (keys and "
+"values)"
+msgstr "領域：表示名、HTML表示名、ローカライズテキスト（キーと値）"
 
 #. type: Plain text
 msgid "Federation Providers: display name"
@@ -64,9 +65,7 @@ msgid ""
 "set in all text fields. Often, this is counterbalanced by shorter maximum "
 "length of the strings than in case of 8-bit encodings."
 msgstr ""
-"上記以外の場合は、8ビットのデータベース・エンコーディングに含まれる文字に制限されます。ただし、データベース・システムによっては"
-"、ユニコード文字のUTF-"
-"8エンコーディングを有効にし、すべてのテキストフィールド内で完全なユニコード文字セットを使用することができます。これは8ビットエンコーディングの場合よりも文字列の最大長を短くすることによって相殺されます。"
+"上記以外の場合は、8ビットのデータベース・エンコーディングに含まれる文字に制限されます。ただし、データベース・システムによっては、ユニコード文字のUTF-8エンコーディングを有効にし、すべてのテキストフィールド内で完全なユニコード文字セットを使用することができます。これは8ビットエンコーディングの場合よりも文字列の最大長を短くすることによって相殺されます。"
 
 #. type: Plain text
 msgid ""
@@ -76,8 +75,7 @@ msgid ""
 "still work properly provided it handles UTF-8 encoding properly both on the "
 "level of database and JDBC driver."
 msgstr ""
-"データベースによっては、ユニコード文字を処理できるようにデータベースとJDBCドライバーの両方、またはいずれかに特別な設定をする必要があります。以下のデータベースの設定を確認してください。データベースがここにリストされている場合"
-"、データベースとJDBCドライバーの両方のレベルでUTF-8エンコーディングが適切に処理されていれば、正常に動きます。この点には注意してください。"
+"データベースによっては、ユニコード文字を処理できるようにデータベースとJDBCドライバーの両方、またはいずれかに特別な設定をする必要があります。以下のデータベースの設定を確認してください。データベースがここにリストされている場合、データベースとJDBCドライバーの両方のレベルでUTF-8エンコーディングが適切に処理されていれば、正常に動きます。この点には注意してください。"
 
 #. type: Plain text
 msgid ""
@@ -97,8 +95,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Oracle Database"
-msgstr "Oracle Database"
+msgid "Oracle database"
+msgstr "オラクルデータベース"
 
 #. type: Plain text
 msgid ""
@@ -133,8 +131,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Microsoft SQL Server Database"
-msgstr "Microsoft SQL Server Database"
+msgid "Microsoft SQL Server database"
+msgstr "Microsoft SQL Serverデータベース"
 
 #. type: Plain text
 msgid ""
@@ -144,8 +142,8 @@ msgstr "ユニコード文字は、特別なフィールドに対してのみ適
 
 #. type: Title ====
 #, no-wrap
-msgid "MySQL Database"
-msgstr "MySQL Database"
+msgid "MySQL database"
+msgstr "MySQLデータベース"
 
 #. type: Plain text
 msgid ""
@@ -176,8 +174,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "PostgreSQL Database"
-msgstr "PostgreSQL Database"
+msgid "PostgreSQL database"
+msgstr "PostgreSQLデータベース"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/database/unicode-considerations.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__database__unicode-considerations
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
