### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,8 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Socket Port Bindings"
-msgstr "ソケットポート・バインディング"
+msgid "Socket port bindings"
+msgstr "ソケット・ポート・バインディング"
 
 #. type: Plain text
 msgid ""
@@ -34,8 +34,8 @@ msgid ""
 "_.../standalone/configuration/standalone.xml_.  Search for `socket-binding-"
 "group`."
 msgstr ""
-"各ソケット用に開けられたポートには、コマンドラインまたは設定内で上書きできるデフォルト値があらかじめ定義されています。この設定方法を学ぶために"
-"、<<_standalone-mode,スタンドアローン・モード>>で実行していると仮定し、 "
+"各ソケット用に開けられたポートには、コマンドラインまたは設定内で上書きできるデフォルト値があらかじめ定義されています。この設定方法を学ぶために、<<_standalone-"
+"mode,スタンドアローン・モード>>で実行していると仮定し、 "
 "_.../standalone/configuration/standalone.xml_ を開いてみましょう。そして `socket-binding-"
 "group` を検索します。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/network/ports.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__network__ports
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
