### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
@@ -23,7 +23,7 @@ msgstr ""
 #. type: Title ==
 #, no-wrap
 msgid "Configuring {project_name} to run in a cluster"
-msgstr "project_name}をクラスターで動作させるための設定"
+msgstr "{project_name}をクラスターで実行させるための設定"
 
 #. type: Plain text
 msgid ""
@@ -53,8 +53,7 @@ msgid ""
 "balancer and supplying a private network as well as booting up a host in the"
 " cluster."
 msgstr ""
-"操作モードの選択と共有データベースの設定については、本ガイドの前半で説明しました。  "
-"本章では、ロードバランサーの設定、プライベートネットワークの提供、クラスター内のホストの起動について説明します。"
+"動作モードの選択と共有データベースの設定については、本ガイドの前半で説明しました。本章では、ロードバランサーの設定、プライベート・ネットワークの提供、クラスター内のホストの起動について説明します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po
@@ -3,11 +3,16 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,17 +20,15 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Attribute :installguide_clustering_name:
+#. type: Title ==
 #, no-wrap
-msgid "Clustering"
-msgstr "クラスタリング"
+msgid "Configuring {project_name} to run in a cluster"
+msgstr "project_name}をクラスターで動作させるための設定"
 
 #. type: Plain text
 msgid ""
-"This section covers configuring {project_name} to run in a cluster.  There's"
-" a number of things you have to do when setting up a cluster, specifically:"
-msgstr ""
-"このセクションでは、{project_name}をクラスター内で実行するように設定する方法について説明します。クラスターを設定する場合、多くの設定が必要になります。具体的には以下のとおりです。"
+"To configure {project_name} to run in a cluster, you perform these actions:"
+msgstr "{project_name}をクラスターで実行するように設定するには、以下の操作を行います。"
 
 #. type: Plain text
 msgid "<<_operating-mode,Pick an operation mode>>"
@@ -46,11 +49,12 @@ msgstr "IPマルチキャストをサポートするプライベート・ネッ�
 #. type: Plain text
 msgid ""
 "Picking an operation mode and configuring a shared database have been "
-"discussed earlier in this guide.  In this chapter we'll discuss setting up a"
-" load balancer and supplying a private network.  We'll also discuss some "
-"issues that you need to be aware of when booting up a host in the cluster."
+"discussed earlier in this guide.  This chapter describes setting up a load "
+"balancer and supplying a private network as well as booting up a host in the"
+" cluster."
 msgstr ""
-"動作モードの選択と共有データベースの設定については、このガイドの前半で説明しました。この章では、ロードバランサーの設定とプライベート・ネットワークの提供について説明します。また、クラスター内でホストを起動する場合の注意点についても説明します。"
+"操作モードの選択と共有データベースの設定については、本ガイドの前半で説明しました。  "
+"本章では、ロードバランサーの設定、プライベートネットワークの提供、クラスター内のホストの起動について説明します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
