### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -38,10 +38,23 @@ msgstr "> ...\\bin\\standalone.bat\n"
 msgid "To boot the server:"
 msgstr "サーバーを起動するには下記を実行します。"
 
-#. type: Block title
+#. type: Plain text
 #, no-wrap
-msgid "Standalone Mode"
-msgstr "スタンドアローン・モード"
+msgid ""
+"Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
+"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
+"      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
+msgstr ""
+"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"
+
+#. type: Plain text
+msgid "image:{project_images}/standalone-boot-files.png[]"
+msgstr "image:{project_images}/standalone-boot-files.png[]"
+
+#. type: Title ===
+#, no-wrap
+msgid "Using standalone mode"
+msgstr "スタンドアロンモードの使用"
 
 #. type: Plain text
 msgid ""
@@ -57,26 +70,22 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Standalone Boot Script"
-msgstr "スタンドアローン起動スクリプト"
+msgid "Booting in standalone mode"
+msgstr "スタンドアロンモードでの起動"
 
 #. type: Plain text
 msgid ""
 "When running the server in standalone mode, there is a specific script you "
-"need to run to boot the server depending on your operating system.  These "
-"scripts live in the _bin/_ directory of the server distribution."
+"need to boot the server depending on your operating system.  These scripts "
+"live in the _bin/_ directory of the server distribution."
 msgstr ""
-"スタンドアローン・モードでサーバーを実行する場合、オペレーティング・システム固有の起動スクリプトを実行する必要があります。これらのスクリプトはサーバー配布物の"
-" _bin/_ ディレクトリーにあります。"
+"スタンドアロンモードでサーバーを実行する場合、お使いのオペレーティングシステムに応じて、サーバーを起動するために必要な特定のスクリプトがあります。  "
+"これらのスクリプトは、サーバー配布物の _bin/_ ディレクトリにあります。"
 
 #. type: Block title
 #, no-wrap
 msgid "Standalone Boot Scripts"
 msgstr "スタンドアローン起動スクリプト"
-
-#. type: Plain text
-msgid "image:{project_images}/standalone-boot-files.png[]"
-msgstr "image:{project_images}/standalone-boot-files.png[]"
 
 #. type: delimited block -
 #, no-wrap
@@ -85,8 +94,8 @@ msgstr "$ .../bin/standalone.sh\n"
 
 #. type: Title ====
 #, no-wrap
-msgid "Standalone Configuration"
-msgstr "スタンドアローン設定"
+msgid "Standalone configuration"
+msgstr "スタンドアロン構成"
 
 #. type: Plain text
 msgid ""
@@ -110,12 +119,3 @@ msgstr "スタンドアローン設定ファイル"
 #. type: Plain text
 msgid "image:{project_images}/standalone-config-file.png[]"
 msgstr "image:{project_images}/standalone-config-file.png[]"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Any changes you make to this file while the server is running will not take effect and may even be overwritten\n"
-"      by the server.  Instead use the command line scripting or the web console of {appserver_name}.  See\n"
-"      the link:{appserver_admindoc_link}[_{appserver_admindoc_name}_] for more information.\n"
-msgstr ""
-"サーバーの実行中にこのファイルに変更を加えても、反映されず、サーバーに上書きされる可能性があります。その場合は、代わりに{appserver_name}のwebコンソールまたはコマンドライン・スクリプトを使用します。詳しくは、link:{appserver_admindoc_link}[_{appserver_admindoc_name}_]を参照してください。\n"

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po
@@ -54,7 +54,7 @@ msgstr "image:{project_images}/standalone-boot-files.png[]"
 #. type: Title ===
 #, no-wrap
 msgid "Using standalone mode"
-msgstr "スタンドアロンモードの使用"
+msgstr "スタンドアローン・モードの使用"
 
 #. type: Plain text
 msgid ""
@@ -71,7 +71,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Booting in standalone mode"
-msgstr "スタンドアロンモードでの起動"
+msgstr "スタンドアローン・モードでの起動"
 
 #. type: Plain text
 msgid ""
@@ -79,8 +79,8 @@ msgid ""
 "need to boot the server depending on your operating system.  These scripts "
 "live in the _bin/_ directory of the server distribution."
 msgstr ""
-"スタンドアロンモードでサーバーを実行する場合、お使いのオペレーティングシステムに応じて、サーバーを起動するために必要な特定のスクリプトがあります。  "
-"これらのスクリプトは、サーバー配布物の _bin/_ ディレクトリにあります。"
+"スタンドアローン・モードでサーバーを実行する場合、使用するオペレーティング・システムに応じて、サーバーを起動するために必要な特定のスクリプトがあります。これらのスクリプトは、サーバー配布物の"
+" _bin/_ ディレクトリーにあります。"
 
 #. type: Block title
 #, no-wrap
@@ -95,7 +95,7 @@ msgstr "$ .../bin/standalone.sh\n"
 #. type: Title ====
 #, no-wrap
 msgid "Standalone configuration"
-msgstr "スタンドアロン構成"
+msgstr "スタンドアローン・モード構成"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
