### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-deleting-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-deleting-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-deleting-user.ja_JP.po
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title =
+#, no-wrap
+msgid "Deleting a user"
+msgstr "ユーザーの削除"
+
+#. type: Plain text
+msgid ""
+"You can delete a user, who no longer needs access to applications. If a user"
+" is deleted, the user profile and data is also deleted."
+msgstr ""
+"アプリケーションへのアクセスが不要になったユーザーを削除することができます。ユーザーを削除すると、ユーザープロファイルやデータも削除されます。"
+
+#. type: Plain text
+msgid "Click *Users* in the menu. The *Users* page is displayed."
+msgstr "メニューの \"Users \"をクリックします。Users \"ページが表示されます。"
+
+#. type: Plain text
+msgid "Click *View all users* to find a user to delete."
+msgstr "すべてのユーザーを見る」をクリックして、削除するユーザーを探します。"
+
+#. type: Plain text
+msgid "Alternatively, you can use the search bar to find a user."
+msgstr "また、検索バーを使ってユーザーを探すこともできます。"
+
+#. type: Plain text
+msgid ""
+"Click *Delete* next to the user you want to remove and confirm deletion."
+msgstr "削除したいユーザーの横にある*Delete*をクリックし、削除を確認します。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-deleting-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-deleting-user.ja_JP.po
@@ -34,21 +34,21 @@ msgid ""
 "You can delete a user, who no longer needs access to applications. If a user"
 " is deleted, the user profile and data is also deleted."
 msgstr ""
-"アプリケーションへのアクセスが不要になったユーザーを削除することができます。ユーザーを削除すると、ユーザープロファイルやデータも削除されます。"
+"アプリケーションへのアクセスが不要になったユーザーを削除することができます。ユーザーを削除すると、ユーザー・プロフィールやデータも削除されます。"
 
 #. type: Plain text
 msgid "Click *Users* in the menu. The *Users* page is displayed."
-msgstr "メニューの \"Users \"をクリックします。Users \"ページが表示されます。"
+msgstr "メニューの *Users* をクリックします。 *Users* ページが表示されます。"
 
 #. type: Plain text
 msgid "Click *View all users* to find a user to delete."
-msgstr "すべてのユーザーを見る」をクリックして、削除するユーザーを探します。"
+msgstr "*View all users* をクリックして、削除するユーザーを探します。"
 
 #. type: Plain text
 msgid "Alternatively, you can use the search bar to find a user."
-msgstr "また、検索バーを使ってユーザーを探すこともできます。"
+msgstr "または、検索バーを使ってユーザーを探すこともできます。"
 
 #. type: Plain text
 msgid ""
 "Click *Delete* next to the user you want to remove and confirm deletion."
-msgstr "削除したいユーザーの横にある*Delete*をクリックし、削除を確認します。"
+msgstr "削除したいユーザーの横にある *Delete* をクリックし、削除を確認します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-deleting-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-deleting-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
