### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,18 +21,25 @@ msgstr ""
 
 #. type: Block title
 #, no-wrap
-msgid "Add Identity Provider"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add identity provider"
 msgstr "アイデンティティー・プロバイダーの追加"
 
-#. type: Block title
-#, no-wrap
-msgid "Add a New App"
-msgstr "新しいアプリの追加"
-
-#. type: Block title
-#, no-wrap
-msgid "Register App"
-msgstr "アプリケーションの登録"
+#. type: Plain text
+msgid "Copy the value of *Redirect URI* to your clipboard."
+msgstr "Redirect URI* の値をクリップボードにコピーしてください。"
 
 #. type: Title ====
 #, no-wrap
@@ -41,85 +47,51 @@ msgid "GitHub"
 msgstr "GitHub"
 
 #. type: Plain text
-msgid ""
-"There are a number of steps you have to complete to be able to enable login "
-"with GitHub.  First, go to the `Identity Providers` left menu item and "
-"select `GitHub` from the `Add provider` drop down list.  This will bring you"
-" to the `Add identity provider` page."
-msgstr ""
-"GitHubでログインできるようにするには、いくつかのステップを完了する必要があります。まず、左のメニュー項目の `Identity "
-"Providers` に移動し、 `Add provider` のドロップダウン・リストから `GitHub` を選択します。これにより、 `Add "
-"identity provider` ページが表示されます。"
+msgid "To log in with Github, perform the following procedure."
+msgstr "Githubでログインするには、以下の手順で行います。"
 
 #. type: Plain text
-msgid "image:{project_images}/github-add-identity-provider.png[]"
-msgstr "image:{project_images}/github-add-identity-provider.png[]"
+msgid "From the `Add provider` list, select `Github`."
+msgstr "`Add provider` のリストから `Github` を選択します。"
 
 #. type: Plain text
 msgid ""
-"You can't click save yet, as you'll need to obtain a `Client ID` and `Client"
-" Secret` from GitHub.  One piece of data you'll need from this page is the "
-"`Redirect URI`.  You'll have to provide that to GitHub when you register "
-"{project_name} as a client there, so copy this URI to your clipboard."
+"image:{project_images}/github-add-identity-provider.png[Add Identity "
+"Provider]"
 msgstr ""
-"GitHubから `Client ID` と `Client Secret` "
-"を取得する必要があるので、まだ保存をクリックすることはできません。このページから必要なデータの1つは、 `Redirect URI` "
-"です。GitHubに{project_name}をクライアントとして登録するときに提供する必要があるため、このURIをクリップボードにコピーしてください。"
+"image:{project_images}/github-add-identity-provider.png[Add Identity "
+"Provider]"
 
 #. type: Plain text
 msgid ""
-"To enable login with GitHub you first have to register an application "
-"project in https://github.com/settings/developers[GitHub Developer "
-"applications]."
+"In a separate browser tab, "
+"https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-"
+"oauth-app[create an OAUTH app]."
 msgstr ""
-"GitHubでログインを可能にするには、まず https://github.com/settings/developers[GitHub "
-"Developer applications] でアプリケーションを登録する必要があります。"
-
-#. type: Plain text
-#, no-wrap
-msgid ""
-"GitHub often changes the look and feel of application registration, so these directions might not always be up to date and the\n"
-"      configuration steps might be slightly different.\n"
-msgstr ""
-"GitHubはアプリケーション登録のデザインを変更することが多いため、これらの指示は常に最新のものではなく、設定手順が多少異なる場合があります。\n"
-
-#. type: Plain text
-msgid "image:images/github-developer-applications.png[]"
-msgstr "image:images/github-developer-applications.png[]"
-
-#. type: Plain text
-msgid "Click the `Register a new application` button."
-msgstr "`Register a new application` ボタンをクリックします。"
-
-#. type: Plain text
-msgid "image:images/github-register-app.png[]"
-msgstr "image:images/github-register-app.png[]"
+"別のブラウザータブで、 https://docs.github.com/en/developers/apps/building-oauth-"
+"apps/creating-an-oauth-app[create an OAUTH app] を実行します。"
 
 #. type: Plain text
 msgid ""
-"You'll have to copy the `Redirect URI` from the {project_name} `Add Identity"
-" Provider` page and enter it into the `Authorization callback URL` field on "
-"the GitHub `Register a new OAuth application` page.  Once you've completed "
-"this page you will be brought to the application's management page."
+"Enter the value of *Redirect URI* into the `Authorization callback URL` "
+"field when creating the app."
 msgstr ""
-"{project_name}の `Add Identity Provider` ページから `Redirect URI` をコピーし、GitHubの "
-"`Register a new OAuth application` ページの `Authorization callback URL` "
-"フィールドにそれを入力する必要があります。このページを完了すると、アプリケーションの管理ページに移動します。"
-
-#. type: Block title
-#, no-wrap
-msgid "GitHub App Page"
-msgstr "GitHubアプリケーション・ページ"
-
-#. type: Plain text
-msgid "image:images/github-app-page.png[]"
-msgstr "image:images/github-app-page.png[]"
+"アプリの作成時に、 `Authorization callback URL` フィールドに *Redirect URI* の値を入力してください。"
 
 #. type: Plain text
 msgid ""
-"You will need to obtain the client ID and secret from this page so you can "
-"enter them into the {project_name} `Add identity provider` page.  Go back to"
-" {project_name} and specify those items."
-msgstr ""
-"このページからクライアントIDとシークレットを取得し、{project_name}の `Add identity provider` "
-"ページに入力する必要があります。{project_name}に戻り、それらの項目を入力します。"
+"Note the Client ID and Client secret on the management page of your OAUTH "
+"app."
+msgstr "OAUTHアプリの管理画面で、Client IDとClient secretをメモします。"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, paste the value of the `Client ID` into the *Client ID* "
+"field."
+msgstr "{project_name}では、`Client ID` の値を *Client ID* フィールドに貼り付けます。"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, paste the value of the `Client Secret` into the *Client "
+"Secret* field."
+msgstr "{project_name}では、`Client Secret` の値を *Client Secret* フィールドに貼り付けます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/social/github.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__social__github
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
