### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Securing Cluster Communication"
+msgid "Secure cluster communication"
 msgstr "クラスター通信のセキュリティー保護"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/securing-cluster-comm.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__securing-cluster-comm
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
