### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -48,15 +48,15 @@ msgstr "Bitbucketでログインするには、以下の手順で行います。
 
 #. type: Plain text
 msgid "From the `Add provider` list, select `Bitbucket`."
-msgstr "Add provider \"のリストから \"Bitbucket \"を選択します。"
+msgstr " `Add provider`の一覧から `Bitbucket` を選択します。"
 
 #. type: Plain text
 msgid ""
 "image:{project_images}/bitbucket-add-identity-provider.png[Add Identity "
 "Provider]"
 msgstr ""
-"image:{project_images}/bitbucket-add-identity-provider.png[Identity "
-"Providerの追加]です。"
+"image:{project_images}/bitbucket-add-identity-provider.png[Add Identity "
+"Provider]"
 
 #. type: Plain text
 msgid "Copy the value of *Redirect URI* to your clipboard."
@@ -68,19 +68,21 @@ msgid ""
 "https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-"
 "cloud/[OAuth on Bitbucket Cloud] process. When you click *Add Consumer*:"
 msgstr ""
-"別のブラウザタブで、https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-"
-"bitbucket-cloud/[OAuth on Bitbucket Cloud]の処理を行います。Add Consumer*」をクリックすると。"
+"ブラウザーの別のタブで、 https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-"
+"on-bitbucket-cloud/[OAuth on Bitbucket Cloud] の処理を行います。 *Add Consumer* "
+"をクリックすると"
 
 #. type: Plain text
 msgid "Paste the value of *Redirect URI* into the *Callback URL* field."
-msgstr "Callback URL \"フィールドに \"Redirect URI \"の値をペーストしてください。"
+msgstr "*Callback URL* フィールドに *Redirect URI* の値を貼り付けてください。"
 
 #. type: Plain text
 msgid ""
 "Ensure you select *Email* and *Read* in the *Account* section to permit your"
 " application to read email."
 msgstr ""
-"アプリケーションがメールを読むことを許可するために、*Account*セクションで*Email*と*Read*を選択していることを確認してください。"
+"アプリケーションがメールを読むことを許可するために、*Account* セクションで *Email* と *Read* "
+"を選択していることを確認してください。"
 
 #. type: Plain text
 msgid ""
@@ -91,10 +93,10 @@ msgstr "コンシューマーを作成する際に Bitbucket が表示する `Ke
 #. type: Plain text
 msgid ""
 "In {project_name}, paste the value of the `Key` into the *Client ID* field."
-msgstr "project_name}では、`Key`の値を*Client ID*欄に貼り付けます。"
+msgstr "{project_name}では、 `Key` の値を *Client ID* フィールドに貼り付けます。"
 
 #. type: Plain text
 msgid ""
 "In {project_name}, paste the value of the `Secret` into the *Client Secret* "
 "field."
-msgstr "project_name}では、`Secret`の値を*Client Secret*欄に貼り付けます。"
+msgstr "{project_name}では、 `Secret` の値を *Client Secret* フィールドに貼り付けます。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +21,20 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add identity provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
 #. type: Title ====
@@ -30,112 +43,58 @@ msgid "Bitbucket"
 msgstr "Bitbucket"
 
 #. type: Plain text
-msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with Bitbucket."
-msgstr "Bitbucketでログインできるようにするには、いくつかのステップを完了しなければなりません。"
+msgid "To log in with Bitbucket, perform the following procedure."
+msgstr "Bitbucketでログインするには、以下の手順で行います。"
+
+#. type: Plain text
+msgid "From the `Add provider` list, select `Bitbucket`."
+msgstr "Add provider \"のリストから \"Bitbucket \"を選択します。"
 
 #. type: Plain text
 msgid ""
-"First, open the `Identity Providers` left menu item and select `Bitbucket` "
-"from the `Add provider` drop down list. This will bring you to the `Add "
-"identity provider` page."
+"image:{project_images}/bitbucket-add-identity-provider.png[Add Identity "
+"Provider]"
 msgstr ""
-"まず、 `Identity Providers` の左メニュー項目に移動し、`Add provider` ドロップダウン・リストから "
-"`Bitbucket` を選択します。これにより、 `Add identity provider` ページが表示されます。"
+"image:{project_images}/bitbucket-add-identity-provider.png[Identity "
+"Providerの追加]です。"
 
 #. type: Plain text
-msgid "image:{project_images}/bitbucket-add-identity-provider.png[]"
-msgstr "image:{project_images}/bitbucket-add-identity-provider.png[]"
-
-#. type: Plain text
-msgid ""
-"Before you can click `Save`, you must obtain a `Client ID` and `Client "
-"Secret` from Bitbucket."
-msgstr ""
-"`Save` をクリックする前に、Bitbucketから `Client ID` と `Client Secret` を取得する必要があります。"
+msgid "Copy the value of *Redirect URI* to your clipboard."
+msgstr "Redirect URI* の値をクリップボードにコピーしてください。"
 
 #. type: Plain text
 msgid ""
-"You will use the `Redirect URI` from this page in a later step, which you "
-"will provide to Bitbucket when you register {project_name} as a client "
-"there."
+"In a separate browser tab, perform the "
+"https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-"
+"cloud/[OAuth on Bitbucket Cloud] process. When you click *Add Consumer*:"
 msgstr ""
-"後で、クライアントとして{project_name}を登録する際に、このページの `Redirect URI` をBitbucketに提供します。"
+"別のブラウザタブで、https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-"
+"bitbucket-cloud/[OAuth on Bitbucket Cloud]の処理を行います。Add Consumer*」をクリックすると。"
 
-#. type: Block title
-#, no-wrap
-msgid "Add a New App"
-msgstr "新しいアプリケーションの追加"
+#. type: Plain text
+msgid "Paste the value of *Redirect URI* into the *Callback URL* field."
+msgstr "Callback URL \"フィールドに \"Redirect URI \"の値をペーストしてください。"
 
 #. type: Plain text
 msgid ""
-"To enable login with Bitbucket you must first register an application "
-"project in https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-"
-"bitbucket-cloud/[OAuth on Bitbucket Cloud]."
+"Ensure you select *Email* and *Read* in the *Account* section to permit your"
+" application to read email."
 msgstr ""
-"Bitbucketでログインできるようにするには、まずアプリケーション・プロジェクトを https://support.atlassian.com"
-"/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/[OAuth on Bitbucket "
-"Cloud] に登録する必要があります。"
+"アプリケーションがメールを読むことを許可するために、*Account*セクションで*Email*と*Read*を選択していることを確認してください。"
 
 #. type: Plain text
 msgid ""
-"Bitbucket often changes the look and feel of application registration, so "
-"what you see on the Bitbucket site may differ. If in doubt, see the "
-"Bitbucket documentation."
-msgstr ""
-"Bitbucketはアプリケーション登録のデザインを変更することが多いため、Bitbucketのサイトに表示される内容は異なる場合があります。疑わしい場合は、Bitbucketのドキュメントを参照してください。"
-
-#. type: Plain text
-msgid "image:images/bitbucket-developer-applications.png[]"
-msgstr "image:images/bitbucket-developer-applications.png[]"
-
-#. type: Plain text
-msgid "Click the `Add consumer` button."
-msgstr "`Add consumer` ボタンをクリックします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Register App"
-msgstr "アプリケーションの登録"
-
-#. type: Plain text
-msgid "image:images/bitbucket-register-app.png[]"
-msgstr "image:images/bitbucket-register-app.png[]"
+"Note the `Key` and `Secret` values Bitbucket displays when you create your "
+"consumer."
+msgstr "コンシューマーを作成する際に Bitbucket が表示する `Key` と `Secret` の値に注意してください。"
 
 #. type: Plain text
 msgid ""
-"Copy the `Redirect URI` from the {project_name} `Add Identity Provider` page"
-" and enter it into the Callback URL field on the Bitbucket Add OAuth "
-"Consumer page."
-msgstr ""
-"{project_name}の `Add Identity Provider` ページから `Redirect URI` "
-"をコピーし、BitbucketのAdd OAuth ConsumerページのCallback URLフィールドに入力します。"
+"In {project_name}, paste the value of the `Key` into the *Client ID* field."
+msgstr "project_name}では、`Key`の値を*Client ID*欄に貼り付けます。"
 
 #. type: Plain text
 msgid ""
-"On the same page, mark the `Email` and `Read` boxes under `Account` to allow"
-" your application to read user email."
-msgstr ""
-"同じページで、 `Account` の下の `Email` と `Read` "
-"のチェックボックスをマークして、アプリケーションがユーザーの電子メールを読めるようにします。"
-
-#. type: Block title
-#, no-wrap
-msgid "Bitbucket App Page"
-msgstr "Bitbucketアプリケーション・ページ"
-
-#. type: Plain text
-msgid "image:images/bitbucket-app-page.png[]"
-msgstr "image:images/bitbucket-app-page.png[]"
-
-#. type: Plain text
-msgid ""
-"When you are done registering, click `Save`. This will open the application "
-"management page in Bitbucket. Find the client ID and secret from this page "
-"so you can enter them into the {project_name} `Add identity provider` page. "
-"Click `Save`."
-msgstr ""
-"登録が完了したら、 `Save` "
-"をクリックしてください。これにより、Bitbucketのアプリケーション管理ページが開きます。このページからクライアントIDとシークレットを取得し、{project_name}の"
-" `Add identity provider` ページに入力する必要があります。 `Save` をクリックしてください。"
+"In {project_name}, paste the value of the `Secret` into the *Client Secret* "
+"field."
+msgstr "project_name}では、`Secret`の値を*Client Secret*欄に貼り付けます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/bitbucket.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__bitbucket
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
