### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -87,14 +87,12 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "You must unzip the Jetty 9.x distro into Jetty 9.x's "
-"link:https://www.eclipse.org/jetty/documentation/jetty-9/index.html#startup-"
-"base-and-home[base directory].  Including adapter's jars within your WEB-"
-"INF/lib directory will not work! In the example below, the Jetty base is "
-"named `your-base`:"
+"link:https://www.eclipse.org/jetty/documentation/jetty-9/index.html[base "
+"directory].  Including adapter's jars within your WEB-INF/lib directory will"
+" not work! In the example below, the Jetty base is named `your-base`:"
 msgstr ""
 "Jetty 9.x用の配布物をJetty "
-"9.xのlink:https://www.eclipse.org/jetty/documentation/jetty-9/index.html"
-"#startup-base-and-home[baseディレクトリー]に解凍する必要があります。WEB-"
+"9.xのlink:https://www.eclipse.org/jetty/documentation/jetty-9/index.html[baseディレクトリー]に解凍する必要があります。WEB-"
 "INF/libディレクトリー内にアダプターのjarを含めても動作しません！以下の例では、Jettyベースの名前は `your-base` です。"
 
 #. type: delimited block -
@@ -251,8 +249,7 @@ msgid ""
 "yourwar.xml.  Jetty should pick it up.  In this mode, you'll have to declare"
 " keycloak.json configuration directly within the xml file."
 msgstr ""
-"KeycloakでWARをセキュリティー保護するために、WARをオープンする必要はありません。代わりに、yourwar"
-".xmlという名前でwebappsディレクトリーにjetty-"
+"KeycloakでWARをセキュリティー保護するために、WARをオープンする必要はありません。代わりに、yourwar.xmlという名前でwebappsディレクトリーにjetty-"
 "web.xmlファイルを作成します。Jettyはそれをピックアップします。このモードでは、keycloak.jsonの設定をxmlファイル内で直接宣言する必要があります。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/jetty9-adapter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__jetty9-adapter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
