### PR TITLE
Translations for i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -89,14 +89,12 @@ msgstr "{project_name}は認証セッションを任意のID（たとえば123�
 msgid ""
 "Infinispan distributed cache assigns the primary owner of the session based "
 "on the hash of session ID.  See "
-"link:https://infinispan.org/docs/stable/titles/configuring/configuring.html"
-"#distribution-configuring[Infinispan documentation] for more details around "
-"this.  Let's assume that Infinispan assigned `node2` to be the owner of this"
-" session."
+"link:https://infinispan.org/docs/10.1.x/titles/configuring/configuring.html#clustered_caches[Infinispan"
+" documentation] for more details around this.  Let's assume that Infinispan "
+"assigned `node2` to be the owner of this session."
 msgstr ""
-"Infinispanの分散キャッシュは、セッションIDのハッシュに基づいてセッションの主な所有者を割り当てます。これに関する詳細は、link:https://infinispan.org/docs/stable/titles/configuring/configuring.html"
-"#distribution-configuring[Infinispan "
-"documentation]を参照してください。Infinispanがこのセッションの所有者として `node2` を割り当てたとしましょう。"
+"Infinispanの分散キャッシュは、セッションIDのハッシュに基づいてセッションの主な所有者を割り当てます。これに関する詳細は、link:https://infinispan.org/docs/10.1.x/titles/configuring/configuring.html#clustered_caches[Infinispan"
+" documentation]を参照してください。Infinispanがこのセッションの所有者として `node2` を割り当てたとしましょう。"
 
 #. type: Plain text
 msgid ""
@@ -195,9 +193,9 @@ msgid ""
 "`RHSSO_HOME/standalone/configuration/standalone-ha.xml` file in the "
 "{project_name} subsystem configuration:"
 msgstr ""
-"必要に応じて、{project_name}サブシステム設定の `RHSSO_HOME/standalone/configuration"
-"/standalone-ha.xml` ファイルに以下を追加することにより、`AUTH_SESSION_ID` "
-"Cookieへの経路情報の追加を無効にすることができます。"
+"必要に応じて、{project_name}サブシステム設定の "
+"`RHSSO_HOME/standalone/configuration/standalone-ha.xml` "
+"ファイルに以下を追加することにより、`AUTH_SESSION_ID` Cookieへの経路情報の追加を無効にすることができます。"
 
 #. type: delimited block -
 #, no-wrap

--- a/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po
@@ -93,8 +93,8 @@ msgid ""
 " documentation] for more details around this.  Let's assume that Infinispan "
 "assigned `node2` to be the owner of this session."
 msgstr ""
-"Infinispanの分散キャッシュは、セッションIDのハッシュに基づいてセッションの主な所有者を割り当てます。これに関する詳細は、link:https://infinispan.org/docs/10.1.x/titles/configuring/configuring.html#clustered_caches[Infinispan"
-" documentation]を参照してください。Infinispanがこのセッションの所有者として `node2` を割り当てたとしましょう。"
+"Infinispanの分散キャッシュは、セッションIDのハッシュに基づいてセッションの主な所有者を割り当てます。これに関する詳細は、link:https://infinispan.org/docs/10.1.x/titles/configuring/configuring.html#clustered_caches[Infinispanのドキュメント]を参照してください。Infinispanがこのセッションの所有者として"
+" `node2` を割り当てたとしましょう。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_installation/topics/clustering/sticky-sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_installation__topics__clustering__sticky-sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
