### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -4,15 +4,13 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,98 +20,125 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Login Tab"
-msgstr "Loginタブ"
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Plain text
-msgid "image:{project_images}/login-tab.png[]"
-msgstr "image:{project_images}/login-tab.png[]"
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
 
-#. type: Title ===
+#. type: Plain text
+msgid "Click the *Flows* tab."
+msgstr "*Flows* タブをクリックします。"
+
+#. type: Title ==
 #, no-wrap
-msgid "Forgot Password"
-msgstr "パスワード忘れ"
+msgid "Enabling forgot password"
+msgstr "パスワード忘れを有効にする"
 
 #. type: Plain text
 msgid ""
-"If you enable it, users are able to reset their credentials if they forget "
-"their password or lose their OTP generator.  Go to the `Realm Settings` left"
-" menu item, and click on the `Login` tab.  Switch on the `Forgot Password` "
-"switch."
+"If you enable `Forgot Password`, users can reset their login credentials if "
+"they forget their passwords or lose their OTP generator."
 msgstr ""
-"これを有効にすると、ユーザーはパスワードを忘れたり、OTPジェネレーターを無くした場合でも、クレデンシャルをリセットできます。左のメニュー項目の "
-"`Realm Settings` に移動し、 `Login` タブをクリックします。 `Forgot Password` スイッチをオンにします。"
+"`Forgot Password` "
+"を有効にすると、ユーザーがパスワードを忘れたり、OTPジェネレーターを紛失した場合に、ログイン・クレデンシャルをリセットすることができます。"
 
 #. type: Plain text
-msgid "A `forgot password` link will now show up on your login pages."
-msgstr "ログインページに `forgot password` リンクが表示されるようになります。"
+msgid "Click *Realm Settings* in the menu."
+msgstr "メニューの *Realm Settings* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Login* tab."
+msgstr "*Login* タブをクリックします。"
 
 #. type: Block title
 #, no-wrap
-msgid "Forgot Password Link"
+msgid "Login tab"
+msgstr "ログインタブ"
+
+#. type: Plain text
+msgid "image:{project_images}/login-tab.png[Login Tab]"
+msgstr "image:{project_images}/login-tab.png[Login Tab]"
+
+#. type: Plain text
+msgid "Toggle *Forgot Password* to *ON*."
+msgstr "*Forgot Password* を *ON* に切り替えてください。"
+
+#. type: Plain text
+msgid "A `forgot password` link displays in your login pages."
+msgstr "ログインページに `forgot password` というリンクが表示される。"
+
+#. type: Block title
+#, no-wrap
+msgid "Forgot password link"
 msgstr "パスワード忘れリンク"
 
 #. type: Plain text
-msgid "image:{project_images}/forgot-password-link.png[]"
-msgstr "image:{project_images}/forgot-password-link.png[]"
+msgid "image:{project_images}/forgot-password-link.png[Forgot Password Link]"
+msgstr "image:{project_images}/forgot-password-link.png[Forgot Password Link]"
 
 #. type: Plain text
 msgid ""
-"Clicking on this link will bring the user to a page where they can enter in "
-"their username or email and receive an email with a link to reset their "
-"credentials."
+"Click this link to bring users where they can enter their username or email "
+"address and receive an email with a link to reset their credentials."
 msgstr ""
-"このリンクをクリックすると、ユーザー名またはメールアドレスを入力できるページに移動し、クレデンシャルをリセットするためのリンクが記載されたメールが送信されます。"
+"このリンクをクリックすると、ユーザーはユーザー名またはメールアドレスを入力し、クレデンシャルをリセットするためのリンクが記載されたメールを受け取ることができます。"
 
 #. type: Block title
 #, no-wrap
-msgid "Forgot Password Page"
+msgid "Forgot password page"
 msgstr "パスワード忘れページ"
 
 #. type: Plain text
-msgid "image:{project_images}/forgot-password-page.png[]"
-msgstr "image:{project_images}/forgot-password-page.png[]"
+msgid "image:{project_images}/forgot-password-page.png[Forgot Password Page]"
+msgstr "image:{project_images}/forgot-password-page.png[Forgot Password Page]"
 
 #. type: Plain text
 msgid ""
-"The text sent in the email is completely configurable. You just need to "
-"extend or edit the theme associated with it.  See the "
+"The text sent in the email is configurable. See "
 "link:{developerguide_link}[{developerguide_name}] for more information."
 msgstr ""
-"電子メールで送信されるテキストは完全に設定可能です。それに関連するテーマを拡張または編集するだけです。詳細については、link:{developerguide_link}[{developerguide_name}]のリンクを参照してください。"
+"電子メールで送信されるテキストは設定可能です。詳しくはlink:{developerguide_link}[{developerguide_name}]をご覧ください。"
 
 #. type: Plain text
 msgid ""
-"When the user clicks on the email link, they will be asked to update their "
-"password, and, if they have an OTP generator set up, they will also be asked"
-" to reconfigure this as well.  Depending on the security requirements of "
-"your organization you may not want users to be able to reset their OTP "
-"generator through email.  You can change this behavior by going to the "
-"`Authentication` left menu item, clicking on the `Flows` tab, and selecting "
-"the `Reset Credentials` flow:"
+"When users click the email link, {project_name} asks them to update their "
+"password, and if they have set up an OTP generator, {project_name} asks them"
+" to reconfigure the OTP generator.  Depending on security requirements of "
+"your organization, you may not want users to reset their OTP generator "
+"through email."
 msgstr ""
-"ユーザーが電子メールのリンクをクリックすると、パスワードの更新が求められ、OTPジェネレーターが設定されている場合は、パスワードの再設定も求められます。組織のセキュリティー要件によっては、電子メールを使ってユーザーがOTPジェネレーターをリセットできないようにすることができます。この動作を変更するには、左メニュー項目の"
-" `Authentication` で `Flows` タブをクリックし、 `Reset Credentials` フローを選択します。"
+"ユーザーがメールのリンクをクリックすると、{project_name} "
+"パスワードを更新するように求められ、OTPジェネレーターを設定している場合は、{project_name} "
+"OTPジェネレーターを再設定するように求められます。  "
+"組織のセキュリティ要件によっては、ユーザーに電子メールでOTPジェネレーターをリセットさせたくない場合もあります。"
+
+#. type: Plain text
+msgid "To change this behavior, perform these steps:"
+msgstr "この動作を変更するには、以下の手順を実行します。"
+
+#. type: Plain text
+msgid "Select the *Reset Credentials* flow."
+msgstr "認証情報のリセット」フローを選択します。"
 
 #. type: Block title
 #, no-wrap
-msgid "Reset Credentials Flow"
-msgstr "Reset Credentialsフロー"
-
-#. type: Plain text
-msgid "image:{project_images}/reset-credentials-flow.png[]"
-msgstr "image:{project_images}/reset-credentials-flow.png[]"
+msgid "Reset credentials flow"
+msgstr "認証情報のリセットフロー"
 
 #. type: Plain text
 msgid ""
-"If you do not want OTP reset, then just chose the `disabled` radio button to"
-" the right of `Reset OTP`."
-msgstr "OTPをリセットしたくない場合は、 `Reset OTP` の右にある `disabled` ラジオボタンを選択してください。"
-
-#. type: Plain text
-msgid ""
-"Be sure to leave Update Password enabled on the Required Actions tab.  "
-"Otherwise, Forgot Password does not work."
+"image:{project_images}/reset-credentials-flow.png[Reset Credentials Flow]"
 msgstr ""
-"Required ActionsタブでUpdate Passwordを有効のままにしてください。そうしないと、Forgot "
-"Passwordは機能しません。"
+"image:{project_images}/reset-credentials-flow.png[Reset Credentials Flow]"
+
+#. type: Plain text
+msgid ""
+"If you do not want to reset the OTP, set the `Reset OTP` requirement to "
+"*Disabled*."
+msgstr "OTPをリセットしたくない場合は、`Reset OTP`の要件を*Disabled*に設定してください。"
+
+#. type: Plain text
+msgid "Click the *Required Actions* tab. Ensure _Update Password_ is enabled."
+msgstr "Required Actions \"タブをクリックします。パスワードの更新 \"が有効になっていることを確認します。"

--- a/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po
@@ -99,7 +99,7 @@ msgid ""
 "The text sent in the email is configurable. See "
 "link:{developerguide_link}[{developerguide_name}] for more information."
 msgstr ""
-"電子メールで送信されるテキストは設定可能です。詳しくはlink:{developerguide_link}[{developerguide_name}]をご覧ください。"
+"電子メールで送信されるテキストは設定可能です。詳しくはlink:{developerguide_link}[{developerguide_name}]を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -109,10 +109,8 @@ msgid ""
 "your organization, you may not want users to reset their OTP generator "
 "through email."
 msgstr ""
-"ユーザーがメールのリンクをクリックすると、{project_name} "
-"パスワードを更新するように求められ、OTPジェネレーターを設定している場合は、{project_name} "
-"OTPジェネレーターを再設定するように求められます。  "
-"組織のセキュリティ要件によっては、ユーザーに電子メールでOTPジェネレーターをリセットさせたくない場合もあります。"
+"ユーザーがメールのリンクをクリックすると、{project_name}のパスワードを更新するように求められ、OTPジェネレーターを設定している場合は、{project_name}のOTPジェネレーターを再設定するように求められます。"
+"  組織のセキュリティー要件によっては、ユーザーに電子メールでOTPジェネレーターをリセットさせたくない場合もあります。"
 
 #. type: Plain text
 msgid "To change this behavior, perform these steps:"
@@ -120,12 +118,12 @@ msgstr "この動作を変更するには、以下の手順を実行します。
 
 #. type: Plain text
 msgid "Select the *Reset Credentials* flow."
-msgstr "認証情報のリセット」フローを選択します。"
+msgstr "*Reset Credentials* フローを選択します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Reset credentials flow"
-msgstr "認証情報のリセットフロー"
+msgstr "リセット・クレデンシャル・フロー"
 
 #. type: Plain text
 msgid ""
@@ -137,8 +135,8 @@ msgstr ""
 msgid ""
 "If you do not want to reset the OTP, set the `Reset OTP` requirement to "
 "*Disabled*."
-msgstr "OTPをリセットしたくない場合は、`Reset OTP`の要件を*Disabled*に設定してください。"
+msgstr "OTPをリセットしたくない場合は、 `Reset OTP` の要件を *Disabled* に設定してください。"
 
 #. type: Plain text
 msgid "Click the *Required Actions* tab. Ensure _Update Password_ is enabled."
-msgstr "Required Actions \"タブをクリックします。パスワードの更新 \"が有効になっていることを確認します。"
+msgstr "*Required Actions* タブをクリックします。 _Update Password_ が有効になっていることを確認します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/login-settings/forgot-password.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__login-settings__forgot-password
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
