### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po
@@ -3,11 +3,15 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Shinsuke UEDA, 2017
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,11 +26,11 @@ msgstr "パスワード・データベースの侵害"
 
 #. type: Plain text
 msgid ""
-"{project_name} does not store passwords in raw text.  It stores a hash of "
-"them using the PBKDF2 algorithm.  It actually uses a default of 20,000 "
-"hashing iterations! This is the security community's recommended number of "
-"iterations.  This can be a rather large performance hit on your system as "
-"PBKDF2, by design, gobbles up a significant amount of CPU.  It is up to you "
-"to decide how serious you want to be to protect your password database."
+"{project_name} does not store passwords in raw text but as hashed text, "
+"using the PBKDF2 hashing algorithm. {project_name} performs 27,500 hashing "
+"iterations, the number of iterations recommended by the security community. "
+"This number of hashing iterations can adversely affect performance as PBKDF2"
+" hashing uses a significant amount of CPU resources."
 msgstr ""
-"{project_name}はパスワードを生のテキストで保存しません。PBKDF2アルゴリズムを使用して、それらのハッシュを保存します。実際には、デフォルトの20,000回のハッシング反復を使用します。これは、セキュリティー・コミュニティが推奨する反復回数です。設計上、PBKDF2が大量のCPUを浪費するため、システムにかなり大きな負荷がかかる可能性があります。パスワード・データベースをどの程度保護したいのかは、要件次第です。"
+"{project_name}は、パスワードを平文のテキストではなく、PBKDF2ハッシングアルゴリズムを用いてハッシュ化したテキストとして保存します。{project_name}は、セキュリティー・コミュニティーで推奨されている回数である27,500回のハッシュ反復を行います。PBKDF2ハッシュ化は大量の"
+" CPUリソースを使用するため、このハッシュ化の反復回数はパフォーマンスに悪影響を及ぼします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/threat/password-db-compromised.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__threat__password-db-compromised
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
