### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -55,13 +55,13 @@ msgid ""
 "creating-oidc-client_{context}[Authorization Code Flow] defined in the "
 "specification to authenticate users and authorize access."
 msgstr ""
-"{project_name} OpenID Connect プロトコルに基づく ID "
-"プロバイダを仲介します。これらのIDプロバイダー（IDP）は、ユーザーを認証してアクセスを許可するために、仕様で定義されているxref:proc-"
-"creating-oidc-client_{context}[Authorization Code Flow]をサポートする必要があります。"
+"{project_name}は、OpenID "
+"Connectプロトコルに基づくアイデンティティー・プロバイダーを仲介します。これらのアイデンティティー・プロバイダー（IDP）は、ユーザーを認証してアクセスを許可するために、仕様で定義されている"
+" xref:proc-creating-oidc-client_{context}[認可コードフロー] をサポートする必要があります。"
 
 #. type: Plain text
 msgid "From the `Add provider` list, select `OpenID Connect v1.0`."
-msgstr "Add provider」のリストから「OpenID Connect v1.0」を選択します。"
+msgstr "`Add provider` のリストから `OpenID Connect v1.0` を選択します。"
 
 #. type: Block title
 #, no-wrap
@@ -79,9 +79,8 @@ msgid ""
 "Enter your initial configuration options. See <<_general-idp-config, General"
 " IDP Configuration>> for more information about configuration options."
 msgstr ""
-"初期設定のオプションを入力します。<_general-idp-config, General IDP "
-"Configuration>設定オプションの詳細</_general-idp-config,>は＜<_general-idp-config, "
-"General IDP Configuration>＞</_general-idp-config,>を参照してください。"
+"初期設定のオプションを入力します。設定オプションの詳細は<<_general-idp-config, General IDP "
+"Configuration>>を参照してください。"
 
 #. type: Block title
 #, no-wrap
@@ -94,7 +93,7 @@ msgstr "Authorization URL"
 
 #. type: Plain text
 msgid "The authorization URL endpoint the OIDC protocol requires."
-msgstr "OIDCプロトコルが要求する認証URLのエンドポイントです。"
+msgstr "OIDCプロトコルが要求する認可URLエンドポイント。"
 
 #. type: Plain text
 msgid "Token URL"
@@ -102,7 +101,7 @@ msgstr "Token URL"
 
 #. type: Plain text
 msgid "The token URL endpoint the OIDC protocol requires."
-msgstr "OIDCプロトコルが要求するトークンのURLエンドポイントです。"
+msgstr "OIDCプロトコルが要求するトークンURLエンドポイント。"
 
 #. type: Plain text
 msgid "Logout URL"
@@ -110,7 +109,7 @@ msgstr "Logout URL"
 
 #. type: Plain text
 msgid "The logout URL endpoint in the OIDC protocol. This value is optional."
-msgstr "OIDCプロトコルのログアウトURLエンドポイントです。この値は任意です。"
+msgstr "OIDCプロトコルのログアウトURLエンドポイント。この値は任意です。"
 
 #. type: Title =====
 #, no-wrap
@@ -123,7 +122,7 @@ msgid ""
 " IDPs perform logout through browser redirects only, as they may identify "
 "sessions using a browser cookie."
 msgstr ""
-"ユーザーをログアウトするためのIDPへのバックグラウンドの帯域外のRESTリクエストです。一部のIDPは、ブラウザのクッキーを使用してセッションを識別する可能性があるため、ブラウザのリダイレクトのみによってログアウトを実行します。"
+"ユーザーをログアウトするためのIDPへのバックグラウンド（アウトオブバンド）のRESTリクエストです。一部のIDPは、ブラウザーのCookieを使用してセッションを識別する可能性があるため、ブラウザーのリダイレクトのみによってログアウトを実行します。"
 
 #. type: Plain text
 msgid "User Info URL"
@@ -133,7 +132,7 @@ msgstr "User Info URL"
 msgid ""
 "An endpoint the OIDC protocol defines. This endpoint points to user profile "
 "information."
-msgstr "OIDC プロトコルが定義するエンドポイントです。このエンドポイントは、ユーザーのプロファイル情報を指します。"
+msgstr "OIDCプロトコルが定義するエンドポイントです。このエンドポイントは、ユーザー・プロフィール情報を指します。"
 
 #. type: Plain text
 msgid ""
@@ -144,10 +143,10 @@ msgid ""
 "core-1_0.html#ClientAuthentication[Client Authentication specifications] for"
 " more information."
 msgstr ""
-"{project_name}がAuthorization Code Flowで使用するClient "
-"Authenticationメソッドを定義します。秘密鍵で署名されたJWTの場合、 {project_name} "
-"はレルムの秘密鍵を使用します。その他のケースでは、クライアントシークレットを定義します。詳細は、https://openid.net/specs/openid-"
-"connect-core-1_0.html#ClientAuthentication「クライアント認証の仕様」を参照してください。"
+"{project_name}が認可コードフローで使用するクライアント認証方式を定義します。秘密鍵で署名されたJWTの場合、 "
+"{project_name}はレルムの秘密鍵を使用します。その他のケースでは、クライアント・シークレットを定義します。詳細は、 "
+"https://openid.net/specs/openid-connect-"
+"core-1_0.html#ClientAuthentication[クライアント認証の仕様] を参照してください。"
 
 #. type: Plain text
 msgid "Client ID"
@@ -159,7 +158,7 @@ msgid ""
 " OIDC client ID if you use the Authorization Code Flow to interact with the "
 "external IDP."
 msgstr ""
-"外部IDPに対するOIDCクライアントとして動作するレルム。認証コードフローを使用して外部IDPとやり取りする場合、このレルムにはOIDCクライアントIDが必要です。"
+"外部IDPに対するOIDCクライアントとして動作するレルム。認可コードフローを使用して外部IDPとやり取りする場合、このレルムにはOIDCクライアントIDが必要です。"
 
 #. type: Plain text
 msgid "Client Secret"
@@ -170,10 +169,8 @@ msgid ""
 "Client secret from an external <<_vault-administration,vault>>. This secret "
 "is necessary if you are using the Authorization Code Flow."
 msgstr ""
-"外部の<_vault-administration,vault>&lt;&gt;</_vault-"
-"administration,vault>からのクライアントシークレット<_vault-administration,vault>です</_vault-"
-"administration,vault>。<_vault-administration,vault>この秘密は、Authorization Code "
-"Flowを使用する場合に必要です。</_vault-administration,vault>"
+"外部の<<_vault-"
+"administration,ボールト>>からのクライアント・シークレットです。このシークレットは、認可コードフローを使用する場合に必要です。"
 
 #. type: Plain text
 msgid "Client Assertion Signature Algorithm"
@@ -196,7 +193,7 @@ msgstr "Issuer"
 msgid ""
 "{project_name} validates issuer claims, in responses from the IDP, against "
 "this value."
-msgstr "{project_name} IDP からの応答にある発行者の主張を、この値に対して検証します。"
+msgstr "{project_name}はIDPから返されるレスポンスに含まれる発行者のクレームを、この値に対して検証します。"
 
 #. type: Plain text
 msgid "Default Scopes"
@@ -207,7 +204,7 @@ msgid ""
 "A list of OIDC scopes {project_name} sends with the authentication request. "
 "The default value is `openid`. A space separates each scope."
 msgstr ""
-"認証リクエストと一緒に送信されるOIDCスコープのリスト {project_name} です。デフォルトの値は `openid` "
+"{project_name}が認証リクエストと一緒に送信するOIDCスコープのリストです。デフォルトの値は `openid` "
 "です。各スコープはスペースで区切られています。"
 
 #. type: Plain text
@@ -215,7 +212,7 @@ msgid ""
 "The prompt parameter in the OIDC specification. Through this parameter, you "
 "can force re-authentication and other options. See the specification for "
 "more details."
-msgstr "OIDC仕様のプロンプトパラメータ。このパラメータを通じて、再認証などを強制的に行うことができます。詳しくは仕様書をご覧ください。"
+msgstr "OIDC仕様のpromptパラメーター。このパラメーターを通じて、再認証などを強制的に行うことができます。詳しくは仕様書をご覧ください。"
 
 #. type: Plain text
 msgid "Accepts prompt=none forward from client"
@@ -235,12 +232,13 @@ msgid ""
 " indicate that the default IDP supports the parameter before redirecting the"
 " authentication request."
 msgstr ""
-"IDPが、`prompt=none`のクエリパラメータを含む転送された認証リクエストを受け入れるかどうかを指定します。あるレルムが "
+"IDPが、 `prompt=none` のクエリー・パラメーターを含む転送された認証リクエストを受け入れるかどうかを指定します。あるレルムが "
 "`prompt=none` を含む認証リクエストを受信すると、そのユーザーが現在認証されているかどうかをチェックし、ユーザーがログインしていない場合は "
-"`login_required` "
-"エラーを返します。{project_name}がauthリクエストに対するデフォルトのIDPを決定した場合（`kc_idp_hint`のクエリパラメータを使うか、レルムのデフォルトIDPを持っている）、`prompt=none`のauthリクエストをデフォルトのIDPに転送することができます。デフォルトのIDPはそこでユーザの認証をチェックします。すべての"
-" IDP が `prompt=none` のリクエストをサポートしているわけではないので、{project_name} "
-"はこのスイッチを使って、認証リクエストをリダイレクトする前に、デフォルトの IDP がこのパラメータをサポートしていることを示します。"
+"`login_required` エラーを返します。{project_name}が認証リクエストに対するデフォルトのIDPを決定した場合（ "
+"`kc_idp_hint` のクエリー・パラメーターを使うか、レルムのデフォルトIDPを持っている）、 `prompt=none` "
+"の認証リクエストをデフォルトのIDPに転送することができます。デフォルトのIDPはそこでユーザーの認証をチェックします。すべてのIDPが "
+"`prompt=none` "
+"のリクエストをサポートしているわけではないので、{project_name}はこのスイッチを使って、認証リクエストをリダイレクトする前に、デフォルトのIDPがこのパラメーターをサポートしていることを示します。"
 
 #. type: Plain text
 msgid ""
@@ -253,8 +251,8 @@ msgid ""
 "login` flow."
 msgstr ""
 "ユーザーがIDPで認証されていない場合、クライアントは依然として `login_required` "
-"エラーを受け取ります。ユーザーがIDPで認証されている場合でも、{project_name} "
-"がユーザーとの対話を必要とする認証ページを表示しなければならない場合、クライアントは `interaction_required` "
+"エラーを受け取ります。ユーザーがIDPで認証されている場合でも、{project_name}がユーザーとの対話を必要とする認証ページを表示しなければならない場合、クライアントは"
+" `interaction_required` "
 "エラーを受け取る可能性があります。この認証には、必須アクション（たとえば、パスワードの変更）、同意画面、および `first broker login`"
 " フローまたは `post broker login` フローで表示するように設定された画面が含まれます。"
 
@@ -271,12 +269,10 @@ msgid ""
 "provider's private key is compromised, update your keys and clear the keys "
 "cache. See <<_clear-cache, Clearing the cache>> section for more details."
 msgstr ""
-"{project_name}が、このIDPが署名した外部ID "
-"Tokenの署名を検証するかどうかを指定します。ON*の場合、{project_name}は外部のOIDC "
-"IDPの公開鍵を知っている必要があります。パフォーマンスのために、{project_name} は外部の OIDC ID "
-"プロバイダの公開鍵をキャッシュします。ID プロバイダの秘密鍵が漏洩した場合は、鍵を更新し、鍵キャッシュをクリアします。<_clear-cache, "
-"Clearing the cache>詳細について</_clear-cache,>は、<_clear-cache, Clearing the "
-"cache>&lt;&gt;セクション</_clear-cache,>を参照してください。"
+"{project_name}が、このIDPが署名した外部IDトークンの署名を検証するかどうかを指定します。*ON* "
+"の場合、{project_name}は外部のOIDC "
+"IDPの公開鍵を知っている必要があります。パフォーマンスのために、{project_name}は外部のOIDCアイデンティティー・プロバイダーの公開鍵をキャッシュします。アイデンティティー・プロバイダーの秘密鍵が漏洩した場合は、鍵を更新し、鍵キャッシュをクリアします。詳細については、<<_clear-"
+"cache, キャッシュのクリア>>のセクションを参照してください。"
 
 #. type: Plain text
 msgid "Use JWKS URL"
@@ -291,9 +287,9 @@ msgid ""
 "database, so when the IDP keypair changes, import the new key to the "
 "{project_name} database as well."
 msgstr ""
-"このスイッチは、`Validate Signatures`が*ON*の場合に適用されます。Use JWKS URL* が *ON* "
-"の場合、{project_name} JWKS URL から IDP の公開鍵をダウンロードする。ID "
-"プロバイダが新しい鍵ペアを生成すると、新しい鍵がダウンロードされます。OFF*の場合、{project_name}はデータベースの公開鍵（または証明書）を使用するため、IDPのキーペアが変更された場合、新しい鍵を{project_name}のデータベースにもインポートします。"
+"このスイッチは、`Validate Signatures` が *ON* の場合に適用されます。 *Use JWKS URL* が *ON* "
+"の場合、{project_name}はJWKS "
+"URLからIDPの公開鍵をダウンロードします。アイデンティティー・プロバイダーが新しい鍵ペアを生成すると、新しい鍵がダウンロードされます。OFF*の場合、{project_name}はデータベースの公開鍵（または証明書）を使用するため、IDPのキーペアが変更された場合、新しい鍵を{project_name}のデータベースにもインポートします。"
 
 #. type: Plain text
 msgid "JWKS URL"
@@ -308,9 +304,9 @@ msgid ""
 "connect/certs if your brokered {project_name} is running on http://broker-"
 "keycloak:8180 and its realm is `test`."
 msgstr ""
-"IDPのJWKキーの場所を指すURLです。詳細については、https://self-issued.info/docs/draft-ietf-jose-"
-"json-web-key.html[JWK仕様]を参照してください。外部の {project_name} を IDP として使用する場合、ブローカーの "
-"{project_name} が http://broker-keycloak:8180 上で動作しており、そのレルムが `test` であれば、 "
+"IDPのJWKキーの場所を指すURL。詳細については、 https://self-issued.info/docs/draft-ietf-jose-"
+"json-web-key.html[JWK仕様] を参照してください。外部の{project_name}をIDPとして使用する場合、ブローカーの "
+"{project_name}が http://broker-keycloak:8180 上で動作しており、そのレルムが `test` であれば、  "
 "http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs "
 "のような URL を使用することができます。"
 
@@ -323,8 +319,8 @@ msgid ""
 "The public key in PEM format that {project_name} uses to verify external IDP"
 " signatures. This key applies if `Use JWKS URL` is *OFF*."
 msgstr ""
-"project_name}が外部IDPの署名を検証するために使用するPEM形式の公開鍵です。この鍵は、`Use JWKS "
-"URL`が*OFF*の場合に適用されます。"
+"{project_name}が外部IDPの署名を検証するために使用するPEM形式の公開鍵です。この鍵は、 `Use JWKS URL` が *OFF* "
+"の場合に適用されます。"
 
 #. type: Plain text
 msgid "Validating Public Key Id"
@@ -341,10 +337,10 @@ msgid ""
 "value is the key ID used by {project_name} for validating signatures from "
 "providers and must match the key ID specified by the IDP."
 msgstr ""
-"この設定は、「Use JWKS "
-"URL」が「OFF」の場合に適用されます。この設定では、公開鍵のIDをPEM形式で指定します。鍵から鍵IDを計算する標準的な方法がないため、外部のIDプロバイダーは{project_name}が使用するものとは異なるアルゴリズムを使用できます。このフィールドの値が指定されていない場合、{project_name}"
-" は、外部の IDP から送信された鍵 ID に関係なく、すべてのリクエストに検証用の公開鍵を使用します。ON*の場合、このフィールドの値は "
-"{project_name} がプロバイダからの署名を検証するために使用する鍵IDであり、IDPが指定する鍵IDと一致しなければなりません。"
+"この設定は、 *Use JWKS URL* が *OFF* "
+"の場合に適用されます。この設定では、公開鍵のIDをPEM形式で指定します。鍵から鍵IDを計算する標準的な方法がないため、外部のアイデンティティー・プロバイダーは{project_name}が使用するものとは異なるアルゴリズムを使用できます。このフィールドの値が指定されていない場合、{project_name}は、外部のIDPから送信された鍵IDに関係なく、すべてのリクエストに検証用の公開鍵を使用します。"
+" *ON* "
+"の場合、このフィールドの値は{project_name}がプロバイダーからの署名を検証するために使用する鍵IDであり、IDPが指定する鍵IDと一致しなければなりません。"
 
 #. type: Plain text
 msgid ""
@@ -355,6 +351,6 @@ msgid ""
 "link is a JSON document describing metadata about the IDP."
 msgstr ""
 "OpenID Provider "
-"Metadataを指し示すURLやファイルを提供することで、これらの設定データをすべてインポートすることができます。プロジェクト名}の外部IDPに接続する場合は、<root>`/auth/realms/{realm-"
-"name}/.well-known/openid-"
-"configuration`</root>からIDPの設定をインポートできます。<root>このリンクは、IDPに関するメタデータを記述したJSONドキュメントです。</root>"
+"Metadataを指し示すURLやファイルを提供することで、これらの設定データをすべてインポートすることができます。{project_name}の外部IDPに接続する場合は、"
+" `<root>/auth/realms/{realm-name}/.well-known/openid-configuration` "
+"からIDPの設定をインポートできます。このリンクは、IDPに関するメタデータを記述したJSONドキュメントです。"

--- a/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po
@@ -4,21 +4,26 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
 
 #. type: Plain text
 #, no-wrap
@@ -31,100 +36,94 @@ msgid "Client Authentication"
 msgstr "クライアント認証"
 
 #. type: Plain text
+msgid "Click *Identity Providers* in the menu."
+msgstr "メニューの *Identity Providers* をクリックします。"
+
+#. type: Plain text
 msgid "Configuration|Description"
 msgstr "設定|説明"
 
-#. type: Plain text
-#, no-wrap
-msgid "Client ID"
-msgstr "Client ID"
-
-#. type: Block title
-#, no-wrap
-msgid "Add Identity Provider"
-msgstr "アイデンティティー・プロバイダーの追加"
-
 #. type: Title ===
 #, no-wrap
-msgid "OpenID Connect v1.0 Identity Providers"
+msgid "OpenID Connect v1.0 identity providers"
 msgstr "OpenID Connect v1.0アイデンティティー・プロバイダー"
 
 #. type: Plain text
 msgid ""
-"{project_name} can broker identity providers based on the OpenID Connect "
-"protocol.  These IDPs must support the <<_oidc, Authorization Code Flow>> as"
-" defined by the specification in order to authenticate the user and "
-"authorize access."
+"{project_name} brokers identity providers based on the OpenID Connect "
+"protocol. These identity providers (IDPs) must support the xref:proc-"
+"creating-oidc-client_{context}[Authorization Code Flow] defined in the "
+"specification to authenticate users and authorize access."
 msgstr ""
-"{project_name}は、OpenID "
-"Connectのプロトコルに基づいて、アイデンティティー・プロバイダーを仲介できます。これらのIDPは、ユーザーを認証してアクセスを認可するため、この仕様で定義されている<<_oidc,"
-" 認可コードフロー>>をサポートしなければなりません。"
+"{project_name} OpenID Connect プロトコルに基づく ID "
+"プロバイダを仲介します。これらのIDプロバイダー（IDP）は、ユーザーを認証してアクセスを許可するために、仕様で定義されているxref:proc-"
+"creating-oidc-client_{context}[Authorization Code Flow]をサポートする必要があります。"
 
 #. type: Plain text
-msgid ""
-"To begin configuring an OIDC provider, go to the `Identity Providers` left "
-"menu item and select `OpenID Connect v1.0` from the `Add provider` drop down"
-" list.  This will bring you to the `Add identity provider` page."
-msgstr ""
-"OIDCプロバイダーの設定を開始するには、左のメニュー項目の `Identity Providers` に移動し、 `Add provider`  "
-"のドロップダウン・リストから `OpenID Connect v1.0` を選択します。これにより、 `Add identity provider` "
-"ページが表示されます。 "
-
-#. type: Plain text
-msgid "image:{project_images}/oidc-add-identity-provider.png[]"
-msgstr "image:{project_images}/oidc-add-identity-provider.png[]"
-
-#. type: Plain text
-msgid ""
-"The initial configuration options on this page are described in <<_general-"
-"idp-config, General IDP Configuration>>.  You must define the OpenID Connect"
-" configuration options as well.  They basically describe the OIDC IDP you "
-"are communicating with."
-msgstr ""
-"このページの初期設定オプションについては、<<_general-idp-config, 共通のIDP設定>>で説明しています。OpenID "
-"Connectの設定オプションも定義する必要があります。それらは基本的に通信しているOIDC IDPを記述します。"
+msgid "From the `Add provider` list, select `OpenID Connect v1.0`."
+msgstr "Add provider」のリストから「OpenID Connect v1.0」を選択します。"
 
 #. type: Block title
 #, no-wrap
-msgid "OpenID Connect Config"
-msgstr "OpenID Connectの設定"
+msgid "Add identity provider"
+msgstr "アイデンティティー・プロバイダーの追加"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/oidc-add-identity-provider.png[Add Identity Provider]"
+msgstr ""
+"image:{project_images}/oidc-add-identity-provider.png[Add Identity Provider]"
+
+#. type: Plain text
+msgid ""
+"Enter your initial configuration options. See <<_general-idp-config, General"
+" IDP Configuration>> for more information about configuration options."
+msgstr ""
+"初期設定のオプションを入力します。<_general-idp-config, General IDP "
+"Configuration>設定オプションの詳細</_general-idp-config,>は＜<_general-idp-config, "
+"General IDP Configuration>＞</_general-idp-config,>を参照してください。"
+
+#. type: Block title
+#, no-wrap
+msgid "OpenID connect config"
+msgstr "OpenID connectの設定"
 
 #. type: Plain text
 msgid "Authorization URL"
 msgstr "Authorization URL"
 
 #. type: Plain text
-msgid "Authorization URL endpoint required by the OIDC protocol."
-msgstr "OIDCプロトコルで必要な認可URLエンドポイント。"
+msgid "The authorization URL endpoint the OIDC protocol requires."
+msgstr "OIDCプロトコルが要求する認証URLのエンドポイントです。"
 
 #. type: Plain text
 msgid "Token URL"
 msgstr "Token URL"
 
 #. type: Plain text
-msgid "Token URL endpoint required by the OIDC protocol."
-msgstr "OIDCプロトコルで必要なトークンURLエンドポイント。"
+msgid "The token URL endpoint the OIDC protocol requires."
+msgstr "OIDCプロトコルが要求するトークンのURLエンドポイントです。"
 
 #. type: Plain text
 msgid "Logout URL"
 msgstr "Logout URL"
 
 #. type: Plain text
-msgid ""
-"Logout URL endpoint defined in the OIDC protocol.  This value is optional."
-msgstr "OIDCプロトコルで定義されたログアウトURLエンドポイント。この値はオプションです。"
+msgid "The logout URL endpoint in the OIDC protocol. This value is optional."
+msgstr "OIDCプロトコルのログアウトURLエンドポイントです。この値は任意です。"
 
-#. type: Plain text
+#. type: Title =====
+#, no-wrap
 msgid "Backchannel Logout"
 msgstr "Backchannel Logout"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Backchannel logout is a background, out-of-band, REST invocation to the IDP to logout the user.  Some IDPs can only perform logout through browser redirects as they may\n"
-" only be able to identity sessions via a browser cookie.\n"
+"A background, out-of-band, REST request to the IDP to log out the user. Some"
+" IDPs perform logout through browser redirects only, as they may identify "
+"sessions using a browser cookie."
 msgstr ""
-"バックチャネル・ログアウトは、バックグラウンド（アウトオブバンド）で、IDPへのREST呼び出しでユーザーをログアウトします。一部のIDPは、ブラウザーのリダイレクトを介してのみログアウトを実行できます。ブラウザーのCookieを使用してセッションを識別できる場合があるためです。\n"
+"ユーザーをログアウトするためのIDPへのバックグラウンドの帯域外のRESTリクエストです。一部のIDPは、ブラウザのクッキーを使用してセッションを識別する可能性があるため、ブラウザのリダイレクトのみによってログアウトを実行します。"
 
 #. type: Plain text
 msgid "User Info URL"
@@ -132,29 +131,35 @@ msgstr "User Info URL"
 
 #. type: Plain text
 msgid ""
-"User Info URL endpoint defined by the OIDC protocol.  This is an endpoint "
-"from which user profile information can be downloaded."
-msgstr ""
-"OIDCプロトコルで定義されたUserInfo URLエンドポイント。これは、ユーザー・プロファイル情報をダウンロードできるエンドポイントです。"
+"An endpoint the OIDC protocol defines. This endpoint points to user profile "
+"information."
+msgstr "OIDC プロトコルが定義するエンドポイントです。このエンドポイントは、ユーザーのプロファイル情報を指します。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Switch to define the Client Authentication method to be used with the Authorization Code Flow.  In the case of JWT signed with private key, the realm private key\n"
-" is used.  In the other cases, a client secret has to be defined.\n"
-" For more details, see the https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication[Client Authentication specifications].\n"
+"Defines the Client Authentication method {project_name} uses with the "
+"Authorization Code Flow. In the case of JWT signed with a private key, "
+"{project_name} uses the realm private key. In the other cases, define a "
+"client secret. See the https://openid.net/specs/openid-connect-"
+"core-1_0.html#ClientAuthentication[Client Authentication specifications] for"
+" more information."
 msgstr ""
-"認可コードフローで使用されるクライアント認証方法を定義するために切り替えます。秘密鍵で署名されたJWTの場合、レルム秘密鍵が使用されます。それ以外の場合、クライアントシークレットを定義する必要があります。詳細については、"
-" https://openid.net/specs/openid-connect-core-"
-"1_0.html#ClientAuthentication[クライアント認証の仕様] を参照してください。\n"
+"{project_name}がAuthorization Code Flowで使用するClient "
+"Authenticationメソッドを定義します。秘密鍵で署名されたJWTの場合、 {project_name} "
+"はレルムの秘密鍵を使用します。その他のケースでは、クライアントシークレットを定義します。詳細は、https://openid.net/specs/openid-"
+"connect-core-1_0.html#ClientAuthentication「クライアント認証の仕様」を参照してください。"
 
 #. type: Plain text
-#, no-wrap
+msgid "Client ID"
+msgstr "Client ID"
+
+#. type: Plain text
 msgid ""
-"This realm will act as an OIDC client to the external IDP.  Your realm will need an OIDC client ID when using the Authorization Code Flow\n"
-" to interact with the external IDP.\n"
+"A realm acting as an OIDC client to the external IDP. The realm must have an"
+" OIDC client ID if you use the Authorization Code Flow to interact with the "
+"external IDP."
 msgstr ""
-"このレルムは、外部IDPへのOIDCクライアントとして機能します。認可コードフローを使用して外部IDPと対話するときに、レルムにはOIDCのクライアントIDが必要になります。\n"
+"外部IDPに対するOIDCクライアントとして動作するレルム。認証コードフローを使用して外部IDPとやり取りする場合、このレルムにはOIDCクライアントIDが必要です。"
 
 #. type: Plain text
 msgid "Client Secret"
@@ -162,12 +167,13 @@ msgstr "Client Secret"
 
 #. type: Plain text
 msgid ""
-"This realm will need a client secret to use when using the Authorization "
-"Code Flow. The value of this field can refer a value from an external "
-"<<_vault-administration,vault>>."
+"Client secret from an external <<_vault-administration,vault>>. This secret "
+"is necessary if you are using the Authorization Code Flow."
 msgstr ""
-"このレルムには、認可コードフローを使用するときに使用するクライアント・シークレットが必要です。このフィールドの値は、外部<<_vault-"
-"administration,ボールト>>の値を参照できます。"
+"外部の<_vault-administration,vault>&lt;&gt;</_vault-"
+"administration,vault>からのクライアントシークレット<_vault-administration,vault>です</_vault-"
+"administration,vault>。<_vault-administration,vault>この秘密は、Authorization Code "
+"Flowを使用する場合に必要です。</_vault-administration,vault>"
 
 #. type: Plain text
 msgid "Client Assertion Signature Algorithm"
@@ -188,11 +194,9 @@ msgstr "Issuer"
 
 #. type: Plain text
 msgid ""
-"Responses from the IDP may contain an issuer claim.  This config value is "
-"optional.  If specified, this claim will be validated against the value you "
-"provide."
-msgstr ""
-"IDPからのレスポンスには、発行者のクレームが含まれる場合があります。この設定値はオプションです。指定されている場合、提供する値に対してこのクレームが検証されます。"
+"{project_name} validates issuer claims, in responses from the IDP, against "
+"this value."
+msgstr "{project_name} IDP からの応答にある発行者の主張を、この値に対して検証します。"
 
 #. type: Plain text
 msgid "Default Scopes"
@@ -200,95 +204,115 @@ msgstr "Default Scopes"
 
 #. type: Plain text
 msgid ""
-"Space-separated list of OIDC scopes to send with the authentication request."
-"  The default is `openid`."
-msgstr "認証リクエストとともに送信される、OIDCスコープのスペース区切りのリスト。デフォルトは `openid` です。"
+"A list of OIDC scopes {project_name} sends with the authentication request. "
+"The default value is `openid`. A space separates each scope."
+msgstr ""
+"認証リクエストと一緒に送信されるOIDCスコープのリスト {project_name} です。デフォルトの値は `openid` "
+"です。各スコープはスペースで区切られています。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Another optional switch.  This is the prompt parameter defined by the OIDC specification. Through it you can force re-authentication and other options.  See the specification for\n"
-" more details.\n"
-msgstr ""
-"オプションの項目。これは、OIDC仕様で定義されたプロンプト・パラメーターです。これにより、再認証やその他のオプションを強制することができます。詳細は、仕様を参照してください。\n"
+"The prompt parameter in the OIDC specification. Through this parameter, you "
+"can force re-authentication and other options. See the specification for "
+"more details."
+msgstr "OIDC仕様のプロンプトパラメータ。このパラメータを通じて、再認証などを強制的に行うことができます。詳しくは仕様書をご覧ください。"
 
 #. type: Plain text
 msgid "Accepts prompt=none forward from client"
 msgstr "Accepts prompt=none forward from client"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Specifies whether the IDP accepts forwarded authentication requests that contain the prompt=none query parameter or not. When a realm receives an auth request with `prompt=none` it checks\n"
-" if the user is currently authenticated and normally returns a `login_required` error if the user is not logged in. However, when a default IDP can be determined\n"
-" for the auth request (either via `kc_idp_hint` query param or by setting up a default IDP for the realm) we should be able to forward the auth request with\n"
-" `prompt=none` to the default IDP so that it checks if the user is currently authenticated there. Because not all IDPs support requests with `prompt=none` this switch\n"
-" is used to indicate if the default IDP supports the param before redirecting the auth request.\n"
+"Specifies if the IDP accepts forwarded authentication requests containing "
+"the `prompt=none` query parameter. If a realm receives an auth request with "
+"`prompt=none`, the realm checks if the user is currently authenticated and "
+"returns a `login_required` error if the user has not logged in. When "
+"{project_name} determines a default IDP for the auth request (using the "
+"`kc_idp_hint` query parameter or having a default IDP for the realm), you "
+"can forward the auth request with `prompt=none` to the default IDP. The "
+"default IDP checks the authentication of the user there. Because not all "
+"IDPs support requests with `prompt=none`, {project_name} uses this switch to"
+" indicate that the default IDP supports the parameter before redirecting the"
+" authentication request."
 msgstr ""
-"IDPが、転送されてきたprompt=noneクエリー・パラメーターを含む認証リクエストを受け入れるかどうかを指定します。レルムが "
-"`prompt=none` の認証リクエストを受信すると、ユーザーが現在認証されているかどうかを確認し、ユーザーがログインしていない場合は通常 "
-"`login_required` エラーを返します。ただし、認証リクエストのデフォルトIDP（ `kc_idp_hint` "
-"クエリー・パラメーターを使用するか、レルムのデフォルトIDPを設定することにより） `prompt=none` "
-"で認証リクエストをデフォルトIDPに転送して、ユーザーが現在認証されているかどうかを確認できるようにする必要があります。すべてのIDPが "
-"`prompt=none` "
-"のリクエストをサポートするわけではないため、このスイッチはデフォルトのIDPが認証リクエストをリダイレクトする前にパラメーターをサポートするかどうかを示すために使用されます。\n"
+"IDPが、`prompt=none`のクエリパラメータを含む転送された認証リクエストを受け入れるかどうかを指定します。あるレルムが "
+"`prompt=none` を含む認証リクエストを受信すると、そのユーザーが現在認証されているかどうかをチェックし、ユーザーがログインしていない場合は "
+"`login_required` "
+"エラーを返します。{project_name}がauthリクエストに対するデフォルトのIDPを決定した場合（`kc_idp_hint`のクエリパラメータを使うか、レルムのデフォルトIDPを持っている）、`prompt=none`のauthリクエストをデフォルトのIDPに転送することができます。デフォルトのIDPはそこでユーザの認証をチェックします。すべての"
+" IDP が `prompt=none` のリクエストをサポートしているわけではないので、{project_name} "
+"はこのスイッチを使って、認証リクエストをリダイレクトする前に、デフォルトの IDP がこのパラメータをサポートしていることを示します。"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-" It is important to note that if the user is not authenticated in the IDP, the client will still get a `login_required` error. Even if the user is currently authenticated in the IDP,\n"
-" the client might still get an `interaction_required` error if authentication or consent pages requiring user interaction would be otherwise displayed. This includes required actions\n"
-" (e.g. change password), consent screens and any screens set to be displayed by the `first broker login` flow or `post broker login` flow.\n"
+"If the user is unauthenticated in the IDP, the client still receives a "
+"`login_required` error. If the user is authentic in the IDP, the client can "
+"still receive an `interaction_required` error if {project_name} must display"
+" authentication pages that require user interaction. This authentication "
+"includes required actions (for example, password change), consent screens, "
+"and screens set to display by the `first broker login` flow or `post broker "
+"login` flow."
 msgstr ""
 "ユーザーがIDPで認証されていない場合、クライアントは依然として `login_required` "
-"エラーを受け取ることに注意することが重要です。ユーザーが現在IDPで認証されている場合でも、ユーザーの操作を必要とする認証または同意ページが表示されると、クライアントは依然として"
-" `interaction_required` エラーを受け取る可能性があります。これには、必須アクション（パスワードの変更など）、同意画面、および "
-"`first broker login` フローまたは `post broker login` "
-"フローによって表示されるように設定された画面が含まれます。\n"
+"エラーを受け取ります。ユーザーがIDPで認証されている場合でも、{project_name} "
+"がユーザーとの対話を必要とする認証ページを表示しなければならない場合、クライアントは `interaction_required` "
+"エラーを受け取る可能性があります。この認証には、必須アクション（たとえば、パスワードの変更）、同意画面、および `first broker login`"
+" フローまたは `post broker login` フローで表示するように設定された画面が含まれます。"
 
 #. type: Plain text
 msgid "Validate Signatures"
 msgstr "Validate Signatures"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Another optional switch. This is to specify if {project_name} will verify the signatures on the external ID Token signed by this identity provider. If this is on,\n"
-"the {project_name} will need to know the public key of the external OIDC identity provider. See below for how to set it up.\n"
-"WARNING: For the performance purposes, {project_name} caches the public key of the external OIDC identity provider. If you think that private key of your identity provider\n"
-"was compromised, it is obviously good to update your keys, but it's also good to clear the keys cache. See\n"
-"<<_clear-cache, Clearing the cache>> section for more details.\n"
+"Specifies if {project_name} verifies signatures on the external ID Token "
+"signed by this IDP. If *ON*, {project_name} must know the public key of the "
+"external OIDC IDP. For performance purposes, {project_name} caches the "
+"public key of the external OIDC identity provider. If your identity "
+"provider's private key is compromised, update your keys and clear the keys "
+"cache. See <<_clear-cache, Clearing the cache>> section for more details."
 msgstr ""
-"オプションの項目。{project_name}がこのアイデンティティー・プロバイダーによって署名された外部IDトークンの署名を検証するかどうかを指定します。これがonの場合、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵を知る必要があります。セットアップ方法は以下を参照してください。\n"
-"警告：パフォーマンスのために、{project_name}は外部OIDCアイデンティティー・プロバイダーの公開鍵をキャッシュします。アイデンティティー・プロバイダーの秘密鍵が侵害されたと思われる場合は、鍵を更新するのは明らか良い方法ですが、鍵キャッシュをクリアするのも良い方法です。詳細については、<<_clear-cache, キャッシュのクリア>>のセクションを参照してください。\n"
+"{project_name}が、このIDPが署名した外部ID "
+"Tokenの署名を検証するかどうかを指定します。ON*の場合、{project_name}は外部のOIDC "
+"IDPの公開鍵を知っている必要があります。パフォーマンスのために、{project_name} は外部の OIDC ID "
+"プロバイダの公開鍵をキャッシュします。ID プロバイダの秘密鍵が漏洩した場合は、鍵を更新し、鍵キャッシュをクリアします。<_clear-cache, "
+"Clearing the cache>詳細について</_clear-cache,>は、<_clear-cache, Clearing the "
+"cache>&lt;&gt;セクション</_clear-cache,>を参照してください。"
 
 #. type: Plain text
 msgid "Use JWKS URL"
 msgstr "Use JWKS URL"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Applicable if `Validate Signatures` is on. If the switch is on, then identity provider public keys will be downloaded from given JWKS URL.\n"
-" This allows great flexibility because new keys will be always re-downloaded when the identity provider generates new keypair. If the switch is off,\n"
-" then public key (or certificate) from the {project_name} DB is used, so whenever the identity provider keypair changes, you will always need to import the new key to the {project_name} DB as well.\n"
+"This switch is applicable if `Validate Signatures` is *ON*. If *Use JWKS "
+"URL* is *ON*, {project_name} downloads the IDP's public keys from the JWKS "
+"URL. New keys download when the identity provider generates a new keypair. "
+"If *OFF*, {project_name} uses the public key (or certificate) from its "
+"database, so when the IDP keypair changes, import the new key to the "
+"{project_name} database as well."
 msgstr ""
-"`Validate Signatures` がonの場合に適用されます。スイッチがonの場合、特定のJWKS URLからアイデンティティー・プロバイダーの公開鍵がダウンロードされます。\n"
-"これにより、アイデンティティー・プロバイダーが新しい鍵ペアを生成するときに、新しい鍵が常に再ダウンロードされるため、柔軟性が向上します。スイッチがoffの場合、{project_name}のDBからの公開鍵（または証明書）が使用されるため、アイデンティティー・プロバイダーの鍵ペアが変更されるたびに、常に新しい鍵を{project_name}のDBにインポートする必要があります。\n"
+"このスイッチは、`Validate Signatures`が*ON*の場合に適用されます。Use JWKS URL* が *ON* "
+"の場合、{project_name} JWKS URL から IDP の公開鍵をダウンロードする。ID "
+"プロバイダが新しい鍵ペアを生成すると、新しい鍵がダウンロードされます。OFF*の場合、{project_name}はデータベースの公開鍵（または証明書）を使用するため、IDPのキーペアが変更された場合、新しい鍵を{project_name}のデータベースにもインポートします。"
 
 #. type: Plain text
 msgid "JWKS URL"
 msgstr "JWKS URL"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"URL where the identity provider JWK keys are stored. See the https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK specification] for more details.\n"
-" If you use an external {project_name} as an identity provider, then you can use URL like http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs assuming your brokered\n"
-" {project_name} is running on http://broker-keycloak:8180 and it's realm is `test`.\n"
+"The URL pointing to the location of the IDP JWK keys. For more information, "
+"see the https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK "
+"specification]. If you use an external {project_name} as an IDP, you can use"
+" a URL such as http://broker-keycloak:8180/auth/realms/test/protocol/openid-"
+"connect/certs if your brokered {project_name} is running on http://broker-"
+"keycloak:8180 and its realm is `test`."
 msgstr ""
-"アイデンティティー・プロバイダーのJWK鍵が保存されているURL。詳細については、 https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK仕様] を参照してください。\n"
-"外部の{project_name}アイデンティティー・プロバイダーを使用している場合、{project_name}は http://broker-keycloak:8180 上で実行されており、そのレルムは `test` であると仮定すると、 http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs のようなURLを使用することができます。\n"
+"IDPのJWKキーの場所を指すURLです。詳細については、https://self-issued.info/docs/draft-ietf-jose-"
+"json-web-key.html[JWK仕様]を参照してください。外部の {project_name} を IDP として使用する場合、ブローカーの "
+"{project_name} が http://broker-keycloak:8180 上で動作しており、そのレルムが `test` であれば、 "
+"http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs "
+"のような URL を使用することができます。"
 
 #. type: Plain text
 msgid "Validating Public Key"
@@ -296,35 +320,41 @@ msgstr "Validating Public Key"
 
 #. type: Plain text
 msgid ""
-"Applicable if `Use JWKS URL` is off. Here is the public key in PEM format "
-"that must be used to verify external IDP signatures."
+"The public key in PEM format that {project_name} uses to verify external IDP"
+" signatures. This key applies if `Use JWKS URL` is *OFF*."
 msgstr ""
-"`Use JWKS URL` がoffの場合に適用されます。外部IDPの署名を検証するために使用する必要がある、PEM形式の公開鍵をここに指定します。"
+"project_name}が外部IDPの署名を検証するために使用するPEM形式の公開鍵です。この鍵は、`Use JWKS "
+"URL`が*OFF*の場合に適用されます。"
 
 #. type: Plain text
 msgid "Validating Public Key Id"
 msgstr "Validating Public Key Id"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Applicable if `Use JWKS URL` is off. This field specifies ID of the public key in PEM format. This config value is optional. As there is no standard way\n"
-" for computing key ID from key, various external identity providers might use different algorithm from {project_name}. If the value of this field\n"
-" is not specified, the validating public key specified above is used for all requests regardless of key ID sent by external IDP. When set, value of this\n"
-" field serves as key ID used by {project_name} for validating signatures from such providers and must match the key ID specified by the IDP.\n"
+"This setting applies if *Use JWKS URL* is *OFF*. This setting specifies the "
+"ID of the public key in PEM format. Because there is no standard way for "
+"computing key ID from the key, external identity providers can use different"
+" algorithms from what {project_name} uses. If this field's value is not "
+"specified, {project_name} uses the validating public key for all requests, "
+"regardless of the key ID sent by the external IDP. When *ON*, this field's "
+"value is the key ID used by {project_name} for validating signatures from "
+"providers and must match the key ID specified by the IDP."
 msgstr ""
-"`Use JWKS URL` "
-"がoffの場合に適用されます。このフィールドは、PEM形式の公開鍵のIDを指定します。この設定値はオプションです。鍵から鍵IDを計算するための標準的な方法は無いので、さまざまな外部アイデンティティー・プロバイダーが{project_name}とは異なるアルゴリズムを使用する可能性があります。このフィールドの値が指定されていない場合、外部IDPから送信された鍵IDに関係なく、上記で指定された検証用公開鍵がすべてのリクエストに使用されます。設定されている場合、このフィールドの値は、そのプロバイダーからの署名を検証するために{project_name}が使用する鍵IDとして機能し、IDPで指定された鍵IDと一致する必要があります。\n"
+"この設定は、「Use JWKS "
+"URL」が「OFF」の場合に適用されます。この設定では、公開鍵のIDをPEM形式で指定します。鍵から鍵IDを計算する標準的な方法がないため、外部のIDプロバイダーは{project_name}が使用するものとは異なるアルゴリズムを使用できます。このフィールドの値が指定されていない場合、{project_name}"
+" は、外部の IDP から送信された鍵 ID に関係なく、すべてのリクエストに検証用の公開鍵を使用します。ON*の場合、このフィールドの値は "
+"{project_name} がプロバイダからの署名を検証するために使用する鍵IDであり、IDPが指定する鍵IDと一致しなければなりません。"
 
 #. type: Plain text
 msgid ""
-"You can also import all this configuration data by providing a URL or file "
-"that points to OpenID Provider Metadata (see OIDC Discovery specification)."
-"  If you are connecting to a {project_name} external IDP, you can import the"
-" IDP settings from the url `<root>/auth/realms/{realm-name}/.well-known"
-"/openid-configuration`.  This link is a JSON document describing metadata "
-"about the IDP."
+"You can import all this configuration data by providing a URL or file that "
+"points to OpenID Provider Metadata. If you connect to a {project_name} "
+"external IDP, you can import the IDP settings from "
+"`<root>/auth/realms/{realm-name}/.well-known/openid-configuration`. This "
+"link is a JSON document describing metadata about the IDP."
 msgstr ""
-"OpenIDプロバイダーのメタデータを指すURLまたはファイルを提供することによって、この設定データをすべてインポートすることもできます（OIDCのディスカバリーの仕様を参照）。{project_name}の外部IDPに接続している場合は、URL"
-" `<root>/auth/realms/{realm-name}/.well-known/openid-configuration` "
-"からIDPの設定をインポートできます。このリンクは、IDPに関するメタデータを記述するJSONドキュメントです。"
+"OpenID Provider "
+"Metadataを指し示すURLやファイルを提供することで、これらの設定データをすべてインポートすることができます。プロジェクト名}の外部IDPに接続する場合は、<root>`/auth/realms/{realm-"
+"name}/.well-known/openid-"
+"configuration`</root>からIDPの設定をインポートできます。<root>このリンクは、IDPに関するメタデータを記述したJSONドキュメントです。</root>"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/identity-broker/oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__identity-broker__oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
