### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms.ja_JP.po
@@ -3,11 +3,14 @@
 # This file is distributed under the same license as the keycloak-documentation-i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2017\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,13 +19,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Title ==
-#: source/server_admin/topics/realms.adoc:2
 #, no-wrap
-msgid "Configuring Realms"
-msgstr "レルムを設定する"
+msgid "Configuring realms"
+msgstr "レルムの設定"
 
 #. type: Plain text
-#: source/server_admin/topics/realms.adoc:9
 msgid ""
 "A realm manages a set of users, credentials, roles, and groups.  A user "
 "belongs to and logs into a realm.  Realms are isolated from one another and "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
