### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,82 +21,90 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
 
 #. type: Block title
 #, no-wrap
-msgid "Register Application"
+msgid "Add identity provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
+msgstr ""
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, paste the value of the *Client ID* into the *Client ID* "
+"field."
+msgstr "{project_name}では、*Client ID* の値を *Client ID* フィールドに貼り付けます。"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, paste the value of the *Client Secret* into the *Client "
+"Secret* field."
+msgstr "{project_name}では、*Client Secret* の値を *Client Secret* フィールドに貼り付けます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Stack overflow"
+msgstr "スタックオーバーフロー"
+
+#. type: Plain text
+msgid "From the `Add provider` list, select `Stack Overflow`."
+msgstr "`Add provider` のリストから `Stack Overflow` を選択します。"
+
+#. type: Plain text
+msgid ""
+"In a separate browser tab, log into "
+"https://stackapps.com/apps/oauth/register[registering your application on "
+"Stack Apps]."
+msgstr ""
+"別のブラウザータブで、 https://stackapps.com/apps/oauth/register[Stack "
+"Appsにアプリケーションを登録] にログインします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Register application"
 msgstr "アプリケーションの登録"
+
+#. type: Plain text
+msgid "image:images/stack-overflow-app-register.png[Register Application]"
+msgstr "image:images/stack-overflow-app-register.png[Register Application]"
+
+#. type: Plain text
+msgid "Enter your application name into the *Application Name* field."
+msgstr "*Application Name* フィールドにアプリケーション名を入力してください。"
+
+#. type: Plain text
+msgid "Enter the OAuth domain into the *OAuth Domain* field."
+msgstr "*OAuth Domain* フィールドにOAuthドメインを入力してください。"
+
+#. type: Plain text
+msgid "Click *Register Your Application*."
+msgstr "*Register Your Application* をクリックします。"
 
 #. type: Block title
 #, no-wrap
 msgid "Settings"
 msgstr "設定"
 
-#. type: Title ====
-#, no-wrap
-msgid "Stack Overflow"
-msgstr "Stack Overflow"
+#. type: Plain text
+msgid "image:images/stack-overflow-app-settings.png[Settings]"
+msgstr "image:images/stack-overflow-app-settings.png[Settings]"
 
 #. type: Plain text
-msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with Stack Overflow.  First, go to the `Identity Providers` left menu item "
-"and select `Stack Overflow` from the `Add provider` drop down list.  This "
-"will bring you to the `Add identity provider` page."
-msgstr ""
-"Stack Overflowでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Stack Overflow` "
-"を選択します。これにより、 `Add identity provider` ページが表示されます。"
-
-#. type: Plain text
-msgid "image:{project_images}/stack-overflow-add-identity-provider.png[]"
-msgstr "image:{project_images}/stack-overflow-add-identity-provider.png[]"
-
-#. type: Plain text
-msgid ""
-"To enable login with Stack Overflow you first have to register an OAuth "
-"application on https://stackapps.com/[StackApps].  Go to "
-"https://stackapps.com/apps/oauth/register[registering your application on "
-"Stack Apps] URL and login."
-msgstr ""
-"Stack Overflowでログインを可能にするには、まず https://stackapps.com/[Stack Apps] "
-"にOAuthアプリケーションを登録する必要があります。 "
-"https://stackapps.com/apps/oauth/register[registering your application on "
-"Stack Apps] のURLにアクセスしてログインします。"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Stack Overflow often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
-"      configuration steps might be slightly different.\n"
-msgstr ""
-"Stack "
-"Overflowはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
-
-#. type: Plain text
-msgid "image:images/stack-overflow-app-register.png[]"
-msgstr "image:images/stack-overflow-app-register.png[]"
-
-#. type: Plain text
-msgid ""
-"Enter in the application name and the OAuth Domain Name of your application "
-"and click `Register your Application`.  Type in anything you want for the "
-"other items."
-msgstr ""
-"アプリケーション名とOAuthドメイン名を入力し、 `Register your Application` "
-"をクリックします。他の項目に必要なものを入力してください。"
-
-#. type: Plain text
-msgid "image:images/stack-overflow-app-settings.png[]"
-msgstr "image:images/stack-overflow-app-settings.png[]"
-
-#. type: Plain text
-msgid ""
-"Finally, you will need to obtain the client ID, secret, and key from this "
-"page so you can enter them back on the {project_name} `Add identity "
-"provider` page.  Go back to {project_name} and specify those items."
-msgstr ""
-"最後に、このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
-"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
+msgid "Note the *Client ID* and *Client Secret*."
+msgstr "*Client ID* と *Client Secret* に注意してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/stack-overflow.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__stack-overflow
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
