### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/conditions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/conditions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/conditions.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2021
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Conditions in Conditional flows"
+msgid "Conditions in conditional flows"
 msgstr "条件付きフロー内のCondition"
 
 #. type: Plain text
@@ -42,7 +42,7 @@ msgstr ""
 
 #. type: Title ====
 #, no-wrap
-msgid "Available Conditions"
+msgid "Available conditions"
 msgstr "利用可能なCondition"
 
 #. type: Labeled list
@@ -105,12 +105,13 @@ msgstr "`Condition - User Attribute`"
 msgid ""
 "This checks if the user has set up the required attribute.  There is a "
 "possibility to negate output, which means the user should not have the "
-"attribute.  The <<_user-attributes,User Attributes>> section shows how to "
-"add a custom attribute.  You can provide these fields:"
+"attribute.  The xref:proc-configuring-user-attributes_{context}[User "
+"Attributes] section shows how to add a custom attribute.  You can provide "
+"these fields:"
 msgstr ""
 "これは、ユーザが必要な属性を設定したかどうかをチェックします。ユーザーがその属性を持つべきではないことを意味する、出力を否定する可能性があります。 "
-"<<_user-attributes,User Attributes>> "
-"セクションでは、カスタム属性を追加する方法を示しています。次のフィールドを提供することができます。"
+"xref:proc-configuring-user-attributes_{context}[ユーザー属性] "
+"のセクションでは、カスタム属性を追加する方法を示しています。次のフィールドを提供することができます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -215,7 +216,7 @@ msgstr "image:images/deny-access-flow.png[]"
 
 #. type: Block title
 #, no-wrap
-msgid "Condition - User Role configuration"
+msgid "Condition - user role configuration"
 msgstr "条件 - ユーザーロールの設定"
 
 #. type: Plain text
@@ -226,7 +227,7 @@ msgstr "image:images/deny-access-role-condition.png[]"
 #, no-wrap
 msgid ""
 "Configuration of the `Deny Access` is really easy. You can specify an "
-"arbitrary alias and required message like this:"
+"arbitrary Alias and required message like this:"
 msgstr "`Deny Access` の設定はとても簡単です。次のように、任意のエイリアスと必要なメッセージを指定できます。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/conditions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__conditions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
