### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -57,7 +57,8 @@ msgstr ""
 msgid ""
 "You can also download package from npm: "
 "https://www.npmjs.com/package/keycloak-js"
-msgstr "npmからパッケージをダウンロードすることもできます。https://www.npmjs.com/package/keycloak-js"
+msgstr ""
+"npm（https://www.npmjs.com/package/keycloak-js）からパッケージをダウンロードすることもできます。"
 
 #. type: Plain text
 msgid ""
@@ -1313,11 +1314,11 @@ msgstr "login(options)"
 
 #. type: Plain text
 msgid "Redirects to login form."
-msgstr "ログインフォームにリダイレクトします。"
+msgstr "ログイン画面にリダイレクトします。"
 
 #. type: Plain text
 msgid "Options is an optional Object, where:"
-msgstr "Optionsは、オプションのObjectで、ここでは"
+msgstr "Optionsは、以下のオプションのObjectです。"
 
 #. type: Plain text
 msgid "redirectUri - Specifies the uri to redirect to after login."
@@ -1386,7 +1387,7 @@ msgid ""
 "first and redirect after authenticated), otherwise to login page."
 msgstr ""
 "action - 値が `register` の場合、ユーザーは登録ページにリダイレクトされ、値が `UPDATE_PASSWORD` "
-"の場合、ユーザーはパスワードリセットページにリダイレクトされます（認証されていない場合は、まずログインページに送られ、認証された後にリダイレクトされます）。"
+"の場合、ユーザーはパスワード・リセット・ページにリダイレクトされます（認証されていない場合は、まずログイン画面に送られ、認証された後にリダイレクトされます）。それ以外の場合はログイン画面にリダイレクトされます。"
 
 #. type: Plain text
 msgid ""
@@ -1418,7 +1419,7 @@ msgstr "createLoginUrl(options)"
 
 #. type: Plain text
 msgid "Returns the URL to login form."
-msgstr "ログインフォームのURLを返します。"
+msgstr "ログイン画面のURLを返します。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,6 +52,12 @@ msgid ""
 "sure you upgrade the adapter only after you have upgraded the server."
 msgstr ""
 "{project_name}サーバーをアップグレードする際に自動的にJavaScriptアダプターが更新されるため、ベスト・プラクティスは{project_name}サーバーからJavaScriptアダプターを直接ロードすることです。そうではなくアダプターをWebアプリケーションにコピーする場合は、サーバーをアップグレードした後に、アダプターもアップグレードするようにしてください。"
+
+#. type: Plain text
+msgid ""
+"You can also download package from npm: "
+"https://www.npmjs.com/package/keycloak-js"
+msgstr "npmからパッケージをダウンロードすることもできます。https://www.npmjs.com/package/keycloak-js"
 
 #. type: Plain text
 msgid ""
@@ -1307,11 +1312,12 @@ msgid "login(options)"
 msgstr "login(options)"
 
 #. type: Plain text
-msgid ""
-"Redirects to login form on (options is an optional object with redirectUri "
-"and/or prompt fields)."
-msgstr ""
-"ログイン・フォームにリダイレクトします（optionsは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+msgid "Redirects to login form."
+msgstr "ログインフォームにリダイレクトします。"
+
+#. type: Plain text
+msgid "Options is an optional Object, where:"
+msgstr "Optionsは、オプションのObjectで、ここでは"
 
 #. type: Plain text
 msgid "redirectUri - Specifies the uri to redirect to after login."
@@ -1375,9 +1381,12 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "action - If value is `register` then user is redirected to registration "
-"page, otherwise to login page."
+"page, if the value is `UPDATE_PASSWORD` then the user will redirected to the"
+" reset password page (if not authenticated will send user to login page "
+"first and redirect after authenticated), otherwise to login page."
 msgstr ""
-"action - 値が `register` の場合、ユーザーは登録ページにリダイレクトされ、そうでない場合はログイン・ページにリダイレクトされます。"
+"action - 値が `register` の場合、ユーザーは登録ページにリダイレクトされ、値が `UPDATE_PASSWORD` "
+"の場合、ユーザーはパスワードリセットページにリダイレクトされます（認証されていない場合は、まずログインページに送られ、認証された後にリダイレクトされます）。"
 
 #. type: Plain text
 msgid ""
@@ -1408,17 +1417,14 @@ msgid "createLoginUrl(options)"
 msgstr "createLoginUrl(options)"
 
 #. type: Plain text
-msgid ""
-"Returns the URL to login form on (options is an optional object with "
-"redirectUri and/or prompt fields)."
-msgstr ""
-"ログイン・フォームへのURLを返します（optionsは、redirectUriおよび/またはpromptフィールドを持つ任意のオブジェクトです）。"
+msgid "Returns the URL to login form."
+msgstr "ログインフォームのURLを返します。"
 
 #. type: Plain text
 msgid ""
-"Options is an Object, which supports same options like the function `login` "
-"."
-msgstr "optionsはオブジェクトで、 `login` 関数と同様のオプションをサポートします。"
+"Options is an optional Object, which supports same options as the function "
+"`login` ."
+msgstr "Options はオプションのオブジェクトで、関数 `login` と同じオプションをサポートします。"
 
 #. type: Title ======
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/javascript-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__javascript-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
