### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/proc-using-admin-console.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/proc-using-admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/proc-using-admin-console.ja_JP.po
@@ -1,0 +1,106 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title ==
+#, no-wrap
+msgid "Using the Admin Console"
+msgstr "管理者コンソールの使用"
+
+#. type: Plain text
+msgid ""
+"You configure realms and perform most administrative tasks in the "
+"{project_name} Admin Console."
+msgstr "レルムを設定し、ほとんどの管理作業は{project_name}で行います。アドミンコンソール"
+
+#. type: Plain text
+msgid ""
+"You need an administrator account.  See xref:creating-first-"
+"admin_{context}[Creating the first administrator]."
+msgstr ""
+"管理者アカウントが必要です。  xref:creating-first-admin_{context}[Creating the first "
+"administrator]をご覧ください。"
+
+#. type: Plain text
+msgid "Go the the URL for the Admin Console."
+msgstr "アドミンコンソールのURLにアクセスします。"
+
+#. type: Plain text
+msgid ""
+"For example, for localhost, use this URL: http://localhost:8080/auth/admin/"
+msgstr "例えば、ローカルホストの場合、次のURLを使用します： http://localhost:8080/auth/admin/"
+
+#. type: Block title
+#, no-wrap
+msgid "Login page"
+msgstr "ログインページ"
+
+#. type: Plain text
+msgid "image:{project_images}/login-page.png[Login page]"
+msgstr "image:{project_images}/login-page.png[Login page]"
+
+#. type: Plain text
+msgid ""
+"Enter the username and password you created on the Welcome Page or the `add-"
+"user-keycloak` script in the bin directory.  This action displays the Admin "
+"Console."
+msgstr ""
+"ウェルカムページで作成したユーザ名とパスワード、またはbinディレクトリにある`add-user-keycloak`スクリプトを入力します。  "
+"このアクションは、アドミンコンソールを表示します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Admin Console"
+msgstr "管理コンソール"
+
+#. type: Plain text
+msgid "image:{project_images}/admin-console.png[Admin Console]"
+msgstr "image:{project_images}/admin-console.png[Admin Console]"
+
+#. type: Plain text
+msgid "Note the menus and other options that you can use:"
+msgstr "使えるメニューなどをメモしておきましょう。"
+
+#. type: Plain text
+msgid ""
+"Click the menu labeled *Master* to pick a realm you want to manage or to "
+"create a new one."
+msgstr "Master \"と書かれたメニューをクリックして、管理したいレルムを選択するか、新しいレルムを作成します。"
+
+#. type: Plain text
+msgid "Click the top right list to view your account or log out."
+msgstr "右上のリストをクリックすると、自分のアカウントを確認したり、ログアウトしたりできます。"
+
+#. type: Plain text
+msgid ""
+"Hover over a question mark *?* icon to show a tooltip text that describes "
+"that field. The image above shows the tooltip in action."
+msgstr ""
+"クエスチョンマーク*?*のアイコンにカーソルを合わせると、そのフィールドを説明するツールチップテキストが表示されます。上の画像は、ツールチップの動作を示しています。"

--- a/i18n/po/ja_JP/server_admin/topics/realms/proc-using-admin-console.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/proc-using-admin-console.ja_JP.po
@@ -32,30 +32,29 @@ msgstr "手順"
 #. type: Title ==
 #, no-wrap
 msgid "Using the Admin Console"
-msgstr "管理者コンソールの使用"
+msgstr "管理コンソールの使用"
 
 #. type: Plain text
 msgid ""
 "You configure realms and perform most administrative tasks in the "
 "{project_name} Admin Console."
-msgstr "レルムを設定し、ほとんどの管理作業は{project_name}で行います。アドミンコンソール"
+msgstr "レルムを設定し、ほとんどの管理作業は{project_name}の管理コンソールで行います。"
 
 #. type: Plain text
 msgid ""
 "You need an administrator account.  See xref:creating-first-"
 "admin_{context}[Creating the first administrator]."
 msgstr ""
-"管理者アカウントが必要です。  xref:creating-first-admin_{context}[Creating the first "
-"administrator]をご覧ください。"
+"管理者アカウントが必要です。 xref:creating-first-admin_{context}[最初の管理者を作成する] を参照してください。"
 
 #. type: Plain text
 msgid "Go the the URL for the Admin Console."
-msgstr "アドミンコンソールのURLにアクセスします。"
+msgstr "管理コンソールのURLにアクセスします。"
 
 #. type: Plain text
 msgid ""
 "For example, for localhost, use this URL: http://localhost:8080/auth/admin/"
-msgstr "例えば、ローカルホストの場合、次のURLを使用します： http://localhost:8080/auth/admin/"
+msgstr "例えば、ローカルホストの場合、http://localhost:8080/auth/admin/のURLを使用します。"
 
 #. type: Block title
 #, no-wrap
@@ -72,8 +71,8 @@ msgid ""
 "user-keycloak` script in the bin directory.  This action displays the Admin "
 "Console."
 msgstr ""
-"ウェルカムページで作成したユーザ名とパスワード、またはbinディレクトリにある`add-user-keycloak`スクリプトを入力します。  "
-"このアクションは、アドミンコンソールを表示します。"
+"ウェルカムページで作成したユーザー名とパスワード、またはbinディレクトリーにある `add-user-keycloak` "
+"スクリプトを入力します。このアクションは、管理コンソールを表示します。"
 
 #. type: Block title
 #, no-wrap
@@ -86,13 +85,13 @@ msgstr "image:{project_images}/admin-console.png[Admin Console]"
 
 #. type: Plain text
 msgid "Note the menus and other options that you can use:"
-msgstr "使えるメニューなどをメモしておきましょう。"
+msgstr "使えるメニューや他のオプションをメモします。"
 
 #. type: Plain text
 msgid ""
 "Click the menu labeled *Master* to pick a realm you want to manage or to "
 "create a new one."
-msgstr "Master \"と書かれたメニューをクリックして、管理したいレルムを選択するか、新しいレルムを作成します。"
+msgstr "*Master* と書かれたメニューをクリックして、管理したいレルムを選択するか、新しいレルムを作成します。"
 
 #. type: Plain text
 msgid "Click the top right list to view your account or log out."
@@ -103,4 +102,5 @@ msgid ""
 "Hover over a question mark *?* icon to show a tooltip text that describes "
 "that field. The image above shows the tooltip in action."
 msgstr ""
-"クエスチョンマーク*?*のアイコンにカーソルを合わせると、そのフィールドを説明するツールチップテキストが表示されます。上の画像は、ツールチップの動作を示しています。"
+"クエスチョン・マーク *?* "
+"のアイコンにカーソルを合わせると、そのフィールドを説明するツールチップ・テキストが表示されます。上の画像は、ツールチップの動作を示しています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/proc-using-admin-console.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__proc-using-admin-console
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
