### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,117 +19,134 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Create*."
+msgstr "*Create* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
 #. type: Title ===
 #, no-wrap
-msgid "Mapping Claims and Assertions"
+msgid "Mapping claims and assertions"
 msgstr "クレームとアサーションのマッピング"
 
 #. type: Plain text
 msgid ""
-"You can import the SAML and OpenID Connect metadata provided by the external"
-" IDP you are authenticating with into the environment of the realm.  This "
-"allows you to extract user profile metadata and other information so that "
-"you can make it available to your applications."
+"You can import the SAML and OpenID Connect metadata, provided by the "
+"external IDP you are authenticating with, into the realm. After importing, "
+"you can extract user profile metadata and other information, so you can make"
+" it available to your applications."
 msgstr ""
-"認証している外部IDPによって提供されるSAMLおよびOpenID "
-"Connectのメタデータを、レルムの環境にインポートすることができます。これにより、ユーザー・プロファイルのメタデータおよびその他の情報を抽出して、アプリケーションで使用できるようにすることができます。"
+"認証先の外部IDPから提供されるSAMLやOpenID "
+"Connectのメタデータをレルムにインポートすることができます。インポート後、ユーザープロファイルのメタデータなどを抽出して、アプリケーションで利用できるようにすることができます。"
 
 #. type: Plain text
 msgid ""
-"Each new user that logs into your realm via an external identity provider "
-"will have an entry for them created in the local {project_name} database, "
-"based on the metadata from the SAML or OIDC assertions and claims."
+"Each user logging into your realm using an external identity provider has an"
+" entry in the local {project_name} database, based on the metadata from the "
+"SAML or OIDC assertions and claims."
 msgstr ""
-"外部アイデンティティー・プロバイダーを使用してレルムにログインする新規ユーザーは、SAMLまたはOIDCのアサーションおよびクレームから取得したメタデータをもとにして、ローカルの{project_name}データベースにエントリーが作成されます。"
+"外部の ID プロバイダを使用してレルムにログインする各ユーザは、SAML または OIDC のアサーションおよび "
+"クレームのメタデータに基づいて、ローカルの {project_name} データベースにエントリを持つ。"
+
+#. type: Plain text
+msgid "Select one of the identity providers in the list."
+msgstr "リストの中からいずれかのIDプロバイダーを選択します。"
+
+#. type: Plain text
+msgid "Click the *Mappers* tab."
+msgstr "Mappers \"タブをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Identity provider mappers"
+msgstr "アイデンティティ プロバイダ マッパー"
 
 #. type: Plain text
 msgid ""
-"If you click on an identity provider listed in the `Identity Providers` page"
-" for your realm, you will be brought to the IDPs `Settings` tab.  On this "
-"page there is also a `Mappers` tab.  Click on that tab to start mapping your"
-" incoming IDP metadata."
+"image:{project_images}/identity-provider-mappers.png[identity provider "
+"mappers]"
 msgstr ""
-"レルムの `Identity Providers` ページにリストされているアイデンティティー・プロバイダーをクリックすると、IDPの "
-"`Settings` タブが表示されます。このページには、 `Mappers` "
-"タブもあります。そのタブをクリックして、受信するIDPメタデータのマッピングを開始します。"
+"image:{project_images}/identity-provider-mappers.png[identity provider "
+"mappers]をご覧ください。"
 
-#. type: Plain text
-msgid "image:{project_images}/identity-provider-mappers.png[]"
-msgstr "image:{project_images}/identity-provider-mappers.png[]"
+#. type: Block title
+#, no-wrap
+msgid "Identity provider mapper"
+msgstr "アイデンティティ プロバイダ マッパー"
 
 #. type: Plain text
 msgid ""
-"There is a `Create` button on this page.  Clicking on this create button "
-"allows you to create a broker mapper.  Broker mappers can import SAML "
-"attributes or OIDC ID/Access token claims into user attributes and user role"
-" mappings."
+"image:{project_images}/identity-provider-mapper.png[identity provider "
+"mapper]"
 msgstr ""
-"このページには `Create` ボタンがあります。このボタンをクリックすると、ブローカー・マッパーを作成できます。 "
-"ブローカー・マッパーは、SAML属性またはOIDCのIDトークン/アクセストークンのクレームをユーザー属性およびユーザー・ロール・マッピングにインポートできます。"
-
-#. type: Plain text
-msgid "image:{project_images}/identity-provider-mapper.png[]"
-msgstr "image:{project_images}/identity-provider-mapper.png[]"
+"image:{project_images}/identity-provider-mapper.png[identity provider "
+"mapper]"
 
 #. type: Plain text
 msgid ""
-"Select a mapper from the `Mapper Type` list.  Hover over the tooltip to see "
-"a description of what the mapper does.  The tooltips also describe what "
-"configuration information you need to enter. Click `Save` and your new "
-"mapper will be added."
+"Select a value for *Sync Mode Override*. The mapper updates user information"
+" when users log in repeatedly according to this setting."
 msgstr ""
-"`Mapper Type` "
-"のリストからマッパーを選択してください。ツールチップにカーソルを合わせると、マッパーの機能の説明が表示されます。ツールチップには、入力する必要がある設定情報も記載されています。"
-" `Save` ボタンをクリックすると、新しいマッパーが追加されます。"
+"Sync Mode Override*の値を選択します。マッパーは、ユーザーが繰り返しログインする際に、この設定に従ってユーザー情報を更新します。"
 
 #. type: Plain text
 msgid ""
-"The mapper will update user information when the user logs in repeatedly "
-"according to the `Sync Mode Override`:"
-msgstr "以下の `Sync Mode Override` の設定により、ユーザーがログインするとマッパーはユーザー情報を更新します。"
+"Select *legacy* to use the behavior of the previous {project_name} version."
+msgstr "前のバージョン {project_name} の動作を使用するには、 *legacy* を選択してください。"
 
 #. type: Plain text
 msgid ""
-"Choose `legacy` to use the behavior in the previous {project_name} version."
-msgstr "以前のバージョンの{project_name}の動作を使用するには、 `legacy` を選択します。"
-
-#. type: Plain text
-msgid ""
-"Choose `import` to import only data from when the user was first created in "
+"Select *import* to import data from when the user was first created in "
 "{project_name} during the first login to {project_name} with a particular "
 "identity provider."
 msgstr ""
-"特定のアイデンティティー・プロバイダーを使用して{project_name}への初回ログイン中に、ユーザーが{project_name}で最初に作成されたときのデータのみをインポートするには、"
-" `import` を選択します。"
+"特定の ID プロバイダを使用して {project_name} に初めてログインした際に、{project_name} "
+"にユーザーが初めて作成された時のデータをインポートする場合は、*import* を選択します。"
 
 #. type: Plain text
-msgid "Choose `force` to update user data at each user login."
-msgstr "ユーザーのログインごとにユーザーデータを更新するには、 `force` を選択します。"
-
-#. type: Plain text
-msgid ""
-"Choose `inherit` to use the sync mode configured in the identity provider, "
-"all other options will override this sync mode."
-msgstr ""
-"アイデンティティー・プロバイダーで設定された同期モードを使用するには、 `inherit` "
-"を選択します。他のすべてのオプションは、この同期モードをオーバーライドします。"
+msgid "Select *force* to update user data at each user login."
+msgstr "ユーザーがログインするたびにユーザーデータを更新する場合は、*force*を選択します。"
 
 #. type: Plain text
 msgid ""
-"For JSON based claims, you can use dot notation for nesting and square "
-"brackets to access array fields by index.  For example "
-"'contact.address[0].country'."
+"Select *inherit* to use the sync mode configured in the identity provider. "
+"All other options will override this sync mode."
 msgstr ""
-"JSONベースのクレームでは、ネストと角括弧にドット表記を使用して、インデックスで配列フィールドにアクセスできます。たとえば、'contact.address[0].country'"
-" です。"
+"ID プロバイダで構成された同期モードを使用するには、*inherit* を選択します。他のすべてのオプションは、この同期モードを上書きします。"
+
+#. type: Plain text
+msgid ""
+"Select a mapper from the *Mapper Type* list. Hover over the *Mapper Type* "
+"for a description of the mapper and configuration to enter for the mapper."
+msgstr ""
+"マッパー・タイプ*のリストからマッパーを選択します。マッパーの種類*にカーソルを合わせると、マッパーの説明とマッパーに入力する設定が表示されます。"
+
+#. type: Plain text
+msgid ""
+"For JSON-based claims, you can use dot notation for nesting and square "
+"brackets to access array fields by index. For example, "
+"`contact.address[0].country`."
+msgstr ""
+"JSONベースのクレームの場合、入れ子にはドット記法、配列のフィールドにインデックスでアクセスするには角括弧を使います。例えば、`contact.address[0].country`のようになります。"
 
 #. type: Plain text
 msgid ""
 "To investigate the structure of user profile JSON data provided by social "
-"providers you can enable the `DEBUG` level logger "
-"`org.keycloak.social.user_profile_dump`.  This is done in the server's app-"
-"server configuration file (domain.xml or standalone.xml)."
+"providers, you can enable the `DEBUG` level logger "
+"`org.keycloak.social.user_profile_dump` in the server's app-server "
+"configuration file (domain.xml or standalone.xml)."
 msgstr ""
-"ソーシャル・プロバイダーが提供するユーザー・プロファイルJSONデータの構造を調べるために、 `DEBUG` レベルのロガー "
-"`org.keycloak.social.user_profile_dump` "
-"を有効にできます。これは、サーバーのアプリケーション・サーバー設定ファイル（domain.xmlまたはstandalone.xml）で行います。"
+"ソーシャルプロバイダが提供するユーザープロファイルのJSONデータの構造を調査するには、サーバーのapp-"
+"server設定ファイル（domain.xmlまたはstandalone.xml）で、`DEBUG`レベルのロガー`org.keycloak.social.user_profile_dump`を有効にします。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po
@@ -49,7 +49,7 @@ msgid ""
 " it available to your applications."
 msgstr ""
 "認証先の外部IDPから提供されるSAMLやOpenID "
-"Connectのメタデータをレルムにインポートすることができます。インポート後、ユーザープロファイルのメタデータなどを抽出して、アプリケーションで利用できるようにすることができます。"
+"Connectのメタデータをレルムにインポートすることができます。インポート後、ユーザー・プロフィールのメタデータなどを抽出して、アプリケーションで利用できるようにすることができます。"
 
 #. type: Plain text
 msgid ""
@@ -57,21 +57,20 @@ msgid ""
 " entry in the local {project_name} database, based on the metadata from the "
 "SAML or OIDC assertions and claims."
 msgstr ""
-"外部の ID プロバイダを使用してレルムにログインする各ユーザは、SAML または OIDC のアサーションおよび "
-"クレームのメタデータに基づいて、ローカルの {project_name} データベースにエントリを持つ。"
+"外部のアイデンティティー・プロバイダーを使用してレルムにログインする各ユーザーは、SAMLまたはOIDCのアサーションおよびクレームのメタデータに基づいて、ローカルの{project_name}データベースにエントリーを持ちます。"
 
 #. type: Plain text
 msgid "Select one of the identity providers in the list."
-msgstr "リストの中からいずれかのIDプロバイダーを選択します。"
+msgstr "リストの中からいずれかのアイデンティティー・プロバイダーを選択します。"
 
 #. type: Plain text
 msgid "Click the *Mappers* tab."
-msgstr "Mappers \"タブをクリックします。"
+msgstr "*Mappers* タブをクリックします。"
 
 #. type: Block title
 #, no-wrap
 msgid "Identity provider mappers"
-msgstr "アイデンティティ プロバイダ マッパー"
+msgstr "アイデンティティー・プロバイダー・マッパー"
 
 #. type: Plain text
 msgid ""
@@ -79,12 +78,12 @@ msgid ""
 "mappers]"
 msgstr ""
 "image:{project_images}/identity-provider-mappers.png[identity provider "
-"mappers]をご覧ください。"
+"mappers]"
 
 #. type: Block title
 #, no-wrap
 msgid "Identity provider mapper"
-msgstr "アイデンティティ プロバイダ マッパー"
+msgstr "アイデンティティー・プロバイダー・マッパー"
 
 #. type: Plain text
 msgid ""
@@ -99,12 +98,12 @@ msgid ""
 "Select a value for *Sync Mode Override*. The mapper updates user information"
 " when users log in repeatedly according to this setting."
 msgstr ""
-"Sync Mode Override*の値を選択します。マッパーは、ユーザーが繰り返しログインする際に、この設定に従ってユーザー情報を更新します。"
+"*Sync Mode Override* の値を選択します。マッパーは、ユーザーが繰り返しログインする際に、この設定に従ってユーザー情報を更新します。"
 
 #. type: Plain text
 msgid ""
 "Select *legacy* to use the behavior of the previous {project_name} version."
-msgstr "前のバージョン {project_name} の動作を使用するには、 *legacy* を選択してください。"
+msgstr "前のバージョンの{project_name}の動作を使用するには、 *legacy* を選択してください。"
 
 #. type: Plain text
 msgid ""
@@ -112,26 +111,28 @@ msgid ""
 "{project_name} during the first login to {project_name} with a particular "
 "identity provider."
 msgstr ""
-"特定の ID プロバイダを使用して {project_name} に初めてログインした際に、{project_name} "
-"にユーザーが初めて作成された時のデータをインポートする場合は、*import* を選択します。"
+"特定のアイデンティティー・プロバイダーを使用して{project_name}に初めてログインした際に、{project_name}にユーザーが初めて作成された時のデータをインポートする場合は、"
+" *import* を選択します。"
 
 #. type: Plain text
 msgid "Select *force* to update user data at each user login."
-msgstr "ユーザーがログインするたびにユーザーデータを更新する場合は、*force*を選択します。"
+msgstr "ユーザーがログインするたびにユーザーデータを更新する場合は、 *force* を選択します。"
 
 #. type: Plain text
 msgid ""
 "Select *inherit* to use the sync mode configured in the identity provider. "
 "All other options will override this sync mode."
 msgstr ""
-"ID プロバイダで構成された同期モードを使用するには、*inherit* を選択します。他のすべてのオプションは、この同期モードを上書きします。"
+"アイデンティティー・プロバイダーで設定された同期モードを使用するには、 *inherit* "
+"を選択します。他のすべてのオプションは、この同期モードを上書きします。"
 
 #. type: Plain text
 msgid ""
 "Select a mapper from the *Mapper Type* list. Hover over the *Mapper Type* "
 "for a description of the mapper and configuration to enter for the mapper."
 msgstr ""
-"マッパー・タイプ*のリストからマッパーを選択します。マッパーの種類*にカーソルを合わせると、マッパーの説明とマッパーに入力する設定が表示されます。"
+"*Mapper Type* のリストからマッパーを選択します。 *Mapper Type* "
+"にカーソルを合わせると、マッパーの説明とマッパーに入力する設定が表示されます。"
 
 #. type: Plain text
 msgid ""
@@ -139,7 +140,8 @@ msgid ""
 "brackets to access array fields by index. For example, "
 "`contact.address[0].country`."
 msgstr ""
-"JSONベースのクレームの場合、入れ子にはドット記法、配列のフィールドにインデックスでアクセスするには角括弧を使います。例えば、`contact.address[0].country`のようになります。"
+"JSONベースのクレームの場合、入れ子にはドット記法、配列のフィールドにインデックスでアクセスするには角括弧を使います。たとえば、 "
+"`contact.address[0].country` のようになります。"
 
 #. type: Plain text
 msgid ""
@@ -148,5 +150,6 @@ msgid ""
 "`org.keycloak.social.user_profile_dump` in the server's app-server "
 "configuration file (domain.xml or standalone.xml)."
 msgstr ""
-"ソーシャルプロバイダが提供するユーザープロファイルのJSONデータの構造を調査するには、サーバーのapp-"
-"server設定ファイル（domain.xmlまたはstandalone.xml）で、`DEBUG`レベルのロガー`org.keycloak.social.user_profile_dump`を有効にします。"
+"ソーシャル・プロバイダーが提供するユーザー・プロフィールのJSONデータの構造を調査するには、サーバーのapp-"
+"server設定ファイル（domain.xmlまたはstandalone.xml）で、 `DEBUG` レベルのロガー "
+"`org.keycloak.social.user_profile_dump` を有効にします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
