### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/oidc/java/logout.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/oidc/java/logout.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/oidc/java/logout.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,21 +19,21 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Plain text
 #, no-wrap
 msgid "Logout"
 msgstr "ログアウト"
 
 #. type: Plain text
 msgid ""
-"You can log out of a web application in multiple ways.  For Java EE servlet "
-"containers, you can call `HttpServletRequest.logout()`. For other browser "
-"applications, you can redirect the browser to `$$http://auth-"
+"You can log out of a web application in multiple ways.  For Jakarta EE "
+"servlet containers, you can call `HttpServletRequest.logout()`. For other "
+"browser applications, you can redirect the browser to `$$http://auth-"
 "server/auth/realms/{realm-name}/protocol/openid-"
 "connect/logout?redirect_uri=encodedRedirectUri$$`, which logs you out if you"
 " have an SSO session with your browser."
 msgstr ""
-"Webアプリケーションからログアウトする方法は複数あります。Java EEサーブレット・コンテナーの場合、 "
+"Webアプリケーションからログアウトする方法は複数あります。Jakarta EEサーブレット・コンテナーの場合、 "
 "`HttpServletRequest.logout()` "
 "を呼び出すことができます。他のブラウザー・アプリケーションの場合、ブラウザーにSSOセッションがあれば、 `$$http://auth-"
 "server/auth/realms/{realm-name}/protocol/openid-"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/oidc/java/logout.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__oidc__java__logout
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
