### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles-groups/con-default-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/con-default-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/con-default-roles.ja_JP.po
@@ -31,10 +31,9 @@ msgid ""
 "Brokering>>.  To specify default roles go to the *Roles* left menu item, and"
 " click the *Default Roles* tab."
 msgstr ""
-"デフォルトロールは、&lt;&gt;で新規作成またはインポートしたユーザーに、自動的にロールマッピングを割り当てることができる機能<_identity_broker,"
-" Identity Brokering>です</_identity_broker,>。<_identity_broker, Identity "
-"Brokering> "
-"デフォルトロールを指定するには、左メニューの*ロール*から、*デフォルトロール*タブをクリックします。</_identity_broker,>"
+"デフォルトロールは、<<_identity_broker, "
+"アイデンティティー・ブローカリング>>で新規作成またはインポートしたユーザーに、自動的にユーザー・ロール・マッピングを割り当てることができる機能です。デフォルトロールを指定するには、左メニューの"
+" *Roles* から、 *Default Roles* タブをクリックします。"
 
 #. type: Plain text
 msgid "image:{project_images}/default-roles.png[]"

--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/con-default-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/con-default-roles.ja_JP.po
@@ -1,0 +1,45 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Default roles"
+msgstr "デフォルトロール"
+
+#. type: Plain text
+msgid ""
+"Default roles allow you to automatically assign user role mappings when any "
+"user is newly created or imported through <<_identity_broker, Identity "
+"Brokering>>.  To specify default roles go to the *Roles* left menu item, and"
+" click the *Default Roles* tab."
+msgstr ""
+"デフォルトロールは、&lt;&gt;で新規作成またはインポートしたユーザーに、自動的にロールマッピングを割り当てることができる機能<_identity_broker,"
+" Identity Brokering>です</_identity_broker,>。<_identity_broker, Identity "
+"Brokering> "
+"デフォルトロールを指定するには、左メニューの*ロール*から、*デフォルトロール*タブをクリックします。</_identity_broker,>"
+
+#. type: Plain text
+msgid "image:{project_images}/default-roles.png[]"
+msgstr "image:{project_images}/default-roles.png[]"
+
+#. type: Plain text
+msgid "This screenshot shows that some _default roles_ already exist."
+msgstr "このスクリーン・ショットは、いくつかの _default roles_ が既に存在していることを示しています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles-groups/con-default-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles-groups__con-default-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
