### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -72,8 +72,8 @@ msgid ""
 "In a separate browser tab, create an app in "
 "https://developer.twitter.com/apps/[Twitter Application Management]."
 msgstr ""
-"別のブラウザタブで、https://developer.twitter.com/apps/[Twitter Application "
-"Management]でアプリを作成します。"
+"ブラウザーの別のタブで https://developer.twitter.com/apps/[Twitter Application "
+"Management] を開き、アプリを作成します。"
 
 #. type: Plain text
 msgid "Enter any value for name and description."
@@ -81,28 +81,28 @@ msgstr "nameとdescriptionには任意の値を入力してください。"
 
 #. type: Plain text
 msgid "The value for *Website* can be any valid URL except `localhost`."
-msgstr "Website*の値には、`localhost`を除く任意の有効なURLを指定します。"
+msgstr "*Website* の値には、 `localhost` を除く任意の有効なURLを指定します。"
 
 #. type: Plain text
 msgid "Paste the value of the *Redirect URL* into the *Callback URL* field."
-msgstr "リダイレクトURL \"の値を \"コールバックURL \"欄に貼り付けてください。"
+msgstr "*Redirect URL* の値を *Callback URL* フィールドに貼り付けてください。"
 
 #. type: Plain text
 msgid ""
 "When you create your Twitter app, note the value of *Consumer Key* and "
 "*Consumer Secret* in the *Keys and Access Tokens* section."
 msgstr ""
-"Twitterアプリを作成する際には、「Keys and Access Tokens」セクションの「*Consumer Key*」と「*Consumer"
-" Secret*」の値に注意してください。"
+"Twitterアプリを作成する際は、 *Keys and Access Tokens* のセクションの *Consumer Secret* と "
+"*Keys and Access Tokens* の値に注意してください。"
 
 #. type: Plain text
 msgid ""
 "In {project_name}, paste the value of the *Consumer Key* into the *Client "
 "ID* field."
-msgstr "project_name}では、*Client ID*フィールドに*Consumer Key*の値を貼り付けます。"
+msgstr "{project_name}では、 *Client ID* フィールドに *Consumer Key* の値を貼り付けます。"
 
 #. type: Plain text
 msgid ""
 "In {project_name}, paste the value of the *Consumer Secret* into the *Client"
 " Secret* field."
-msgstr "project_name}では、*Client Secret*の欄に*Consumer Secret*の値を貼り付けます。"
+msgstr "{project_name}では、 *Client Secret* フィールドに *Consumer Secret* の値を貼り付けます。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,10 +19,32 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add identity provider"
 msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+msgid "Copy the value of *Redirect URI* to your clipboard."
+msgstr "Redirect URI* の値をクリップボードにコピーしてください。"
 
 #. type: Title ====
 #, no-wrap
@@ -31,108 +52,57 @@ msgid "Twitter"
 msgstr "Twitter"
 
 #. type: Plain text
+msgid "A Twitter developer account."
+msgstr "Twitterの開発者アカウントです。"
+
+#. type: Plain text
+msgid "From the `Add provider` list, select `Twitter`."
+msgstr "Add provider \"のリストから \"Twitter \"を選択します。"
+
+#. type: Plain text
 msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with Twitter.  First, go to the `Identity Providers` left menu item and "
-"select `Twitter` from the `Add provider` drop down list.  This will bring "
-"you to the `Add identity provider` page."
+"image:{project_images}/twitter-add-identity-provider.png[Add Identity "
+"Provider]"
 msgstr ""
-"Twitterでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add identity provider` のドロップダウン・リストから `Twitter` "
-"を選択します。これにより、 `Add identity provider` ページが表示されます。"
-
-#. type: Plain text
-msgid "image:{project_images}/twitter-add-identity-provider.png[]"
-msgstr "image:{project_images}/twitter-add-identity-provider.png[]"
+"image:{project_images}/twitter-add-identity-provider.png[Add Identity "
+"Provider]"
 
 #. type: Plain text
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from Twitter.  One piece of data you'll need from this page is the "
-"`Redirect URI`.  You'll have to provide that to Twitter when you register "
-"{project_name} as a client there, so copy this URI to your clipboard."
-msgstr ""
-"Twitterから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
-"です。Twitterに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
-
-#. type: Plain text
-msgid ""
-"To enable login with Twtter you first have to create an application in the "
+"In a separate browser tab, create an app in "
 "https://developer.twitter.com/apps/[Twitter Application Management]."
 msgstr ""
-"Twtterでログインを可能にするには、まず https://developer.twitter.com/apps/[Twitter "
-"Application Management] でアプリケーションを作成する必要があります。"
-
-#. type: Block title
-#, no-wrap
-msgid "Register Application"
-msgstr "アプリケーションの登録"
+"別のブラウザタブで、https://developer.twitter.com/apps/[Twitter Application "
+"Management]でアプリを作成します。"
 
 #. type: Plain text
-msgid "image:images/twitter-app-register.png[]"
-msgstr "image:images/twitter-app-register.png[]"
+msgid "Enter any value for name and description."
+msgstr "nameとdescriptionには任意の値を入力してください。"
 
 #. type: Plain text
-msgid ""
-"Click on the `Create New App` button.  This will bring you to the `Create an"
-" Application` page."
-msgstr ""
-"`Create New App` ボタンをクリックします。これにより、 `Create an Application` ページが表示されます。"
+msgid "The value for *Website* can be any valid URL except `localhost`."
+msgstr "Website*の値には、`localhost`を除く任意の有効なURLを指定します。"
 
 #. type: Plain text
-msgid "image:images/twitter-app-create.png[]"
-msgstr "image:images/twitter-app-create.png[]"
+msgid "Paste the value of the *Redirect URL* into the *Callback URL* field."
+msgstr "リダイレクトURL \"の値を \"コールバックURL \"欄に貼り付けてください。"
 
 #. type: Plain text
 msgid ""
-"Enter in a Name and Description.  The Website can be anything, but cannot "
-"have a `localhost` address.  For the `Callback URL` you must copy the "
-"`Redirect URI` from the {project_name} `Add Identity Provider` page."
+"When you create your Twitter app, note the value of *Consumer Key* and "
+"*Consumer Secret* in the *Keys and Access Tokens* section."
 msgstr ""
-"NameとDescriptionを入力します。Websiteは何でも構いませんが、 `localhost` アドレスを持つことはできません。 "
-"`Callback URL` には、{project_name} の `Add Identity Provider` ページから `Redirect "
-"URI` をコピーする必要があります。"
+"Twitterアプリを作成する際には、「Keys and Access Tokens」セクションの「*Consumer Key*」と「*Consumer"
+" Secret*」の値に注意してください。"
 
 #. type: Plain text
 msgid ""
-"You cannot use `localhost` in the `Callback URL`.  Instead replace it with "
-"`127.0.0.1` if you are trying to test drive Twitter login on your laptop."
-msgstr ""
-"`Callback URL` に `localhost` を使うことはできません。ラップトップでTwitterのログインをテストしてみる場合は、 "
-"`127.0.0.1` に置き換えてください。"
-
-#. type: Plain text
-msgid "After clicking save you will be brought to the `Details` page."
-msgstr "保存をクリックすると、 `Details` ページに移動します。"
-
-#. type: Block title
-#, no-wrap
-msgid "App Details"
-msgstr "App Details"
-
-#. type: Plain text
-msgid "image:images/twitter-details.png[]"
-msgstr "image:images/twitter-details.png[]"
-
-#. type: Plain text
-msgid "Next go to the `Keys and Access Tokens` tab."
-msgstr "次に、 `Keys and Access Tokens` タブをクリックします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Keys and Access Tokens"
-msgstr "Keys and Access Tokens"
-
-#. type: Plain text
-msgid "image:images/twitter-keys.png[]"
-msgstr "image:images/twitter-keys.png[]"
+"In {project_name}, paste the value of the *Consumer Key* into the *Client "
+"ID* field."
+msgstr "project_name}では、*Client ID*フィールドに*Consumer Key*の値を貼り付けます。"
 
 #. type: Plain text
 msgid ""
-"Finally, you will need to obtain the API Key and secret from this page and "
-"copy them back into the `Client ID` and `Client Secret` fields on the "
-"{project_name} `Add identity provider` page."
-msgstr ""
-"最後に、このページからAPIキーとシークレットを取得し、{project_name}の `Add identity provider` ページの "
-"`Client ID` フィールドと `Client Secret` フィールドにコピーする必要があります。"
+"In {project_name}, paste the value of the *Consumer Secret* into the *Client"
+" Secret* field."
+msgstr "project_name}では、*Client Secret*の欄に*Consumer Secret*の値を貼り付けます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/twitter.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__twitter
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
