### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/operator/monitoring-stack.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/operator/monitoring-stack.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/operator/monitoring-stack.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,20 +19,20 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Block title
+#. type: Title ==
 #, no-wrap
 msgid "Prerequisites"
 msgstr "前提条件"
 
 #. type: Block title
 #, no-wrap
-msgid "Additional resources"
-msgstr "追加のリソース"
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Block title
 #, no-wrap
-msgid "Procedure"
-msgstr "手順"
+msgid "Additional resources"
+msgstr "追加のリソース"
 
 #. type: Plain text
 msgid ""
@@ -53,8 +53,8 @@ msgstr "{application_monitoring_operator}"
 msgid ""
 "Before using the Operator to install {project_name} or create components, we"
 " recommend that you install the {application_monitoring_operator}, which "
-"that tracks Operator activity. To view metrics for the Operator, you can use"
-" the Grafana Dashboard and Prometheus Alerts from the "
+"tracks Operator activity. To view metrics for the Operator, you can use the "
+"Grafana Dashboard and Prometheus Alerts from the "
 "{application_monitoring_operator}. For example, you can view metrics such as"
 " the number of controller runtime reconciliation loops, the reconcile loop "
 "time, and errors."


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/operator/monitoring-stack.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__operator__monitoring-stack
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
