### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,9 +28,9 @@ msgstr "RoleIdentifiers要素"
 msgid ""
 "The `RoleIdentifiers` element defines what SAML attributes within the "
 "assertion received from the user should be used as role identifiers within "
-"the Java EE Security Context for the user."
+"the Jakarta EE Security Context for the user."
 msgstr ""
-"`RoleIdentifiers` 要素は、ユーザーから受信したアサーション内のどのSAML属性が、Java "
+"`RoleIdentifiers` 要素は、ユーザーから受信したアサーション内のどのSAML属性が、Jakarta "
 "EEのセキュリティー・コンテキスト内のロール識別子として使用されるか定義します。"
 
 #. type: delimited block -
@@ -46,11 +50,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"By default `Role` attribute values are converted to Java EE roles.  Some "
+"By default `Role` attribute values are converted to Jakarta EE roles.  Some "
 "IdPs send roles using a `member` or `memberOf` attribute assertion.  You can"
 " define one or more `Attribute` elements to specify which SAML attributes "
 "must be converted into roles."
 msgstr ""
-"デフォルトでは、 `Role` 属性の値はJava EEのロールに変換されます。いくつかのIdPは、 `member` または `memberOf` "
-"属性アサーションを使用してロールを送信します。どのSAML属性をロールに変換すべきかを指定するために、1つ以上の `Attribute` "
-"要素を定義できます。"
+"デフォルトでは、 `Role` 属性の値はJakarta EEのロールに変換されます。いくつかのIdPは、 `member` または "
+"`memberOf` 属性アサーションを使用してロールを送信します。どのSAML属性をロールに変換すべきかを指定するために、1つ以上の "
+"`Attribute` 要素を定義できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/saml/java/general-config/roleidentifiers_element.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__saml__java__general-config__roleidentifiers_element
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
