### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po
@@ -4,14 +4,13 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,28 +20,28 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Retrieving External IDP Tokens"
+msgid "Retrieving external IDP tokens"
 msgstr "外部IDPトークンの取得"
 
 #. type: Plain text
 msgid ""
-"{project_name} allows you to store tokens and responses from the "
-"authentication process with the external IDP.  For that, you can use the "
-"`Store Token` configuration option on the IDP's settings page."
+"With {project_name}, you can store tokens and responses from the "
+"authentication process with the external IDP using the `Store Token` "
+"configuration option on the IDP's settings page."
 msgstr ""
-"{project_name}は、外部IDPとの認証プロセスから取得したトークンとレスポンスを保存できます。そのために、IDPの設定ページで `Store"
-" Token` の設定オプションを使用できます。"
+"{project_name}では、IDPの設定ページにある `Store Token` "
+"という設定オプションを使って、外部IDPでの認証プロセスから得たトークンとレスポンスを保存することができます。"
 
 #. type: Plain text
 msgid ""
-"Application code can retrieve these tokens and responses to pull in extra "
-"user information, or to securely invoke requests on the external IDP.  For "
-"example, an application might want to use the Google token to invoke on "
-"other Google services and REST APIs.  To retrieve a token for a particular "
-"identity provider you need to send a request as follows:"
+"Application code can retrieve these tokens and responses to import extra "
+"user information or to request the external IDP securely. For example, an "
+"application can use the Google token to use other Google services and REST "
+"APIs. To retrieve a token for a particular identity provider, send a request"
+" as follows:"
 msgstr ""
-"アプリケーション・コードで、追加のユーザー情報を取得するためにこれらのトークンとレスポンスを検索したり、外部IDPにリクエストを送信することができます。たとえば、アプリケーションは、Googleトークンを使用して、他のGoogleサービスやREST"
-" APIを呼び出すことができます。特定のアイデンティティー・プロバイダーのトークンを取得するには、次のようにリクエストを送信する必要があります。"
+"アプリケーション・コードは、これらのトークンとレスポンスを取得して、追加のユーザー情報をインポートしたり、外部のIDPを安全に要求したりすることができます。たとえば、アプリケーションはGoogleトークンを使用して、他のGoogleサービスやREST"
+" APIを使用することができます。特定のアイデンティティー・プロバイダーのトークンを取得するには、次のようなリクエストを送信します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -57,26 +56,24 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"An application must have authenticated with {project_name} and have received"
-" an access token.  This access token will need to have the `broker` client-"
-"level role `read-token` set.  This means that the user must have a role "
-"mapping for this role and the client application must have that role within "
-"its scope.  In this case, given that you are accessing a protected service "
-"in {project_name}, you need to send the access token issued by "
-"{project_name} during the user authentication.  In the broker configuration "
-"page you can automatically assign this role to newly imported users by "
-"turning on the `Stored Tokens Readable` switch."
+"An application must authenticate with {project_name} and receive an access "
+"token. This access token must have the `broker` client-level role `read-"
+"token` set, so the user must have a role mapping for this role, and the "
+"client application must have that role within its scope. In this case, since"
+" you are accessing a protected service in {project_name}, send the access "
+"token issued by {project_name} during the user authentication. You can "
+"assign this role to newly imported users in the broker configuration page by"
+" setting the *Stored Tokens Readable* switch to *ON*."
 msgstr ""
-"アプリケーションは{project_name}で認証され、アクセストークンを受け取っている必要があります。このアクセストークンには、 `broker` "
-"クライアントレベルの `read-token` "
-"ロールが設定されている必要があります。つまり、ユーザーはこのロールのロールマッピングを持っていなければならず、クライアント・アプリケーションのスコープ内でそのロールが必要です。この場合（{project_name}内のセキュリティー保護されたサービスにアクセスしている場合）は、ユーザー認証時に{project_name}が発行したアクセストークンを送信する必要があります。ブローカーの設定ページでは、"
-" `Stored Tokens Readable` "
-"のスイッチをオンにすることで、新しくインポートされたユーザーにこのロールを自動的に割り当てることができます。"
+"アプリケーションは{project_name}で認証を行い、アクセストークンを受け取る必要があります。このアクセストークンには、 `broker` "
+"クライアントレベル・ロールの `read-token` "
+"が設定されていなければなりません。したがって、ユーザーはこのロールに対応するロールマッピングを持っている必要があり、クライアント・アプリケーションはそのスコープ内にそのロールを持っている必要があります。この場合、{project_name}の保護されたサービスにアクセスしているので、ユーザー認証の際に{project_name}が発行したアクセストークンを送信します。ブローカー設定ページで、"
+" *Stored Tokens Readable* スイッチを *ON* "
+"に設定することで、新規にインポートしたユーザーにこのロールを割り当てることができます。"
 
 #. type: Plain text
 msgid ""
-"These external tokens can be re-established by either logging in again "
-"through the provider, or using the client-initiated account linking API."
+"These external tokens can be re-established by logging in again through the "
+"provider or using the client-initiated account linking API."
 msgstr ""
-"これらの外部トークンは、プロバイダーを介して再度ログインするか、Client-Initiated Account Linking "
-"APIを使用して再確立できます。"
+"これらの外部トークンは、プロバイダーを介して再度ログインするか、クライアントが主導するアカウント・リンキングAPIを使用することで、再設定することができます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/tokens.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__tokens
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
