### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/microsoft.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/microsoft.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/microsoft.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,13 +21,33 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
 
 #. type: Block title
 #, no-wrap
-msgid "Register Application"
-msgstr "アプリケーションの登録"
+msgid "Add identity provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+msgid "Copy the value of *Redirect URI* to your clipboard."
+msgstr "Redirect URI* の値をクリップボードにコピーしてください。"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
+msgstr ""
+"image:{project_images}/google-add-identity-provider.png[Add Identity "
+"Provider]"
 
 #. type: Title ====
 #, no-wrap
@@ -36,120 +55,35 @@ msgid "Microsoft"
 msgstr "Microsoft"
 
 #. type: Plain text
-msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with Microsoft.  First, go to the `Identity Providers` left menu item and "
-"select `Microsoft` from the `Add provider` drop down list.  This will bring "
-"you to the `Add identity provider` page."
-msgstr ""
-"Microsoftでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `Microsoft` を選択します。これにより、 "
-"`Add identity provider` ページが表示されます。"
-
-#. type: Plain text
-msgid "image:{project_images}/microsoft-add-identity-provider.png[]"
-msgstr "image:{project_images}/microsoft-add-identity-provider.png[]"
+msgid "From the `Add provider` list, select `Microsoft`."
+msgstr " `Add provider`の一覧から `Microsoft` を選択します。"
 
 #. type: Plain text
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from Microsoft.  One piece of data you'll need from this page is "
-"the `Redirect URI`.  You'll have to provide that to Microsoft when you "
-"register {project_name} as a client there, so copy this URI to your "
-"clipboard."
+"In a separate browser tab, "
+"https://account.live.com/developers/applications/create[create a Microsoft "
+"app]."
 msgstr ""
-"Microsoftから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存ボタンをクリックすることはできません。このページで必須入力のデータの1つは、 `Redirect URI` "
-"です。Microsoftに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
+"別のブラウザータブで、 https://account.live.com/developers/applications/create[create a"
+" Microsoft app] を実行します。"
+
+#. type: Plain text
+msgid "Click *Add URL* to add the redirect URL to the Microsoft app."
+msgstr "*Add URL* をクリックして、MicrosoftアプリにリダイレクトURLを追加します。"
+
+#. type: Plain text
+msgid "Note the *Application ID* and *Application Secret*."
+msgstr "*Application ID* と *Application Secret* に注意してください。"
 
 #. type: Plain text
 msgid ""
-"To enable login with Microsoft account you first have to register an OAuth "
-"application at Microsoft.  Go to the "
-"https://account.live.com/developers/applications/create[Microsoft "
-"Application Registration] url."
-msgstr ""
-"Microsoftアカウントでログインを可能にするには、まずMicrosoftでOAuthアプリケーションを登録する必要があります。 "
-"https://account.live.com/developers/applications/create[Microsoft "
-"Application Registration] のURLにアクセスします。"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"Microsoft often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
-"      configuration steps might be slightly different.\n"
-msgstr ""
-"Microsoftはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
-
-#. type: Plain text
-msgid "image:images/microsoft-app-register.png[]"
-msgstr "image:images/microsoft-app-register.png[]"
+"In {project_name}, paste the value of the *Application ID* into the *Client "
+"ID* field."
+msgstr "{project_name}では、*Application ID* の値を *Client ID* フィールドに貼り付けます。"
 
 #. type: Plain text
 msgid ""
-"Enter in the application name and click `Create application`.  This will "
-"bring you to the application settings page of your new application."
+"In {project_name}, paste the value of the *Application Secret* into the "
+"*Client Secret* field."
 msgstr ""
-"アプリケーション名を入力し、 `Create application` をクリックします。 "
-"これにより、新しいアプリケーションのアプリケーション設定ページが表示されます。"
-
-#. type: Block title
-#, no-wrap
-msgid "Settings"
-msgstr "設定"
-
-#. type: Plain text
-msgid "image:images/microsoft-app-settings.png[]"
-msgstr "image:images/microsoft-app-settings.png[]"
-
-#. type: Plain text
-msgid ""
-"You'll have to copy the `Redirect URI` from the {project_name} `Add Identity"
-" Provider` page and add it to the `Redirect URIs` field on the Microsoft "
-"application page.  Be sure to click the `Add Url` button and `Save` your "
-"changes."
-msgstr ""
-"{project_name}の `Add Identity Provider` ページから `Redirect URI` "
-"をコピーし、それをMicrosoftアプリケーション・ページの `Redirect URIs` フィールドに追加する必要があります。 `Add Url`"
-" ボタンをクリックし、変更を `Save` してください。"
-
-#. type: Plain text
-msgid ""
-"Finally, you will need to obtain the Application ID and secret from this "
-"page so you can enter them back on the {project_name} `Add identity "
-"provider` page.  Go back to {project_name} and specify those items."
-msgstr ""
-"最後に、このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
-"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"From November 2018 onwards, Microsoft is removing support for the Live SDK API in favor of the new Microsoft Graph API.\n"
-"         The {project_name} Microsoft identity provider has been updated to use the new endpoints so make sure to upgrade to\n"
-"         {project_name} version 4.6.0 or later in order to use this provider.\n"
-"         Furthermore, client applications registered with Microsoft under \"Live SDK applications\" will need to be re-registered\n"
-"         in the https://account.live.com/developers/applications/create[Microsoft Application Registration] portal to obtain an application id that\n"
-"         is compatible with the Microsoft Graph API.\n"
-msgstr ""
-"2018年11月以降、Microsoftは新しいMicrosoft Graph APIを支持して、Live SDK "
-"APIのサポートを削除しています。{project_name} Microsoft "
-"アイデンティティー・プロバイダーは新しいエンドポイントを使用するように更新されました。このプロバイダーを使用するには、必ず{project_name}バージョン4.6.0以降にアップグレードしてください。さらに、"
-" https://account.live.com/developers/applications/create[Live SDKアプリケーション] "
-"でMicrosoftに登録されているクライアント・アプリケーションは、 "
-"https://account.live.com/developers/applications/create[Microsoft "
-"Application Registration] ポータルに再登録して、Microsoft Graph "
-"APIと互換性があるアプリケーションIDを取得する必要があります。\n"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"From November 2018 onwards, Microsoft is removing support for the Live SDK API in favor of the new Microsoft Graph API.\n"
-"         The {project_name} Microsoft identity provider has been updated to use the new endpoints so make sure to upgrade to\n"
-"         {project_name} version 7.2.5 or later in order to use this provider.\n"
-"         Furthermore, client applications registered with Microsoft under \"Live SDK applications\" will need to be re-registered\n"
-"         in the https://account.live.com/developers/applications/create[Microsoft Application Registration] portal to obtain an application id that\n"
-"         is compatible with the Microsoft Graph API.\n"
-msgstr ""
-"2018年11月以降、Microsoftは新しいMicrosoft Graph APIを支持して、Live SDK APIのサポートを削除しています。\n"
-"{project_name} Microsoftアイデンティティー・プロバイダーは新しいエンドポイントを使用するように更新されました。このプロバイダーを使用するには、必ず{project_name}バージョン7.2.5以降にアップグレードしてください。さらに、 https://account.live.com/developers/applications/create[Live SDKアプリケーション] でMicrosoftに登録されているクライアントアプリケーションは、 https://account.live.com/developers/applications/create[Microsoft Application Registration] ポータルに再登録して、Microsoft Graph APIと互換性があるアプリケーションIDを取得する必要があります。\n"
+"{project_name}では、*Application Secret* の値を *Client Secret* フィールドに貼り付けます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/microsoft.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__microsoft
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
