### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,21 +19,21 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Plain text
 #, no-wrap
 msgid "Logout"
 msgstr "ログアウト"
 
 #. type: Plain text
 msgid ""
-"There are multiple ways you can logout from a web application.  For Java EE "
-"servlet containers, you can call `HttpServletRequest.logout()`. For any "
+"There are multiple ways you can logout from a web application.  For Jakarta "
+"EE servlet containers, you can call `HttpServletRequest.logout()`. For any "
 "other browser application, you can point the browser at any url of your web "
 "application that has a security constraint and pass in a query parameter "
 "GLO, i.e. `$$http://myapp?GLO=true$$`.  This will log you out if you have an"
 " SSO session with your browser."
 msgstr ""
-"Webアプリケーションからログアウトするには、複数の方法があります。Java EEサーブレット・コンテナーの場合は、 "
+"Webアプリケーションからログアウトするには、複数の方法があります。Jakarta EEサーブレット・コンテナーの場合は、 "
 "`HttpServletRequest.logout()` "
 "を呼び出すことができます。他のブラウザーアプリケーションでは、ブラウザーにセキュリティー制約のあるWebアプリケーションのURLを指定し、クエリー・パラメーターGLO、つまり、"
 " `$$http://myapp?GLO=true$$` "
@@ -134,14 +134,14 @@ msgstr ""
 
 #. type: Title =====
 #, no-wrap
-msgid "Logout in Cross DC Scenario"
-msgstr "クロスDCシナリオでのログアウト"
+msgid "Logout in cross-site scenario"
+msgstr "クロスサイトのシナリオでのログアウト"
 
 #. type: Plain text
 msgid ""
-"The cross DC scenario only applies to WildFly 10 and higher, and EAP 7 and "
-"higher."
-msgstr "クロスDCシナリオは、WildFly 10以上、EAP 7以上にのみ適用されます。"
+"The cross-site scenario only applies to WildFly 10 and higher, and EAP 7 and"
+" higher."
+msgstr "クロスサイトのシナリオは、WildFly 10以上、EAP 7以上にのみ適用されます。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/logout.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__logout
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
