### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
@@ -4,13 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,18 +21,28 @@ msgstr ""
 
 #. type: Title ==
 #, no-wrap
-msgid "Choosing an Operating Mode"
-msgstr "動作モードの選択"
+msgid "Using operating modes"
+msgstr "操作モードの使い方"
 
 #. type: Plain text
 msgid ""
 "Before deploying {project_name} in a production environment you need to "
-"decide which type of operating mode you are going to use.  Will you run "
-"{project_name} within a cluster? Do you want a centralized way to manage "
-"your server configurations? Your choice of operating mode affects how you "
-"configure databases, configure caching and even how you boot the server."
-msgstr ""
-"プロダクション環境で{project_name}をデプロイする前に、どのタイプの動作モードを使用するか決定する必要があります。クラスター内で{project_name}を実行しますか？サーバー設定を一元管理しますか？どの動作モードを選択するかによって、データベースやキャッシュをどのように設定するか、さらにはサーバーをどのように起動するかさえ変わってきます。"
+"decide which type of operating mode you are going to use."
+msgstr "本番環境に {project_name} を導入する前に、どのタイプのオペレーティング・モードを使用するかを決める必要があります。"
+
+#. type: Plain text
+msgid "Will you run {project_name} within a cluster?"
+msgstr "{project_name} をクラスタ内で実行するのか？"
+
+#. type: Plain text
+msgid "Do you want a centralized way to manage your server configurations?"
+msgstr "サーバーの設定を一元的に管理したいと思いませんか？"
+
+#. type: Plain text
+msgid ""
+"Your choice of operating mode affects how you configure databases, configure"
+" caching and even how you boot the server."
+msgstr "オペレーティングモードの選択は、データベースの設定やキャッシングの設定、さらにはサーバーの起動方法にも影響します。"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po
@@ -22,27 +22,27 @@ msgstr ""
 #. type: Title ==
 #, no-wrap
 msgid "Using operating modes"
-msgstr "操作モードの使い方"
+msgstr "動作モードの使い方"
 
 #. type: Plain text
 msgid ""
 "Before deploying {project_name} in a production environment you need to "
 "decide which type of operating mode you are going to use."
-msgstr "本番環境に {project_name} を導入する前に、どのタイプのオペレーティング・モードを使用するかを決める必要があります。"
+msgstr "プロダクション環境に{project_name}を導入する前に、どのタイプの動作モードを使用するかを決める必要があります。"
 
 #. type: Plain text
 msgid "Will you run {project_name} within a cluster?"
-msgstr "{project_name} をクラスタ内で実行するのか？"
+msgstr "{project_name}をクラスター内で実行するか？"
 
 #. type: Plain text
 msgid "Do you want a centralized way to manage your server configurations?"
-msgstr "サーバーの設定を一元的に管理したいと思いませんか？"
+msgstr "サーバーの設定を一元的に管理したいか？"
 
 #. type: Plain text
 msgid ""
 "Your choice of operating mode affects how you configure databases, configure"
 " caching and even how you boot the server."
-msgstr "オペレーティングモードの選択は、データベースの設定やキャッシングの設定、さらにはサーバーの起動方法にも影響します。"
+msgstr "動作モードの選択は、データベースの設定やキャッシングの設定、さらにはサーバーの起動方法にも影響します。"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
