### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -85,20 +85,20 @@ msgid ""
 "the link:https://docs.docker.com/registry/configuration/[registry config "
 "file specification] for more information on how the file should be set up, "
 "or start with "
-"link:https://github.com/distribution/distribution/blob/main/cmd/registry"
-"/config-example.yml[a basic example]."
+"link:https://github.com/distribution/distribution/blob/main/cmd/registry/config-"
+"example.yml[a basic example]."
 msgstr ""
-"この出力は、既存のレジストリー設定ファイルにコピーできます。ファイルの設定方法の詳細については、link:https://docs.docker.com/registry/configuration/[レジストリー設定ファイルの仕様]を参照してください。または、link:https://github.com/distribution/distribution/blob/main/cmd/registry"
-"/config-example.yml[基本的な例]から始めてください。"
+"この出力は、既存のレジストリー設定ファイルにコピーできます。ファイルの設定方法の詳細については、link:https://docs.docker.com/registry/configuration/[レジストリー設定ファイルの仕様]を参照してください。または、link:https://github.com/distribution/distribution/blob/main/cmd/registry/config-"
+"example.yml[基本的な例]から始めてください。"
 
 #. type: Plain text
 msgid ""
 "Don't forget to configure the `rootcertbundle` field with the location of "
-"the {project_name} realm's public certificate.  The auth configuration will "
-"not work without this argument."
+"the {project_name} realm's public key.  The auth configuration will not work"
+" without this argument."
 msgstr ""
 "`rootcertbundle` "
-"フィールドに{project_name}のレルムの公開証明書の場所を設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"
+"フィールドに{project_name}のレルムの公開鍵の場所を設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"
 
 #. type: Title ===
 #, no-wrap
@@ -131,11 +131,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "Don't forget to configure the `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` override "
-"with the location of the {project_name} realm's public certificate.  The "
-"auth configuration will not work without this argument."
+"with the location of the {project_name} realm's public key.  The auth "
+"configuration will not work without this argument."
 msgstr ""
 "`REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` "
-"オーバーライドを{project_name}レルムの公開証明書の場所で設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"
+"オーバーライドを{project_name}レルムの公開鍵の場所で設定するのを忘れないでください。auth設定は、この引数なしでは動作しません。"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/docker/docker-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__docker__docker-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
