### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,118 +19,116 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Block title
-#: source/server_admin/topics/events/admin.adoc:2
-#: source/server_admin/topics/events/admin.adoc:23
 #, no-wrap
-msgid "Admin Events"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Admin events"
 msgstr "管理イベント"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:7
 msgid ""
-"Any action an admin performs within the admin console can be recorded for "
-"auditing purposes.  The Admin Console performs administrative functions by "
-"invoking on the {project_name} REST interface.  {project_name} audits these "
-"REST invocations.  The resulting events can then be viewed in the Admin "
-"Console."
+"You can record all actions that are performed by an administrator in the "
+"Admin Console. The Admin Console performs administrative actions by invoking"
+" the {project_name} REST interface and {project_name} audits these REST "
+"invocations. You can view the resulting events in the Admin Console."
 msgstr ""
-"管理コンソール内で管理者が実行するアクションは、監査目的で記録できます。管理コンソールは、{project_name} "
-"RESTインターフェイスを使用して管理機能を実行します。{project_name}は、これらのREST呼び出しを監査します。結果のイベントは、管理コンソールで表示できます。"
+"管理者がAdmin Consoleで実行したすべてのアクションを記録することができます。アドミンコンソールは、{project_name} REST "
+"インターフェイスを呼び出して管理アクションを実行します。REST インターフェイスを呼び出し、{project_name} これらの REST "
+"呼び出しを監査します。結果のイベントは、Admin Console で確認できます。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:9
-msgid ""
-"To enable auditing of Admin actions, go to the `Events` left menu item and "
-"select the `Config` tab."
-msgstr "管理者のアクションの監査を有効にするには、左側の `Events` メニュー項目で、 `Config` タブを選択します。"
+msgid "To enable auditing of Admin actions:"
+msgstr "管理者アクションの監査を有効にするには"
+
+#. type: Plain text
+msgid "Click *Events* in the menu."
+msgstr "メニューの *Events* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Config* tab."
+msgstr "*Config* タブをクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/events/admin.adoc:10
-#: source/server_admin/topics/events/login.adoc:9
 #, no-wrap
-msgid "Event Configuration"
+msgid "Event configuration"
 msgstr "イベントの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:12
-#: source/server_admin/topics/events/login.adoc:11
-msgid "image:{project_images}/login-events-config.png[]"
-msgstr "image:{project_images}/login-events-config.png[]"
+msgid "image:{project_images}/login-events-config.png[Event Configuration]"
+msgstr "image:{project_images}/login-events-config.png[Event Configuration]"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:14
 msgid ""
-"In the `Admin Events Settings` section, turn on the `Save Events` switch."
-msgstr "`Admin Events Settings` セクションで `Save Events` スイッチをオンにします。"
+"Toggle *Save Events* to *ON* in the *Admin Events Settings* section. "
+"{project_name} displays the *Include Representation* switch."
+msgstr ""
+"管理者用イベント設定」セクションで、「イベントの保存」を*ON*に切り替えます。{project_name} は、*代表を含める*スイッチを表示します。"
 
 #. type: Block title
-#: source/server_admin/topics/events/admin.adoc:15
 #, no-wrap
-msgid "Admin Event Configuration"
+msgid "Admin event configuration"
 msgstr "管理イベントの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:17
-msgid "image:{project_images}/admin-events-settings.png[]"
-msgstr "image:{project_images}/admin-events-settings.png[]"
-
-#. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:20
 msgid ""
-"The `Include Representation` switch will include any JSON document that is "
-"sent through the admin REST API.  This allows you to view exactly what an "
-"admin has done, but can lead to a lot of information stored in the database."
-"  The `Clear admin events` button allows you to wipe out the current "
-"information stored."
+"image:{project_images}/admin-events-settings.png[Admin Event Configuration]"
 msgstr ""
-"`Include Representation` スイッチには、管理REST "
-"APIを介して送信される任意のJSONドキュメントが含まれます。これにより、管理者が行ったことを正確に表示できますが、多くの情報がデータベースに保存されることになる可能性があります。"
-" `Clear admin events` ボタンを押すと、保存されている現在の情報を消去することができます。"
+"image:{project_images}/admin-events-settings.png[Admin Event Configuration]"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:22
-msgid "To view the admin events go to the `Admin Events` tab."
-msgstr "管理イベントを表示するには、 `Admin Events` タブをクリックします。"
+msgid "Toggle *Include Representation* to *ON*."
+msgstr "表現を含む」を*ON*に切り替えます。"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:25
-msgid "image:{project_images}/admin-events.png[]"
-msgstr "image:{project_images}/admin-events.png[]"
-
-#. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:27
 msgid ""
-"If the `Details` column has a `Representation` box, you can click on that to"
-" view the JSON that was sent with that operation."
+"The `Include Representation` switch includes JSON documents sent through the"
+" admin REST API so you can view the administrators actions. To clear the "
+"database of stored actions, click *Clear admin events*."
 msgstr ""
-"`Details` カラムに `Representation` "
-"ボックスがある場合、それをクリックして、その操作で送られたJSONを表示することができます。"
+"Include Representation`スイッチは、管理者のアクションを表示できるように、admin REST "
+"APIを通して送られたJSONドキュメントを含みます。保存されているアクションのデータベースをクリアするには、*Clear admin "
+"events*をクリックします。"
+
+#. type: Plain text
+msgid "To view the admin events, click the *Admin Events* tab."
+msgstr "管理イベントを表示するには、*Admin Events*タブをクリックします。"
+
+#. type: Plain text
+msgid "image:{project_images}/admin-events.png[Admin Events]"
+msgstr "image:{project_images}/admin-events.png[Admin Events]"
+
+#. type: Plain text
+msgid ""
+"If the `Details` column has a *Representation* button, click the "
+"*Representation* button to view the JSON {project_name} sent with the "
+"operation."
+msgstr ""
+"Details`列に*Representation*ボタンがある場合、*Representation*ボタンをクリックすると、操作で送られたJSON "
+"{project_name}が表示されます。"
 
 #. type: Block title
-#: source/server_admin/topics/events/admin.adoc:28
 #, no-wrap
-msgid "Admin Representation"
+msgid "Admin representation"
 msgstr "管理イベントの表現"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:30
-msgid "image:{project_images}/admin-events-representation.png[]"
-msgstr "image:{project_images}/admin-events-representation.png[]"
+msgid ""
+"image:{project_images}/admin-events-representation.png[Admin Representation]"
+msgstr ""
+"image:{project_images}/admin-events-representation.png[Admin Representation]"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:32
-msgid ""
-"You can also filter for the events you are interested in by clicking the "
-"`Filter` button."
-msgstr "`Filter` ボタンをクリックすることで、興味のあるイベントをフィルタリングすることもできます。"
+msgid "Click `Filter` to view specific events."
+msgstr "特定のイベントを表示するには、「フィルタ」をクリックします。"
 
 #. type: Block title
-#: source/server_admin/topics/events/admin.adoc:33
 #, no-wrap
-msgid "Admin Event Filter"
+msgid "Admin event filter"
 msgstr "管理イベントのフィルター"
 
 #. type: Plain text
-#: source/server_admin/topics/events/admin.adoc:35
-msgid "image:{project_images}/admin-events-filter.png[]"
-msgstr "image:{project_images}/admin-events-filter.png[]"
+msgid "image:{project_images}/admin-events-filter.png[Admin Event Filter]"
+msgstr "image:{project_images}/admin-events-filter.png[Admin Event Filter]"

--- a/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po
@@ -35,13 +35,11 @@ msgid ""
 " the {project_name} REST interface and {project_name} audits these REST "
 "invocations. You can view the resulting events in the Admin Console."
 msgstr ""
-"管理者がAdmin Consoleで実行したすべてのアクションを記録することができます。アドミンコンソールは、{project_name} REST "
-"インターフェイスを呼び出して管理アクションを実行します。REST インターフェイスを呼び出し、{project_name} これらの REST "
-"呼び出しを監査します。結果のイベントは、Admin Console で確認できます。"
+"管理者が管理コンソールで実行したすべてのアクションを記録することができます。管理コンソールは、{project_name}のRESTインターフェイスを呼び出して管理アクションを実行します。RESTインターフェイスを呼び出し、{project_name}はこれらのREST呼び出しを監査します。結果のイベントは、管理コンソールで確認できます。"
 
 #. type: Plain text
 msgid "To enable auditing of Admin actions:"
-msgstr "管理者アクションの監査を有効にするには"
+msgstr "管理アクションの監査を有効にするには以下を行います。"
 
 #. type: Plain text
 msgid "Click *Events* in the menu."
@@ -65,7 +63,8 @@ msgid ""
 "Toggle *Save Events* to *ON* in the *Admin Events Settings* section. "
 "{project_name} displays the *Include Representation* switch."
 msgstr ""
-"管理者用イベント設定」セクションで、「イベントの保存」を*ON*に切り替えます。{project_name} は、*代表を含める*スイッチを表示します。"
+"*Admin Events Settings* のセクションで、 *Save Events* を *ON* "
+"に切り替えます。{project_name}は、 *Include Representation* スイッチを表示します。"
 
 #. type: Block title
 #, no-wrap
@@ -80,7 +79,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Toggle *Include Representation* to *ON*."
-msgstr "表現を含む」を*ON*に切り替えます。"
+msgstr "*Include Representation* を*ON*に切り替えます。"
 
 #. type: Plain text
 msgid ""
@@ -88,13 +87,13 @@ msgid ""
 " admin REST API so you can view the administrators actions. To clear the "
 "database of stored actions, click *Clear admin events*."
 msgstr ""
-"Include Representation`スイッチは、管理者のアクションを表示できるように、admin REST "
-"APIを通して送られたJSONドキュメントを含みます。保存されているアクションのデータベースをクリアするには、*Clear admin "
-"events*をクリックします。"
+"`Include Representation` スイッチは、管理者のアクションを表示できるように、管理REST "
+"APIを通して送られたJSONドキュメントを含みます。データベースに保存されているアクションをクリアするには、 *Clear admin events*"
+" をクリックします。"
 
 #. type: Plain text
 msgid "To view the admin events, click the *Admin Events* tab."
-msgstr "管理イベントを表示するには、*Admin Events*タブをクリックします。"
+msgstr "管理イベントを表示するには、 *Admin Events* タブをクリックします。"
 
 #. type: Plain text
 msgid "image:{project_images}/admin-events.png[Admin Events]"
@@ -106,8 +105,8 @@ msgid ""
 "*Representation* button to view the JSON {project_name} sent with the "
 "operation."
 msgstr ""
-"Details`列に*Representation*ボタンがある場合、*Representation*ボタンをクリックすると、操作で送られたJSON "
-"{project_name}が表示されます。"
+"`Details` 列に *Representation* ボタンがある場合、 *Representation* "
+"ボタンをクリックして、{project_name}が操作で送信したJSONを表示します。"
 
 #. type: Block title
 #, no-wrap
@@ -122,7 +121,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Click `Filter` to view specific events."
-msgstr "特定のイベントを表示するには、「フィルタ」をクリックします。"
+msgstr "特定のイベントを表示するには、 `Filter` をクリックします。"
 
 #. type: Block title
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/events/admin.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__events__admin
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
