### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -35,24 +35,24 @@ msgstr "サーバーを起動するには下記を実行します"
 
 #. type: Title ===
 #, no-wrap
-msgid "Standalone Clustered Mode"
-msgstr "スタンドアローン・クラスター・モード"
+msgid "Using standalone clustered mode"
+msgstr "スタンドアローン・クラスター・モードの使用"
 
 #. type: Plain text
 msgid ""
-"Standalone clustered operation mode is for when you want to run "
+"Standalone clustered operation mode applies when you want to run "
 "{project_name} within a cluster.  This mode requires that you have a copy of"
-" the {project_name} distribution on each machine you want to run a server "
-"instance.  This mode can be very easy to deploy initially, but can become "
-"quite cumbersome. To make a configuration change you'll have to modify each "
-"distribution on each machine.  For a large cluster this can become time "
-"consuming and error prone."
+" the {project_name} distribution on each machine where you want to run a "
+"server instance.  This mode can be very easy to deploy initially, but can "
+"become quite cumbersome. To make a configuration change, you modify each "
+"distribution on each machine.  For a large cluster, this mode can become "
+"time consuming and error prone."
 msgstr ""
-"スタンドアローン・クラスター動作モードは、クラスター内で{project_name}を実行するためのものです。このモードでは、サーバー・インスタンスを実行する各マシンに{project_name}の配布物のコピーが保存されている必要があります。このモードは、最初は非常に簡単にデプロイできますが、後でかなり煩雑になる可能性があります。設定を変更するには、各マシンの配布物を修正する必要があります。大規模なクラスターの場合、時間がかかり、エラーも発生しやすくなります。"
+"スタンドアローン・クラスター動作モードは、クラスター内で{project_name}を実行するときに適用します。このモードでは、サーバー・インスタンスを実行する各マシンに{project_name}の配布物のコピーが保存されている必要があります。このモードは、最初は非常に簡単にデプロイできますが、後でかなり煩雑になる可能性があります。設定を変更するには、各マシンの配布物を修正します。大規模なクラスターの場合、時間がかかり、エラーも発生しやすくなります。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Standalone Clustered Configuration"
+msgid "Standalone clustered configuration"
 msgstr "スタンドアローン・クラスター設定"
 
 #. type: Plain text
@@ -91,8 +91,8 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Standalone Clustered Boot Script"
-msgstr "スタンドアローン・クラスター起動スクリプト"
+msgid "Booting in standalone clustered mode"
+msgstr "スタンドアロン・クラスター・モードでの起動"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po
@@ -92,7 +92,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "Booting in standalone clustered mode"
-msgstr "スタンドアロン・クラスター・モードでの起動"
+msgstr "スタンドアローン・クラスター・モードでの起動"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/standalone-ha.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__standalone-ha
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
