### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,17 +21,25 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Plain text
-msgid ""
-"You will need to obtain the client ID and secret from this page so you can "
-"enter them into the {project_name} `Add identity provider` page.  Go back to"
-" {project_name} and specify those items."
-msgstr ""
-"このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
-"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
+msgid "Click *Create*."
+msgstr "*Create* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add identity provider"
+msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ====
 #, no-wrap
@@ -40,206 +47,80 @@ msgid "Google"
 msgstr "Google"
 
 #. type: Plain text
-msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with Google.  First, go to the `Identity Providers` left menu item and "
-"select `Google` from the `Add provider` drop down list.  This will bring you"
-" to the `Add identity provider` page."
-msgstr ""
-"Googleでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Google` を選択します。これにより、 `Add "
-"identity provider` ページが表示されます。"
-
-#. type: Plain text
-msgid "image:{project_images}/google-add-identity-provider.png[]"
-msgstr "image:{project_images}/google-add-identity-provider.png[]"
+msgid "From the `Add provider` list, select `Google`."
+msgstr "`Add provider` のリストから `Google` を選択します。"
 
 #. type: Plain text
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from Google.  One piece of data you'll need from this page is the "
-"`Redirect URI`.  You'll have to provide that to Google when you register "
-"{project_name} as a client there, so copy this URI to your clipboard."
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
 msgstr ""
-"Googleから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
-"です。Googleに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
 
 #. type: Plain text
 msgid ""
-"To enable login with Google you first have to create a project and a client "
-"in the https://console.cloud.google.com/project[Google Developer Console].  "
-"Then you need to copy the client ID and secret into the {project_name} Admin"
-" Console."
+"In a separate browser tab open https://console.cloud.google.com/[the Google "
+"Cloud Platform console]."
 msgstr ""
-"Googleでのログインを可能にするには、まず https://console.cloud.google.com/project[Google "
-"Developer Console] "
-"でプロジェクトとクライアントを作成する必要があります。次に、クライアントIDとシークレットを{project_name}の管理コンソールにコピーする必要があります。"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Google often changes the look and feel of the Google Developer Console, so these directions might not always be up to date and the\n"
-"      configuration steps might be slightly different.\n"
-msgstr ""
-"GoogleはGoogle Developer "
-"Consoleのデザインを変更することが多いため、これらの指示が常に最新のものではなく、設定手順が多少異なる場合があります。\n"
-
-#. type: Plain text
-msgid "Let's see first how to create a project with Google."
-msgstr "最初にGoogleでプロジェクトを作成する方法を説明します。"
+"ブラウザーの別のタブで、 https://console.cloud.google.com/[Google Cloud Platformのコンソール] "
+"を開きます。"
 
 #. type: Plain text
 msgid ""
-"Log in to the link:https://console.cloud.google.com/project[Google Developer"
-" Console]."
+"In the Google dashboard for your Google app, click the *OAuth consent "
+"screen* menu. Create a consent screen, ensuring that the user type of the "
+"consent screen is external."
 msgstr ""
-"link:https://console.cloud.google.com/project[Google Developer "
-"Console]にログインします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Google Developer Console"
-msgstr "Google Developer Console"
+"GoogleアプリのGoogleダッシュボードで、 *OAuth consent screen* "
+"メニューをクリックします。同意画面を作成し、同意画面のユーザータイプが外部であることを確認します。"
 
 #. type: Plain text
-msgid "image:images/google-developer-console.png[]"
-msgstr "image:images/google-developer-console.png[]"
+msgid "In the Google dashboard:"
+msgstr "Googleのダッシュボードで以下を行います。"
+
+#. type: Plain text
+msgid "Click the *Credentials* menu."
+msgstr "*Credentials* メニューをクリックします。"
+
+#. type: Plain text
+msgid "Click *CREATE CREDENTIALS* - *OAuth Client ID*."
+msgstr "*CREATE CREDENTIALS* - *OAuth Client ID* をクリックします。"
+
+#. type: Plain text
+msgid "From the *Application type* list, select *Web application*."
+msgstr "*Application type* の一覧から *Web application* を選択します。"
+
+#. type: Plain text
+msgid "Note *Your Client ID* and *Your Client Secret*."
+msgstr "*Your Client ID* と *Your Client Secret* に注意してください。"
 
 #. type: Plain text
 msgid ""
-"Click the `Create Project` button.  Use any value for `Project name` and "
-"`Project ID` you want, then click the `Create` button.  Wait for the project"
-" to be created (this may take a while).  Once created you will be brought to"
-" the project's dashboard."
-msgstr ""
-"`Create Project` ボタンをクリックします。 `Project name` と `Project ID` に任意の値を使用し、 "
-"`Create` "
-"ボタンをクリックします。プロジェクトが作成されるのを待ちます（これには時間がかかることがあります）。作成されると、プロジェクトのダッシュボードに遷移します。"
-
-#. type: Block title
-#, no-wrap
-msgid "Dashboard"
-msgstr "ダッシュボード"
-
-#. type: Plain text
-msgid "image:images/google-dashboard.png[]"
-msgstr "image:images/google-dashboard.png[]"
+"In {project_name}, paste the value of the *Your Client ID* into the *Client "
+"ID* field."
+msgstr "{project_name}では、*Your Client ID* の値を *Client ID* フィールドに貼り付けます。"
 
 #. type: Plain text
 msgid ""
-"Then navigate to the `APIs & Services` section in the Google Developer "
-"Console. On that screen, navigate to `Credentials` administration."
+"In {project_name}, paste the value of the *Your Client Secret* into the "
+"*Client Secret* field."
 msgstr ""
-"次に、Googleデベロッパーコンソールの `APIs & Services` セクションに移動します。その画面で、 `Credentials` "
-"管理に移動します。"
+"{project_name}では、*Your Client Secret* の値を *Client Secret* フィールドに貼り付けます。"
 
 #. type: Plain text
 msgid ""
-"When users log into Google from {project_name} they will see a consent "
-"screen from Google which will ask the user if {project_name} is allowed to "
-"view information about their user profile. Thus Google requires some basic "
-"information about the product before creating any secrets for it. For a new "
-"project, you have first to configure `OAuth consent screen`."
+"Enter the required scopes into the *Default Scopes* field. By default, "
+"{project_name} uses the following scopes: `openid` `profile` `email`. See "
+"the https://developers.google.com/oauthplayground/[OAuth Playground] for a "
+"list of Google scopes."
 msgstr ""
-"ユーザーが{project_name}からGoogleにログインすると、Googleからの同意画面が表示され、{project_name}にユーザー・プロファイルに関する情報の表示が許可されているかどうかが尋ねられます。そのため、Googleはプロダクトのシークレットを作成する前に、プロダクトに関するいくつかの基本情報を必要とします。新しいプロジェクトのために、あなたは最初に"
-" `OAuth同意画面` を設定しなければなりません。"
+"*Default Scopes* の欄に必要なスコープを入力してください。デフォルトでは、{project_name}は `openid` 、 "
+"`profile`  、`email` のスコープを使用します。Googleのスコープの一覧は、 "
+"https://developers.google.com/oauthplayground/[OAuth Playground] を参照してください。"
 
 #. type: Plain text
 msgid ""
-"For the very basic setup, filling in the Application name is sufficient. You"
-" can also set additional details like scopes for Google APIs in this page."
-msgstr ""
-"非常に基本的な設定では、アプリケーション名を入力するだけで十分です。このページでは、Google "
-"APIのスコープなど、追加の詳細を設定することもできます。"
-
-#. type: Block title
-#, no-wrap
-msgid "Fill in OAuth consent screen details"
-msgstr "OAuth同意画面の詳細を入力"
-
-#. type: Plain text
-msgid "image:images/google-oauth-consent-screen.png[]"
-msgstr "image:images/google-oauth-consent-screen.png[]"
-
-#. type: Plain text
-msgid ""
-"The next step is to create OAuth client ID and client secret. Back in "
-"`Credentials` administration, navigate to `Credentials` tab and select "
-"`OAuth client ID` under the `Create credentials` button."
-msgstr ""
-"次のステップは、OAuthクライアントIDとクライアント・シークレットを作成することです。 `Credentials` "
-"管理に戻り、`Credentials` タブに行き、 `Create credentials` ボタンの下の `OAuth client ID` "
-"を選択してください。"
-
-#. type: Block title
-#, no-wrap
-msgid "Create credentials"
-msgstr "クレデンシャルの作成"
-
-#. type: Plain text
-msgid "image:images/google-create-credentials.png[]"
-msgstr "image:images/google-create-credentials.png[]"
-
-#. type: Plain text
-msgid ""
-"You will then be brought to the `Create OAuth client ID` page. Select `Web "
-"application` as the application type. Specify the name you want for your "
-"client.  You'll also need to copy and paste the `Redirect URI` from the "
-"{project_name} `Add Identity Provider` page into the `Authorized redirect "
-"URIs` field.  After you do this, click the `Create` button."
-msgstr ""
-"そうすると `Create OAuth client ID` ページが表示されます。アプリケーション・タイプとして `Web application` "
-"を選択します。また、{project_name}の `Add Identity Provider` ページから `Redirect URI` "
-"をコピーし、 `Authorized redirect URIs` フィールドに貼り付ける必要があります。これを済ませたら、 `Create` "
-"ボタンをクリックします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Create OAuth client ID"
-msgstr "OAuthクライアントIDの作成"
-
-#. type: Plain text
-msgid "image:images/google-create-oauth-id.png[]"
-msgstr "image:images/google-create-oauth-id.png[]"
-
-#. type: Plain text
-msgid ""
-"After you click `Create` you will be brought to the `Credentials` page. "
-"Click on your new OAuth 2.0 Client ID to view the settings of your new "
-"Google Client."
-msgstr ""
-"`Create` をクリックすると、 `Credentials` ページが表示されます。新しいOAuth "
-"2.0クライアントのIDをクリックすると、新しいGoogleクライアントの設定が表示されます。"
-
-#. type: Block title
-#, no-wrap
-msgid "Google Client Credentials"
-msgstr "Googleクライアント・クレデンシャル"
-
-#. type: Plain text
-msgid "image:images/google-client-credentials.png[]"
-msgstr "image:images/google-client-credentials.png[]"
-
-#. type: Plain text
-msgid ""
-"One config option to note on the `Add identity provider` page for Google is "
-"the `Default Scopes` field.  This field allows you to manually specify the "
-"scopes that users must authorize when authenticating with this provider.  "
-"For a complete list of scopes, please take a look at "
-"https://developers.google.com/oauthplayground/ . By default, {project_name} "
-"uses the following scopes: `openid` `profile` `email`."
-msgstr ""
-"Google用の `Add identity provider` ページで注意が必要な1つの設定オプションは、 `Default Scopes` "
-"フィールドです。 このフィールドでは、プロバイダーで認証するときにユーザーが認可する必要があるスコープを手動で指定できます。スコープの一覧については、 "
-"https://developers.google.com/oauthplayground/ を参照してください。 "
-"デフォルトでは、{project_name}は `openid` `profile` `email` のスコープを使用します。"
-
-#. type: Plain text
-msgid ""
-"If your organization uses the G Suite and you want to restrict access to "
-"only members of your organization, you must enter the domain that is used "
-"for the G Suite into the `Hosted Domain` field to enable it."
-msgstr ""
-"あなたの組織がG Suiteを使用していて、組織のメンバーだけにアクセスを制限したい場合は、G Suiteに対して使用するドメインを `Hosted "
-"Domain` フィールドに入力して有効にする必要があります。"
+"To restrict access to your GSuite organization's members only, enter the G "
+"Suite domain into the `Hosted Domain` field."
+msgstr "GSuite組織のメンバーのみにアクセスを制限するには、 `Hosted Domain` フィールドにG Suiteドメインを入力します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/google.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__google
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
