### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
@@ -71,15 +71,16 @@ msgid ""
 "In a separate browser tab, open the "
 "https://developers.facebook.com/[Facebook Developer Console]."
 msgstr ""
-"別のブラウザタブで、https://developers.facebook.com/[Facebook Developer Console]を開きます。"
+"別のブラウザータブで、 https://developers.facebook.com/[Facebook Developer Console] "
+"を開きます。"
 
 #. type: Plain text
 msgid "Click *My Apps*."
-msgstr "My Apps \"をクリックします。"
+msgstr "*My Apps* をクリックします。"
 
 #. type: Plain text
 msgid "Select *Add a New App*."
-msgstr "Add a New App*」を選択します。"
+msgstr "*Add a New App* を選択します。"
 
 #. type: Block title
 #, no-wrap
@@ -109,11 +110,11 @@ msgstr "必須項目をすべて入力してください。"
 
 #. type: Plain text
 msgid "Click *Create App*. Facebook then brings you to the dashboard."
-msgstr "アプリを作成する」をクリックします。すると、Facebookがダッシュボードを表示します。"
+msgstr "*Create App* をクリックすると、Facebookはダッシュボードを表示します。"
 
 #. type: Plain text
 msgid "In the navigation panel, select *Settings* - *Basic*."
-msgstr "ナビゲーションパネルで、「設定」-「基本」を選択します。"
+msgstr "ナビゲーション・パネルで、 *Settings* - *Basic* を選択します。"
 
 #. type: Block title
 #, no-wrap
@@ -130,7 +131,7 @@ msgstr "*+ Add Platform*を選択します。"
 
 #. type: Plain text
 msgid "Click *[Website]*."
-msgstr "ウェブサイト]*をクリックします。"
+msgstr "*[Website]* をクリックします。"
 
 #. type: Plain text
 msgid "Enter a URL for your site."
@@ -147,24 +148,24 @@ msgstr "image:images/instagram-add-product.png[]"
 
 #. type: Plain text
 msgid "Select `Dashboard` from the menu."
-msgstr "メニューから「ダッシュボード」を選択します。"
+msgstr "メニューから `Dashboard` を選択します。"
 
 #. type: Plain text
 msgid "Click *Set Up* in the Instagram box."
-msgstr "インスタグラムのボックスにある*Set Up*をクリックします。"
+msgstr "Instagramのボックスにある *Set Up* をクリックします。"
 
 #. type: Plain text
 msgid "Select *Instagram* - *Basic Display* from the menu."
-msgstr "メニューから「*Instagram* - *Basic Display*」を選択します。"
+msgstr "メニューから *Instagram* - *Basic Display* を選択します。"
 
 #. type: Plain text
 msgid "Click *Create New App*."
-msgstr "Create New App*をクリックします。"
+msgstr "*Create New App* をクリックします。"
 
 #. type: Block title
 #, no-wrap
 msgid "Create a new Instagram app ID"
-msgstr "インスタグラムのアプリIDを新規に作成する"
+msgstr "インスタグラムのアプリIDを新規に作成します。"
 
 #. type: Plain text
 msgid ""
@@ -176,7 +177,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Enter a value into *Display Name*."
-msgstr "Display Name \"に値を入力してください。"
+msgstr "*Display Name* に値を入力してください。"
 
 #. type: Block title
 #, no-wrap
@@ -192,27 +193,31 @@ msgid ""
 "Paste the *Redirect URL* from {project_name} into the *Valid OAuth Redirect "
 "URIs* field."
 msgstr ""
-"project_name} の *Redirect URL* を *Valid OAuth Redirect URIs* 欄に貼り付けてください。"
+"{project_name}の *Redirect URL* を *Valid OAuth Redirect URIs* "
+"フィールドに貼り付けてください。"
 
 #. type: Plain text
 msgid ""
 "Paste the *Redirect URL* from {project_name} into the *Deauthorize Callback "
 "URL* field."
-msgstr "project_name}の*Redirect URL*を*Deauthorize Callback URL*欄に貼り付けてください。"
+msgstr ""
+"{project_name}の *Redirect URL* を *Deauthorize Callback URL* フィールドに貼り付けてください。"
 
 #. type: Plain text
 msgid ""
 "Paste the *Redirect URL* from {project_name} into the *Data Deletion Request"
 " URL* field."
-msgstr "project_name}の*Redirect URL*を*Data Deletion Request URL*欄に貼り付けてください。"
+msgstr ""
+"{project_name}の *Redirect URL* を *Data Deletion Request URL* "
+"フィールドに貼り付けてください。"
 
 #. type: Plain text
 msgid "Click *Show* in the *Instagram App Secret* field."
-msgstr "Instagram App Secret」欄の「Show」をクリックします。"
+msgstr "*Instagram App Secret* フィールドの *Show* をクリックします。"
 
 #. type: Plain text
 msgid "Note the *Instagram App ID* and the *Instagram App Secret*."
-msgstr "*Instagram App ID*」と「*Instagram App Secret*」に注意してください。"
+msgstr "*Instagram App ID* と *Instagram App Secret* に注意してください。"
 
 #. type: Plain text
 msgid "Click *App Review* - *Requests*."
@@ -222,10 +227,11 @@ msgstr "*App Review* - *Requests* をクリックします。"
 msgid ""
 "In {project_name}, paste the value of the *Instagram App ID* into the "
 "*Client ID* field."
-msgstr "{project_name}では、*Instagram App ID*の値を*Client ID*欄に貼り付けます。"
+msgstr "{project_name}では、*Instagram App ID* の値を *Client ID* フィールドに貼り付けます。"
 
 #. type: Plain text
 msgid ""
 "In {project_name}, paste the value of the *Instagram App Secret* into the "
 "*Client Secret* field."
-msgstr "{project_name}では、*Instagram App Secret*の値を*Client Secret*欄に貼り付けます。"
+msgstr ""
+"{project_name}では、 *Instagram App Secret* の値を *Client Secret* フィールドに貼り付けます。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,13 +21,29 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Follow the instructions on the screen."
+msgstr "画面の指示に従ってください。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
 
 #. type: Block title
 #, no-wrap
-msgid "Add a New App"
-msgstr "新しいアプリケーションの追加"
+msgid "Add identity provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+msgid "Copy the value of *Redirect URI* to your clipboard."
+msgstr "Redirect URI* の値をクリップボードにコピーしてください。"
 
 #. type: Title ====
 #, no-wrap
@@ -36,60 +52,43 @@ msgstr "Instagram"
 
 #. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with Instagram.  First, go to the `Identity Providers` left menu item and "
-"select `Instagram` from the `Add provider` drop down list.  This will bring "
-"you to the `Add identity provider` page."
+"From the `Add provider` list, select `Instagram`. {project_name} displays "
+"the configuration page for the Instagram identity provider."
 msgstr ""
-"Instagramでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Instagram` を選択します。これにより、 "
-"`Add identity provider` ページが表示されます。"
-
-#. type: Plain text
-msgid "image:{project_images}/instagram-add-identity-provider.png[]"
-msgstr "image:{project_images}/instagram-add-identity-provider.png[]"
+"`Add provider` の一覧から `Instagram` "
+"を選択します。{project_name}はInstagramのアイデンティティー・プロバイダーの設定ページを表示します。"
 
 #. type: Plain text
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from Instagram.  One piece of data you'll need from this page is "
-"the `Redirect URI`.  You'll have to provide that to Instagram when you "
-"register {project_name} as a client there, so copy this URI to your "
-"clipboard."
+"image:{project_images}/instagram-add-identity-provider.png[Add Identity "
+"Provider]"
 msgstr ""
-"Instagramから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
-"です。Instagramに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
+"image:{project_images}/instagram-add-identity-provider.png[Add Identity "
+"Provider]"
 
 #. type: Plain text
 msgid ""
-"To enable login with Instagram you first have to create a project and a "
-"client. Instagram API is managed through the "
+"In a separate browser tab, open the "
 "https://developers.facebook.com/[Facebook Developer Console]."
 msgstr ""
-"Instagramでのログインを可能にするには、まずプロジェクトとクライアントを作成する必要があります。Instagram APIは、 "
-"https://developers.facebook.com/[Facebook Developer Console] を通じて管理されます。"
+"別のブラウザタブで、https://developers.facebook.com/[Facebook Developer Console]を開きます。"
 
 #. type: Plain text
+msgid "Click *My Apps*."
+msgstr "My Apps \"をクリックします。"
+
+#. type: Plain text
+msgid "Select *Add a New App*."
+msgstr "Add a New App*」を選択します。"
+
+#. type: Block title
 #, no-wrap
-msgid ""
-"Facebook often changes the look and feel of the Facebook Developer Console, so these directions might not always be up to date and the\n"
-"      configuration steps might be slightly different.\n"
-msgstr ""
-"FacebookはFacebook Developer "
-"Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
+msgid "Add a new app"
+msgstr "Add a new app"
 
 #. type: Plain text
-msgid ""
-"Once you've logged into the console there is a menu in the top right corner "
-"of the screen that says `My Apps`.  Select the `Add a New App` menu item."
-msgstr ""
-"コンソールにログインすると、画面の右上に `My Apps` と表示されるメニューが表示されます。 `Add a New App` "
-"メニュー項目を選択します。"
-
-#. type: Plain text
-msgid "image:images/instagram-add-new-app.png[]"
-msgstr "image:images/instagram-add-new-app.png[]"
+msgid "image:images/instagram-add-new-app.png[Add a New App]"
+msgstr "image:images/instagram-add-new-app.png[Add a New App]"
 
 #. type: Plain text
 msgid "Select `For Everything Else`."
@@ -97,114 +96,136 @@ msgstr "`For Everything Else` を選択します。"
 
 #. type: Block title
 #, no-wrap
-msgid "Create a New App ID"
-msgstr "新しいApp IDの作成"
+msgid "Create a new app ID"
+msgstr "新規アプリIDの作成"
 
 #. type: Plain text
 msgid "image:images/instagram-create-app-id.png[]"
 msgstr "image:images/instagram-create-app-id.png[]"
 
 #. type: Plain text
-msgid ""
-"Fill all required fields. Once you're done with that, you will be brought to"
-" the dashboard for the application. In the menu in the left navigation panel"
-" select `Basic` under `Settings`."
-msgstr ""
-"すべての必須フィールドに入力します。これを完了すると、アプリケーションのダッシュボードが表示されます。左側のナビゲーション・パネルのメニューで、 "
-"`Settings` の下の `Basic` を選択します。"
+msgid "Fill in all required fields."
+msgstr "必須項目をすべて入力してください。"
+
+#. type: Plain text
+msgid "Click *Create App*. Facebook then brings you to the dashboard."
+msgstr "アプリを作成する」をクリックします。すると、Facebookがダッシュボードを表示します。"
+
+#. type: Plain text
+msgid "In the navigation panel, select *Settings* - *Basic*."
+msgstr "ナビゲーションパネルで、「設定」-「基本」を選択します。"
 
 #. type: Block title
 #, no-wrap
-msgid "Add Platform"
+msgid "Add platform"
 msgstr "プラットフォームの追加"
 
 #. type: Plain text
-msgid "image:images/instagram-add-platform.png[]"
-msgstr "image:images/instagram-add-platform.png[]"
+msgid "image:images/instagram-add-platform.png[Add Platform]"
+msgstr "image:images/instagram-add-platform.png[Add Platform]"
 
 #. type: Plain text
-msgid ""
-"Select `+ Add Platform` at the bottom and then click `[Website]` with the "
-"globe icon. Specify URL of your site."
-msgstr ""
-"下部にある `+ Add Platform` を選択し、地球のアイコンの付いた `[Website]` をクリックします。サイトのURLを指定します。"
+msgid "Select *+ Add Platform*."
+msgstr "*+ Add Platform*を選択します。"
+
+#. type: Plain text
+msgid "Click *[Website]*."
+msgstr "ウェブサイト]*をクリックします。"
+
+#. type: Plain text
+msgid "Enter a URL for your site."
+msgstr "あなたのサイトのURLを入力してください。"
 
 #. type: Block title
 #, no-wrap
-msgid "Add a Product"
-msgstr "プロダクトの追加"
+msgid "Add a product"
+msgstr "製品の追加"
 
 #. type: Plain text
 msgid "image:images/instagram-add-product.png[]"
 msgstr "image:images/instagram-add-product.png[]"
 
 #. type: Plain text
-msgid ""
-"Select `Dashboard` from the left menu and click `Set Up` in the Instagram "
-"box. In the left menu then select `Basic Display` under `Instagram` and "
-"click `Create New App`."
-msgstr ""
-"左側のメニューから `Dashboard` を選択し、Instagramボックスの `Set Up` をクリックします。左側のメニューで、 "
-"`Instagram` の下の `Basic Display` を選択し、 `Create New App` をクリックします。"
+msgid "Select `Dashboard` from the menu."
+msgstr "メニューから「ダッシュボード」を選択します。"
+
+#. type: Plain text
+msgid "Click *Set Up* in the Instagram box."
+msgstr "インスタグラムのボックスにある*Set Up*をクリックします。"
+
+#. type: Plain text
+msgid "Select *Instagram* - *Basic Display* from the menu."
+msgstr "メニューから「*Instagram* - *Basic Display*」を選択します。"
+
+#. type: Plain text
+msgid "Click *Create New App*."
+msgstr "Create New App*をクリックします。"
 
 #. type: Block title
 #, no-wrap
-msgid "Create a New Instagram App ID"
-msgstr "新しいInstagram App IDの作成"
+msgid "Create a new Instagram app ID"
+msgstr "インスタグラムのアプリIDを新規に作成する"
 
 #. type: Plain text
-msgid "image:images/instagram-create-instagram-app-id.png[]"
-msgstr "image:images/instagram-create-instagram-app-id.png[]"
+msgid ""
+"image:images/instagram-create-instagram-app-id.png[Create a New Instagram "
+"App ID]"
+msgstr ""
+"image:images/instagram-create-instagram-app-id.png[Create a New Instagram "
+"App ID]"
 
 #. type: Plain text
-msgid "Specify `Display Name`."
-msgstr "`Display Name` を指定します。"
+msgid "Enter a value into *Display Name*."
+msgstr "Display Name \"に値を入力してください。"
 
 #. type: Block title
 #, no-wrap
-msgid "Setup the App"
-msgstr "アプリのセットアップ"
+msgid "Setup the app"
+msgstr "アプリの設定"
 
 #. type: Plain text
-msgid "image:images/instagram-app-settings.png[]"
-msgstr "image:images/instagram-app-settings.png[]"
-
-#. type: Plain text
-msgid ""
-"Copy and paste the `Redirect URI` from the {project_name} `Add identity "
-"provider` page into the `Valid OAuth Redirect URIs` of the Instagram `Client"
-" OAuth Settings` settings block."
-msgstr ""
-"{project_name}の `Add identity provider` ページから取得した `Redirect URI` をInstagramの"
-" `Client OAuth Settings` 設定ブロックの `Valid OAuth Redirect URIs` "
-"にコピー・アンド・ペーストします。"
+msgid "image:images/instagram-app-settings.png[Setup the App]"
+msgstr "image:images/instagram-app-settings.png[Setup the App]"
 
 #. type: Plain text
 msgid ""
-"You can use this URL also for `Deauthorize Callback URL` and `Data Deletion "
-"Request URL`. {project_name} currently doesn't support either of them, but "
-"the Facebook Developer Console requires both of them to be filled."
+"Paste the *Redirect URL* from {project_name} into the *Valid OAuth Redirect "
+"URIs* field."
 msgstr ""
-"このURLは、 `Deauthorize Callback URL` にも `Data Deletion Request URL` "
-"にも使用できます。{project_name}は現在どちらもサポートしていませんが、Facebook Developer "
-"Consoleでは両方に入力する必要があります。"
+"project_name} の *Redirect URL* を *Valid OAuth Redirect URIs* 欄に貼り付けてください。"
 
 #. type: Plain text
 msgid ""
-"You will need also to obtain the App ID and App Secret from this page so you"
-" can enter them into the {project_name} `Add identity provider` page.  To "
-"obtain this click on `Show` under `App Secret`. Go back to {project_name} "
-"and specify those items and finally save your Instagram Identity Provider."
-msgstr ""
-"このページからApp IDとApp Secretを取得して、{project_name}の `Add identity provider` "
-"ページに入力する必要があります。これを取得するには、 `App Secret` の下の `Show` "
-"をクリックします。{project_name}に戻り、これらの項目を指定し、最後にInstagramアイデンティティー・プロバイダーを保存します。"
+"Paste the *Redirect URL* from {project_name} into the *Deauthorize Callback "
+"URL* field."
+msgstr "project_name}の*Redirect URL*を*Deauthorize Callback URL*欄に貼り付けてください。"
 
 #. type: Plain text
 msgid ""
-"After this it is necessary to make the Instagram app public. Click `App "
-"Review` left menu item and then `Requests`. After that follow the "
-"instructions on screen."
-msgstr ""
-"この後、Instagramアプリを公開する必要があります。左側のメニュー項目の `App Review` をクリックし、次に `Requests` "
-"をクリックします。その後、画面の指示に従ってください。"
+"Paste the *Redirect URL* from {project_name} into the *Data Deletion Request"
+" URL* field."
+msgstr "project_name}の*Redirect URL*を*Data Deletion Request URL*欄に貼り付けてください。"
+
+#. type: Plain text
+msgid "Click *Show* in the *Instagram App Secret* field."
+msgstr "Instagram App Secret」欄の「Show」をクリックします。"
+
+#. type: Plain text
+msgid "Note the *Instagram App ID* and the *Instagram App Secret*."
+msgstr "*Instagram App ID*」と「*Instagram App Secret*」に注意してください。"
+
+#. type: Plain text
+msgid "Click *App Review* - *Requests*."
+msgstr "*App Review* - *Requests* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, paste the value of the *Instagram App ID* into the "
+"*Client ID* field."
+msgstr "{project_name}では、*Instagram App ID*の値を*Client ID*欄に貼り付けます。"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, paste the value of the *Instagram App Secret* into the "
+"*Client Secret* field."
+msgstr "{project_name}では、*Instagram App Secret*の値を*Client Secret*欄に貼り付けます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/instagram.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__instagram
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
