### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +21,37 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add identity provider"
 msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+msgid "Copy the value of *Redirect URI* to your clipboard."
+msgstr "Redirect URI* の値をクリップボードにコピーしてください。"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
+msgstr ""
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
+
+#. type: Plain text
+msgid "Note *Your Client ID* and *Your Client Secret*."
+msgstr "*Your Client ID* と *Your Client Secret* に注意してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -31,104 +59,35 @@ msgid "LinkedIn"
 msgstr "LinkedIn"
 
 #. type: Plain text
+msgid "From the `Add provider` list, select `LinkedIn`."
+msgstr "`Add provider` のリストから `LinkedIn` を選択します。"
+
+#. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with LinkedIn.  First, go to the `Identity Providers` left menu item and "
-"select `LinkedIn` from the `Add provider` drop down list.  This will bring "
-"you to the `Add identity provider` page."
+"In a separate browser tab, https://www.linkedin.com/developer/apps[create an"
+" app]."
 msgstr ""
-"LinkedInでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `LinkedIn` を選択します。 これにより、 "
-"`Add identity provider` ページが表示されます。"
+"別のブラウザータブで、 https://www.linkedin.com/developer/apps[create an app] を実行します。"
 
 #. type: Plain text
-msgid "image:{project_images}/linked-in-add-identity-provider.png[]"
-msgstr "image:{project_images}/linked-in-add-identity-provider.png[]"
+msgid "After you create the app, click the *Auth* tab."
+msgstr "アプリを作成した後、 *Auth* タブをクリックします。"
 
 #. type: Plain text
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from LinkedIn.  One piece of data you'll need from this page is the"
-" `Redirect URI`.  You'll have to provide that to LinkedIn when you register "
-"{project_name} as a client there, so copy this URI to your clipboard."
+"Enter the value of *Redirect URI* into the *Authorized redirect URLs for "
+"your app* field."
 msgstr ""
-"LinkedInから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `Redirect URI` "
-"です。クライアントとして{project_name}を登録するときに、LinkedInにそれを提供する必要がありますので、このURIをクリップボードにコピーしておいてください。"
+"*Authorized redirect URLs for your app* フィールドに、 *Redirect URI* の値を入力してください。"
 
 #. type: Plain text
 msgid ""
-"To enable login with LinkedIn you first have to create an application in "
-"https://www.linkedin.com/developer/apps[LinkedIn Developer Network]."
-msgstr ""
-"LinkedInでログインを可能にするには、まず https://www.linkedin.com/developer/apps[LinkedIn "
-"Developer Network] でアプリケーションを作成する必要があります。"
+"In {project_name}, paste the value of the *Client ID* into the *Client ID* "
+"field."
+msgstr "{project_name}では、*Client ID* の値を *Client ID* フィールドに貼り付けます。"
 
 #. type: Plain text
 msgid ""
-"LinkedIn may change the look and feel of application registration, so these "
-"directions may not always be up to date."
-msgstr "LinkedInはアプリケーション登録のデザインを変更する可能性があるため、これらの指示は常に最新のものではない場合があります。"
-
-#. type: Block title
-#, no-wrap
-msgid "Developer Network"
-msgstr "Developer Network"
-
-#. type: Plain text
-msgid "image:images/linked-in-developer-network.png[]"
-msgstr "image:images/linked-in-developer-network.png[]"
-
-#. type: Plain text
-msgid ""
-"Click on the `Create Application` button.  This will bring you to the "
-"`Create a New Application` Page."
-msgstr ""
-"`Create Application` ボタンをクリックします。これにより、 `Create a New Application` "
-"ページが表示されます。"
-
-#. type: Block title
-#, no-wrap
-msgid "Create App"
-msgstr "アプリケーションの作成"
-
-#. type: Plain text
-msgid "image:images/linked-in-create-app.png[]"
-msgstr "image:images/linked-in-create-app.png[]"
-
-#. type: Plain text
-msgid ""
-"Fill in the form with the appropriate values, then click the `Submit` "
-"button.  This will bring you to the new application's settings page."
-msgstr "フォームに適切な値を入力し、 `Submit` ボタンをクリックします。 これにより、新しいアプリケーションの設定ページが表示されます。"
-
-#. type: Block title
-#, no-wrap
-msgid "App Settings"
-msgstr "アプリケーションの設定"
-
-#. type: Plain text
-msgid "image:images/linked-in-app-settings.png[]"
-msgstr "image:images/linked-in-app-settings.png[]"
-
-#. type: Plain text
-msgid ""
-"Select `r_basicprofile` and `r_emailaddress` in the `Default Application "
-"Permissions` section.  You'll have to copy the `Redirect URI` from the "
-"{project_name} `Add Identity Provider` page and enter it into the `OAuth "
-"2.0` `Authorized Redirect URLs` field on the LinkedIn app settings page.  "
-"Don't forget to click the `Update` button after you do this!"
-msgstr ""
-"`Default Application Permissions` セクションで `r_basicprofile` と `r_emailaddress`"
-" を選択してください。{project_name}の `Add Identity Provider` ページから `Redirect URI` "
-"をコピーし、それをLinkedInアプリ設定ページの `OAuth 2.0` の `Authorized Redirect URLs` "
-"フィールドに入力する必要があります。入力後、 `Update` ボタンをクリックすることを忘れないでください！"
-
-#. type: Plain text
-msgid ""
-"You will then need to obtain the client ID and secret from this page so you "
-"can enter them into the {project_name} `Add identity provider` page.  Go "
-"back to {project_name} and specify those items."
-msgstr ""
-"このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
-"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
+"In {project_name}, paste the value of the *Client Secret* into the *Client "
+"Secret* field."
+msgstr "{project_name}では、*Client Secret* の値を *Client Secret* フィールドに貼り付けます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/linked-in.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__linked-in
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
