### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -53,9 +53,7 @@ msgid ""
 " interact with the realm honor the SSL/HTTPS requirements defined by the SSL"
 " Mode or they cannot interact with the server."
 msgstr ""
-"各レルムには、そのレルムと通信するためのSSL/HTTPSの要件を定義する、SSLモードが関連付けられています。  "
-"レルムとやりとりするブラウザやアプリケーションは、SSL "
-"Modeによって定義されたSSL/HTTPSの要件を守らなければ、サーバとやりとりすることができません。"
+"各レルムには、そのレルムと通信するためのSSL/HTTPSの要件を定義する、SSLモードが関連付けられています。レルムとやりとりするブラウザーやアプリケーションは、SSLモードによって定義されたSSL/HTTPSの要件を守らなければ、サーバーとやりとりすることができません。"
 
 #. type: Plain text
 msgid ""
@@ -103,8 +101,7 @@ msgid ""
 "development when you are experimenting and do not plan to support this "
 "deployment."
 msgstr ""
-"{project_name}はSSLを必要としません。  "
-"この選択は、開発時に実験的に使用し、このデプロイメントのサポートを予定していない場合にのみ適用されます。"
+"{project_name}はSSLを必要としません。この選択は、開発時に実験的に使用し、このデプロイメントのサポートを予定していない場合にのみ適用されます。"
 
 #. type: Labeled list
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po
@@ -4,16 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2018
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,48 +19,43 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Labeled list
+#. type: Block title
 #, no-wrap
-msgid "external requests"
-msgstr "external requests"
-
-#. type: Labeled list
-#, no-wrap
-msgid "none"
-msgstr "none"
-
-#. type: Labeled list
-#, no-wrap
-msgid "all requests"
-msgstr "all requests"
+msgid "Procedure "
+msgstr "手順"
 
 #. type: Plain text
 msgid "{project_name} requires SSL for all IP addresses."
 msgstr "{project_name}はすべてのIPアドレスに対してSSLを要求します。"
 
-#. type: Block title
-#, no-wrap
-msgid "Login Tab"
-msgstr "Loginタブ"
+#. type: Plain text
+msgid "Click *Realm Settings* in the menu."
+msgstr "メニューの *Realm Settings* をクリックします。"
 
 #. type: Plain text
-msgid "image:{project_images}/login-tab.png[]"
-msgstr "image:{project_images}/login-tab.png[]"
+msgid "Click the *Login* tab."
+msgstr "*Login* タブをクリックします。"
 
-#. type: Title ===
+#. type: Block title
 #, no-wrap
-msgid "SSL Mode"
-msgstr "SSLモード"
+msgid "Login tab"
+msgstr "Loginタブ"
+
+#. type: Title =
+#, no-wrap
+msgid "Configuring SSL for a realm"
+msgstr "レルムにSSLを設定する"
 
 #. type: Plain text
 msgid ""
-"Each realm has an SSL Mode associated with it.  The SSL Mode defines the "
-"SSL/HTTPS requirements for interacting with the realm.  Browsers and "
-"applications that interact with the realm must honor the SSL/HTTPS "
-"requirements defined by the SSL Mode or they will not be allowed to interact"
-" with the server."
+"Each realm has an associated SSL Mode, which defines the SSL/HTTPS "
+"requirements for interacting with the realm.  Browsers and applications that"
+" interact with the realm honor the SSL/HTTPS requirements defined by the SSL"
+" Mode or they cannot interact with the server."
 msgstr ""
-"各レルムには、SSLモードが関連付けられています。SSLモードは、レルムと対話するためのSSL/HTTPS要件を定義します。レルムと対話するブラウザーとアプリケーションは、SSLモードで定義されたSSL/HTTPS要件を満たしている必要があり、そうでなければサーバーと対話できません。"
+"各レルムには、そのレルムと通信するためのSSL/HTTPSの要件を定義する、SSLモードが関連付けられています。  "
+"レルムとやりとりするブラウザやアプリケーションは、SSL "
+"Modeによって定義されたSSL/HTTPSの要件を守らなければ、サーバとやりとりすることができません。"
 
 #. type: Plain text
 msgid ""
@@ -77,32 +70,43 @@ msgstr ""
 " {installguide_link}[{installguide_name}] を参照してください。"
 
 #. type: Plain text
-msgid ""
-"To configure the SSL Mode of your realm, you need to click on the `Realm "
-"Settings` left menu item and go to the `Login` tab."
-msgstr ""
-"レルムのSSLモードを設定するには、左のメニュー項目の `Realm Settings` をクリックし、 `Login` タブに移動する必要があります。"
+msgid "image:{project_images}/login-tab.png[Login tab]"
+msgstr "image:{project_images}/login-tab.png[Login tab]"
 
 #. type: Plain text
-msgid ""
-"The `Require SSL` option allows you to pick the SSL Mode you want.  Here is "
-"an explanation of each mode:"
-msgstr "`Require SSL` オプションにより、SSLモードが選択できます。各モードの説明は次のとおりです。"
+msgid "Set *Require SSL* to one of the following SSL modes:"
+msgstr "*Require SSL*を以下のSSLモードのいずれかに設定してください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "* external requests"
+msgstr "* external requests"
 
 #. type: Plain text
 msgid ""
 "Users can interact with {project_name} without SSL so long as they stick to "
-"private IP addresses like `localhost`, `127.0.0.1`, `10.x.x.x`, "
+"private IP addresses such as `localhost`, `127.0.0.1`, `10.x.x.x`, "
 "`192.168.x.x`, and `172.16.x.x`.  If you try to access {project_name} "
-"without SSL from a non-private IP address you will get an error."
+"without SSL from a non-private IP address, you will get an error."
 msgstr ""
 "`localhost` 、 `127.0.0.1` 、 `10.x.x.x` 、 `192.168.x.x` 、 `172.16.x.x` "
 "のようなプライベートIPアドレスに固定する限り、ユーザーはSSL無しで{project_name}と対話できます。非プライベートIPアドレスからSSL無しで{project_name}にアクセスしようとすると、エラーが発生します。"
 
+#. type: Labeled list
+#, no-wrap
+msgid "* none"
+msgstr "* none"
+
 #. type: Plain text
 msgid ""
-"{project_name} does not require SSL.  This should really only be used in "
-"development when you are playing around with things and don't want to bother"
-" configuring SSL on your server."
+"{project_name} does not require SSL.  This choice applies only in "
+"development when you are experimenting and do not plan to support this "
+"deployment."
 msgstr ""
-"{project_name}はSSLを必要としません。この設定は、サーバー上でSSLの設定を気にせずにいろいろと触ってみる開発段階にのみ使用すべきです。"
+"{project_name}はSSLを必要としません。  "
+"この選択は、開発時に実験的に使用し、このデプロイメントのサポートを予定していない場合にのみ適用されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "* all requests"
+msgstr "* all requests"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/ssl.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__ssl
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
