### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/saml/proc-using-an-entity-descriptor.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-using-an-entity-descriptor.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-using-an-entity-descriptor.ja_JP.po
@@ -1,0 +1,80 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Add client"
+msgstr "Add client"
+
+#. type: Plain text
+msgid "image:{project_images}/add-client-saml.png[]"
+msgstr "image:{project_images}/add-client-saml.png[]"
+
+#. type: Title =
+#, no-wrap
+msgid "Using an entity descriptor to create a client"
+msgstr "エンティティ記述子を使用したクライアントの作成"
+
+#. type: Plain text
+msgid ""
+"Instead of registering a SAML 2.0 client manually, you can import the client"
+" using a standard SAML Entity Descriptor XML file."
+msgstr ""
+"SAML 2.0クライアントを手動で登録する代わりに、標準のSAML Entity Descriptor "
+"XMLファイルを使用してクライアントをインポートすることができます。"
+
+#. type: Plain text
+msgid "The Add Client page includes an *Import* option."
+msgstr "クライアントの追加」ページには、「インポート」オプションがあります。"
+
+#. type: Plain text
+msgid "Click *Select File*."
+msgstr "Select File \"をクリックします。"
+
+#. type: Plain text
+msgid "Load the file that contains the XML entity descriptor information."
+msgstr "XMLエンティティ記述子の情報を含むファイルを読み込みます。"
+
+#. type: Plain text
+msgid "Review the information to ensure everything is set up correctly."
+msgstr "すべての設定が正しく行われているか、情報を確認してください。"
+
+#. type: Plain text
+msgid ""
+"Some SAML client adapters, such as _mod-auth-mellon_, need the XML Entity "
+"Descriptor for the IDP.  You can find this descriptor by going to this URL:"
+msgstr ""
+"mod-auth-melon_などの一部のSAMLクライアントアダプタは、IDPのXML Entity Descriptorを必要とする。  "
+"この記述子は、このURLにアクセスして見つけることができます。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "root/auth/realms/{realm}/protocol/saml/descriptor\n"
+msgstr "root/auth/realms/{realm}/protocol/saml/descriptor\n"
+
+#. type: Plain text
+msgid "where _realm_ is the realm of your client."
+msgstr "ここで、_realm_はクライアントのレルムです。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-using-an-entity-descriptor.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-using-an-entity-descriptor.ja_JP.po
@@ -27,7 +27,7 @@ msgstr "手順"
 #. type: Block title
 #, no-wrap
 msgid "Add client"
-msgstr "Add client"
+msgstr "Add Client"
 
 #. type: Plain text
 msgid "image:{project_images}/add-client-saml.png[]"
@@ -36,27 +36,27 @@ msgstr "image:{project_images}/add-client-saml.png[]"
 #. type: Title =
 #, no-wrap
 msgid "Using an entity descriptor to create a client"
-msgstr "エンティティ記述子を使用したクライアントの作成"
+msgstr "エンティティー記述子を使用したクライアントの作成"
 
 #. type: Plain text
 msgid ""
 "Instead of registering a SAML 2.0 client manually, you can import the client"
 " using a standard SAML Entity Descriptor XML file."
 msgstr ""
-"SAML 2.0クライアントを手動で登録する代わりに、標準のSAML Entity Descriptor "
-"XMLファイルを使用してクライアントをインポートすることができます。"
+"SAML "
+"2.0クライアントを手動で登録する代わりに、標準のSAMLエンティティー記述子XMLファイルを使用してクライアントをインポートすることができます。"
 
 #. type: Plain text
 msgid "The Add Client page includes an *Import* option."
-msgstr "クライアントの追加」ページには、「インポート」オプションがあります。"
+msgstr "Add Clientページには、 *Import* オプションがあります。"
 
 #. type: Plain text
 msgid "Click *Select File*."
-msgstr "Select File \"をクリックします。"
+msgstr "*Select File* をクリックします。"
 
 #. type: Plain text
 msgid "Load the file that contains the XML entity descriptor information."
-msgstr "XMLエンティティ記述子の情報を含むファイルを読み込みます。"
+msgstr "XMLエンティティー記述子の情報を含むファイルを読み込みます。"
 
 #. type: Plain text
 msgid "Review the information to ensure everything is set up correctly."
@@ -67,8 +67,8 @@ msgid ""
 "Some SAML client adapters, such as _mod-auth-mellon_, need the XML Entity "
 "Descriptor for the IDP.  You can find this descriptor by going to this URL:"
 msgstr ""
-"mod-auth-melon_などの一部のSAMLクライアントアダプタは、IDPのXML Entity Descriptorを必要とする。  "
-"この記述子は、このURLにアクセスして見つけることができます。"
+"_mod-auth-melon_ "
+"などの一部のSAMLクライアント・アダプターは、IDPのXMLエンティティー記述子を必要とします。この記述子は、このURLにアクセスして見つけることができます。"
 
 #. type: delimited block -
 #, no-wrap
@@ -77,4 +77,4 @@ msgstr "root/auth/realms/{realm}/protocol/saml/descriptor\n"
 
 #. type: Plain text
 msgid "where _realm_ is the realm of your client."
-msgstr "ここで、_realm_はクライアントのレルムです。"
+msgstr "ここで、 _realm_ はクライアントのレルムです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/saml/proc-using-an-entity-descriptor.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__saml__proc-using-an-entity-descriptor
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
