### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -49,8 +49,8 @@ msgid ""
 " them for every application by default. Users from a realm can use any of "
 "the registered identity providers when signing in to an application."
 msgstr ""
-"アイデンティティ・ブローカー構成の基礎となるのは、アイデンティティ・プロバイダ（IDP）です。{project_name} は、各レルムに対して ID "
-"プロバイダを作成し、デフォルトですべてのアプリケーションに対して有効にします。レルムのユーザは、アプリケーションにサインインする際に、登録されたIDプロバイダのいずれかを使用できます。"
+"アイデンティティー・ブローカーの設定の基礎となるのは、アイデンティティー・プロバイダー（IDP）です。{project_name}は、各レルムに対して "
+"アイデンティティー・プロバイダーを作成し、デフォルトですべてのアプリケーションに対して有効にします。レルムのユーザーは、アプリケーションにサインインする際に、登録されたアイデンティティー・プロバイダーのいずれかを使用できます。"
 
 #. type: Block title
 #, no-wrap
@@ -67,13 +67,13 @@ msgid ""
 "{project_name} displays the configuration page for the identity provider you"
 " selected."
 msgstr ""
-"Add provider`のリストから、追加したいIDプロバイダーを選択します。{project_name} 選択した ID "
-"プロバイダーの設定ページが表示されます。"
+"`Add provider` "
+"のリストから、追加したいアイデンティティー・プロバイダーを選択します。{project_name}は、選択したアイデンティティー・プロバイダーの設定ページを表示します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Add facebook identity Provider"
-msgstr "facebook IDプロバイダの追加"
+msgstr "facebookアイデンティティー・プロバイダーの追加"
 
 #. type: Plain text
 msgid ""
@@ -91,9 +91,9 @@ msgid ""
 "link:{developerguide_link}#custom-identity-providers-icons[custom icons] for"
 " more information."
 msgstr ""
-"ID プロバイダを構成すると、{project_name} ログイン画面に ID プロバイダがオプションとして表示されます。ログイン画面には、ID "
-"プロバイダごとにカスタム アイコンを配置できます。詳しくはlink:{developerguide_link}#custom-identity-"
-"providers-icons[custom icons]をご覧ください。"
+"アイデンティティー・プロバイダーを設定すると、{project_name}のログイン画面にアイデンティティー・プロバイダーがオプションとして表示されます。ログイン画面には、アイデンティティー・プロバイダーごとにカスタムアイコンを配置できます。詳しくは"
+" link:{developerguide_link}#custom-identity-providers-icons[カスタムアイコン] "
+"を参照してください。"
 
 #. type: Block title
 #, no-wrap
@@ -117,8 +117,7 @@ msgid ""
 "Instagram, Microsoft, PayPal, Openshift v3, GitHub, GitLab, Bitbucket, and "
 "Stack Overflow."
 msgstr ""
-"ソーシャルプロバイダーは、あなたのレルムでソーシャル認証を可能にします。{project_name} "
-"を使用すると、ユーザーはソーシャルネットワークアカウントを使用してアプリケーションにログインできます。サポートされているプロバイダは、Twitter、Facebook、Google、LinkedIn、Instagram、Microsoft、PayPal、Openshift"
+"ソーシャル・プロバイダーは、あなたのレルムでソーシャル認証を可能にします。{project_name}を使用すると、ユーザーはソーシャル・ネットワーク・アカウントを使用してアプリケーションにログインできます。サポートされているプロバイダーは、Twitter、Facebook、Google、LinkedIn、Instagram、Microsoft、PayPal、Openshift"
 " v3、GitHub、GitLab、Bitbucket、Stack Overflowです。"
 
 #. type: Labeled list
@@ -134,15 +133,16 @@ msgid ""
 " for SAML v2.0 and OpenID Connect v1.0 protocols. You can configure and "
 "broker any identity provider based on these open standards."
 msgstr ""
-"プロトコルベースのプロバイダは、特定のプロトコルに依存してユーザの認証と認可を行います。これらのプロバイダを使用することで、特定のプロトコルに準拠した任意のIDプロバイダに接続することができます。{project_name}"
-" は、SAML v2.0 および OpenID Connect v1.0 "
-"プロトコルに対応しています。これらのオープンスタンダードに基づいて、任意のIDプロバイダーを構成し、仲介することができます。"
+"プロトコルベースのプロバイダーは、特定のプロトコルに依存してユーザーの認証と認可を行います。これらのプロバイダーを使用することで、特定のプロトコルに準拠した任意のアイデンティティー・プロバイダーに接続することができます。{project_name}は、SAML"
+" v2.0およびOpenID Connect "
+"v1.0プロトコルに対応しています。これらのオープンスタンダードに基づいて、任意のアイデンティティー・プロバイダーを設定し、仲介することができます。"
 
 #. type: Plain text
 msgid ""
 "Although each type of identity provider has its configuration options, all "
 "share a common configuration. The following configuration options available:"
-msgstr "ID プロバイダの種類ごとに設定オプションがありますが、すべてのタイプに共通する設定があります。以下の構成オプションがあります。"
+msgstr ""
+"アイデンティティー・プロバイダーの種類ごとに設定オプションがありますが、すべてのタイプに共通する設定があります。以下の設定オプションが利用可能です。"
 
 #. type: Block title
 #, no-wrap
@@ -163,10 +163,9 @@ msgid ""
 "have an alias. Alias examples include `facebook`, `google`, and "
 "`idp.acme.com`."
 msgstr ""
-"エイリアスは、ID プロバイダの一意の識別子であり、内部の ID プロバイダを参照します。{project_name} "
-"は、エイリアスを使用して、IDプロバイダーとの通信にリダイレクトURIまたはコールバックURLを必要とするOpenID "
-"ConnectプロトコルのリダイレクトURIを構築します。すべての ID "
-"プロバイダにはエイリアスが必要です。エイリアスの例としては、`facebook`、`google`、`idp.acme.com`などがあります。"
+"エイリアスは、アイデンティティー・プロバイダーの一意の識別子であり、内部のアイデンティティー・プロバイダーを参照します。{project_name}は、エイリアスを使用して、アイデンティティー・プロバイダーとの通信にリダイレクトURIまたはコールバックURLを必要とするOpenID"
+" ConnectプロトコルのリダイレクトURIを構築します。すべてのアイデンティティー・プロバイダーにはエイリアスが必要です。エイリアスの例としては、 "
+"`facebook`、 `google` 、 `idp.acme.com` などがあります。"
 
 #. type: Plain text
 msgid "Enabled"
@@ -174,7 +173,7 @@ msgstr "Enabled"
 
 #. type: Plain text
 msgid "Toggles the provider ON or OFF."
-msgstr "プロバイダのON/OFFを切り替えます。"
+msgstr "プロバイダーのON/OFFを切り替えます。"
 
 #. type: Plain text
 msgid "Hide on Login Page"
@@ -186,8 +185,9 @@ msgid ""
 "on the login page. Clients can request this provider by using the "
 "'kc_idp_hint' parameter in the URL to request a login."
 msgstr ""
-"ON*の場合、{project_name} "
-"は、ログインページのログインオプションとしてこのプロバイダを表示しません。クライアントは、ログインを要求するURLに「kc_idp_hint」パラメータを使用して、このプロバイダを要求できます。"
+"*ON* "
+"の場合、{project_name}は、ログインページのログイン・オプションとしてこのプロバイダーを表示しません。クライアントは、ログインを要求するURLに"
+" 'kc_idp_hint' パラメーターを使用して、このプロバイダーを要求できます。"
 
 #. type: Plain text
 msgid "Account Linking Only"
@@ -199,9 +199,7 @@ msgid ""
 "provider cannot log users in, and {project_name} does not display this "
 "provider as an option on the login page."
 msgstr ""
-"ON*の場合、{project_name} "
-"既存のアカウントとこのプロバイダをリンクします。このプロバイダーはユーザーをログインさせることができず、{project_name} "
-"はログインページのオプションとしてこのプロバイダーを表示しません。"
+"*ON*の場合、{project_name}は既存のアカウントとこのプロバイダーをリンクします。このプロバイダーはユーザーをログインさせることができず、{project_name}はログインページのオプションとしてこのプロバイダーを表示しません。"
 
 #. type: Plain text
 msgid "Store Tokens"
@@ -209,7 +207,7 @@ msgstr "Store Tokens"
 
 #. type: Plain text
 msgid "When *ON*, {project_name} stores tokens from the identity provider."
-msgstr "ON*の場合、{project_name}はIDプロバイダーからのトークンを保存します。"
+msgstr "*ON* の場合、{project_name}はアイデンティティー・プロバイダーから取得したトークンを保存します。"
 
 #. type: Plain text
 msgid "Stored Tokens Readable"
@@ -220,8 +218,9 @@ msgid ""
 "When *ON*, users can retrieve the stored identity provider token. This "
 "action also applies to the _broker_ client-level role _read token_."
 msgstr ""
-"ON*の場合、ユーザは保存されているIDプロバイダトークンを取得できます。このアクションは、_broker_クライアントレベルロールの_read "
-"token_にも適用されます。"
+"*ON* "
+"の場合、ユーザーは保存されているアイデンティティー・プロバイダーのトークンを取得できます。このアクションは、_broker_クライアントレベル・ロールの"
+" _read token_ にも適用されます。"
 
 #. type: Plain text
 msgid "Trust Email"
@@ -233,8 +232,8 @@ msgid ""
 " If the realm requires email validation, users that log in from this "
 "identity provider do not need to perform the email verification process."
 msgstr ""
-"ON*の場合、{project_name} "
-"IDプロバイダからの電子メールアドレスを信頼します。レルムが電子メールの検証を必要とする場合、このIDプロバイダからログインするユーザーは、電子メールの検証プロセスを実行する必要はありません。"
+"*ON* "
+"の場合、{project_name}はアイデンティティー・プロバイダーからの電子メールアドレスを信頼します。レルムが電子メールの検証を必要とする場合、このアイデンティティー・プロバイダーからログインするユーザーは、電子メールの検証プロセスを実行する必要はありません。"
 
 #. type: Plain text
 msgid "GUI Order"
@@ -242,7 +241,7 @@ msgstr "GUI Order"
 
 #. type: Plain text
 msgid "The sort order of the available identity providers on the login page."
-msgstr "ログインページで利用可能なIDプロバイダーのソート順を指定します。"
+msgstr "ログインページで利用可能なアイデンティティー・プロバイダーのソート順を指定します。"
 
 #. type: Plain text
 msgid "First Login Flow"
@@ -253,8 +252,7 @@ msgid ""
 "The authentication flow {project_name} triggers when users use this identity"
 " provider to log into {project_name} for the first time."
 msgstr ""
-"認証フロー {project_name} は、ユーザーがこの ID プロバイダーを使用して {project_name} "
-"に初めてログインしたときにトリガーされます。"
+"ユーザーがこのアイデンティティー・プロバイダーを使用して{project_name}に初めてログインしたときに{project_name}がトリガーする認証フロー。"
 
 #. type: Plain text
 msgid "Post Login Flow"
@@ -264,7 +262,7 @@ msgstr "Post Login Flow"
 msgid ""
 "The authentication flow {project_name} triggers when a user finishes logging"
 " in with the external identity provider."
-msgstr "認証フロー {project_name} は、ユーザーが外部の ID プロバイダーでのログインを完了したときにトリガーされます。"
+msgstr "ユーザーが外部アイデンティティー・プロバイダーへのログインを終了したときに{project_name}がトリガーする認証フロー。"
 
 #. type: Plain text
 msgid "Sync Mode"
@@ -277,7 +275,6 @@ msgid ""
 "*Import* does not update user data and *force* updates user data when "
 "possible. See <<_mappers, Identity Provider Mappers>> for more information."
 msgstr ""
-"ID プロバイダーからマッパーを介してユーザー情報を更新する戦略。*legacy* を選択する際、{project_name} "
-"は現在の動作を使用しました。*Import* はユーザーデータを更新せず、*force* "
-"は可能な限りユーザーデータを更新します。詳しく<_mappers, Identity Provider "
-"Mappers>は&lt;&gt;</_mappers,>を参照してください。"
+"アイデンティティー・プロバイダーからマッパーを介してユーザー情報を更新する戦略。 *legacy* "
+"を選択する際、{project_name}は現在の動作を使用します。 *Import* はユーザーデータを更新せず、 *force* "
+"は可能な限りユーザーデータを更新します。詳しくは<<_mappers, アイデンティティー・プロバイダー・マッパー>> を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po
@@ -4,20 +4,29 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの「Identity Providers」をクリックします。"
 
 #. type: Plain text
 #, no-wrap
@@ -28,31 +37,20 @@ msgstr "Alias"
 msgid "Configuration|Description"
 msgstr "設定|説明"
 
-#. type: Plain text
-#, no-wrap
-msgid "Enabled"
-msgstr "Enabled"
-
 #. type: Title ===
 #, no-wrap
-msgid "General Configuration"
-msgstr "共通設定"
+msgid "General configuration"
+msgstr "一般的な構成"
 
 #. type: Plain text
 msgid ""
-"The identity broker configuration is all based on identity providers.  "
-"Identity providers are created for each realm and by default they are "
-"enabled for every single application.  That means that users from a realm "
-"can use any of the registered identity providers when signing in to an "
-"application."
+"The foundations of the identity broker configuration are identity providers "
+"(IDPs). {project_name} creates identity providers for each realm and enables"
+" them for every application by default. Users from a realm can use any of "
+"the registered identity providers when signing in to an application."
 msgstr ""
-"アイデンティティー・ブローカーの設定は、すべてアイデンティティー・プロバイダーに基づいています。アイデンティティー・プロバイダーは各レルムに対して作成され、デフォルトでは単一アプリケーションごとに有効化されます。つまり、レルムのユーザーは、アプリケーションにサインインするときに、登録されているアイデンティティー・プロバイダーのいずれかを使用することができます。"
-
-#. type: Plain text
-msgid ""
-"In order to create an identity provider click the `Identity Providers` left "
-"menu item."
-msgstr "アイデンティティー・プロバイダーを作成するには、左側の `Identity Providers` をクリックします。"
+"アイデンティティ・ブローカー構成の基礎となるのは、アイデンティティ・プロバイダ（IDP）です。{project_name} は、各レルムに対して ID "
+"プロバイダを作成し、デフォルトですべてのアプリケーションに対して有効にします。レルムのユーザは、アプリケーションにサインインする際に、登録されたIDプロバイダのいずれかを使用できます。"
 
 #. type: Block title
 #, no-wrap
@@ -60,38 +58,42 @@ msgid "Identity Providers"
 msgstr "アイデンティティー・プロバイダー"
 
 #. type: Plain text
-msgid "image:{project_images}/identity-providers.png[]"
-msgstr "image:{project_images}/identity-providers.png[]"
+msgid "image:{project_images}/identity-providers.png[Identity Providers]"
+msgstr "image:{project_images}/identity-providers.png[Identity Providers]"
 
 #. type: Plain text
 msgid ""
-"In the drop down list box, choose the identity provider you want to add.  "
-"This will bring you to the configuration page for that identity provider "
-"type."
+"From the `Add provider` list, select the identity provider you want to add. "
+"{project_name} displays the configuration page for the identity provider you"
+" selected."
 msgstr ""
-"ドロップ・ダウン・リスト・ボックスで、追加するアイデンティティー・プロバイダを選択します。 "
-"これにより、そのアイデンティティー・プロバイダー・タイプの設定ページが表示されます。"
+"Add provider`のリストから、追加したいIDプロバイダーを選択します。{project_name} 選択した ID "
+"プロバイダーの設定ページが表示されます。"
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
-
-#. type: Plain text
-msgid "image:{project_images}/add-identity-provider.png[]"
-msgstr "image:{project_images}/add-identity-provider.png[]"
+msgid "Add facebook identity Provider"
+msgstr "facebook IDプロバイダの追加"
 
 #. type: Plain text
 msgid ""
-"Above is an example of configuring a Facebook social login provider.  Once "
-"you configure an IDP, it will appear on the {project_name} login page as an "
-"option. It's possible to have custom icons on login screen for each identity"
-" provider.  For more details, please refer to the link:{developerguide_link"
-"}#custom-identity-providers-icons[custom icons]."
+"image:{project_images}/add-identity-provider.png[Add Facebook Identity "
+"Provider]"
 msgstr ""
-"上記は、Facebookのソーシャル・ログイン・プロバイダーを設定する例です。IdPを設定すると、オプションとして{project_name}のログイン・ページにそれが表示されます。アイデンティティー・プロバイダーごとにログイン画面にカスタムアイコンを表示することができます。詳細については、"
-" link:{developerguide_link}#custom-identity-providers-icons[カスタムアイコン] "
-"を参照してください。"
+"image:{project_images}/add-identity-provider.png[Add Facebook Identity "
+"Provider]"
+
+#. type: Plain text
+msgid ""
+"When you configure an identity provider, the identity provider appears on "
+"the {project_name} login page as an option. You can place custom icons on "
+"the login screen for each identity provider. See "
+"link:{developerguide_link}#custom-identity-providers-icons[custom icons] for"
+" more information."
+msgstr ""
+"ID プロバイダを構成すると、{project_name} ログイン画面に ID プロバイダがオプションとして表示されます。ログイン画面には、ID "
+"プロバイダごとにカスタム アイコンを配置できます。詳しくはlink:{developerguide_link}#custom-identity-"
+"providers-icons[custom icons]をご覧ください。"
 
 #. type: Block title
 #, no-wrap
@@ -109,14 +111,15 @@ msgstr "ソーシャル"
 
 #. type: Plain text
 msgid ""
-"Social providers allow you to enable social authentication in your realm.  "
-"{project_name} makes it easy to let users log in to your application using "
-"an existing account with a social network.  Currently supported providers "
-"include: Twitter, Facebook, Google, LinkedIn, Instagram, Microsoft, PayPal, "
-"Openshift v3, GitHub, GitLab, Bitbucket, and Stack Overflow."
+"Social providers enable social authentication in your realm. With "
+"{project_name}, users can log in to your application using a social network "
+"account. Supported providers include Twitter, Facebook, Google, LinkedIn, "
+"Instagram, Microsoft, PayPal, Openshift v3, GitHub, GitLab, Bitbucket, and "
+"Stack Overflow."
 msgstr ""
-"ソーシャル・プロバイダーは、レルムでソーシャル認証を有効にすることができます。{project_name}は、ユーザーがソーシャル・ネットワークの既存アカウントを使用して、アプリケーションに簡単にログインできるようにします。現在、Twitter、Facebook、Google、LinkedIn、Instagram、Microsoft、PayPal、Openshift"
-" v3、GitHub、GitLab、Bitbucket、Stack Overflowがサポートされています。"
+"ソーシャルプロバイダーは、あなたのレルムでソーシャル認証を可能にします。{project_name} "
+"を使用すると、ユーザーはソーシャルネットワークアカウントを使用してアプリケーションにログインできます。サポートされているプロバイダは、Twitter、Facebook、Google、LinkedIn、Instagram、Microsoft、PayPal、Openshift"
+" v3、GitHub、GitLab、Bitbucket、Stack Overflowです。"
 
 #. type: Labeled list
 #, no-wrap
@@ -125,25 +128,21 @@ msgstr "プロトコル・ ベース"
 
 #. type: Plain text
 msgid ""
-"Protocol-based providers are those that rely on a specific protocol in order"
-" to authenticate and authorize users.  They allow you to connect to any "
-"identity provider compliant with a specific protocol.  {project_name} "
-"provides support for SAML v2.0 and OpenID Connect v1.0 protocols.  It makes "
-"it easy to configure and broker any identity provider based on these open "
-"standards."
+"Protocol-based providers rely on specific protocols to authenticate and "
+"authorize users. Using these providers, you can connect to any identity "
+"provider compliant with a specific protocol. {project_name} provides support"
+" for SAML v2.0 and OpenID Connect v1.0 protocols. You can configure and "
+"broker any identity provider based on these open standards."
 msgstr ""
-"プロトコル・ベースのプロバイダーは、特定のプロトコルに依存してユーザーを認証および認可するものです。特定のプロトコルに準拠しているすべてのアイデンティティー・プロバイダーに接続できます。{project_name}はSAML"
-" v2.0とOpenID Connect "
-"v1.0プロトコルをサポートしています。これにより、これらのオープンスタンダードに基づいた任意のアイデンティティー・プロバイダーを簡単に設定および仲介できるようになります。"
+"プロトコルベースのプロバイダは、特定のプロトコルに依存してユーザの認証と認可を行います。これらのプロバイダを使用することで、特定のプロトコルに準拠した任意のIDプロバイダに接続することができます。{project_name}"
+" は、SAML v2.0 および OpenID Connect v1.0 "
+"プロトコルに対応しています。これらのオープンスタンダードに基づいて、任意のIDプロバイダーを構成し、仲介することができます。"
 
 #. type: Plain text
 msgid ""
-"Although each type of identity provider has its own configuration options, "
-"all of them share some very common configuration.  Regardless of which "
-"identity provider you are creating, you'll see the following configuration "
-"options available:"
-msgstr ""
-"各タイプのアイデンティティー・プロバイダーには独自の設定オプションがありますが、すべて共通の設定を共有しています。作成しているアイデンティティー・プロバイダーに関係なく、次の設定オプションが使用できます。"
+"Although each type of identity provider has its configuration options, all "
+"share a common configuration. The following configuration options available:"
+msgstr "ID プロバイダの種類ごとに設定オプションがありますが、すべてのタイプに共通する設定があります。以下の構成オプションがあります。"
 
 #. type: Block title
 #, no-wrap
@@ -156,21 +155,26 @@ msgid "1,1"
 msgstr "1,1"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"The alias is a unique identifier for an identity provider. It is used to reference an identity provider internally.\n"
-" Some protocols such as OpenID Connect require a redirect URI or callback url in order to communicate with an identity provider.\n"
-" In this case, the alias is used to build the redirect URI.\n"
-" Every single identity provider must have an alias. Examples are `facebook`, `google`, `idp.acme.com`, etc.\n"
+"The alias is a unique identifier for an identity provider and references an "
+"internal identity provider. {project_name} uses the alias to build redirect "
+"URIs for OpenID Connect protocols that require a redirect URI or callback "
+"URL to communicate with an identity provider. All identity providers must "
+"have an alias. Alias examples include `facebook`, `google`, and "
+"`idp.acme.com`."
 msgstr ""
-"エイリアスは、アイデンティティー・プロバイダーの一意な識別子です。アイデンティティー・プロバイダーを内部的に参照するために使用されます。\n"
-"OpenID Connectなどの一部のプロトコルでは、アイデンティティー・プロバイダーと通信するために、リダイレクトURIまたはコールバックURLが必要です。\n"
-"この場合、エイリアスはリダイレクトURIを構築するために使用されます。\n"
-"すべてのアイデンティティー・プロバイダーにエイリアスが必要です。例としては、 `facebook` 、 `google` 、 `idp.acme.com` などです。\n"
+"エイリアスは、ID プロバイダの一意の識別子であり、内部の ID プロバイダを参照します。{project_name} "
+"は、エイリアスを使用して、IDプロバイダーとの通信にリダイレクトURIまたはコールバックURLを必要とするOpenID "
+"ConnectプロトコルのリダイレクトURIを構築します。すべての ID "
+"プロバイダにはエイリアスが必要です。エイリアスの例としては、`facebook`、`google`、`idp.acme.com`などがあります。"
 
 #. type: Plain text
-msgid "Turn the provider on/off."
-msgstr "プロバイダーのオン/オフの設定です。"
+msgid "Enabled"
+msgstr "Enabled"
+
+#. type: Plain text
+msgid "Toggles the provider ON or OFF."
+msgstr "プロバイダのON/OFFを切り替えます。"
 
 #. type: Plain text
 msgid "Hide on Login Page"
@@ -178,12 +182,12 @@ msgstr "Hide on Login Page"
 
 #. type: Plain text
 msgid ""
-"When this switch is on, this provider will not be shown as a login option on"
-" the login page.  Clients can still request to use this provider by using "
-"the 'kc_idp_hint' parameter in the URL they use to request a login."
+"When *ON*, {project_name} does not display this provider as a login option "
+"on the login page. Clients can request this provider by using the "
+"'kc_idp_hint' parameter in the URL to request a login."
 msgstr ""
-"このスイッチがオンの場合、このプロバイダーはログイン・ページにログイン・オプションとして表示されません。クライアントは、ログインを要求するために使用するURLの"
-" 'kc_idp_hint' パラメーターを使用して、このプロバイダーの使用を引き続き依頼できます。"
+"ON*の場合、{project_name} "
+"は、ログインページのログインオプションとしてこのプロバイダを表示しません。クライアントは、ログインを要求するURLに「kc_idp_hint」パラメータを使用して、このプロバイダを要求できます。"
 
 #. type: Plain text
 msgid "Account Linking Only"
@@ -191,66 +195,66 @@ msgstr "Account Linking Only"
 
 #. type: Plain text
 msgid ""
-"When this switch is on, this provider cannot be used to login users and will"
-" not be shown as an option on the login page.  Existing accounts can still "
-"be linked with this provider though."
+"When *ON*, {project_name} links existing accounts with this provider. This "
+"provider cannot log users in, and {project_name} does not display this "
+"provider as an option on the login page."
 msgstr ""
-"このスイッチをオンにすると、このプロバイダーはユーザーのログインでは使用することができず、ログイン・ページにはオプションとして表示されません。しかし、既存のアカウントはこのプロバイダーとリンクできます。"
+"ON*の場合、{project_name} "
+"既存のアカウントとこのプロバイダをリンクします。このプロバイダーはユーザーをログインさせることができず、{project_name} "
+"はログインページのオプションとしてこのプロバイダーを表示しません。"
 
 #. type: Plain text
 msgid "Store Tokens"
 msgstr "Store Tokens"
 
 #. type: Plain text
-msgid "Whether or not to store the token received from the identity provider."
-msgstr "アイデンティティー・プロバイダーから受け取ったトークンを保存するかどうか。"
+msgid "When *ON*, {project_name} stores tokens from the identity provider."
+msgstr "ON*の場合、{project_name}はIDプロバイダーからのトークンを保存します。"
 
 #. type: Plain text
 msgid "Stored Tokens Readable"
 msgstr "Stored Tokens Readable"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Whether or not users are allowed to retrieve the stored identity provider token.  This also applies to the _broker_ client-level\n"
-" role _read token_.\n"
+"When *ON*, users can retrieve the stored identity provider token. This "
+"action also applies to the _broker_ client-level role _read token_."
 msgstr ""
-"ユーザーが保存されたアイデンティティー・プロバイダー・トークンを取得できるかどうか。 _broker_ クライアント・レベルのロール _read "
-"token_ にも適用されます。\n"
+"ON*の場合、ユーザは保存されているIDプロバイダトークンを取得できます。このアクションは、_broker_クライアントレベルロールの_read "
+"token_にも適用されます。"
 
 #. type: Plain text
 msgid "Trust Email"
 msgstr "Trust Email"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"If the identity provider supplies an email address this email address will be trusted.  If the realm required email validation,\n"
-" users that log in from this IDP will not have to go through the email verification process.\n"
+"When *ON*, {project_name} trusts email addresses from the identity provider."
+" If the realm requires email validation, users that log in from this "
+"identity provider do not need to perform the email verification process."
 msgstr ""
-"アイデンティティー・プロバイダーがメールアドレスを提供する場合、このメールアドレスは信頼されます。レルムに電子メールの検証が必要な場合、このIDPからログインしたユーザーは電子メールの検証プロセスを経る必要はありません。\n"
+"ON*の場合、{project_name} "
+"IDプロバイダからの電子メールアドレスを信頼します。レルムが電子メールの検証を必要とする場合、このIDプロバイダからログインするユーザーは、電子メールの検証プロセスを実行する必要はありません。"
 
 #. type: Plain text
 msgid "GUI Order"
 msgstr "GUI Order"
 
 #. type: Plain text
-msgid ""
-"The order number that sorts how the available IDPs are listed on the login "
-"page."
-msgstr "利用可能なIDPがログインページにどのように表示されるかを並べ替える順番設定です。"
+msgid "The sort order of the available identity providers on the login page."
+msgstr "ログインページで利用可能なIDプロバイダーのソート順を指定します。"
 
-#. type: Title ===
-#, no-wrap
+#. type: Plain text
 msgid "First Login Flow"
 msgstr "First Login Flow"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"This is the authentication flow that will be triggered for users that log into {project_name} through this IDP\n"
-" for the first time ever.\n"
-msgstr "このIDPを通じて、初めて{project_name}にログインするユーザーのためにトリガーされる認証フローです。\n"
+"The authentication flow {project_name} triggers when users use this identity"
+" provider to log into {project_name} for the first time."
+msgstr ""
+"認証フロー {project_name} は、ユーザーがこの ID プロバイダーを使用して {project_name} "
+"に初めてログインしたときにトリガーされます。"
 
 #. type: Plain text
 msgid "Post Login Flow"
@@ -258,20 +262,22 @@ msgstr "Post Login Flow"
 
 #. type: Plain text
 msgid ""
-"Authentication flow that is triggered after the user finishes logging in "
-"with the external identity provider."
-msgstr "ユーザーが外部アイデンティティー・プロバイダーへのログインを完了した後にトリガーされる認証フロー。"
+"The authentication flow {project_name} triggers when a user finishes logging"
+" in with the external identity provider."
+msgstr "認証フロー {project_name} は、ユーザーが外部の ID プロバイダーでのログインを完了したときにトリガーされます。"
 
 #. type: Plain text
 msgid "Sync Mode"
 msgstr "Sync Mode"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Strategy of how to update user information from the idp through mappers: When choosing `legacy`, the current behavior is kept, \n"
-" `import` will never update user data, while `force` will always update user data when possible. See also the documentation for <<_mappers, Identity Provider Mappers>> for more details.\n"
+"Strategy to update user information from the identity provider through "
+"mappers. When choosing *legacy*, {project_name} used the current behavior. "
+"*Import* does not update user data and *force* updates user data when "
+"possible. See <<_mappers, Identity Provider Mappers>> for more information."
 msgstr ""
-"マッパーを通じてIdPからユーザー情報を更新する方法の戦略： `legacy` を選択すると、現在の動作が維持されます。 `import` "
-"はユーザーデータを更新しませんが、 `force` は常にユーザーデータを更新します。詳細については、<<_mappers, "
-"アイデンティティー・プロバイダー・マッパー>>のドキュメントも参照してください。\n"
+"ID プロバイダーからマッパーを介してユーザー情報を更新する戦略。*legacy* を選択する際、{project_name} "
+"は現在の動作を使用しました。*Import* はユーザーデータを更新せず、*force* "
+"は可能な限りユーザーデータを更新します。詳しく<_mappers, Identity Provider "
+"Mappers>は&lt;&gt;</_mappers,>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/configuration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__configuration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
