### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po
@@ -21,14 +21,15 @@ msgstr ""
 #. type: Title =
 #, no-wrap
 msgid "Setting up cross-site with {jdgserver_name} {jdgserver_version_latest}"
-msgstr "{jdgserver_name}でクロスサイトを設定する{jdgserver_version_latest}"
+msgstr "{jdgserver_name} {jdgserver_version_latest}でクロスサイトを設定する"
 
 #. type: Plain text
 msgid ""
 "Use the following procedures for {jdgserver_name} {jdgserver_version_latest}"
 " to perform a basic setup of cross-site replication."
 msgstr ""
-"以下の手順で{jdgserver_name}。{jdgserver_version_latest}クロスサイトレプリケーションの基本的な設定を行います。"
+"以下の手順で、{jdgserver_name} "
+"{jdgserver_version_latest}のクロスサイト・レプリケーションの基本的な設定を行います。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po
@@ -4,13 +4,13 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,16 +20,15 @@ msgstr ""
 
 #. type: Title =
 #, no-wrap
-msgid "Setting Up Cross DC with {jdgserver_name} {jdgserver_version_latest}"
-msgstr "{jdgserver_name} {jdgserver_version_latest}を使用したクロスDCの設定"
+msgid "Setting up cross-site with {jdgserver_name} {jdgserver_version_latest}"
+msgstr "{jdgserver_name}でクロスサイトを設定する{jdgserver_version_latest}"
 
 #. type: Plain text
 msgid ""
 "Use the following procedures for {jdgserver_name} {jdgserver_version_latest}"
-" to perform a basic setup of Cross-Datacenter replication."
+" to perform a basic setup of cross-site replication."
 msgstr ""
-"{jdgserver_name} "
-"{jdgserver_version_latest}に対して次の手順を使用して、データセンター間レプリケーションの基本的なセットアップを実行します。"
+"以下の手順で{jdgserver_name}。{jdgserver_version_latest}クロスサイトレプリケーションの基本的な設定を行います。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operating-mode/crossdc/assembly-setting-up-crossdc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operating-mode__crossdc__assembly-setting-up-crossdc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
