### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: jic_m_mito <jic-m-mito@nri.co.jp>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +21,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Booting the Cluster"
+msgid "Booting the cluster"
 msgstr "クラスターの起動"
 
 #. type: Plain text
@@ -26,7 +30,7 @@ msgid ""
 "operating mode>>"
 msgstr "クラスター内での{project_name}の起動は<<_operating-mode, 動作モード>>によって異なります。"
 
-#. type: Title ===
+#. type: Block title
 #, no-wrap
 msgid "Standalone Mode"
 msgstr "スタンドアローン・モード"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/booting.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__booting
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
