### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,31 +19,101 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"    <bean id=\"keycloakConfigResolver\" class=\"org.keycloak.adapters.osgi.BundleBasedKeycloakConfigResolver\" >\n"
-"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
-"    </bean>\n"
-msgstr ""
-"    <bean id=\"keycloakConfigResolver\" class=\"org.keycloak.adapters.osgi.BundleBasedKeycloakConfigResolver\" >\n"
-"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
-"    </bean>\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "</blueprint>\n"
-msgstr "</blueprint>\n"
+#. type: Plain text
+msgid "For example:"
+msgstr "例："
 
 #. type: Title =====
 #, no-wrap
 msgid "Securing an Apache Camel Application"
 msgstr "Apache Camelアプリケーションのセキュリティー保護"
 
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <bean id=\"helloProcessor\" "
+"class=\"org.keycloak.example.CamelHelloProcessor\" />\n"
+msgstr ""
+"    <bean id=\"helloProcessor\" "
+"class=\"org.keycloak.example.CamelHelloProcessor\" />\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "</blueprint>\n"
+msgstr "</blueprint>\n"
+
+#. type: Plain text
+msgid ""
+"The `Import-Package` in `META-INF/MANIFEST.MF` needs to contain these "
+"imports:"
+msgstr "`META-INF/MANIFEST.MF` の `Import-Package` には、以下のインポートが含まれている必要があります。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Camel RestDSL"
+msgstr "Camel RestDSL"
+
+#. type: Plain text
+msgid ""
+"Camel RestDSL is a Camel feature used to define your REST endpoints in a "
+"fluent way. But you must still use specific implementation classes and "
+"provide instructions on how to integrate with {project_name}."
+msgstr ""
+"Camel "
+"RestDSLは、流暢な方法でRESTエンドポイントを定義するために使用されるCamelの機能です。しかし、依然として特定の実装クラスを使用し、{project_name}との統合方法に関する指示を提供する必要があります。"
+
+#. type: Plain text
+msgid ""
+"The way to configure the integration mechanism depends on the Camel "
+"component for which you configure your RestDSL-defined routes."
+msgstr "統合機構を設定する方法は、RestDSLで定義されたルートを設定するCamelコンポーネントによって異なります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<camelContext id=\"blueprintContext\"\n"
+"              trace=\"false\"\n"
+"              xmlns=\"http://camel.apache.org/schema/blueprint\">\n"
+msgstr ""
+"<camelContext id=\"blueprintContext\"\n"
+"              trace=\"false\"\n"
+"              xmlns=\"http://camel.apache.org/schema/blueprint\">\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    </rest>\n"
+msgstr "    </rest>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    <route id=\"justDirect\">\n"
+"        <from uri=\"direct:justDirect\"/>\n"
+"        <process ref=\"helloProcessor\" />\n"
+"        <log message=\"RestDSL correctly invoked ${body}\"/>\n"
+"        <setBody>\n"
+"            <constant>(__This second sentence is returned from a Camel RestDSL endpoint__)</constant>\n"
+"        </setBody>\n"
+"    </route>\n"
+msgstr ""
+"    <route id=\"justDirect\">\n"
+"        <from uri=\"direct:justDirect\"/>\n"
+"        <process ref=\"helloProcessor\" />\n"
+"        <log message=\"RestDSL correctly invoked ${body}\"/>\n"
+"        <setBody>\n"
+"            <constant>(__This second sentence is returned from a Camel RestDSL endpoint__)</constant>\n"
+"        </setBody>\n"
+"    </route>\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "</camelContext>\n"
+msgstr "</camelContext>\n"
+
 #. type: Plain text
 msgid ""
 "You can secure Apache Camel endpoints implemented with the "
-"https://camel.apache.org/components/latest/undertow-component.html[camel-"
+"https://camel.apache.org/components/next/undertow-component.html[camel-"
 "undertow] component by injecting the proper security constraints via "
 "blueprint and updating the used component to `undertow-keycloak`. You have "
 "to add the `OSGI-INF/blueprint/blueprint.xml` file to your Camel application"
@@ -51,7 +121,7 @@ msgid ""
 "mappings, and adapter configuration might differ slightly depending on your "
 "environment and needs."
 msgstr ""
-"https://camel.apache.org/components/latest/undertow-component.html[camel-"
+"https://camel.apache.org/components/next/undertow-component.html[camel-"
 "undertow]コンポーネントで実装されたApache "
 "Camelエンドポイントをセキュリティー保護するには、適切なセキュリティー制約をBlueprintを介して注入し、使用されるコンポーネントを "
 "`undertow-keycloak` に更新します。以下のような設定で、 `OSGI-INF/blueprint/blueprint.xml` "
@@ -82,10 +152,6 @@ msgstr ""
 "`allowedRoles` "
 "はカンマで区切られたロールのリストです。サービスにアクセスするユーザーは、アクセスを許可されるロールを少なくとも1つは持っていなければなりません。"
 
-#. type: Plain text
-msgid "For example:"
-msgstr "例："
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -108,11 +174,13 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"    <bean id=\"helloProcessor\" "
-"class=\"org.keycloak.example.CamelHelloProcessor\" />\n"
+"    <bean id=\"keycloakConfigResolver\" class=\"org.keycloak.adapters.osgi.BundleBasedKeycloakConfigResolver\" >\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"    </bean>\n"
 msgstr ""
-"    <bean id=\"helloProcessor\" "
-"class=\"org.keycloak.example.CamelHelloProcessor\" />\n"
+"    <bean id=\"keycloakConfigResolver\" class=\"org.keycloak.adapters.osgi.BundleBasedKeycloakConfigResolver\" >\n"
+"        <property name=\"bundleContext\" ref=\"blueprintBundleContext\" />\n"
+"    </bean>\n"
 
 #. type: delimited block -
 #, no-wrap
@@ -145,12 +213,6 @@ msgstr ""
 msgid "    </camelContext>\n"
 msgstr "    </camelContext>\n"
 
-#. type: Plain text
-msgid ""
-"The `Import-Package` in `META-INF/MANIFEST.MF` needs to contain these "
-"imports:"
-msgstr "`META-INF/MANIFEST.MF` の `Import-Package` には、以下のインポートが含まれている必要があります。"
-
 #. type: delimited block -
 #, no-wrap
 msgid ""
@@ -173,26 +235,6 @@ msgstr ""
 "org.keycloak.*;version=\"{project_versionMvn}\",\n"
 "org.osgi.service.blueprint,\n"
 "org.osgi.service.blueprint.container\n"
-
-#. type: Title =====
-#, no-wrap
-msgid "Camel RestDSL"
-msgstr "Camel RestDSL"
-
-#. type: Plain text
-msgid ""
-"Camel RestDSL is a Camel feature used to define your REST endpoints in a "
-"fluent way. But you must still use specific implementation classes and "
-"provide instructions on how to integrate with {project_name}."
-msgstr ""
-"Camel "
-"RestDSLは、流暢な方法でRESTエンドポイントを定義するために使用されるCamelの機能です。しかし、依然として特定の実装クラスを使用し、{project_name}との統合方法に関する指示を提供する必要があります。"
-
-#. type: Plain text
-msgid ""
-"The way to configure the integration mechanism depends on the Camel "
-"component for which you configure your RestDSL-defined routes."
-msgstr "統合機構を設定する方法は、RestDSLで定義されたルートを設定するCamelコンポーネントによって異なります。"
 
 #. type: Plain text
 msgid ""
@@ -206,17 +248,6 @@ msgstr ""
 #. type: delimited block -
 #, no-wrap
 msgid ""
-"<camelContext id=\"blueprintContext\"\n"
-"              trace=\"false\"\n"
-"              xmlns=\"http://camel.apache.org/schema/blueprint\">\n"
-msgstr ""
-"<camelContext id=\"blueprintContext\"\n"
-"              trace=\"false\"\n"
-"              xmlns=\"http://camel.apache.org/schema/blueprint\">\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
 "    <!--the link with Keycloak security handlers happens by using undertow-keycloak component -->\n"
 "    <restConfiguration apiComponent=\"undertow-keycloak\" contextPath=\"/restdsl\" port=\"8484\">\n"
 "        <endpointProperty key=\"configResolver\" value=\"#keycloakConfigResolver\" />\n"
@@ -245,34 +276,3 @@ msgstr ""
 "            <description>Just a hello</description>\n"
 "            <to uri=\"direct:justDirect\" />\n"
 "        </get>\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "    </rest>\n"
-msgstr "    </rest>\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid ""
-"    <route id=\"justDirect\">\n"
-"        <from uri=\"direct:justDirect\"/>\n"
-"        <process ref=\"helloProcessor\" />\n"
-"        <log message=\"RestDSL correctly invoked ${body}\"/>\n"
-"        <setBody>\n"
-"            <constant>(__This second sentence is returned from a Camel RestDSL endpoint__)</constant>\n"
-"        </setBody>\n"
-"    </route>\n"
-msgstr ""
-"    <route id=\"justDirect\">\n"
-"        <from uri=\"direct:justDirect\"/>\n"
-"        <process ref=\"helloProcessor\" />\n"
-"        <log message=\"RestDSL correctly invoked ${body}\"/>\n"
-"        <setBody>\n"
-"            <constant>(__This second sentence is returned from a Camel RestDSL endpoint__)</constant>\n"
-"        </setBody>\n"
-"    </route>\n"
-
-#. type: delimited block -
-#, no-wrap
-msgid "</camelContext>\n"
-msgstr "</camelContext>\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse7/camel.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse7__camel
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
