### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,11 +69,11 @@ msgstr "Pax Web Whiteboard Extenderを使用して、FuseにOSGIサービスと�
 #. type: Plain text
 msgid ""
 "https://camel.apache.org/[Apache Camel] Jetty endpoints running with the "
-"https://camel.apache.org/components/latest/jetty-component.html[Camel Jetty]"
-" component"
+"https://camel.apache.org/components/next/jetty-component.html[Camel Jetty] "
+"component"
 msgstr ""
-"https://camel.apache.org/components/latest/jetty-component.html[Camel Jetty]"
-"  コンポーネントで動作する https://camel.apache.org/[Apache Camel] Jettyエンドポイント"
+"https://camel.apache.org/components/next/jetty-component.html[Camel Jetty]  "
+"コンポーネントで動作する https://camel.apache.org/[Apache Camel] Jettyエンドポイント"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/fuse-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__fuse-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
