### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,13 +26,10 @@ msgstr "ソーシャル・アイデンティティー・プロバイダー"
 
 #. type: Plain text
 msgid ""
-"For Internet facing applications, it is quite burdensome for users to have "
-"to register at your site to obtain access.  It requires them to remember yet"
-" another username and password combination.  Social identity providers allow"
-" you to delegate authentication to a semi-trusted and respected entity where"
-" the user probably already has an account.  {project_name} provides built-in"
-" support for the most common social networks out there, such as Google, "
-"Facebook, Twitter, GitHub, LinkedIn, Microsoft and Stack Overflow."
+"A social identity provider can delegate authentication to a trusted, "
+"respected social media account. {project_name} includes support for social "
+"networks such as Google, Facebook, Twitter, GitHub, LinkedIn, Microsoft, and"
+" Stack Overflow."
 msgstr ""
-"インターネット上のアプリケーションでは、ユーザーはアクセスするためにサイトに登録する必要があります。さらに別のユーザー名とパスワードの組み合わせを覚えておく必要があります。ソーシャル・アイデンティティー・プロバイダーを使用すると、ユーザーはすでにアカウントを持っている可能性のある、ある程度信頼性があり評判のよい事業者に認証を委譲することができます。{project_name}は、Google、Facebook、Twitter、GitHub、LinkedIn、Microsoft、Stack"
-" Overflowなど、最も一般的なソーシャル・ネットワークのビルトイン・サポートを提供しています。"
+"ソーシャル・アイデンティティー・プロバイダーは、信頼され、評判の高いソーシャル・メディアのアカウントに認証を委ねることができます。{project_name}には、Google、Facebook、Twitter、GitHub、LinkedIn、Microsoft、Stack"
+" Overflowなどのソーシャル・ネットワークのサポートが含まれています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social-login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social-login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
