### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
@@ -31,24 +31,20 @@ msgstr "キャッシングの無効化"
 
 #. type: Plain text
 msgid "You can disable the realm or user cache."
-msgstr "レルムやユーザーキャッシュを無効にすることができます。"
+msgstr "レルムキャッシュやユーザーキャッシュを無効にすることができます。"
 
 #. type: Plain text
 msgid ""
 "Edit the `standalone.xml`, `standalone-ha.xml`, or `domain.xml` file in your"
 " distribution."
 msgstr ""
-"ディストリビューション内の `standalone.xml`, `standalone-ha.xml`, `domain.xml` "
-"ファイルを編集します。"
+"配布物内の `standalone.xml` 、 `standalone-ha.xml` 、  `domain.xml` ファイルを編集します。"
 
 #. type: Plain text
 msgid ""
 "The location of this file depends on your <<_operating-mode, operating "
 "mode>>.  Here is a sample config file."
-msgstr ""
-"このファイルの場所は、あなたの<_operating-mode, operating mode>&lt;&gt;</_operating-"
-"mode,>に依存します。<_operating-mode, operating mode> "
-"以下に設定ファイルのサンプルを示します。</_operating-mode,>"
+msgstr "このファイルの場所は、<<_operating-mode, 動作モード>>に依存します。以下に設定ファイルのサンプルを示します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -75,7 +71,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Set the `enabled` attribute to false for the cache you want to disable."
-msgstr "無効にしたいキャッシュの `enabled` 属性を false に設定します。"
+msgstr "無効にしたいキャッシュの `enabled` 属性をfalseに設定します。"
 
 #. type: Plain text
 msgid "Reboot your server for this change to take effect."

--- a/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,27 +19,38 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
-#: source/server_installation/topics/cache/disable.adoc:2
+#. type: Block title
 #, no-wrap
-msgid "Disabling Caching"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Attribute :installguide_disablingcaching_name:
+#, no-wrap
+msgid "Disabling caching"
 msgstr "キャッシングの無効化"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/disable.adoc:8
-#, no-wrap
+msgid "You can disable the realm or user cache."
+msgstr "レルムやユーザーキャッシュを無効にすることができます。"
+
+#. type: Plain text
 msgid ""
-"To disable the realm or user cache, you must edit the `standalone.xml`, `standalone-ha.xml`,\n"
-" or `domain.xml` file in your distribution.  The location of this file \n"
-"depends on your <<_operating-mode, operating mode>>.  \n"
-"Here's what the config looks like initially.\n"
+"Edit the `standalone.xml`, `standalone-ha.xml`, or `domain.xml` file in your"
+" distribution."
 msgstr ""
-"レルムまたはユーザー・キャッシュを無効にするには、配布物内の `standalone.xml` 、 `standalone-ha.xml` または "
-"`domain.xml` を編集する必要があります。このファイルの場所は、<<_operating-mode, "
-"動作モード>>によって異なります。初期状態の設定は以下のようになっています。\n"
+"ディストリビューション内の `standalone.xml`, `standalone-ha.xml`, `domain.xml` "
+"ファイルを編集します。"
+
+#. type: Plain text
+msgid ""
+"The location of this file depends on your <<_operating-mode, operating "
+"mode>>.  Here is a sample config file."
+msgstr ""
+"このファイルの場所は、あなたの<_operating-mode, operating mode>&lt;&gt;</_operating-"
+"mode,>に依存します。<_operating-mode, operating mode> "
+"以下に設定ファイルのサンプルを示します。</_operating-mode,>"
 
 #. type: delimited block -
-#: source/server_installation/topics/cache/disable.adoc:16
 #, no-wrap
 msgid ""
 "    <spi name=\"userCache\">\n"
@@ -47,7 +62,6 @@ msgstr ""
 "    </spi>\n"
 
 #. type: delimited block -
-#: source/server_installation/topics/cache/disable.adoc:20
 #, no-wrap
 msgid ""
 "    <spi name=\"realmCache\">\n"
@@ -59,11 +73,10 @@ msgstr ""
 "    </spi>\n"
 
 #. type: Plain text
-#: source/server_installation/topics/cache/disable.adoc:25
 msgid ""
-"To disable the cache set the `enabled` attribute to false for the cache you "
-"want to disable.  You must reboot your server for this change to take "
-"effect."
-msgstr ""
-"キャッシュを無効にするには、無効にするキャッシュの `enabled` "
-"属性をfalseに設定します。この変更を有効にするには、サーバーを再起動する必要があります。"
+"Set the `enabled` attribute to false for the cache you want to disable."
+msgstr "無効にしたいキャッシュの `enabled` 属性を false に設定します。"
+
+#. type: Plain text
+msgid "Reboot your server for this change to take effect."
+msgstr "この変更を有効にするには、サーバーを再起動してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/disable.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__disable
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
