### PR TITLE
Translations for i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
+++ b/i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,11 +26,11 @@ msgstr "Token Exchange"
 
 #. type: delimited block =
 msgid ""
-"In order to use token exchange you should also enable the "
-"`admin_fine_grained_authz` feature. Please, take a look at "
+"In order to use token exchange you should also enable the `token_exchange` "
+"feature. Please, take a look at "
 "link:{installguide_profile_link}[{installguide_profile_name}]."
 msgstr ""
-"Token Exchangeを使用するには、 `admin_fine_grained_authz` 機能も有効にする必要があります。 "
+"Token Exchangeを使用するには、 `token_exchange` 機能も有効にする必要があります。 "
 "link:{installguide_profile_link}[{installguide_profile_name}] を参照してください。"
 
 #. type: Plain text
@@ -215,8 +215,8 @@ msgstr ""
 "Connectのみがサポートされています。デフォルト値は、これが `urn:ietf:params:oauth:token-"
 "type:refresh_token` "
 "であるかどうかによって決まります。この場合、レスポンス内でアクセストークンとリフレッシュトークンの両方が返されます。その他の適切な値は "
-"`urn:ietf:params:oauth:token-type:access_token` と `urn:ietf:params:oauth"
-":token-type:id_token` です。"
+"`urn:ietf:params:oauth:token-type:access_token` と "
+"`urn:ietf:params:oauth:token-type:id_token` です。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/securing_apps/topics/token-exchange/token-exchange.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/securing_apps__topics__token-exchange__token-exchange
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
