### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po
@@ -37,7 +37,7 @@ msgid ""
 "the cluster. It is also used to broadcast messages for the replication and "
 "invalidation of distributed caches used by {project_name}."
 msgstr ""
-"デフォルトのクラスタリングサポートには、IPマルチキャストが必要です。マルチキャストは、ネットワークのブロードキャストプロトコルです。このプロトコルは、起動時にクラスタの検出と参加に使用されます。また、{project_name}が使用する分散キャッシュの複製や無効化のためのメッセージをブロードキャストするためにも使用されます。"
+"デフォルトのクラスタリング・サポートには、IPマルチキャストが必要です。マルチキャストは、ネットワークのブロードキャスト・プロトコルです。このプロトコルは、起動時にクラスターの検出と参加に使用されます。また、{project_name}が使用する分散キャッシュのレプリケーションや無効化のためのメッセージをブロードキャストするためにも使用されます。"
 
 #. type: Plain text
 msgid ""
@@ -45,16 +45,16 @@ msgid ""
 "of the box, the bind addresses for clustering are bound to a private network"
 " interface with 127.0.0.1 as default IP address."
 msgstr ""
-"project_name} のクラスタリングサブシステムは JGroups "
-"スタックで動作しています。クラスタリング用のバインドアドレスは、デフォルトIPアドレスとして127.0.0.1を持つプライベートネットワークインターフェースにバインドされています。"
+"{project_name} "
+"のクラスタリング・サブシステムはJGroupsスタックで動作しています。クラスタリング用のバインドアドレスは、デフォルトIPアドレスとして127.0.0.1を持つプライベート・ネットワーク・インターフェースにバインドされています。"
 
 #. type: Plain text
 msgid ""
 "Edit your the _standalone-ha.xml_ or _domain.xml_ sections discussed in the "
 "<<_bind-address,Bind Address>> chapter."
 msgstr ""
-"<_bind-address,Bind Address>&lt;&gt;の章</_bind-address,Bind>で説明した_standalone-"
-"ha.xml_または_domain.xml_セクションを編集してください。"
+"<<_bind-address,Bind Address>>の章で説明した _standalone-ha.xml_ または _domain.xml_ "
+"のセクションを編集してください。"
 
 #. type: Block title
 #, no-wrap
@@ -104,8 +104,8 @@ msgid ""
 "`jboss.default.multicast.address` as well as the ports of the services on "
 "the clustering stack."
 msgstr ""
-"クラスタリングスタック上のサービスの `jboss.bind.address.private` と "
-"`jboss.default.multicast.address` 、およびポートを設定します。"
+"クラスタリングスタック上のサービスのポートと同様に、 `jboss.bind.address.private` と  "
+"`jboss.default.multicast.address`  を設定します。"
 
 #. type: Plain text
 msgid ""
@@ -114,5 +114,5 @@ msgid ""
 "link:{appserver_jgroups_link}[JGroups] in the _{appserver_jgroups_name}_."
 msgstr ""
 "IPマルチキャストなしで{project_name}をクラスタリングすることは可能ですが、このトピックはこのガイドの説明範囲を超えています。詳しくは、 "
-"_{appserver_jgroups_name}_ "
-"内のlink:{appserver_jgroups_link}[JGroups]を参照してください。"
+"_{appserver_jgroups_name}_ 内の link:{appserver_jgroups_link}[JGroups] "
+"を参照してください。"

--- a/i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,31 +20,41 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
 #. type: Title ===
 #, no-wrap
-msgid "Multicast Network Setup"
-msgstr "マルチキャスト・ネットワークの設定"
+msgid "Setting up multicast networking"
+msgstr "マルチキャストネットワークの設定"
 
 #. type: Plain text
 msgid ""
-"Out of the box clustering support needs IP Multicast. Multicast is a network"
-" broadcast protocol. This protocol is used at boot time to discover and join"
-" the cluster. It is also used to broadcast messages for the replication and "
+"The default clustering support needs IP Multicast. Multicast is a network "
+"broadcast protocol. This protocol is used at boot time to discover and join "
+"the cluster. It is also used to broadcast messages for the replication and "
 "invalidation of distributed caches used by {project_name}."
 msgstr ""
-"ほとんど設定せずにクラスタリングを利用するには、IPマルチキャストが必要となります。マルチキャストとはネットワーク・ブロードキャスト・プロトコルのことです。このプロトコルは、起動時にクラスターを検出して参加させるために使用されます。また、{project_name}が使用する分散キャッシュのレプリケーションおよび無効化のためのメッセージをブロードキャストするためにも使用されます。"
+"デフォルトのクラスタリングサポートには、IPマルチキャストが必要です。マルチキャストは、ネットワークのブロードキャストプロトコルです。このプロトコルは、起動時にクラスタの検出と参加に使用されます。また、{project_name}が使用する分散キャッシュの複製や無効化のためのメッセージをブロードキャストするためにも使用されます。"
 
 #. type: Plain text
 msgid ""
 "The clustering subsystem for {project_name} runs on the JGroups stack. Out "
 "of the box, the bind addresses for clustering are bound to a private network"
-" interface with 127.0.0.1 as default IP address.  You have to edit your the "
-"_standalone-ha.xml_ or _domain.xml_ sections discussed in the <<_bind-"
-"address,Bind Address>> chapter."
+" interface with 127.0.0.1 as default IP address."
 msgstr ""
-"{project_name}のクラスタリング・サブシステムは、JGroupsスタック上で実行されます。クラスタリングのためのバインドアドレスは、デフォルトのIPアドレスとして127.0.0.1で、プライベート・ネットワーク・インターフェイスにバインドされています"
-"。<<_bind-address,バインドアドレス>>の章で説明した _standalone-ha.xml_ または _domain.xml_ "
-"セクションを編集する必要があります。"
+"project_name} のクラスタリングサブシステムは JGroups "
+"スタックで動作しています。クラスタリング用のバインドアドレスは、デフォルトIPアドレスとして127.0.0.1を持つプライベートネットワークインターフェースにバインドされています。"
+
+#. type: Plain text
+msgid ""
+"Edit your the _standalone-ha.xml_ or _domain.xml_ sections discussed in the "
+"<<_bind-address,Bind Address>> chapter."
+msgstr ""
+"<_bind-address,Bind Address>&lt;&gt;の章</_bind-address,Bind>で説明した_standalone-"
+"ha.xml_または_domain.xml_セクションを編集してください。"
 
 #. type: Block title
 #, no-wrap
@@ -85,12 +100,12 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Things you'll want to configure are the `jboss.bind.address.private` and "
+"Configure the `jboss.bind.address.private` and "
 "`jboss.default.multicast.address` as well as the ports of the services on "
 "the clustering stack."
 msgstr ""
-"設定したい項目は `jboss.bind.address.private` 、 `jboss.default.multicast.address` "
-"そしてクラスタリング・スタック上のサービスのポートになるでしょう。"
+"クラスタリングスタック上のサービスの `jboss.bind.address.private` と "
+"`jboss.default.multicast.address` 、およびポートを設定します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/multicast.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__multicast
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
