### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
@@ -31,7 +31,7 @@ msgstr "メニューの *Realm Settings* をクリックします。"
 #. type: Title =
 #, no-wrap
 msgid "Configuring email for a realm"
-msgstr "レルムにメールを設定する"
+msgstr "レルムに電子メールを設定する"
 
 #. type: Plain text
 msgid ""
@@ -40,17 +40,16 @@ msgid ""
 "notifications about a server event. To enable {project_name} to send emails,"
 " you provide {project_name} with your SMTP server settings."
 msgstr ""
-"{project_name} "
-"は、ユーザーがメールアドレスを確認するとき、パスワードを忘れたとき、あるいは管理者がサーバーのイベントに関する通知を受け取る必要があるときに、メールを送信します。{project_name}がメールを送信できるようにするには、{project_name}にSMTPサーバーの設定を提供します。"
+"{project_name}は、ユーザーが電子メールアドレスを確認するとき、パスワードを忘れたとき、あるいは管理者がサーバーイベントに関する通知を受け取る必要があるときに、電子メールを送信します。{project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を提供します。"
 
 #. type: Plain text
 msgid "Click the *Email* tab."
-msgstr "Eメール」タブをクリックします。"
+msgstr "*Email* タブをクリックします。"
 
 #. type: Block title
 #, no-wrap
 msgid "Email tab"
-msgstr "メールタブ"
+msgstr "Emailタブ"
 
 #. type: Plain text
 msgid "image:{project_images}/email-tab.png[Email Tab]"
@@ -68,7 +67,7 @@ msgstr "Host"
 #. type: Plain text
 #, no-wrap
 msgid "*Host* denotes the SMTP server hostname used for sending emails.\n"
-msgstr "*Host*は、メール送信時に使用するSMTPサーバーのホスト名を示します。\n"
+msgstr "*Host* は、電子メール送信時に使用するSMTPサーバーのホスト名を示します。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -78,7 +77,7 @@ msgstr "Port"
 #. type: Plain text
 #, no-wrap
 msgid "*Port* denotes the SMTP server port.\n"
-msgstr "*Port*はSMTPサーバーのポートを示す。\n"
+msgstr "*Port* はSMTPサーバーのポートを示します。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -90,7 +89,7 @@ msgstr "From"
 msgid ""
 "*From* denotes the address used for the *From* SMTP-Header for the emails "
 "sent.\n"
-msgstr "*From*は、送信されるメールの*From* SMTP-Headerに使用されるアドレスです。\n"
+msgstr "*From* は、送信されるメールの *From* SMTPヘッダーに使用されるアドレスです。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -104,8 +103,9 @@ msgid ""
 "aliases (optional). If not set the plain *From* email address will be "
 "displayed in email clients.\n"
 msgstr ""
-"*From Display "
-"Name*では、ユーザーフレンドリーなEメールアドレスのエイリアスを設定できます（オプション）。設定されていない場合、メールクライアントでは通常の*From*メールアドレスが表示されます。\n"
+"*From Display Name* "
+"では、ユーザーフレンドリーなメールアドレスのエイリアスを設定できます（オプション）。設定されていない場合、電子メールクライアントでは通常の *From*"
+" メールアドレスが表示されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -119,8 +119,8 @@ msgid ""
 "mails sent (optional). If not set the plain *From* email address will be "
 "used.\n"
 msgstr ""
-"*Reply To*は、送信されるメールの*Reply-To* SMTP-"
-"Headerに使用されるアドレスを示します（オプション）。設定されていない場合は、通常の*From*電子メールアドレスが使用されます。\n"
+"*Reply To* は、送信されるメールの *Reply-To* "
+"SMTPヘッダーに使用されるアドレスを示します（オプション）。設定されていない場合は、通常の *From* 電子メールアドレスが使用されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -135,8 +135,8 @@ msgid ""
 "displayed.\n"
 msgstr ""
 "*Reply To Display "
-"Name*では、ユーザーフレンドリーなメールアドレスのエイリアスを設定することができます（オプション）。設定されていない場合は、通常の*Reply "
-"To*のメールアドレスが表示されます。\n"
+"Name*では、ユーザー・フレンドリーなメールアドレスのエイリアスを設定することができます（オプション）。設定されていない場合は、通常の *Reply "
+"To* のメールアドレスが表示されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -150,9 +150,8 @@ msgid ""
 "https://en.wikipedia.org/wiki/Bounce_address[Bounce Address] used for the "
 "*Return-Path* SMTP-Header for the mails sent (optional).\n"
 msgstr ""
-"*Envelope From*は、送信されるメールの*Return-Path* SMTP-"
-"Headerに使用されるhttps://en.wikipedia.org/wiki/Bounce_address[Bounce "
-"Address]を示します（オプション）。\n"
+"*Envelope From* は、送信されるメールの *Return-Path* SMTPヘッダーに使用される "
+"https://en.wikipedia.org/wiki/Bounce_address[Bounce Address] を示します（オプション）。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -166,7 +165,9 @@ msgid ""
 "external network. You will most likely need to change the *Port* to 465, the"
 " default port for SSL/TLS."
 msgstr ""
-"特にSMTPサーバーが外部ネットワーク上にある場合、ユーザー名とパスワードを回復するためのメール送信をサポートするには、これらのスイッチの1つを*ON*に切り替えます。特にSMTPサーバーが外部ネットワーク上にある場合は、これらのスイッチのうち1つをONにしてください。"
+"特にSMTPサーバーが外部ネットワーク上にある場合は、これらのスイッチの1つを *ON* "
+"に切り替えて、ユーザー名とパスワードを回復するための電子メールの送信をサポートします。ほとんどの場合、 *Port* "
+"をSSL/TLSのデフォルトポートである465に変更する必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -179,5 +180,6 @@ msgid ""
 "prompted, supply the *Username* and *Password*. The value of the *Password* "
 "field can refer a value from an external <<_vault-administration,vault>>."
 msgstr ""
-"SMTPサーバーで認証が必要な場合は、このスイッチを*ON*に設定してください。プロンプトが表示されたら、*Username*と*Password*を入力してください。Password*フィールドの値は、外部の<_vault-"
-"administration,vault>&lt;&gt;</_vault-administration,vault>からの値を参照することができます。"
+"SMTPサーバーで認証が必要な場合は、このスイッチを *ON* に設定してください。プロンプトが表示されたら、 *Username* と "
+"*Password* を入力してください。 *Password* フィールドの値は、外部の<<_vault-"
+"administration,ボールト>>からの値を参照することができます。"

--- a/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po
@@ -5,14 +5,13 @@
 # 
 # Translators:
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,31 +19,46 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Block title
 #, no-wrap
-msgid "Email Settings"
-msgstr "電子メールの設定"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Realm Settings* in the menu."
+msgstr "メニューの *Realm Settings* をクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Configuring email for a realm"
+msgstr "レルムにメールを設定する"
 
 #. type: Plain text
 msgid ""
-"{project_name} sends emails to users to verify their email address, when "
-"they forget their passwords, or when an admin needs to receive notifications"
-" about a server event.  To enable {project_name} to send emails you need to "
-"provide {project_name} with your SMTP server settings.  This is configured "
-"per realm.  Go to the `Realm Settings` left menu item and click the `Email` "
-"tab."
+"{project_name} sends emails to users to verify their email addresses, when "
+"they forget their passwords, or when an administrator needs to receive "
+"notifications about a server event. To enable {project_name} to send emails,"
+" you provide {project_name} with your SMTP server settings."
 msgstr ""
-"{project_name}は、パスワードを忘れたとき、または管理者がサーバーイベントに関する通知を受け取るときに、メールアドレスの確認するためユーザーに電子メールを送信します。{project_name}が電子メールを送信できるようにするには、{project_name}にSMTPサーバーの設定を行う必要があります。SMTPサーバーの設定は、レルムごとに設定することができます。"
-" `Realm Settings` 左のメニュー項目に移動し、 `Email` タブをクリックしてください。"
+"{project_name} "
+"は、ユーザーがメールアドレスを確認するとき、パスワードを忘れたとき、あるいは管理者がサーバーのイベントに関する通知を受け取る必要があるときに、メールを送信します。{project_name}がメールを送信できるようにするには、{project_name}にSMTPサーバーの設定を提供します。"
+
+#. type: Plain text
+msgid "Click the *Email* tab."
+msgstr "Eメール」タブをクリックします。"
 
 #. type: Block title
 #, no-wrap
-msgid "Email Tab"
-msgstr "Emailタブ"
+msgid "Email tab"
+msgstr "メールタブ"
 
 #. type: Plain text
-msgid "image:{project_images}/email-tab.png[]"
-msgstr "image:{project_images}/email-tab.png[]"
+msgid "image:{project_images}/email-tab.png[Email Tab]"
+msgstr "image:{project_images}/email-tab.png[Emailタブ]"
+
+#. type: Plain text
+msgid "Fill in the fields and toggle the switches as needed."
+msgstr "必要に応じてフィールドに入力し、スイッチを切り替えてください。"
 
 #. type: Title ===
 #, no-wrap
@@ -52,8 +66,9 @@ msgid "Host"
 msgstr "Host"
 
 #. type: Plain text
-msgid "`Host` denotes the SMTP server hostname used for sending emails."
-msgstr "`Host` は、電子メールの送信に使用されるSMTPサーバーのホスト名です。"
+#, no-wrap
+msgid "*Host* denotes the SMTP server hostname used for sending emails.\n"
+msgstr "*Host*は、メール送信時に使用するSMTPサーバーのホスト名を示します。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -61,8 +76,9 @@ msgid "Port"
 msgstr "Port"
 
 #. type: Plain text
-msgid "`Port` denotes the SMTP server port."
-msgstr "`Port` は、SMTPサーバーのポート番号です。"
+#, no-wrap
+msgid "*Port* denotes the SMTP server port.\n"
+msgstr "*Port*はSMTPサーバーのポートを示す。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -70,10 +86,11 @@ msgid "From"
 msgstr "From"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`From` denotes the address used for the `From` SMTP-Header for the emails "
-"sent."
-msgstr "`From` は、送信された電子メールの `From` SMTPヘッダーに使用されるアドレスです。"
+"*From* denotes the address used for the *From* SMTP-Header for the emails "
+"sent.\n"
+msgstr "*From*は、送信されるメールの*From* SMTP-Headerに使用されるアドレスです。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -81,14 +98,14 @@ msgid "From Display Name"
 msgstr "From Display Name"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`From Display Name` allows to configure a user friendly email address "
-"aliases (optional). If not set the plain `From` email address will be "
-"displayed in email clients."
+"*From Display Name* allows to configure a user friendly email address "
+"aliases (optional). If not set the plain *From* email address will be "
+"displayed in email clients.\n"
 msgstr ""
-"`From Display Name` "
-"は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。設定されていない場合は、電子メールクライアントに `From` "
-"メールアドレスが表示されます。"
+"*From Display "
+"Name*では、ユーザーフレンドリーなEメールアドレスのエイリアスを設定できます（オプション）。設定されていない場合、メールクライアントでは通常の*From*メールアドレスが表示されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -96,13 +113,14 @@ msgid "Reply To"
 msgstr "Reply To"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`Reply To` denotes the address used for the `Reply-To` SMTP-Header for the "
-"mails sent (optional). If not set the plain `From` email address will be "
-"used."
+"*Reply To* denotes the address used for the *Reply-To* SMTP-Header for the "
+"mails sent (optional). If not set the plain *From* email address will be "
+"used.\n"
 msgstr ""
-"`Reply To` は、送信された電子メールの `Reply-To` SMTPヘッダーに使用されるアドレスです（オプション）。 "
-"設定されていない場合は、通常の `From` メールアドレスが使用されます。"
+"*Reply To*は、送信されるメールの*Reply-To* SMTP-"
+"Headerに使用されるアドレスを示します（オプション）。設定されていない場合は、通常の*From*電子メールアドレスが使用されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -110,13 +128,15 @@ msgid "Reply To Display Name"
 msgstr "Reply To Display Name"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`Reply To Display Name` allows to configure a user friendly email address "
-"aliases (optional). If not set the plain `Reply To` email address will be "
-"displayed."
+"*Reply To Display Name* allows to configure a user friendly email address "
+"aliases (optional). If not set the plain *Reply To* email address will be "
+"displayed.\n"
 msgstr ""
-"`Reply To Display Name` は、ユーザー・フレンドリーなメールアドレスのエイリアスを設定します（オプション）。 "
-"設定されていない場合は、 `Reply To` 電子メールアドレスが表示されます。"
+"*Reply To Display "
+"Name*では、ユーザーフレンドリーなメールアドレスのエイリアスを設定することができます（オプション）。設定されていない場合は、通常の*Reply "
+"To*のメールアドレスが表示されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -124,32 +144,40 @@ msgid "Envelope From"
 msgstr "Envelope From"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`Envelope From` denotes the "
+"*Envelope From* denotes the "
 "https://en.wikipedia.org/wiki/Bounce_address[Bounce Address] used for the "
-"`Return-Path` SMTP-Header for the mails sent (optional)."
+"*Return-Path* SMTP-Header for the mails sent (optional).\n"
 msgstr ""
-"`Envelope From` は、送信された電子メールの `Return-Path` "
-"SMTPヘッダーに使用されるlink:https://en.wikipedia.org/wiki/Bounce_address[バウンスアドレス]です（オプション）。"
+"*Envelope From*は、送信されるメールの*Return-Path* SMTP-"
+"Headerに使用されるhttps://en.wikipedia.org/wiki/Bounce_address[Bounce "
+"Address]を示します（オプション）。\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Enable SSL and Enable StartTSL"
+msgstr "SSLの有効化とStartTSLの有効化"
 
 #. type: Plain text
 msgid ""
-"As emails are used for recovering usernames and passwords it's recommended "
-"to use SSL or TLS, especially if the SMTP server is on an external network."
-"  To enable SSL click on `Enable SSL` or to enable TLS click on `Enable "
-"TLS`.  You will most likely also need to change the `Port` (the default port"
-" for SSL/TLS is 465)."
+"Toggle one of these switches to *ON* to support sending emails for "
+"recovering usernames and passwords, especially if the SMTP server is on an "
+"external network. You will most likely need to change the *Port* to 465, the"
+" default port for SSL/TLS."
 msgstr ""
-"電子メールは、ユーザー名とパスワードの回復に使用されるため、特にSMTPサーバーが外部ネットワーク上にある場合は、SSLまたはTLSを使用することを推奨します。SSLを有効にするため"
-" `Enable SSL` をクリックするか、TLSを有効にするため `Enable TLS` をクリックします。 `Port` "
-"も変更する必要があります（SSL/TLSのデフォルトポートは465）。"
+"特にSMTPサーバーが外部ネットワーク上にある場合、ユーザー名とパスワードを回復するためのメール送信をサポートするには、これらのスイッチの1つを*ON*に切り替えます。特にSMTPサーバーが外部ネットワーク上にある場合は、これらのスイッチのうち1つをONにしてください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Enable Authentication"
+msgstr "認証の有効化"
 
 #. type: Plain text
 msgid ""
-"If your SMTP server requires authentication click on `Enable Authentication`"
-" and insert the `Username` and `Password`. The value of the `Password` field"
-" can refer a value from an external <<_vault-administration,vault>>."
+"Set this switch to *ON* if your SMTP server requires authentication. When "
+"prompted, supply the *Username* and *Password*. The value of the *Password* "
+"field can refer a value from an external <<_vault-administration,vault>>."
 msgstr ""
-"SMTPサーバーが認証を必要とする場合は、 `Enable Authentication` をクリックし、 `Username` と "
-"`Password` を入力します。 `Password` フィールドの値は、外部<<_vault-"
-"administration,ボールト>>からの値を参照できます。"
+"SMTPサーバーで認証が必要な場合は、このスイッチを*ON*に設定してください。プロンプトが表示されたら、*Username*と*Password*を入力してください。Password*フィールドの値は、外部の<_vault-"
+"administration,vault>&lt;&gt;</_vault-administration,vault>からの値を参照することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/email.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__email
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
