### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/con-user-impersonation.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/con-user-impersonation.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/con-user-impersonation.ja_JP.po
@@ -34,23 +34,23 @@ msgid ""
 "For example, if a user experiences a bug in an application, an administrator"
 " can impersonate the user to investigate or duplicate the issue."
 msgstr ""
-"適切な権限を持つ管理者は、ユーザーになりすますことができます。例えば、あるユーザーがアプリケーションのバグに遭遇した場合、管理者はそのユーザーになりすまして問題を調査したり、複製したりすることができます。"
+"適切なパーミッションを持つ管理者は、ユーザーに成りすますことができます。例えば、あるユーザーがアプリケーションのバグに遭遇した場合、管理者はそのユーザーに成りすまして問題を調査したり、再現したりすることができます。"
 
 #. type: Plain text
 msgid ""
 "Any user with the `impersonation` role in the realm can impersonate a user."
-msgstr "レルム内で `impersonation` ロールを持つすべてのユーザが、あるユーザになりすますことができます。"
+msgstr "レルム内で `impersonation` ロールを持つすべてのユーザーが、あるユーザーになりすますことができます。"
 
 #. type: Plain text
 msgid "Image:{project_images}/user-details.png[]"
-msgstr "Image:{project_images}/user-details.png[]をご覧ください。"
+msgstr "Image:{project_images}/user-details.png[]"
 
 #. type: Plain text
 msgid ""
 "If the administrator and the user are in the same realm, then the "
 "administrator will be logged out and automatically logged in as the user "
 "being impersonated."
-msgstr "管理者とユーザーが同じレルムにいる場合は、管理者がログアウトし、自動的になりすましされるユーザーとしてログインします。"
+msgstr "管理者とユーザーが同じレルムにいる場合は、管理者がログアウトし、成りすましをされるユーザーとして自動的にログインします。"
 
 #. type: Plain text
 msgid ""
@@ -63,18 +63,16 @@ msgstr "管理者とユーザーが異なるレルムにいる場合、管理者
 msgid ""
 "In both instances, the *User Account Management* page of the impersonated "
 "user is displayed."
-msgstr "いずれの場合も、なりすましたユーザーの「ユーザーアカウント管理」ページが表示されます。"
+msgstr "いずれの場合も、なりすましたユーザーの *User Account Management* ページが表示されます。"
 
 #. type: Plain text
 msgid ""
 "You can access the *Impersonate* button from the *Details* tab on the "
 "*Users* page."
-msgstr "インパーソナル」ボタンは、「ユーザー」ページの「詳細」タブからアクセスできます。"
+msgstr "*Impersonate* ボタンは、 *Users* ページの *Details* タブからアクセスできます。"
 
 #. type: Plain text
 msgid ""
 "For more information on assigning administration permissions, see the "
 "<<_admin_permissions,Admin Console Access Control>> chapter."
-msgstr ""
-"管理権限の割り当てについては、＜＞の<_admin_permissions,Admin Console Access "
-"Control>章</_admin_permissions,Admin>を参照してください。"
+msgstr "管理パーミッションの割り当てについては、<<_admin_permissions,管理コンソールのアクセス制御>>の章を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/users/con-user-impersonation.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/con-user-impersonation.ja_JP.po
@@ -1,0 +1,80 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Title =
+#, no-wrap
+msgid "User impersonation"
+msgstr "ユーザーの成り代わり"
+
+#. type: Plain text
+msgid ""
+"An administrator with the appropriate permissions can impersonate a user. "
+"For example, if a user experiences a bug in an application, an administrator"
+" can impersonate the user to investigate or duplicate the issue."
+msgstr ""
+"適切な権限を持つ管理者は、ユーザーになりすますことができます。例えば、あるユーザーがアプリケーションのバグに遭遇した場合、管理者はそのユーザーになりすまして問題を調査したり、複製したりすることができます。"
+
+#. type: Plain text
+msgid ""
+"Any user with the `impersonation` role in the realm can impersonate a user."
+msgstr "レルム内で `impersonation` ロールを持つすべてのユーザが、あるユーザになりすますことができます。"
+
+#. type: Plain text
+msgid "Image:{project_images}/user-details.png[]"
+msgstr "Image:{project_images}/user-details.png[]をご覧ください。"
+
+#. type: Plain text
+msgid ""
+"If the administrator and the user are in the same realm, then the "
+"administrator will be logged out and automatically logged in as the user "
+"being impersonated."
+msgstr "管理者とユーザーが同じレルムにいる場合は、管理者がログアウトし、自動的になりすましされるユーザーとしてログインします。"
+
+#. type: Plain text
+msgid ""
+"If the administrator and user are in different realms, the administrator "
+"will remain logged in, and additionally will be logged in as the user in "
+"that user's realm."
+msgstr "管理者とユーザーが異なるレルムにいる場合、管理者はログインしたままで、さらにそのユーザーのレルムのユーザーとしてログインします。"
+
+#. type: Plain text
+msgid ""
+"In both instances, the *User Account Management* page of the impersonated "
+"user is displayed."
+msgstr "いずれの場合も、なりすましたユーザーの「ユーザーアカウント管理」ページが表示されます。"
+
+#. type: Plain text
+msgid ""
+"You can access the *Impersonate* button from the *Details* tab on the "
+"*Users* page."
+msgstr "インパーソナル」ボタンは、「ユーザー」ページの「詳細」タブからアクセスできます。"
+
+#. type: Plain text
+msgid ""
+"For more information on assigning administration permissions, see the "
+"<<_admin_permissions,Admin Console Access Control>> chapter."
+msgstr ""
+"管理権限の割り当てについては、＜＞の<_admin_permissions,Admin Console Access "
+"Control>章</_admin_permissions,Admin>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/con-user-impersonation.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__con-user-impersonation
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
