### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Configure SPI Providers"
+msgid "Configure SPI providers"
 msgstr "SPIプロバイダーの設定"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/config-subsystem/configure-spi-providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__config-subsystem__configure-spi-providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
