### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-configuring-user-attributes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-configuring-user-attributes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-configuring-user-attributes.ja_JP.po
@@ -41,7 +41,7 @@ msgstr "メニューの *Users* をクリックします。"
 #. type: Title =
 #, no-wrap
 msgid "Configuring user attributes"
-msgstr "ユーザー属性を設定する"
+msgstr "ユーザー属性の設定"
 
 #. type: Plain text
 msgid ""
@@ -49,7 +49,7 @@ msgid ""
 "create a personalized identity for each user in the console by configuring "
 "user attributes."
 msgstr ""
-"ユーザー属性は、各ユーザーにカスタマイズされたエクスペリエンスを提供します。ユーザー属性を設定することで、コンソールで各ユーザーにパーソナライズされたアイデンティティを作成することができます。"
+"ユーザー属性は、各ユーザーにカスタマイズされた体験を提供します。ユーザー属性を設定することで、コンソールで各ユーザーにパーソナライズされたアイデンティティーを作成することができます。"
 
 #. type: Plain text
 msgid "image:{project_images}/user-attributes.png[]"
@@ -62,7 +62,7 @@ msgstr "前提条件"
 
 #. type: Plain text
 msgid "You are in the realm where the user exists."
-msgstr "ユーザーが存在する領域にいます。"
+msgstr "ユーザーが存在するレルムにいます。"
 
 #. type: Plain text
 msgid "Select a user to manage."
@@ -70,19 +70,19 @@ msgstr "管理するユーザーを選択します。"
 
 #. type: Plain text
 msgid "Click the *Attributes* tab."
-msgstr "属性*」タブをクリックします。"
+msgstr "*Attributes* タブをクリックします。"
 
 #. type: Plain text
 msgid "Enter the attribute name in the *Key* field."
-msgstr "Key*欄に属性名を入力します。"
+msgstr "*Key* フィールドに属性名を入力します。"
 
 #. type: Plain text
 msgid "Enter the attribute value in the *Value* field."
-msgstr "属性値を*Value*欄に入力します。"
+msgstr "*Value* フィールドに属性値を入力します。"
 
 #. type: Plain text
 msgid "Click *Add*."
-msgstr "追加*をクリックします。"
+msgstr "*Add* をクリックします。"
 
 #. type: Plain text
 msgid ""
@@ -93,6 +93,6 @@ msgid ""
 "due to security reasons. See the details in the "
 "xref:_read_only_user_attributes[Mitigating security threats] chapter."
 msgstr ""
-"読み取り専用の属性の中には、管理者が更新してはいけないものがあります。これには、例えば `LDAP_ID` のように、LDAP "
-"プロバイダが自動的に入力するような、設計上読み取り専用になっている属性が含まれます。他のいくつかの属性は、セキュリティ上の理由から、典型的なユーザー管理者のために読み取り専用にする必要があります。詳細は"
-" xref:_read_only_user_attributes[Mitigating security threats] の章を参照してください。"
+"読み取り専用の属性の中には、管理者が更新してはいけないものがあります。これには、たとえば、 `LDAP_ID` "
+"のように、LDAPプロバイダーが自動的に入力するような、設計上読み取り専用になっている属性が含まれます。他のいくつかの属性は、セキュリティー上の理由から、典型的なユーザー管理者のために読み取り専用にする必要があります。詳細は"
+" xref:_read_only_user_attributes[セキュリティー上の脅威の軽減] の章を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-configuring-user-attributes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-configuring-user-attributes.ja_JP.po
@@ -1,0 +1,98 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Users"
+msgstr "Users"
+
+#. type: Plain text
+msgid "Click *Users* in the menu."
+msgstr "メニューの *Users* をクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Configuring user attributes"
+msgstr "ユーザー属性を設定する"
+
+#. type: Plain text
+msgid ""
+"User attributes provide a customized experience for each user. You can "
+"create a personalized identity for each user in the console by configuring "
+"user attributes."
+msgstr ""
+"ユーザー属性は、各ユーザーにカスタマイズされたエクスペリエンスを提供します。ユーザー属性を設定することで、コンソールで各ユーザーにパーソナライズされたアイデンティティを作成することができます。"
+
+#. type: Plain text
+msgid "image:{project_images}/user-attributes.png[]"
+msgstr "image:{project_images}/user-attributes.png[]"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisite"
+msgstr "前提条件"
+
+#. type: Plain text
+msgid "You are in the realm where the user exists."
+msgstr "ユーザーが存在する領域にいます。"
+
+#. type: Plain text
+msgid "Select a user to manage."
+msgstr "管理するユーザーを選択します。"
+
+#. type: Plain text
+msgid "Click the *Attributes* tab."
+msgstr "属性*」タブをクリックします。"
+
+#. type: Plain text
+msgid "Enter the attribute name in the *Key* field."
+msgstr "Key*欄に属性名を入力します。"
+
+#. type: Plain text
+msgid "Enter the attribute value in the *Value* field."
+msgstr "属性値を*Value*欄に入力します。"
+
+#. type: Plain text
+msgid "Click *Add*."
+msgstr "追加*をクリックします。"
+
+#. type: Plain text
+msgid ""
+"Some read-only attributes are not supposed to be updated by the "
+"administrators. This includes attributes that are read-only by design like "
+"for example `LDAP_ID`, which is filled automatically by the LDAP provider. "
+"Some other attributes should be read-only for typical user administrators "
+"due to security reasons. See the details in the "
+"xref:_read_only_user_attributes[Mitigating security threats] chapter."
+msgstr ""
+"読み取り専用の属性の中には、管理者が更新してはいけないものがあります。これには、例えば `LDAP_ID` のように、LDAP "
+"プロバイダが自動的に入力するような、設計上読み取り専用になっている属性が含まれます。他のいくつかの属性は、セキュリティ上の理由から、典型的なユーザー管理者のために読み取り専用にする必要があります。詳細は"
+" xref:_read_only_user_attributes[Mitigating security threats] の章を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-configuring-user-attributes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-configuring-user-attributes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
