### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po
@@ -5,25 +5,20 @@
 # 
 # Translators:
 # KojiNose <knose.dev@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Title ====
-#, no-wrap
-msgid "Installation"
-msgstr "インストール"
 
 #. type: delimited block -
 #, no-wrap
@@ -111,9 +106,8 @@ msgid ""
 "skipPattern is configured."
 msgstr ""
 "設定された `url-patterns` "
-"の下にあるいくつかのパスを除外する必要がある場合は、keycloakフィルターが直ちにフィルター・チェーンに委譲すべきパス・パターンを記述する正規表現を設定するために"
-"、フィルターのinit-param `keycloak.config.skipPattern` "
-"を使用できます。デフォルトでは、skipPatternは設定されていません。"
+"の下にあるいくつかのパスを除外する必要がある場合は、keycloakフィルターが直ちにフィルター・チェーンに委譲すべきパス・パターンを記述する正規表現を設定するために、フィルターのinit-"
+"param `keycloak.config.skipPattern` を使用できます。デフォルトでは、skipPatternは設定されていません。"
 
 #. type: Plain text
 msgid ""
@@ -157,6 +151,30 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
+"If you need to customize the session ID mapper, you can configure the fully "
+"qualified name of the class in the Filter init-param "
+"keycloak.config.idMapper. Session ID mapper is a mapper that is used to map "
+"user IDs and session IDs. By default "
+"org.keycloak.adapters.spi.InMemorySessionIdMapper is configured."
+msgstr ""
+"セッションIDマッパーをカスタマイズする必要がある場合は、Filter init-param "
+"keycloak.config.idMapperでクラスの完全修飾名を設定することができます。セッションIDマッパーは、ユーザIDとセッションIDをマッピングするために使用されるマッパーです。デフォルトではorg.keycloak.adapters.spi.InMemorySessionIdMapperが設定されています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<init-param>\n"
+"    <param-name>keycloak.config.idMapper</param-name>\n"
+"    <param-value>org.keycloak.adapters.spi.InMemorySessionIdMapper</param-value>\n"
+"</init-param>\n"
+msgstr ""
+"<init-param>\n"
+"    <param-name>keycloak.config.idMapper</param-name>\n"
+"    <param-value>org.keycloak.adapters.spi.InMemorySessionIdMapper</param-value>\n"
+"</init-param>\n"
+
+#. type: Plain text
+msgid ""
 "The {project_name} filter has the same configuration parameters as the other"
 " adapters except you must define them as filter init params instead of "
 "context params."
@@ -195,6 +213,11 @@ msgid ""
 msgstr ""
 "サーブレット・フィルター・アダプターは、OSGiバンドルとしてパッケージされているため、HTTP ServiceとHTTP "
 "Whiteboardを使用する汎用OSGi環境（R6以上）で使用できます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Installation"
+msgstr "インストール"
 
 #. type: Plain text
 msgid ""
@@ -407,5 +430,6 @@ msgid ""
 "the-osgi-http-whiteboard[Apache Felix HTTP Service] for more info on "
 "programmatic registration."
 msgstr ""
-"プログラムによる登録の詳細については、 https://github.com/apache/felix-dev/tree/master/http"
-"#using-the-osgi-http-whiteboard[Apache Felix HTTP Service] を参照してください。"
+"プログラムによる登録の詳細については、 https://github.com/apache/felix-"
+"dev/tree/master/http#using-the-osgi-http-whiteboard[Apache Felix HTTP "
+"Service] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/servlet-filter-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__servlet-filter-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
