### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/ref-user-credentials.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/ref-user-credentials.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/ref-user-credentials.ja_JP.po
@@ -32,7 +32,7 @@ msgstr "ユーザー・クレデンシャル"
 
 #. type: Plain text
 msgid "You can manage credentials of a user in the *Credentials* tab."
-msgstr "ユーザーの認証情報は、「Credentials」タブで管理できます。"
+msgstr "ユーザーのクレデンシャルは、「Credentials」タブで管理できます。"
 
 #. type: Block title
 #, no-wrap
@@ -59,7 +59,7 @@ msgid ""
 "priority. The priority determines which credential is displayed first after "
 "a user logs in."
 msgstr ""
-"位置]列の矢印ボタンで、ユーザーに対するクレデンシャルの優先順位を変更することができます。一番上のクレデンシャルが最も高い優先度を持ちます。この優先順位によって、ユーザーがログインした後にどのクレデンシャルが最初に表示されるかが決まります。"
+"「Position」列の矢印ボタンで、ユーザーに対するクレデンシャルの優先順位を変更することができます。一番上のクレデンシャルが最も高い優先度になります。この優先順位によって、ユーザーがログインした後にどのクレデンシャルが最初に表示されるかが決まります。"
 
 #. type: Plain text
 #, no-wrap
@@ -70,7 +70,7 @@ msgstr "Type"
 msgid ""
 "This column displays the type of credential, for example *password* or "
 "*OTP*."
-msgstr "この欄には、*password*や*OTP*など、クレデンシャルの種類が表示されます。"
+msgstr "この欄には、「password」や「OTP」など、クレデンシャルの種類が表示されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -83,7 +83,7 @@ msgid ""
 "selection option during login. It can be set to any value to describe the "
 "credential."
 msgstr ""
-"これは、ログイン時の選択オプションとして提示されたときにクレデンシャルを認識するための割り当て可能なラベルである。クレデンシャルを説明するために任意の値を設定することができる。"
+"これは、ログイン時の選択オプションとして提示されたときにクレデンシャルを認識するための割り当てることができるラベルです。クレデンシャルを説明するために任意の値を設定することができます。"
 
 #. type: Plain text
 msgid ""
@@ -91,7 +91,8 @@ msgid ""
 "is hidden, by default. You can click *Show data...* to display the data for "
 "a\t credential."
 msgstr ""
-"これは、クレデンシャルに関する非機密の技術情報である。デフォルトでは非表示になっています。データを表示...*をクリックすると、クレデンシャルのデータを表示することができます。"
+"これは、クレデンシャルに関する非機密の技術情報です。デフォルトでは非表示になっています。「Show "
+"data...」をクリックすると、クレデンシャルのデータを表示することができます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -103,14 +104,13 @@ msgid ""
 "This column has two actions. Click *Save* to record the value or the user "
 "field. Click *Delete* to remove the credential."
 msgstr ""
-"この列には2つのアクションがあります。Save "
-"\"をクリックすると、ユーザーフィールドの値が記録されます。クレデンシャルを削除するには、*Delete*をクリックします。"
+"この列には2つのアクションがあります。「Save」をクリックすると、ユーザー・フィールドの値が記録されます。クレデンシャルを削除するには、「Delete」をクリックします。"
 
 #. type: Plain text
 msgid ""
 "You cannot configure other types of credentials for a specific user in the "
 "admin console; that task is the user's responsibility."
-msgstr "特定のユーザーに対して、他のタイプの認証情報を管理コンソールで設定することはできません。"
+msgstr "特定のユーザーに対して、他のタイプのクレデンシャルを管理コンソールで設定することはできません。"
 
 #. type: Plain text
 msgid ""
@@ -118,4 +118,4 @@ msgid ""
 "device or if credentials have been compromised. You can only delete "
 "credentials of a user in the *Credentials* tab."
 msgstr ""
-"ユーザーがOTPデバイスを紛失した場合や、認証情報が漏洩した場合に、ユーザーの認証情報を削除することができます。ユーザーの認証情報の削除は、*Credentials*タブでのみ可能です。"
+"ユーザーがOTPデバイスを紛失した場合や、クレデンシャルが漏洩した場合に、ユーザーのクレデンシャルを削除することができます。ユーザーのクレデンシャルの削除は、「Credentials」タブでのみ可能です。"

--- a/i18n/po/ja_JP/server_admin/topics/users/ref-user-credentials.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/ref-user-credentials.ja_JP.po
@@ -1,0 +1,121 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# katakura__pro <h.katakura@pro-japan.co.jp>, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Data"
+msgstr "Data"
+
+#. type: Title =
+#, no-wrap
+msgid "User credentials"
+msgstr "ユーザー・クレデンシャル"
+
+#. type: Plain text
+msgid "You can manage credentials of a user in the *Credentials* tab."
+msgstr "ユーザーの認証情報は、「Credentials」タブで管理できます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Credential management"
+msgstr "クレデンシャル管理"
+
+#. type: Plain text
+msgid "image:{project_images}/user-credentials.png[]"
+msgstr "image:{project_images}/user-credentials.png[]"
+
+#. type: Plain text
+msgid "This tab includes the following fields:"
+msgstr "このタブには以下のフィールドがあります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Position"
+msgstr "Position"
+
+#. type: Plain text
+msgid ""
+"The arrow buttons in the *Position* column allow you to shift the priority "
+"of the credential for the user. The topmost credential has the highest "
+"priority. The priority determines which credential is displayed first after "
+"a user logs in."
+msgstr ""
+"位置]列の矢印ボタンで、ユーザーに対するクレデンシャルの優先順位を変更することができます。一番上のクレデンシャルが最も高い優先度を持ちます。この優先順位によって、ユーザーがログインした後にどのクレデンシャルが最初に表示されるかが決まります。"
+
+#. type: Plain text
+#, no-wrap
+msgid "Type"
+msgstr "Type"
+
+#. type: Plain text
+msgid ""
+"This column displays the type of credential, for example *password* or "
+"*OTP*."
+msgstr "この欄には、*password*や*OTP*など、クレデンシャルの種類が表示されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "User Label"
+msgstr "User Label"
+
+#. type: Plain text
+msgid ""
+"This is an assignable label to recognize the credential when presented as a "
+"selection option during login. It can be set to any value to describe the "
+"credential."
+msgstr ""
+"これは、ログイン時の選択オプションとして提示されたときにクレデンシャルを認識するための割り当て可能なラベルである。クレデンシャルを説明するために任意の値を設定することができる。"
+
+#. type: Plain text
+msgid ""
+"This is the non-confidential technical information about the credential. It "
+"is hidden, by default. You can click *Show data...* to display the data for "
+"a\t credential."
+msgstr ""
+"これは、クレデンシャルに関する非機密の技術情報である。デフォルトでは非表示になっています。データを表示...*をクリックすると、クレデンシャルのデータを表示することができます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Actions"
+msgstr "Actions"
+
+#. type: Plain text
+msgid ""
+"This column has two actions. Click *Save* to record the value or the user "
+"field. Click *Delete* to remove the credential."
+msgstr ""
+"この列には2つのアクションがあります。Save "
+"\"をクリックすると、ユーザーフィールドの値が記録されます。クレデンシャルを削除するには、*Delete*をクリックします。"
+
+#. type: Plain text
+msgid ""
+"You cannot configure other types of credentials for a specific user in the "
+"admin console; that task is the user's responsibility."
+msgstr "特定のユーザーに対して、他のタイプの認証情報を管理コンソールで設定することはできません。"
+
+#. type: Plain text
+msgid ""
+"You can delete the credentials of a user in the event a user loses an OTP "
+"device or if credentials have been compromised. You can only delete "
+"credentials of a user in the *Credentials* tab."
+msgstr ""
+"ユーザーがOTPデバイスを紛失した場合や、認証情報が漏洩した場合に、ユーザーの認証情報を削除することができます。ユーザーの認証情報の削除は、*Credentials*タブでのみ可能です。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/ref-user-credentials.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__ref-user-credentials
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
