### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,11 +26,6 @@ msgstr "アダプターのインストール"
 
 #. type: Plain text
 msgid ""
-"Each adapter is a separate download on the {project_name} download site."
-msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードできます。"
-
-#. type: Plain text
-msgid ""
 "We only test and maintain adapter with the most recent version of WildFly "
 "available upon the release. Once new version of WildFly is released, the "
 "current adapters become deprecated and support for them will be removed "
@@ -40,6 +35,38 @@ msgid ""
 msgstr ""
 "今回のリリースでは、WildFlyの最新バージョンでのみアダプターのテストとメンテナンスを行っています。WildFlyの新しいバージョンがリリースされると、現在のアダプターは非推奨になり、WildFlyの次のリリース後にサポートが削除されます。もう一つの選択肢は、JBoss"
 " EAPアダプターの場合はより長期間サポートされるので、アプリケーションをWildFlyからJBoss EAPに切り替えることです。"
+
+#. type: Block title
+#, no-wrap
+msgid "WildFly 11 or newer"
+msgstr "WildFly 11以上"
+
+#. type: Block title
+#, no-wrap
+msgid "JBoss EAP 7.1 or newer"
+msgstr "JBoss EAP 7.1以上"
+
+#. type: Title =====
+#, no-wrap
+msgid "JBoss SSO"
+msgstr "JBoss SSO"
+
+#. type: Plain text
+msgid ""
+"{appserver_name} has built-in support for single sign-on for web "
+"applications deployed to the same {appserver_name} instance. This should not"
+" be enabled when using {project_name}."
+msgstr ""
+"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。これは、{project_name}を使用しているときは有効にしないでください。"
+
+#. type: Plain text
+msgid "The security context is propagated to the EJB tier automatically."
+msgstr "セキュリティー・コンテキストは、EJB層に自動的に伝播されます。"
+
+#. type: Plain text
+msgid ""
+"Each adapter is a separate download on the {project_name} download site."
+msgstr "各アダプターは、{project_name}のダウンロード・サイトで個別にダウンロードできます。"
 
 #. type: Plain text
 msgid "Install on WildFly 9 or newer or on JBoss EAP 7:"
@@ -119,11 +146,6 @@ msgid ""
 "Start the server and run the script from the server's bin directory:"
 msgstr "サーバー設定の変更に役立つCLIスクリプトがあります。サーバーを起動し、サーバーの `bin` ディレクトリーからスクリプトを実行します。"
 
-#. type: Block title
-#, no-wrap
-msgid "WildFly 11 or newer"
-msgstr "WildFly 11以上"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -142,10 +164,10 @@ msgstr "WildFly 10以下"
 #, no-wrap
 msgid ""
 "$ cd $JBOSS_HOME\n"
-"$ /bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
+"$ ./bin/jboss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
 msgstr ""
 "$ cd $JBOSS_HOME\n"
-"$ /bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
+"$ ./bin/jboss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
 
 #. type: Plain text
 msgid ""
@@ -158,22 +180,8 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "JBoss EAP 7.1 or newer"
-msgstr "JBoss EAP 7.1以上"
-
-#. type: Block title
-#, no-wrap
 msgid "JBoss EAP 7.0 and EAP 6.4"
 msgstr "JBoss EAP 7.0とEAP 6.4"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"$ cd $JBOSS_HOME\n"
-"$ ./bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
-msgstr ""
-"$ cd $JBOSS_HOME\n"
-"$ ./bin/boss-cli.sh -c --file=bin/adapter-install-saml.cli\n"
 
 #. type: Plain text
 msgid ""
@@ -257,20 +265,3 @@ msgstr ""
 "          </authentication>\n"
 "      </security-domain>\n"
 "    </security-domains>\n"
-
-#. type: Plain text
-msgid "The security context is propagated to the EJB tier automatically."
-msgstr "セキュリティー・コンテキストは、EJB層に自動的に伝播されます。"
-
-#. type: Title =====
-#, no-wrap
-msgid "JBoss SSO"
-msgstr "JBoss SSO"
-
-#. type: Plain text
-msgid ""
-"{appserver_name} has built-in support for single sign-on for web "
-"applications deployed to the same {appserver_name} instance. This should not"
-" be enabled when using {project_name}."
-msgstr ""
-"{appserver_name}には、同じ{appserver_name}インスタンスにデプロイされたWebアプリケーションのシングル・サインオンのサポートが組み込まれています。これは、{project_name}を使用しているときは有効にしないでください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/jboss-adapter/jboss_adapter_installation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__jboss-adapter__jboss_adapter_installation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
