### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/cache/eviction.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/cache/eviction.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/cache/eviction.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2018\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Eviction and Expiration"
+msgid "Eviction and expiration"
 msgstr "退避と有効期限"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/cache/eviction.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__cache__eviction
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
