### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
@@ -30,9 +30,7 @@ msgid ""
 "external identity provider to use the provider's identities to access the "
 "internal services the service provider exposes."
 msgstr ""
-"アイデンティティ・ブローカーは、サービス・プロバイダと ID "
-"プロバイダをつなぐ仲介サービスである。アイデンティティ・ブローカーは、外部のアイデンティティ・プロバイダとの関係を構築し、プロバイダの ID "
-"を使用して、サービス・プロバイダが公開している内部サービスにアクセスします。"
+"アイデンティティー・ブローカーは、サービス・プロバイダーとアイデンティティー・プロバイダーをつなぐ仲介サービスです。アイデンティティー・ブローカーは、外部のアイデンティティー・プロバイダーとの関係を構築し、プロバイダーのアイデンティティーを使用して、サービス・プロバイダーが公開している内部サービスにアクセスします。"
 
 #. type: Plain text
 msgid ""
@@ -41,31 +39,32 @@ msgid ""
 "can link an account with one or more identities from identity providers or "
 "create an account based on the identity information from them."
 msgstr ""
-"ユーザの視点から見ると、アイデンティティ・ブローカーは、ユーザを中心とした、セキュリティ・ドメインやレルムのアイデンティティを一元的に管理する方法を提供します。アカウントをIDプロバイダからの1つまたは複数のIDとリンクさせたり、IDプロバイダからのID情報に基づいてアカウントを作成することができます。"
+"ユーザーの視点から見ると、アイデンティティー・ブローカーは、ユーザーを中心とした、セキュリティー・ドメインやレルムのアイデンティティーを一元的に管理する方法を提供します。アカウントをアイデンティティー・プロバイダーから取得した1つまたは複数のアイデンティティーとリンクさせたり、アイデンティティー・プロバイダーから取得したアイデンティティー情報をもとにアカウントを作成することができます。"
 
 #. type: Plain text
 msgid ""
 "An identity provider derives from a specific protocol used to authenticate "
 "and send authentication and authorization information to users. It can be:"
-msgstr "ID プロバイダは、ユーザを認証し、認証・認可情報を送信するために使用される特定のプロトコルに由来する。ることができる。"
+msgstr ""
+"アイデンティティー・プロバイダーは、ユーザーを認証し、認証・認可情報を送信するために使用される特定のプロトコルに由来します。アイデンティティー・プロバイダーは、以下を行うことができます。"
 
 #. type: Plain text
 msgid "A social provider such as Facebook, Google, or Twitter."
-msgstr "Facebook、Google、Twitterなどのソーシャルプロバイダー。"
+msgstr "Facebook、Google、Twitterなどのソーシャル・プロバイダー"
 
 #. type: Plain text
 msgid "A business partner whose users need to access your services."
-msgstr "ユーザーがあなたのサービスにアクセスする必要があるビジネスパートナー。"
+msgstr "サービスにアクセスする必要があるユーザーの所属するビジネスパートナー"
 
 #. type: Plain text
 msgid "A cloud-based identity service you want to integrate."
-msgstr "統合したいクラウドベースのIDサービスです。"
+msgstr "統合したいクラウドベースのアイデンティティー・サービス"
 
 #. type: Plain text
 msgid ""
 "Typically, {project_name} bases identity providers on the following "
 "protocols:"
-msgstr "通常、{project_name} は、以下のプロトコルに基づいて ID プロバイダを構築します。"
+msgstr "通常、{project_name}は、以下のプロトコルに基づいてアイデンティティー・プロバイダーを構築します。"
 
 #. type: Plain text
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,43 +20,52 @@ msgstr ""
 
 #. type: Title ==
 #, no-wrap
-msgid "Identity Brokering"
-msgstr "アイデンティティー・ブローカリング"
+msgid "Integrating identity providers"
+msgstr "アイデンティティー・プロバイダーの統合"
 
 #. type: Plain text
 msgid ""
-"An Identity Broker is an intermediary service that connects multiple service"
-" providers with different identity providers.  As an intermediary service, "
-"the identity broker is responsible for creating a trust relationship with an"
-" external identity provider in order to use its identities to access "
-"internal services exposed by service providers."
+"An Identity Broker is an intermediary service connecting service providers "
+"with identity providers. The identity broker creates a relationship with an "
+"external identity provider to use the provider's identities to access the "
+"internal services the service provider exposes."
 msgstr ""
-"アイデンティティー・ブローカーは、複数のサービス・プロバイダーを異なるアイデンティティー・プロバイダーに接続する仲介サービスです。仲介サービスとして、アイデンティティー・ブローカーは、サービス・プロバイダーによって公開される内部サービスへのアクセスでアイデンティティーを使用するために、外部アイデンティティー・プロバイダーとの信頼関係を作成する責任があります。"
+"アイデンティティ・ブローカーは、サービス・プロバイダと ID "
+"プロバイダをつなぐ仲介サービスである。アイデンティティ・ブローカーは、外部のアイデンティティ・プロバイダとの関係を構築し、プロバイダの ID "
+"を使用して、サービス・プロバイダが公開している内部サービスにアクセスします。"
 
 #. type: Plain text
 msgid ""
-"From a user perspective, an identity broker provides a user-centric and "
-"centralized way to manage identities across different security domains or "
-"realms. An existing account can be linked with one or more identities from "
-"different identity providers or even created based on the identity "
-"information obtained from them."
+"From a user perspective, identity brokers provide a user-centric, "
+"centralized way to manage identities for security domains and realms. You "
+"can link an account with one or more identities from identity providers or "
+"create an account based on the identity information from them."
 msgstr ""
-"ユーザーの観点から、アイデンティティー・ブローカーは、異なるセキュリティー・ドメインまたはレルム間のアイデンティティーを管理するための、ユーザー中心かつ一元的な方法を提供します。既存のアカウントは、異なるアイデンティティー・プロバイダーの1つ以上のアイデンティティーとリンクすることも、それらから取得したアイデンティティー情報に基づいて作成することもできます。"
+"ユーザの視点から見ると、アイデンティティ・ブローカーは、ユーザを中心とした、セキュリティ・ドメインやレルムのアイデンティティを一元的に管理する方法を提供します。アカウントをIDプロバイダからの1つまたは複数のIDとリンクさせたり、IDプロバイダからのID情報に基づいてアカウントを作成することができます。"
 
 #. type: Plain text
 msgid ""
-"An identity provider is usually based on a specific protocol that is used to"
-" authenticate and communicate authentication and authorization information "
-"to their users.  It can be a social provider such as Facebook, Google or "
-"Twitter.  It can be a business partner whose users need to access your "
-"services. Or it can be a cloud-based identity service that you want to "
-"integrate with."
-msgstr ""
-"アイデンティティー・プロバイダーは、通常、認証して、ユーザーに認証と認可の情報を伝えるために使用される特定のプロトコルに基づいています。Facebook、Google、Twitterなどのソーシャル・プロバイダーや、サービスにアクセスする必要のあるユーザーの属するビジネス・パートナー、または統合したいクラウドベースのアイデンティティー・サービスにすることもできます。"
+"An identity provider derives from a specific protocol used to authenticate "
+"and send authentication and authorization information to users. It can be:"
+msgstr "ID プロバイダは、ユーザを認証し、認証・認可情報を送信するために使用される特定のプロトコルに由来する。ることができる。"
 
 #. type: Plain text
-msgid "Usually, identity providers are based on the following protocols:"
-msgstr "通常、アイデンティティー・プロバイダーは次のプロトコルに基づいて実装されています。"
+msgid "A social provider such as Facebook, Google, or Twitter."
+msgstr "Facebook、Google、Twitterなどのソーシャルプロバイダー。"
+
+#. type: Plain text
+msgid "A business partner whose users need to access your services."
+msgstr "ユーザーがあなたのサービスにアクセスする必要があるビジネスパートナー。"
+
+#. type: Plain text
+msgid "A cloud-based identity service you want to integrate."
+msgstr "統合したいクラウドベースのIDサービスです。"
+
+#. type: Plain text
+msgid ""
+"Typically, {project_name} bases identity providers on the following "
+"protocols:"
+msgstr "通常、{project_name} は、以下のプロトコルに基づいて ID プロバイダを構築します。"
 
 #. type: Plain text
 #, no-wrap
@@ -69,30 +81,3 @@ msgstr "`OpenID Connect v1.0`            \n"
 #, no-wrap
 msgid "`OAuth v2.0`            \n"
 msgstr "`OAuth v2.0`            \n"
-
-#. type: Plain text
-msgid ""
-"In the next sections we'll see how to configure and use {project_name} as an"
-" identity broker, covering some important aspects such as:"
-msgstr ""
-"次のセクションでは、{project_name}をアイデンティティー・ブローカーとして設定および使用する方法を説明します。以下のいくつかの重要な側面について説明します。"
-
-#. type: Plain text
-#, no-wrap
-msgid "`Social Authentication`            \n"
-msgstr "`Social Authentication`            \n"
-
-#. type: Plain text
-#, no-wrap
-msgid "`OpenID Connect v1.0 Brokering`            \n"
-msgstr "`OpenID Connect v1.0 Brokering`            \n"
-
-#. type: Plain text
-#, no-wrap
-msgid "`SAML v2.0 Brokering`            \n"
-msgstr "`SAML v2.0 Brokering`            \n"
-
-#. type: Plain text
-#, no-wrap
-msgid "`Identity Federation`            \n"
-msgstr "`Identity Federation`            \n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
