### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-using-a-service-account.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-using-a-service-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-using-a-service-account.ja_JP.po
@@ -1,0 +1,225 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Prerequisites"
+msgstr "前提条件"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Plain text
+msgid "Click *Clients* in the menu."
+msgstr "メニューの「Clients」をクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Using a service account"
+msgstr "サービスアカウントの利用"
+
+#. type: Plain text
+msgid ""
+"Each OIDC client has a built-in _service account_. Use this _service "
+"account_ to obtain an access token."
+msgstr ""
+"OIDCの各クライアントには、「サービスアカウント」が組み込まれています。この_service account_を使ってアクセストークンを取得します。"
+
+#. type: Plain text
+msgid "Select your client."
+msgstr "お客様をお選びください。"
+
+#. type: Plain text
+msgid "Click the *Settings* tab."
+msgstr "設定 \"タブをクリックします。"
+
+#. type: Plain text
+msgid ""
+"Set the <<_access-type, Access Type>> of your client to *confidential*."
+msgstr ""
+"<_access-type, Access Type>クライアントの&lt;&gt;を*confidential*</_access-"
+"type,>に設定してください。"
+
+#. type: Plain text
+msgid "Toggle *Service Accounts Enabled* to *ON*."
+msgstr "Service Accounts Enabled \"を \"ON \"に切り替えてください。"
+
+#. type: Plain text
+msgid "Configure your <<_client-credentials, client credentials>>."
+msgstr ""
+"<_client-credentials, client credentials>&lt;&gt;</_client-"
+"credentials,>の設定を行います。"
+
+#. type: Plain text
+msgid "Click the *Scope* tab."
+msgstr "Scope \"タブをクリックします。"
+
+#. type: Plain text
+msgid "Verify that you have roles or toggle *Full Scope Allowed* to *ON*."
+msgstr "ロールがあることを確認するか、*Full Scope Allowed*を*ON*に切り替えてください。"
+
+#. type: Plain text
+msgid "Click the *Service Account Roles* tab"
+msgstr "サービスアカウントの役割 \"タブをクリック"
+
+#. type: Plain text
+msgid "Configure the roles available to this service account for your client."
+msgstr "このサービスアカウントで利用可能な役割をクライアントに設定します。"
+
+#. type: Plain text
+msgid "Roles from access tokens are the intersection of:"
+msgstr "アクセストークンからのロールは、以下の交点となります。"
+
+#. type: Plain text
+msgid ""
+"Role scope mappings of a client combined with the role scope mappings "
+"inherited from linked client scopes."
+msgstr "クライアントのロールスコープのマッピングと、リンクされたクライアントのスコープから継承されたロールスコープのマッピングを組み合わせたもの。"
+
+#. type: Plain text
+msgid "Service account roles."
+msgstr "サービスアカウントの役割"
+
+#. type: Plain text
+msgid ""
+"The REST URL to invoke is `/auth/realms/{realm-name}/protocol/openid-"
+"connect/token`. This URL must be invoked as a POST request and requires that"
+" you post the client credentials with the request."
+msgstr ""
+"起動するREST URLは、`/auth/realms/{realm-name}/protocol/openid-"
+"connect/token`です。このURLはPOSTリクエストとして呼び出す必要があり、クライアントの認証情報をリクエストに添付する必要があります。"
+
+#. type: Plain text
+msgid ""
+"By default, client credentials are represented by the clientId and "
+"clientSecret of the client in the *Authorization: Basic* header but you can "
+"also authenticate the client with a signed JWT assertion or any other custom"
+" mechanism for client authentication."
+msgstr ""
+"デフォルトでは、クライアントの認証情報は、*Authorization.Basic*ヘッダ内のクライアントのclientIdおよびclientSecretによって表されます。しかし、署名されたJWTアサーションやその他のカスタムメカニズムを使ってクライアントを認証することもできます。"
+
+#. type: Plain text
+msgid ""
+"You also need to set the *grant_type* parameter to \"client_credentials\" as"
+" per the OAuth2 specification."
+msgstr "また、OAuth2の仕様に従って、*grant_type*パラメータを「client_credentials」に設定する必要があります。"
+
+#. type: Plain text
+msgid ""
+"For example, the POST invocation to retrieve a service account can look like"
+" this:"
+msgstr "例えば、サービスアカウントを取得するためのPOST呼び出しは次のようになります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"    POST /auth/realms/demo/protocol/openid-connect/token\n"
+"    Authorization: Basic cHJvZHVjdC1zYS1jbGllbnQ6cGFzc3dvcmQ=\n"
+"    Content-Type: application/x-www-form-urlencoded\n"
+msgstr ""
+"POST /auth/realms/demo/protocol/openid-connect/token\n"
+" Authorization: Basic cHJvZHVjdC1zYS1jbGllbnQ6cGFzc3dvcmQ=\n"
+" Content-Type: application/x-www-form-urlencoded\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid "    grant_type=client_credentials\n"
+msgstr "grant_type=client_credentials\n"
+
+#. type: Plain text
+msgid ""
+"The response would be similar to this "
+"https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3[Access Token "
+"Response] from the OAuth 2.0 specification."
+msgstr ""
+"このレスポンスは、OAuth 2.0仕様の "
+"https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3[Access Token "
+"Response] に似ています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"HTTP/1.1 200 OK\n"
+"Content-Type: application/json;charset=UTF-8\n"
+"Cache-Control: no-store\n"
+"Pragma: no-cache\n"
+msgstr ""
+"HTTP/1.1 200 OK\n"
+"Content-Type: application/json;charset=UTF-8\n"
+"Cache-Control: no-store\n"
+"Pragma: no-cache\n"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"{\n"
+"    \"access_token\":\"2YotnFZFEjr1zCsicMWpAA\",\n"
+"    \"token_type\":\"bearer\",\n"
+"    \"expires_in\":60\n"
+"}\n"
+msgstr ""
+"{\n"
+"    \"access_token\":\"2YotnFZFEjr1zCsicMWpAA\",\n"
+"    \"token_type\":\"bearer\",\n"
+"    \"expires_in\":60\n"
+"}\n"
+
+#. type: Plain text
+msgid ""
+"Only the access token is returned by default. No refresh token is returned "
+"and no user session is created on the {project_name} side upon successful "
+"authentication by default. Due to the lack of refresh token, re-"
+"authentication is required when the access token expires. However, this "
+"situation does not mean any additional overhead for the {project_name} "
+"server because sessions are not created by default."
+msgstr ""
+"デフォルトではアクセストークンのみが返されます。デフォルトでは、認証に成功してもリフレッシュ・トークンは返されず、{project_name}側にユーザー・セッションは作成されません。リフレッシュトークンがないため、アクセストークンの有効期限が切れると再認証が必要になります。しかし、デフォルトではセッションが作成されないため、この状況は"
+" {project_name} サーバーにとって追加のオーバーヘッドを意味しません。"
+
+#. type: Plain text
+msgid ""
+"In this situation, logout is unnecessary. However, issued access tokens can "
+"be revoked by sending requests to the OAuth2 Revocation Endpoint as "
+"described in the xref:con-oidc_{context}[OpenID Connect Endpoints] section."
+msgstr ""
+"このような場合、ログアウトは不要です。ただし、発行されたアクセストークンは、xref:con-oidc_{context}[OpenID Connect"
+" Endpoints]のセクションで説明されているように、OAuth2 Revocation "
+"Endpointにリクエストを送ることで失効させることができます。"
+
+#. type: Plain text
+msgid ""
+"For more details, see <<_client_credentials_grant,Client Credentials "
+"Grant>>."
+msgstr ""
+"詳しくは＜<_client_credentials_grant,Client Credentials "
+"Grant>＞</_client_credentials_grant,Client>をご覧ください。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-using-a-service-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-using-a-service-account.ja_JP.po
@@ -41,74 +41,71 @@ msgstr "追加のリソース"
 
 #. type: Plain text
 msgid "Click *Clients* in the menu."
-msgstr "メニューの「Clients」をクリックします。"
+msgstr "メニューの *Clients* をクリックします。"
 
 #. type: Title =
 #, no-wrap
 msgid "Using a service account"
-msgstr "サービスアカウントの利用"
+msgstr "サービス・アカウントの使用"
 
 #. type: Plain text
 msgid ""
 "Each OIDC client has a built-in _service account_. Use this _service "
 "account_ to obtain an access token."
 msgstr ""
-"OIDCの各クライアントには、「サービスアカウント」が組み込まれています。この_service account_を使ってアクセストークンを取得します。"
+"OIDCの各クライアントには、 _サービス・アカウント_ が組み込まれています。この _サービス・アカウント_ を使ってアクセストークンを取得します。"
 
 #. type: Plain text
 msgid "Select your client."
-msgstr "お客様をお選びください。"
+msgstr "クライアントを選択してださい。"
 
 #. type: Plain text
 msgid "Click the *Settings* tab."
-msgstr "設定 \"タブをクリックします。"
+msgstr "*Settings* タブをクリックします。"
 
 #. type: Plain text
 msgid ""
 "Set the <<_access-type, Access Type>> of your client to *confidential*."
-msgstr ""
-"<_access-type, Access Type>クライアントの&lt;&gt;を*confidential*</_access-"
-"type,>に設定してください。"
+msgstr "クライアントの<<_access-type, Access Type>>を *confidential* に設定してください。"
 
 #. type: Plain text
 msgid "Toggle *Service Accounts Enabled* to *ON*."
-msgstr "Service Accounts Enabled \"を \"ON \"に切り替えてください。"
+msgstr "*Service Accounts Enabled* を *ON* に切り替えてください。"
 
 #. type: Plain text
 msgid "Configure your <<_client-credentials, client credentials>>."
-msgstr ""
-"<_client-credentials, client credentials>&lt;&gt;</_client-"
-"credentials,>の設定を行います。"
+msgstr "<<_client-credentials, クライアント・クレデンシャル>>の設定を行います。"
 
 #. type: Plain text
 msgid "Click the *Scope* tab."
-msgstr "Scope \"タブをクリックします。"
+msgstr "*Scope* タブをクリックします。"
 
 #. type: Plain text
 msgid "Verify that you have roles or toggle *Full Scope Allowed* to *ON*."
-msgstr "ロールがあることを確認するか、*Full Scope Allowed*を*ON*に切り替えてください。"
+msgstr "ロールがあることを確認するか、 *Full Scope Allowed* を *ON* に切り替えてください。"
 
 #. type: Plain text
 msgid "Click the *Service Account Roles* tab"
-msgstr "サービスアカウントの役割 \"タブをクリック"
+msgstr "*Service Account Roles* タブをクリックします。"
 
 #. type: Plain text
 msgid "Configure the roles available to this service account for your client."
-msgstr "このサービスアカウントで利用可能な役割をクライアントに設定します。"
+msgstr "このサービス・アカウントで利用可能なロールをクライアントに設定します。"
 
 #. type: Plain text
 msgid "Roles from access tokens are the intersection of:"
-msgstr "アクセストークンからのロールは、以下の交点となります。"
+msgstr "アクセストークンからのロールは、以下の論理積となります。"
 
 #. type: Plain text
 msgid ""
 "Role scope mappings of a client combined with the role scope mappings "
 "inherited from linked client scopes."
-msgstr "クライアントのロールスコープのマッピングと、リンクされたクライアントのスコープから継承されたロールスコープのマッピングを組み合わせたもの。"
+msgstr ""
+"クライアントのロール・スコープ・マッピングと、リンクされたクライアントのスコープから継承されたロール・スコープ・マッピングを組み合わせたもの。"
 
 #. type: Plain text
 msgid "Service account roles."
-msgstr "サービスアカウントの役割"
+msgstr "サービス・アカウント・ロール"
 
 #. type: Plain text
 msgid ""
@@ -116,8 +113,8 @@ msgid ""
 "connect/token`. This URL must be invoked as a POST request and requires that"
 " you post the client credentials with the request."
 msgstr ""
-"起動するREST URLは、`/auth/realms/{realm-name}/protocol/openid-"
-"connect/token`です。このURLはPOSTリクエストとして呼び出す必要があり、クライアントの認証情報をリクエストに添付する必要があります。"
+"起動するREST URLは、 `/auth/realms/{realm-name}/protocol/openid-connect/token` "
+"です。このURLはPOSTリクエストとして呼び出す必要があり、クライアントのクレデンシャルをリクエストに添付する必要があります。"
 
 #. type: Plain text
 msgid ""
@@ -126,19 +123,21 @@ msgid ""
 "also authenticate the client with a signed JWT assertion or any other custom"
 " mechanism for client authentication."
 msgstr ""
-"デフォルトでは、クライアントの認証情報は、*Authorization.Basic*ヘッダ内のクライアントのclientIdおよびclientSecretによって表されます。しかし、署名されたJWTアサーションやその他のカスタムメカニズムを使ってクライアントを認証することもできます。"
+"デフォルトでは、クライアントのクレデンシャルは、 *Authorization.Basic* "
+"ヘッダー内のクライアントのclientIdおよびclientSecretによって表されます。しかし、署名されたJWTアサーションやその他のカスタム・メカニズムを使ってクライアントを認証することもできます。"
 
 #. type: Plain text
 msgid ""
 "You also need to set the *grant_type* parameter to \"client_credentials\" as"
 " per the OAuth2 specification."
-msgstr "また、OAuth2の仕様に従って、*grant_type*パラメータを「client_credentials」に設定する必要があります。"
+msgstr ""
+"また、OAuth 2の仕様に従って、 *grant_type* パラメーターを \"client_credentials\" に設定する必要があります。"
 
 #. type: Plain text
 msgid ""
 "For example, the POST invocation to retrieve a service account can look like"
 " this:"
-msgstr "例えば、サービスアカウントを取得するためのPOST呼び出しは次のようになります。"
+msgstr "たとえば、サービス・アカウントを取得するためのPOST呼び出しは次のようになります。"
 
 #. type: delimited block -
 #, no-wrap
@@ -162,7 +161,7 @@ msgid ""
 "https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3[Access Token "
 "Response] from the OAuth 2.0 specification."
 msgstr ""
-"このレスポンスは、OAuth 2.0仕様の "
+"このレスポンスは、OAuth 2.0の仕様の "
 "https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3[Access Token "
 "Response] に似ています。"
 
@@ -203,8 +202,7 @@ msgid ""
 "situation does not mean any additional overhead for the {project_name} "
 "server because sessions are not created by default."
 msgstr ""
-"デフォルトではアクセストークンのみが返されます。デフォルトでは、認証に成功してもリフレッシュ・トークンは返されず、{project_name}側にユーザー・セッションは作成されません。リフレッシュトークンがないため、アクセストークンの有効期限が切れると再認証が必要になります。しかし、デフォルトではセッションが作成されないため、この状況は"
-" {project_name} サーバーにとって追加のオーバーヘッドを意味しません。"
+"デフォルトでは、アクセストークンのみが返されます。デフォルトでは、認証に成功してもリフレッシュ・トークンは返されず、{project_name}側にユーザー・セッションは作成されません。リフレッシュトークンがないため、アクセストークンの有効期限が切れると再認証が必要になります。しかし、デフォルトではセッションが作成されないため、この状況は{project_name}サーバーにとって追加のオーバーヘッドを意味しません。"
 
 #. type: Plain text
 msgid ""
@@ -212,14 +210,12 @@ msgid ""
 "be revoked by sending requests to the OAuth2 Revocation Endpoint as "
 "described in the xref:con-oidc_{context}[OpenID Connect Endpoints] section."
 msgstr ""
-"このような場合、ログアウトは不要です。ただし、発行されたアクセストークンは、xref:con-oidc_{context}[OpenID Connect"
-" Endpoints]のセクションで説明されているように、OAuth2 Revocation "
+"このような場合、ログアウトは不要です。ただし、発行されたアクセストークンは、 xref:con-oidc_{context}[OpenID "
+"Connect Endpoints] のセクションで説明されているように、OAuth 2 Revocation "
 "Endpointにリクエストを送ることで失効させることができます。"
 
 #. type: Plain text
 msgid ""
 "For more details, see <<_client_credentials_grant,Client Credentials "
 "Grant>>."
-msgstr ""
-"詳しくは＜<_client_credentials_grant,Client Credentials "
-"Grant>＞</_client_credentials_grant,Client>をご覧ください。"
+msgstr "詳しくは<<_client_credentials_grant,Client Credentials Grant>>を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-using-a-service-account.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__proc-using-a-service-account
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
