### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po
@@ -5,14 +5,14 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Replication and Failover"
+msgid "Replication and failover"
 msgstr "レプリケーションとフェイルオーバー"
 
 #. type: Plain text
@@ -89,5 +89,5 @@ msgid ""
 "     as {project_name} server, where the particular request is served, will be usually the owner of the data from the distributed cache\n"
 "     and will therefore be able to look up the data locally. See <<sticky-sessions>> for more details.\n"
 msgstr ""
-"スティッキー・セッションでロードバランサーを使用するように環境を設定することは、一般的には賢明です。通常は、特定のリクエストが処理される{project_name}サーバーが分散キャッシュデータの所有者であるため、ローカルでデータをルックアップできますので、パフォーマンスを向上させるために有益です。詳細は"
-"<<sticky-sessions>>を参照してください。\n"
+"スティッキー・セッションでロードバランサーを使用するように環境を設定することは、一般的には賢明です。通常は、特定のリクエストが処理される{project_name}サーバーが分散キャッシュデータの所有者であるため、ローカルでデータをルックアップできますので、パフォーマンスを向上させるために有益です。詳細は<<sticky-"
+"sessions>>を参照してください。\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/replication.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__replication
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
