### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-registering-new-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-registering-new-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-registering-new-user.ja_JP.po
@@ -37,7 +37,7 @@ msgstr "前提条件"
 #. type: Title =
 #, no-wrap
 msgid "Registering as a new user"
-msgstr "新しいユーザーとして登録する"
+msgstr "新規ユーザーとして登録する"
 
 #. type: Plain text
 msgid ""
@@ -62,11 +62,11 @@ msgstr "ユーザー登録が可能です。"
 msgid ""
 "Click the *Register* link on the login page. The registration page is "
 "displayed."
-msgstr "ログインページの「*Register*」リンクをクリックします。登録ページが表示されます。"
+msgstr "ログインページの *Register* のリンクをクリックすると、登録ページが表示されます。"
 
 #. type: Plain text
 msgid "Enter the user profile information."
-msgstr "ユーザープロファイル情報を入力します。"
+msgstr "ユーザー・プロフィール情報を入力します。"
 
 #. type: Plain text
 msgid "Enter the new password."

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-registering-new-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-registering-new-user.ja_JP.po
@@ -1,0 +1,73 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# katakura__pro <h.katakura@pro-japan.co.jp>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisite"
+msgstr "前提条件"
+
+#. type: Title =
+#, no-wrap
+msgid "Registering as a new user"
+msgstr "新しいユーザーとして登録する"
+
+#. type: Plain text
+msgid ""
+"As a new user, you must complete a registration form to log in for the first"
+" time. You add profile information and a password to register."
+msgstr "新規ユーザーとして初めてログインするには、登録フォームに記入する必要があります。プロフィール情報とパスワードを入力して登録します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Registration form"
+msgstr "登録フォーム"
+
+#. type: Plain text
+msgid "image:{project_images}/registration-form.png[]"
+msgstr "image:{project_images}/registration-form.png[]"
+
+#. type: Plain text
+msgid "User registration is enabled."
+msgstr "ユーザー登録が可能です。"
+
+#. type: Plain text
+msgid ""
+"Click the *Register* link on the login page. The registration page is "
+"displayed."
+msgstr "ログインページの「*Register*」リンクをクリックします。登録ページが表示されます。"
+
+#. type: Plain text
+msgid "Enter the user profile information."
+msgstr "ユーザープロファイル情報を入力します。"
+
+#. type: Plain text
+msgid "Enter the new password."
+msgstr "新しいパスワードを入力します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-registering-new-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-registering-new-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
