### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc.ja_JP.po
@@ -1,0 +1,105 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "OpenID Connect"
+msgstr "OpenID Connect"
+
+#. type: Plain text
+msgid ""
+"link:https://openid.net/connect/[OpenID Connect] (OIDC) is an authentication"
+" protocol that is an extension of "
+"link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0]."
+msgstr ""
+"link:https://openid.net/connect/[OpenID "
+"Connect](OIDC)は、link:https://datatracker.ietf.org/doc/html/rfc6749[OAuth "
+"2.0]を拡張した認証プロトコルです。"
+
+#. type: Plain text
+msgid ""
+"OAuth 2.0 is a framework for building authorization protocols and is "
+"incomplete. OIDC, however, is a full authentication and authorization "
+"protocol that uses the link:https://jwt.io[Json Web Token] (JWT) standards."
+"  The JWT standards define an identity token JSON format and methods to "
+"digitally sign and encrypt data in a compact and web-friendly way."
+msgstr ""
+"OAuth 2.0は、認可プロトコルを構築するためのフレームワークであり、不完全なものです。しかし、OIDCは、 "
+"link:https://jwt.io[Json Web Token] "
+"（JWT）標準を使用した完全な認証・認可プロトコルです。JWT標準は、IDトークンのJSONフォーマットと、コンパクトでウェブに適した方法でデータをデジタル署名・暗号化する方法を定義しています。"
+
+#. type: Plain text
+msgid ""
+"In general, OIDC implements two use cases. The first case is an application "
+"requesting that a {project_name} server authenticates a user. Upon "
+"successful login, the application receives an _identity token_ and an "
+"_access token_.  The _identity token_ contains user information including "
+"user name, email, and profile information. The realm digitally signs the "
+"_access token_ which contains access information (such as user role "
+"mappings) that applications use to determine the resources users can access "
+"in the application."
+msgstr ""
+"一般的に、OIDCは2つのユースケースを実装しています。1つ目のケースは、アプリケーションが{project_name}サーバーにユーザーの認証を要求する場合です。ログインに成功すると、アプリケーションは"
+" _IDトークン_ と _アクセストークン_ "
+"を受け取ります。アイデンティティー・トークンには、ユーザー名、電子メール、プロフィール情報などのユーザー情報が含まれています。レルムは、ユーザーがアプリケーションでアクセスできるリソースを決定するためにアプリケーションが使用するアクセス情報（ユーザー・ロール・マッピングなど）を含む"
+" _アクセストークン_ にデジタル署名します。"
+
+#. type: Plain text
+msgid "The second use case is a client accessing remote services."
+msgstr "2つ目のユースケースは、クライアントがリモートサービスにアクセスする場合です。"
+
+#. type: Plain text
+msgid ""
+"The client requests an _access token_ from {project_name} to invoke on "
+"remote services on behalf of the user."
+msgstr ""
+"クライアントは、ユーザーに代わってリモートサービスを呼び出すために、{project_name} に _access token_ を要求します。"
+
+#. type: Plain text
+msgid ""
+"{project_name} authenticates the user and asks the user for consent to grant"
+" access to the requesting client."
+msgstr "{project_name} ユーザーを認証し、リクエストしたクライアントにアクセスを許可することへの同意を求めます。"
+
+#. type: Plain text
+msgid ""
+"The client receives the _access token_ which is digitally signed by the "
+"realm."
+msgstr "クライアントは、レルムによってデジタル署名された「アクセストークン」を受け取ります。"
+
+#. type: Plain text
+msgid ""
+"The client makes REST requests on remote services using the _access token_."
+msgstr "クライアントは、アクセストークンを使ってリモートサービスにRESTリクエストを行います。"
+
+#. type: Plain text
+msgid "The remote REST service extracts the _access token_."
+msgstr "リモートRESTサービスは、_access token_を抽出します。"
+
+#. type: Plain text
+msgid "The remote REST service verifies the tokens signature."
+msgstr "リモートRESTサービスがトークンの署名を検証します。"
+
+#. type: Plain text
+msgid ""
+"The remote REST service decides, based on access information within the "
+"token, to process or reject the request."
+msgstr "リモートRESTサービスは、トークン内のアクセス情報に基づいて、リクエストを処理するか拒否するかを決定します。"

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc.ja_JP.po
@@ -70,33 +70,32 @@ msgstr "2つ目のユースケースは、クライアントがリモートサ�
 msgid ""
 "The client requests an _access token_ from {project_name} to invoke on "
 "remote services on behalf of the user."
-msgstr ""
-"クライアントは、ユーザーに代わってリモートサービスを呼び出すために、{project_name} に _access token_ を要求します。"
+msgstr "クライアントは、ユーザーに代わってリモートサービスを呼び出すために、{project_name}に _アクセストークン_ を要求します。"
 
 #. type: Plain text
 msgid ""
 "{project_name} authenticates the user and asks the user for consent to grant"
 " access to the requesting client."
-msgstr "{project_name} ユーザーを認証し、リクエストしたクライアントにアクセスを許可することへの同意を求めます。"
+msgstr "{project_name}はユーザーを認証し、リクエストしたクライアントにアクセスを許可することへの同意を求めます。"
 
 #. type: Plain text
 msgid ""
 "The client receives the _access token_ which is digitally signed by the "
 "realm."
-msgstr "クライアントは、レルムによってデジタル署名された「アクセストークン」を受け取ります。"
+msgstr "クライアントは、レルムによってデジタル署名された _アクセストークン_ を受け取ります。"
 
 #. type: Plain text
 msgid ""
 "The client makes REST requests on remote services using the _access token_."
-msgstr "クライアントは、アクセストークンを使ってリモートサービスにRESTリクエストを行います。"
+msgstr "クライアントは、 _アクセストークン_ を使ってリモートサービスにRESTリクエストを行います。"
 
 #. type: Plain text
 msgid "The remote REST service extracts the _access token_."
-msgstr "リモートRESTサービスは、_access token_を抽出します。"
+msgstr "リモートRESTサービスは、 _アクセストークン_ を抽出します。"
 
 #. type: Plain text
 msgid "The remote REST service verifies the tokens signature."
-msgstr "リモートRESTサービスがトークンの署名を検証します。"
+msgstr "リモートRESTサービスはトークンの署名を検証します。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__con-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
