### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-allow-user-to-delete-account.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-allow-user-to-delete-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-allow-user-to-delete-account.ja_JP.po
@@ -110,27 +110,26 @@ msgstr "*Client Roles* のリストから *account* を選択します。"
 
 #. type: Plain text
 msgid "Under *Available Roles*, select *delete-account*."
-msgstr "Available Roles*の下で、*delete-account*を選択します。"
+msgstr "*Available Roles* の下で、 *delete-account* を選択します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Delete-account role"
-msgstr "アカウント・ロールの削除"
+msgstr "Delete-accountロール"
 
 #. type: Plain text
 msgid "image:images/delete-account-client-role.png[delete-account role]"
-msgstr ""
-"image:images/delete-account-client-role.png[delete-account role]をご覧ください。"
+msgstr "image:images/delete-account-client-role.png[delete-account role]"
 
 #. type: Title ==
 #, no-wrap
 msgid "Deleting your account"
-msgstr "お客様のアカウントを削除する"
+msgstr "アカウントの削除"
 
 #. type: Plain text
 msgid ""
 "Once you have the *delete-account* role, you can delete your own account."
-msgstr "delete-account*ロールを取得すると、自分のアカウントを削除できるようになります。"
+msgstr "*delete-account* ロールを取得すると、自分のアカウントを削除できるようになります。"
 
 #. type: Plain text
 msgid "Log into the Account Console."
@@ -138,7 +137,7 @@ msgstr "アカウントコンソールにログインします。"
 
 #. type: Plain text
 msgid "At the bottom of the *Personal Info* page, click *Delete Account*."
-msgstr "個人情報」ページの下部にある「アカウントの削除」をクリックします。"
+msgstr "Delete-accountページの下部にある *Delete Account* をクリックします。"
 
 #. type: Block title
 #, no-wrap
@@ -147,15 +146,15 @@ msgstr "アカウント削除ページ"
 
 #. type: Plain text
 msgid "Enter your credentials and confirm the deletion."
-msgstr "認証情報を入力し、削除を確認します。"
+msgstr "クレデンシャルを入力し、削除を確認します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Delete confirmation"
-msgstr "削除確認"
+msgstr "削除の確認"
 
 #. type: delimited block =
 msgid ""
 "This action is irreversible. All your data in {project_name} will be "
 "removed."
-msgstr "このアクションは不可逆的です。project_name}にあるあなたのデータはすべて削除されます。"
+msgstr "このアクションは不可逆的です。{project_name}にあるデータはすべて削除されます。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-allow-user-to-delete-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-allow-user-to-delete-account.ja_JP.po
@@ -1,0 +1,161 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure "
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Required Actions* tab."
+msgstr "*Required Actions* タブをクリックします。"
+
+#. type: Plain text
+msgid "Click *Users* in the menu."
+msgstr "メニューの *Users* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Role Mappings* tab."
+msgstr "*Role Mappings* タブをクリックします。"
+
+#. type: Plain text
+msgid "Click *Add selected*."
+msgstr "*Add selected* をクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Enabling account deletion by users"
+msgstr "ユーザーによるアカウント削除の有効化"
+
+#. type: Plain text
+msgid "image:images/enable-delete-account-action.png[]"
+msgstr "image:images/enable-delete-account-action.png[]"
+
+#. type: Plain text
+msgid "image:images/delete-account-page.png[]"
+msgstr "image:images/delete-account-page.png[]"
+
+#. type: Plain text
+msgid "image:images/delete-account-confirm.png[]"
+msgstr "image:images/delete-account-confirm.png[]"
+
+#. type: Plain text
+msgid ""
+"End users and applications can delete their accounts in the Account Console "
+"if you enable this capability in the Admin Console. Once you enable this "
+"capability, you can give that capability to specific users."
+msgstr ""
+"管理コンソールでこの機能を有効にすると、エンドユーザーやアプリケーションはアカウント・コンソールでアカウントを削除することができます。この機能を有効にすると、その機能を特定のユーザーに与えることができます。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Enabling the Delete Account Capability"
+msgstr "アカウント削除機能の有効化"
+
+#. type: Plain text
+msgid "You enable this capability on the *Required Actions* tab."
+msgstr "この機能を有効にするには、 *Required Actions* タブで設定します。"
+
+#. type: Plain text
+msgid "Select *Enabled* on the *Delete Account* row."
+msgstr "*Delete Account*の行で *Enabled* を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Delete account on required actions tab"
+msgstr "必須アクションタブでのアカウント削除"
+
+#. type: Title ==
+#, no-wrap
+msgid "Giving a user the *delete-account* role"
+msgstr "ユーザーに *delete-account* ロールを与える"
+
+#. type: Plain text
+msgid "You can give specific users a role that allows account deletion."
+msgstr "特定のユーザーにアカウントの削除を許可するロールを与えることができます。"
+
+#. type: Plain text
+msgid "Select a user."
+msgstr "ユーザーを選択します。"
+
+#. type: Plain text
+msgid "From the *Client Roles* list, select *account*."
+msgstr "*Client Roles* のリストから *account* を選択します。"
+
+#. type: Plain text
+msgid "Under *Available Roles*, select *delete-account*."
+msgstr "Available Roles*の下で、*delete-account*を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Delete-account role"
+msgstr "アカウント・ロールの削除"
+
+#. type: Plain text
+msgid "image:images/delete-account-client-role.png[delete-account role]"
+msgstr ""
+"image:images/delete-account-client-role.png[delete-account role]をご覧ください。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Deleting your account"
+msgstr "お客様のアカウントを削除する"
+
+#. type: Plain text
+msgid ""
+"Once you have the *delete-account* role, you can delete your own account."
+msgstr "delete-account*ロールを取得すると、自分のアカウントを削除できるようになります。"
+
+#. type: Plain text
+msgid "Log into the Account Console."
+msgstr "アカウントコンソールにログインします。"
+
+#. type: Plain text
+msgid "At the bottom of the *Personal Info* page, click *Delete Account*."
+msgstr "個人情報」ページの下部にある「アカウントの削除」をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Delete account page"
+msgstr "アカウント削除ページ"
+
+#. type: Plain text
+msgid "Enter your credentials and confirm the deletion."
+msgstr "認証情報を入力し、削除を確認します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Delete confirmation"
+msgstr "削除確認"
+
+#. type: delimited block =
+msgid ""
+"This action is irreversible. All your data in {project_name} will be "
+"removed."
+msgstr "このアクションは不可逆的です。project_name}にあるあなたのデータはすべて削除されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-allow-user-to-delete-account.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-allow-user-to-delete-account
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
