### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
@@ -5,19 +5,36 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
+#. type: Plain text
+msgid "Select *Identity Provider Redirector* from the drop-down list."
+msgstr "ドロップダウンリストから \"Identity Provider Redirector \"を選択します。"
+
+#. type: Plain text
+msgid "Click the *Browser* flow."
+msgstr "Browser \"フローをクリックします。"
 
 #. type: Title ===
 #, no-wrap
@@ -26,30 +43,29 @@ msgstr "デフォルトのアイデンティティー・プロバイダー"
 
 #. type: Plain text
 msgid ""
-"It is possible to automatically redirect to a identity provider instead of "
-"displaying the login form. To enable this go to the `Authentication` page in"
-" the administration console and select the `Browser` flow. Then click on "
-"config for the `Identity Provider Redirector` authenticator. Set `Default "
-"Identity Provider` to the alias of the identity provider you want to "
-"automatically redirect users to."
+"{project_name} can redirect to an identity provider rather than displaying "
+"the login form. To enable this redirection:"
 msgstr ""
-"ログイン・フォームを表示する代わりに、アイデンティティー・プロバイダーに自動的にリダイレクトすることが可能です。これを有効にするには、管理コンソールの "
-"`Authentication` のページを開き、 `Browser` フローを選択してください。次に、 `Identity Provider "
-"Redirector` オーセンティケーターの設定をクリックします。 `Default Identity Provider` "
-"を、自動的にユーザーをリダイレクトするアイデンティティー・プロバイダーのエイリアスに設定します。"
+"{project_name} は、ログインフォームを表示するのではなく、IDプロバイダにリダイレクトすることができます。このリダイレクトを有効にするには"
 
 #. type: Plain text
 msgid ""
-"If the configured default identity provider is not found the login form will"
-" be displayed instead."
-msgstr "設定されたデフォルトのアイデンティティー・プロバイダーが見つからない場合は、代わりにログイン・フォームが表示されます。"
+"Set *Default Identity Provider* to the identity provider you want to "
+"redirect users to."
+msgstr "Default Identity Provider*に、ユーザーをリダイレクトしたいIDプロバイダーを設定します。"
 
 #. type: Plain text
 msgid ""
-"This authenticator is also responsible for dealing with the `kc_idp_hint` "
-"query parameter. See <<_client_suggested_idp, client suggested identity "
-"provider>> section for more details."
+"If {project_name} does not find the configured default identity provider, "
+"the login form is displayed."
+msgstr "{project_name} が設定されたデフォルトの ID プロバイダを見つけられない場合は、ログインフォームが表示されます。"
+
+#. type: Plain text
+msgid ""
+"This authenticator is responsible for processing the `kc_idp_hint` query "
+"parameter. See the <<_client_suggested_idp, client suggested identity "
+"provider>> section for more information."
 msgstr ""
-"このオーセンティケーターは、 `kc_idp_hint` "
-"クエリー・パラメーターを扱う責任も持っています。詳細については、<<_client_suggested_idp, "
-"クライアント提案のアイデンティティー・プロバイダー>>のセクションを参照してください。"
+"このオーセンティケーターは、`kc_idp_hint`のクエリパラメーターの処理を担当します。詳細は<_client_suggested_idp, "
+"client suggested identity provider>&lt;&gt; "
+"セクション</_client_suggested_idp,>を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po
@@ -30,11 +30,11 @@ msgstr "メニューの *Authentication* をクリックします。"
 
 #. type: Plain text
 msgid "Select *Identity Provider Redirector* from the drop-down list."
-msgstr "ドロップダウンリストから \"Identity Provider Redirector \"を選択します。"
+msgstr "ドロップダウン・リストから *Identity Provider Redirector* を選択します。"
 
 #. type: Plain text
 msgid "Click the *Browser* flow."
-msgstr "Browser \"フローをクリックします。"
+msgstr "*Browser* フローをクリックします。"
 
 #. type: Title ===
 #, no-wrap
@@ -46,19 +46,19 @@ msgid ""
 "{project_name} can redirect to an identity provider rather than displaying "
 "the login form. To enable this redirection:"
 msgstr ""
-"{project_name} は、ログインフォームを表示するのではなく、IDプロバイダにリダイレクトすることができます。このリダイレクトを有効にするには"
+"{project_name}は、ログイン画面を表示するのではなく、アイデンティティー・プロバイダーにリダイレクトすることができます。このリダイレクトを有効にするには以下を行います。"
 
 #. type: Plain text
 msgid ""
 "Set *Default Identity Provider* to the identity provider you want to "
 "redirect users to."
-msgstr "Default Identity Provider*に、ユーザーをリダイレクトしたいIDプロバイダーを設定します。"
+msgstr "*Default Identity Provider* に、ユーザーをリダイレクトしたいアイデンティティー・プロバイダーを設定します。"
 
 #. type: Plain text
 msgid ""
 "If {project_name} does not find the configured default identity provider, "
 "the login form is displayed."
-msgstr "{project_name} が設定されたデフォルトの ID プロバイダを見つけられない場合は、ログインフォームが表示されます。"
+msgstr "{project_name}が設定されたデフォルトのアイデンティティー・プロバイダーを見つけられない場合は、ログイン画面が表示されます。"
 
 #. type: Plain text
 msgid ""
@@ -66,6 +66,6 @@ msgid ""
 "parameter. See the <<_client_suggested_idp, client suggested identity "
 "provider>> section for more information."
 msgstr ""
-"このオーセンティケーターは、`kc_idp_hint`のクエリパラメーターの処理を担当します。詳細は<_client_suggested_idp, "
-"client suggested identity provider>&lt;&gt; "
-"セクション</_client_suggested_idp,>を参照してください。"
+"このオーセンティケーターは、 `kc_idp_hint` "
+"のクエリー・パラメーターの処理を担当します。詳細は<<_client_suggested_idp, "
+"クライアント提案のアイデンティティー・プロバイダー>のセクションを参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/default-provider.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__default-provider
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
