### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po
@@ -4,14 +4,13 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,17 +20,17 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Available User Session Data"
+msgid "Available user session data"
 msgstr "利用可能なユーザー・セッション・ データ"
 
 #. type: Plain text
 msgid ""
-"After a user logs in from the external IDP, there is some additional user "
-"session note data that {project_name} stores that you can access.  This data"
-" can be propagated to the client requesting a login via the token or SAML "
-"assertion being passed back to it by using an appropriate client mapper."
+"After a user login from an external IDP, {project_name} stores user session "
+"note data that you can access. This data can be propagated to the client "
+"requesting log in using the token or SAML assertion passed back to the "
+"client using an appropriate client mapper."
 msgstr ""
-"ユーザーが外部IDPからログインすると、アクセス可能なユーザー・セッション・ノート・データが{project_name}に追加で保存されます。このデータは、適切なクライアント・マッパーを使用して戻されるトークンまたはSAMLアサーションを介して、ログインを要求するクライアントに伝播できます。"
+"外部のIDPからユーザーがログインした後、{project_name}は、アクセス可能なユーザー・セッション・ノート・データを保存します。このデータは、適切なクライアント・マッパーを使用して、トークンまたはSAMLアサーションを使用して、ログインを要求するクライアントに伝搬させることができます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -39,8 +38,8 @@ msgid "identity_provider"
 msgstr "identity_provider"
 
 #. type: Plain text
-msgid "This is the IDP alias of the broker used to perform the login."
-msgstr "ログインを実行するために使用されるブローカーのIDPエイリアスです。"
+msgid "The IDP alias of the broker used to perform the login."
+msgstr "ログインを実行するために使用されるブローカーのIDPエイリアス。"
 
 #. type: Labeled list
 #, no-wrap
@@ -49,15 +48,14 @@ msgstr "identity_provider_identity"
 
 #. type: Plain text
 msgid ""
-"This is the IDP username of the currently authenticated user. This is often "
-"the same as the {project_name} username, but doesn't necessarily needs to "
-"be.  For example {project_name} user `john` can be linked to the Facebook "
-"user `john123@gmail.com`, so in that case value of user session note will be"
-" `john123@gmail.com` ."
+"The IDP username of the currently authenticated user. Often, but not always,"
+" the same as the {project_name} username. For example, {project_name} can "
+"link a user john` to a Facebook user `john123@gmail.com`. In that case, the "
+"value of the user session note is `john123@gmail.com`."
 msgstr ""
-"現在認証されているユーザーのIDPユーザー名です。これは{project_name}ユーザー名と同じことが多いですが、必ずしもそうである必要はありません。たとえば、{project_name}のユーザー"
-" `john` は、Facebookのユーザー `john123@gmail.com` にリンクできます。その場合、ユーザー・セッション・ノートの値は "
-"`john123@gmail.com` になります。"
+"現在認証されているユーザーのIDPのユーザー名です。多くの場合、{project_name}のユーザー名と同じですが、必ずしもそうではありません。たとえば、{project_name}は、ユーザー"
+" john` をFacebookユーザー `john123@gmail.com` にリンクすることができます。この場合、ユーザーセッションノートの値は "
+"`john123@gmail.com` となります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/session-data.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__session-data
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
