### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/saml/proc-creating-saml-client.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-creating-saml-client.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-creating-saml-client.ja_JP.po
@@ -1,0 +1,542 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2022
+# Shinsuke UEDA, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Client ID*"
+msgstr "*Client ID*"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Name*"
+msgstr "*Name*"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Description*"
+msgstr "*Description*"
+
+#. type: Plain text
+msgid "The description of the client.  This setting can also be localized."
+msgstr "クライアントの説明文です。  この設定はローカライズすることも可能です。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Enabled*"
+msgstr "*Enabled*"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Consent Required*"
+msgstr "*Consent Required*"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Root URL*"
+msgstr "*Root URL*"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Valid Redirect URIs*"
+msgstr "*Valid Redirect URIs*"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Base URL*"
+msgstr "*Base URL*"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Logo URL*\n"
+msgstr "*Logo URL*\n"
+
+#. type: Plain text
+msgid "URL that references a logo for the Client application."
+msgstr "クライアントアプリケーション用のロゴを参照するURL。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Policy URL*\n"
+msgstr "*Policy URL*\n"
+
+#. type: Plain text
+msgid ""
+"URL that the Relying Party Client provides to the End-User to read about how"
+" the profile data will be used."
+msgstr "プロファイルデータがどのように使用されるかについて読むために、依拠当事者クライアントがエンドユーザーに提供するURL。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Terms of Service URL*\n"
+msgstr "*Terms of Service URL*\n"
+
+#. type: Plain text
+msgid ""
+"URL that the Relying Party Client provides to the End-User to read about the"
+" Relying Party's terms of service."
+msgstr "信頼当事者のクライアントが、信頼当事者の利用規約を読むためにエンドユーザーに提供するURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Front Channel Logout*"
+msgstr "*Front Channel Logout*"
+
+#. type: Plain text
+msgid "Click *Clients* in the menu."
+msgstr "メニューの *Clients* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Create* to go to the *Add Client* page."
+msgstr "Create*をクリックすると、*Add Client*のページに移動します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add client"
+msgstr "Add client"
+
+#. type: Block title
+#, no-wrap
+msgid "Client settings"
+msgstr "クライアント設定"
+
+#. type: Title =
+#, no-wrap
+msgid "Creating a SAML client"
+msgstr "SAMLクライアントの作成"
+
+#. type: Plain text
+msgid ""
+"{project_name} supports <<_saml,SAML 2.0>> for registered applications.  "
+"POST and Redirect bindings are supported. You can choose to require client "
+"signature validation. You can have the server sign and/or encrypt responses "
+"as well."
+msgstr ""
+"{project_name} は、<_saml,SAML 2.0>登録されたアプリケーションの</_saml,SAML>&lt;&gt; "
+"をサポートしています。<_saml,SAML 2.0> POST と Redirect "
+"のバインディングに対応しています。クライアント署名の検証を要求するかどうかを選択できます。サーバに署名や暗号化をさせることもできます。</_saml,SAML>"
+
+#. type: Plain text
+msgid "image:{project_images}/add-client-saml.png[]"
+msgstr "image:{project_images}/add-client-saml.png[]"
+
+#. type: Plain text
+msgid ""
+"Enter the *Client ID* of the client. This is often a URL and is the expected"
+" *issuer* value in SAML requests sent by the application."
+msgstr ""
+"クライアントの *Client ID* "
+"を入力します。これは多くの場合URLであり、アプリケーションから送信されるSAMLリクエストで期待される*発行者*の値である。"
+
+#. type: Plain text
+msgid "Select *saml* in the *Client Protocol* drop down box."
+msgstr "Client Protocol* ドロップダウン・ボックスで *saml* を選択します。"
+
+#. type: Plain text
+msgid ""
+"Enter the *Client SAML Endpoint* URL. This URL is where you want the "
+"{project_name} server to send SAML requests and responses. Generally, "
+"applications have one URL for processing SAML requests. Multiple URLs can be"
+" set in the *Settings* tab of the client."
+msgstr ""
+"Client SAML Endpoint* URL を入力します。この URL は、{project_name} サーバに SAML "
+"要求と応答を送信させる場所である。一般に、アプリケーションには、SAML 要求を処理するための 1 つの URL がある。複数の URL "
+"を、クライアントの *Settings* タブで設定することができる。"
+
+#. type: Plain text
+msgid ""
+"Click *Save*.  This action creates the client and brings you to the "
+"*Settings* tab."
+msgstr "保存*をクリックします。  この操作でクライアントが作成され、*Settings*タブが表示されます。"
+
+#. type: Plain text
+msgid "image:{project_images}/client-settings-saml.png[]"
+msgstr "image:{project_images}/client-settings-saml.png[]"
+
+#. type: Plain text
+msgid "The following list describes each setting:"
+msgstr "各設定について、次の一覧で説明します。"
+
+#. type: Plain text
+msgid ""
+"The alpha-numeric ID string that is used in OIDC requests and in the "
+"{project_name} database to identify the client. This value must match the "
+"issuer value sent with AuthNRequests. {project_name} pulls the issuer from "
+"the Authn SAML request and match it to a client by this value."
+msgstr ""
+"OIDC リクエストおよび {project_name} データベースでクライアントを識別するために使用される英数字の ID "
+"文字列です。この値はAuthNRequestsで送信されるissuerの値と一致しなければならない。{project_name} は Authn "
+"SAML リクエストから発行者を取り出し、この値でクライアントとマッチングさせる。"
+
+#. type: Plain text
+msgid ""
+"The name for the client in a {project_name} UI screen. To localize the name,"
+" set up a replacement string value. For example, a string value such as "
+"$\\{myapp}.  See the link:{developerguide_link}[{developerguide_name}] for "
+"more information."
+msgstr ""
+"project_name} "
+"におけるクライアントの名前です。UI画面。名前をローカライズするには、置換文字列値を設定します。例えば、${myapp}のような文字列値です。  "
+"詳しくは、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
+
+#. type: Plain text
+msgid "When set to OFF, the client cannot request authentication."
+msgstr "OFFに設定すると、クライアントは認証を要求できなくなります。"
+
+#. type: Plain text
+msgid ""
+"When set to ON, users see a consent page that grants access to that "
+"application.  The page also displays the metadata of the information that "
+"the client can access. If you have ever done a social login to Facebook, you"
+" often see a similar page. Red Hat Single Sign-On provides the same "
+"functionality."
+msgstr ""
+"ONに設定すると、ユーザーはそのアプリケーションへのアクセスを許可する同意ページを見ることができます。  "
+"また、このページには、クライアントがアクセスできる情報のメタデータが表示されます。Facebookへのソーシャルログインをしたことがある人は、よく似たページを見ることができます。Red"
+" Hat Single Sign-On は同じ機能を提供します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Include AuthnStatement*"
+msgstr "*Include AuthnStatement*"
+
+#. type: Plain text
+msgid ""
+"SAML login responses may specify the authentication method used, such as "
+"password, as well as timestamps of the login and the session expiration.  "
+"*Include AuthnStatement* is enabled by default, so that the *AuthnStatement*"
+" element will be included in login responses. Setting this to OFF prevents "
+"clients from determining the maximum session length, which can create client"
+" sessions that do not expire."
+msgstr ""
+"SAMLログインレスポンスには、パスワードなど使用された認証方法、ログインとセッションの有効期限のタイムスタンプを指定することができます。  "
+"*AuthnStatement* を含める] はデフォルトで有効になっており、ログイン・レスポンスに *AuthnStatement* "
+"要素が含まれるようになります。これをOFFに設定すると、クライアントが最大セッション長を決定できなくなり、期限切れにならないクライアントセッションが作成される可能性があります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Sign Documents*"
+msgstr "*Sign Documents*"
+
+#. type: Plain text
+msgid ""
+"When set to ON, {project_name} signs the document using the realms private "
+"key."
+msgstr "ONに設定すると、{project_name}はrealmsの秘密鍵を使ってドキュメントに署名します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Optimize REDIRECT signing key lookup*"
+msgstr "*Optimize REDIRECT signing key lookup*"
+
+#. type: Plain text
+msgid ""
+"When set to ON, the SAML protocol messages include the {project_name} native"
+" extension. This extension contains a hint with the signing key ID. The SP "
+"uses the extension for signature validation instead of attempting to "
+"validate the signature using keys."
+msgstr ""
+"ON に設定すると、SAML プロトコルメッセージに {project_name} ネイティブ拡張子が含まれる。この拡張には、署名キー ID "
+"を示すヒントが含まれる。SP は，鍵を用いた署名の検証を試みる代わりに，この拡張機能を署名の検証に用いる。"
+
+#. type: Plain text
+msgid ""
+"This option applies to REDIRECT bindings where the signature is transferred "
+"in query parameters and this information is not found in the signature "
+"information. This is contrary to POST binding messages where key ID is "
+"always included in document signature."
+msgstr ""
+"このオプションは、署名がクエリパラメータで転送される REDIRECT "
+"バインディングに適用され、この情報は署名情報には含まれません。これは、キーIDが常にドキュメント署名に含まれるPOSTバインディングメッセージとは異なります。"
+
+#. type: Plain text
+msgid ""
+"This option is used when {project_name} server and adapter provide the IDP "
+"and SP. This option is only relevant when *Sign Documents* is set to ON."
+msgstr ""
+"このオプションは、{project_name} サーバとアダプタが IDP と SP を提供する場合に使用されます。このオプションは、*Sign "
+"Documents* がオンに設定されている場合にのみ関連します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Sign Assertions*"
+msgstr "*Sign Assertions*"
+
+#. type: Plain text
+msgid "The assertion is signed and embedded in the SAML XML Auth response."
+msgstr "アサーションは署名され、SAML XML Auth 応答に埋め込まれる。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Signature Algorithm*"
+msgstr "*Signature Algorithm*"
+
+#. type: Plain text
+msgid "The algorithm used in signing SAML documents."
+msgstr "SAML文書に署名する際に使用されるアルゴリズム。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*SAML Signature Key Name*"
+msgstr "*SAML Signature Key Name*"
+
+#. type: Plain text
+msgid ""
+"Signed SAML documents sent using POST binding contain the identification of "
+"the signing key in the *KeyName* element. This action can be controlled by "
+"the *SAML Signature Key Name* option. This option controls the contents of "
+"the *Keyname*."
+msgstr ""
+"POST バインディングを使用して送信される署名付き SAML ドキュメントには、*KeyName* "
+"要素に署名鍵の識別情報が含まれています。この動作は、*SAML Signature Key Name* "
+"オプションで制御することができる。このオプションは、*Keyname* の内容を制御する。"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"*KEY_ID* The *KeyName* contains the key ID. This option is the default "
+"option.\n"
+msgstr "*KEY_ID* *KeyName*にはキーIDが含まれます。このオプションはデフォルトのオプションです。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"*CERT_SUBJECT* The *KeyName* contains the subject from the certificate "
+"corresponding to the realm key. This option is expected by Microsoft Active "
+"Directory Federation Services.\n"
+msgstr ""
+"*CERT_SUBJECT* *KeyName*は、realmキーに対応する証明書からのサブジェクトを含む。このオプションは、Microsoft "
+"Active Directoryフェデレーションサービスによって期待されています。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*NONE* The *KeyName* hint is completely omitted from the SAML message.\n"
+msgstr "*NONE* SAMLメッセージでは、*KeyName*ヒントは完全に省略される。\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Canonicalization Method*"
+msgstr "*Canonicalization Method*"
+
+#. type: Plain text
+msgid "The canonicalization method for XML signatures."
+msgstr "XML署名の正準化手法。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Encrypt Assertions*"
+msgstr "*Encrypt Assertions*"
+
+#. type: Plain text
+msgid ""
+"Encrypts the assertions in SAML documents with the realms private key. The "
+"AES algorithm uses a key size of 128 bits."
+msgstr "SAML 文書のアサーションをレルム秘密鍵で暗号化する。AES アルゴリズムは、128 ビットのキー・サイズを使用する。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Client Signature Required*"
+msgstr "*Client Signature Required*"
+
+#. type: Plain text
+msgid ""
+"If *Client Signature Required* is enabled, documents coming from a client "
+"are expected to be signed. {project_name} will validate this signature using"
+" the client public key or cert set up in the `Keys` tab."
+msgstr ""
+"Client Signature Required* "
+"が有効な場合、クライアントからのドキュメントは署名されていることが期待されます。{project_name}は、`鍵`タブで設定されたクライアントの公開鍵または証明書を使用して、この署名を検証します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Force POST Binding*"
+msgstr "*Force POST Binding*"
+
+#. type: Plain text
+msgid ""
+"By default, {project_name} responds using the initial SAML binding of the "
+"original request. By enabling *Force POST Binding*, {project_name} responds "
+"using the SAML POST binding even if the original request used the redirect "
+"binding."
+msgstr ""
+"デフォルトでは、{project_name} は元のリクエストの最初の SAML バインディングを使用して応答します。Force POST "
+"Binding* を有効にすると、{project_name} は、元の要求がリダイレクトバインディングを使用していたとしても、SAML POST "
+"バインディングを使用して応答します。"
+
+#. type: Plain text
+msgid ""
+"If *Front Channel Logout* is enabled, the application requires a browser "
+"redirect to perform a logout. For example, the application may require a "
+"cookie to be reset which could only be done via a redirect. If *Front "
+"Channel Logout* is disabled, {project_name} invokes a background SAML "
+"request to log out of the application."
+msgstr ""
+"Front Channel "
+"Logout*が有効な場合、アプリケーションはログアウトを実行するためにブラウザのリダイレクトを必要とします。例えば、アプリケーションはリダイレクトによってのみ実行可能なクッキーのリセットを要求するかもしれません。Front"
+" Channel Logout* が無効な場合、{project_name} はアプリケーションからログアウトするためにバックグラウンドの SAML "
+"リクエストを呼び出す。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Force Name ID Format*"
+msgstr "*Force Name ID Format*"
+
+#. type: Plain text
+msgid ""
+"If a request has a name ID policy, ignore it and use the value configured in"
+" the Admin Console under *Name ID Format*."
+msgstr "リクエストに名前IDのポリシーがある場合、それを無視してAdmin Consoleの*名前IDの形式*で設定された値を使用します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Name ID Format*"
+msgstr "*Name ID Format*"
+
+#. type: Plain text
+msgid ""
+"The Name ID Format for the subject. This format is used if no name ID policy"
+" is specified in a request, or if the Force Name ID Format attribute is set "
+"to ON."
+msgstr ""
+"サブジェクトの名前IDの形式。この形式は、リクエストで名前IDポリシーが指定されていない場合、または名前ID形式の強制属性がONに設定されている場合に使用されます。"
+
+#. type: Plain text
+msgid ""
+"When {project_name} uses a configured relative URL, this value is prepended "
+"to the URL."
+msgstr "project_name} が設定された相対 URL を使用する場合、この値が URL の前に付加される。"
+
+#. type: Plain text
+msgid ""
+"Enter a URL pattern and click the + sign to add.  Click the - sign to "
+"remove. Click *Save* to save these changes.  Wildcards values are allowed "
+"only at the end of a URL. For example, http://host.com/*$$.  This field is "
+"used when the exact SAML endpoints are not registered and {project_name} "
+"pulls the Assertion Consumer URL from a request."
+msgstr ""
+"URLパターンを入力し、＋記号をクリックすると追加されます。  削除する場合は、-記号をクリックします。保存*をクリックして、これらの変更を保存します。"
+"  ワイルドカードの値は、URLの末尾にのみ使用できます。例えば、http://host.com/*$$のようになります。  このフィールドは、正確な "
+"SAML エンドポイントが登録されておらず、{project_name} 要求から Assertion Consumer URL "
+"を引き出す場合に使用される。"
+
+#. type: Plain text
+msgid "If {project_name} needs to link to a client, this URL is used."
+msgstr "project_name} がクライアントにリンクする必要がある場合、この URL が使用される。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Master SAML Processing URL*"
+msgstr "*Master SAML Processing URL*"
+
+#. type: Plain text
+msgid ""
+"This URL is used for all SAML requests and the response is directed to the "
+"SP. It is used as the Assertion Consumer Service URL and the Single Logout "
+"Service URL."
+msgstr ""
+"この URL は、すべての SAML リクエストに使用され、応答は SP に向けられる。これは、アサーション・コンシューマ・サービスの URL "
+"およびシングル・ログアウト・サービスの URL として使用される。"
+
+#. type: Plain text
+msgid ""
+"If login requests contain the Assertion Consumer Service URL then those "
+"login requests will take precedence. This URL must be validated by a "
+"registered Valid Redirect URI pattern."
+msgstr ""
+"ログイン要求にアサーション・コンシューマー・サービスのURLが含まれている場合、そのログイン要求が優先されます。このURLは、登録された有効なリダイレクトURIパターンによって検証される必要があります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Assertion Consumer Service POST Binding URL*"
+msgstr "*Assertion Consumer Service POST Binding URL*"
+
+#. type: Plain text
+msgid "POST Binding URL for the Assertion Consumer Service."
+msgstr "アサーション・コンシューマー・サービスのPOSTバインディングURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Assertion Consumer Service Redirect Binding URL*"
+msgstr "*Assertion Consumer Service Redirect Binding URL*"
+
+#. type: Plain text
+msgid "Redirect Binding URL for the Assertion Consumer Service."
+msgstr "アサーション・コンシューマー・サービスのREDIRECTバインディングURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Logout Service POST Binding URL*"
+msgstr "*Logout Service POST Binding URL*"
+
+#. type: Plain text
+msgid "POST Binding URL for the Logout Service."
+msgstr "ログアウト・サービスのPOSTバインディングURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Logout Service Redirect Binding URL*"
+msgstr "*Logout Service Redirect Binding URL*"
+
+#. type: Plain text
+msgid "Redirect Binding URL for the Logout Service."
+msgstr "ログアウト・サービスのREDIRECTバインディングURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Logout Service Artifact Binding URL*"
+msgstr "*Logout Service Artifact Binding URL*"
+
+#. type: Plain text
+msgid ""
+"_Artifact_ Binding URL for the Logout Service. When set together with the "
+"`Force Artifact Binding` option, _Artifact_ binding is forced for both login"
+" and logout flows. _Artifact_ binding is not used for logout unless this "
+"property is set."
+msgstr ""
+"Logout Serviceの_Artifact_ Binding URLです。Force Artifact Binding` "
+"オプションと一緒に設定すると、ログインとログアウトの両方のフローで _Artifact_ "
+"バインディングが強制される。このプロパティが設定されない限り、ログアウトに_Artifact_バインディングは使用されません。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Artifact Binding URL*"
+msgstr "*Artifact Binding URL*"
+
+#. type: Plain text
+msgid "URL to send the HTTP artifact messages to."
+msgstr "HTTPアーティファクト・メッセージの送信先のURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Artifact Resolution Service*"
+msgstr "*Artifact Resolution Service*"
+
+#. type: Plain text
+msgid ""
+"URL of the client SOAP endpoint where to send the `ArtifactResolve` messages"
+" to."
+msgstr "`ArtifactResolve` メッセージの送信先となるクライアントSOAPエンドポイントのURL。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-creating-saml-client.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/proc-creating-saml-client.ja_JP.po
@@ -43,7 +43,7 @@ msgstr "*Description*"
 
 #. type: Plain text
 msgid "The description of the client.  This setting can also be localized."
-msgstr "クライアントの説明文です。  この設定はローカライズすることも可能です。"
+msgstr "クライアントの説明文です。この設定はローカライズすることも可能です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -77,7 +77,7 @@ msgstr "*Logo URL*\n"
 
 #. type: Plain text
 msgid "URL that references a logo for the Client application."
-msgstr "クライアントアプリケーション用のロゴを参照するURL。"
+msgstr "クライアント・アプリケーション用のロゴを参照するURL。"
 
 #. type: Plain text
 #, no-wrap
@@ -88,7 +88,7 @@ msgstr "*Policy URL*\n"
 msgid ""
 "URL that the Relying Party Client provides to the End-User to read about how"
 " the profile data will be used."
-msgstr "プロファイルデータがどのように使用されるかについて読むために、依拠当事者クライアントがエンドユーザーに提供するURL。"
+msgstr "プロファイル・データがどのように使用されるかについて読むために、Relying Partyがエンドユーザーに提供するURL。"
 
 #. type: Plain text
 #, no-wrap
@@ -99,7 +99,7 @@ msgstr "*Terms of Service URL*\n"
 msgid ""
 "URL that the Relying Party Client provides to the End-User to read about the"
 " Relying Party's terms of service."
-msgstr "信頼当事者のクライアントが、信頼当事者の利用規約を読むためにエンドユーザーに提供するURL。"
+msgstr "Relying Partyが、エンドユーザーにRelying Partyの利用規約を提供するURL。"
 
 #. type: Labeled list
 #, no-wrap
@@ -112,7 +112,7 @@ msgstr "メニューの *Clients* をクリックします。"
 
 #. type: Plain text
 msgid "Click *Create* to go to the *Add Client* page."
-msgstr "Create*をクリックすると、*Add Client*のページに移動します。"
+msgstr "*Create* をクリックすると、 *Add Client* のページに移動します。"
 
 #. type: Block title
 #, no-wrap
@@ -136,9 +136,8 @@ msgid ""
 "signature validation. You can have the server sign and/or encrypt responses "
 "as well."
 msgstr ""
-"{project_name} は、<_saml,SAML 2.0>登録されたアプリケーションの</_saml,SAML>&lt;&gt; "
-"をサポートしています。<_saml,SAML 2.0> POST と Redirect "
-"のバインディングに対応しています。クライアント署名の検証を要求するかどうかを選択できます。サーバに署名や暗号化をさせることもできます。</_saml,SAML>"
+"{project_name}は、登録されたアプリケーションに対して<<_saml,SAML "
+"2.0>>をサポートし、POSTとRedirectのバインディングに対応しています。クライアント署名の検証を要求するかどうかを選択したり、サーバーに署名や暗号化をさせることもできます。"
 
 #. type: Plain text
 msgid "image:{project_images}/add-client-saml.png[]"
@@ -149,12 +148,12 @@ msgid ""
 "Enter the *Client ID* of the client. This is often a URL and is the expected"
 " *issuer* value in SAML requests sent by the application."
 msgstr ""
-"クライアントの *Client ID* "
-"を入力します。これは多くの場合URLであり、アプリケーションから送信されるSAMLリクエストで期待される*発行者*の値である。"
+"クライアントの *Client ID* を入力します。これは多くの場合URLであり、アプリケーションから送信されるSAMLリクエストで期待される "
+"*issuer* の値です。"
 
 #. type: Plain text
 msgid "Select *saml* in the *Client Protocol* drop down box."
-msgstr "Client Protocol* ドロップダウン・ボックスで *saml* を選択します。"
+msgstr "*Client Protocol* ドロップダウン・ボックスで *saml* を選択します。"
 
 #. type: Plain text
 msgid ""
@@ -163,15 +162,15 @@ msgid ""
 "applications have one URL for processing SAML requests. Multiple URLs can be"
 " set in the *Settings* tab of the client."
 msgstr ""
-"Client SAML Endpoint* URL を入力します。この URL は、{project_name} サーバに SAML "
-"要求と応答を送信させる場所である。一般に、アプリケーションには、SAML 要求を処理するための 1 つの URL がある。複数の URL "
-"を、クライアントの *Settings* タブで設定することができる。"
+"*Client SAML Endpoint* "
+"URLを入力します。このURLは、{project_name}サーバーにSAMLリクエストとレスポンスを送信させる場所です。一般的に、アプリケーションには、SAMLリクエストを処理するための1つのURLがあります。複数のURLを、クライアントの"
+" *Settings* タブで設定することができます。"
 
 #. type: Plain text
 msgid ""
 "Click *Save*.  This action creates the client and brings you to the "
 "*Settings* tab."
-msgstr "保存*をクリックします。  この操作でクライアントが作成され、*Settings*タブが表示されます。"
+msgstr "*保存* をクリックします。この操作でクライアントが作成され、 *Settings*タブが表示されます。"
 
 #. type: Plain text
 msgid "image:{project_images}/client-settings-saml.png[]"
@@ -188,7 +187,7 @@ msgid ""
 "issuer value sent with AuthNRequests. {project_name} pulls the issuer from "
 "the Authn SAML request and match it to a client by this value."
 msgstr ""
-"OIDC リクエストおよび {project_name} データベースでクライアントを識別するために使用される英数字の ID "
+"OIDCリクエストおよび {project_name} データベースでクライアントを識別するために使用される英数字の ID "
 "文字列です。この値はAuthNRequestsで送信されるissuerの値と一致しなければならない。{project_name} は Authn "
 "SAML リクエストから発行者を取り出し、この値でクライアントとマッチングさせる。"
 
@@ -199,9 +198,8 @@ msgid ""
 "$\\{myapp}.  See the link:{developerguide_link}[{developerguide_name}] for "
 "more information."
 msgstr ""
-"project_name} "
-"におけるクライアントの名前です。UI画面。名前をローカライズするには、置換文字列値を設定します。例えば、${myapp}のような文字列値です。  "
-"詳しくは、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
+"{project_name}のUI画面におけるクライアントの名前です。名前をローカライズするには、置換文字列値を設定します。たとえば、$\\{myapp}のような文字列値です。詳しくは、"
+" link:{developerguide_link}[{developerguide_name}] を参照してください。"
 
 #. type: Plain text
 msgid "When set to OFF, the client cannot request authentication."
@@ -215,8 +213,7 @@ msgid ""
 " often see a similar page. Red Hat Single Sign-On provides the same "
 "functionality."
 msgstr ""
-"ONに設定すると、ユーザーはそのアプリケーションへのアクセスを許可する同意ページを見ることができます。  "
-"また、このページには、クライアントがアクセスできる情報のメタデータが表示されます。Facebookへのソーシャルログインをしたことがある人は、よく似たページを見ることができます。Red"
+"ONに設定すると、ユーザーはそのアプリケーションへのアクセスを許可する同意ページを見ることができます。また、このページには、クライアントがアクセスできる情報のメタデータが表示されます。Facebookへのソーシャル・ログインをしたことがある人は、よく似たページを見ることができます。Red"
 " Hat Single Sign-On は同じ機能を提供します。"
 
 #. type: Labeled list
@@ -233,9 +230,9 @@ msgid ""
 "clients from determining the maximum session length, which can create client"
 " sessions that do not expire."
 msgstr ""
-"SAMLログインレスポンスには、パスワードなど使用された認証方法、ログインとセッションの有効期限のタイムスタンプを指定することができます。  "
-"*AuthnStatement* を含める] はデフォルトで有効になっており、ログイン・レスポンスに *AuthnStatement* "
-"要素が含まれるようになります。これをOFFに設定すると、クライアントが最大セッション長を決定できなくなり、期限切れにならないクライアントセッションが作成される可能性があります。"
+"SAMLログイン・レスポンスには、使用された認証方式（パスワードなど）、ログインのタイムスタンプおよびセッションの有効期限を指定することができます。 "
+"*Include AuthnStatement* はデフォルトで有効になっており、ログイン・レスポンスに *AuthnStatement* "
+"要素が含まれるようになります。これをOFFに設定すると、クライアントが最大セッション長を決定できなくなり、期限切れにならないクライアント・セッションが作成される可能性があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -246,7 +243,7 @@ msgstr "*Sign Documents*"
 msgid ""
 "When set to ON, {project_name} signs the document using the realms private "
 "key."
-msgstr "ONに設定すると、{project_name}はrealmsの秘密鍵を使ってドキュメントに署名します。"
+msgstr "ONに設定すると、{project_name}はレルムの秘密鍵を使ってドキュメントに署名します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -260,8 +257,7 @@ msgid ""
 "uses the extension for signature validation instead of attempting to "
 "validate the signature using keys."
 msgstr ""
-"ON に設定すると、SAML プロトコルメッセージに {project_name} ネイティブ拡張子が含まれる。この拡張には、署名キー ID "
-"を示すヒントが含まれる。SP は，鍵を用いた署名の検証を試みる代わりに，この拡張機能を署名の検証に用いる。"
+"ONに設定すると、SAMLプロトコル・メッセージに{project_name}ネイティブ拡張が含まれます。この拡張には、署名鍵IDを示すヒントが含まれます。SPは、鍵を用いた署名の検証を試みる代わりに、この拡張機能を署名の検証に用います。"
 
 #. type: Plain text
 msgid ""
@@ -270,16 +266,15 @@ msgid ""
 "information. This is contrary to POST binding messages where key ID is "
 "always included in document signature."
 msgstr ""
-"このオプションは、署名がクエリパラメータで転送される REDIRECT "
-"バインディングに適用され、この情報は署名情報には含まれません。これは、キーIDが常にドキュメント署名に含まれるPOSTバインディングメッセージとは異なります。"
+"このオプションは、署名がクエリー・パラメーターで転送されるREDIRECTバインディングに適用され、この情報は署名情報には含まれません。これは、鍵IDが常にドキュメント署名に含まれるPOSTバインディング・メッセージとは異なります。"
 
 #. type: Plain text
 msgid ""
 "This option is used when {project_name} server and adapter provide the IDP "
 "and SP. This option is only relevant when *Sign Documents* is set to ON."
 msgstr ""
-"このオプションは、{project_name} サーバとアダプタが IDP と SP を提供する場合に使用されます。このオプションは、*Sign "
-"Documents* がオンに設定されている場合にのみ関連します。"
+"このオプションは、{project_name}サーバーとアダプターがIDPとSPを提供する場合に使用されます。このオプションは、*Sign "
+"Documents* がONに設定されている場合にのみ影響します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -288,7 +283,7 @@ msgstr "*Sign Assertions*"
 
 #. type: Plain text
 msgid "The assertion is signed and embedded in the SAML XML Auth response."
-msgstr "アサーションは署名され、SAML XML Auth 応答に埋め込まれる。"
+msgstr "アサーションは署名され、SAML XML認証レスポンスに埋め込まれます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -313,14 +308,14 @@ msgid ""
 msgstr ""
 "POST バインディングを使用して送信される署名付き SAML ドキュメントには、*KeyName* "
 "要素に署名鍵の識別情報が含まれています。この動作は、*SAML Signature Key Name* "
-"オプションで制御することができる。このオプションは、*Keyname* の内容を制御する。"
+"オプションで制御することができます。このオプションは、*Keyname* の内容を制御します。"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "*KEY_ID* The *KeyName* contains the key ID. This option is the default "
 "option.\n"
-msgstr "*KEY_ID* *KeyName*にはキーIDが含まれます。このオプションはデフォルトのオプションです。\n"
+msgstr "*KEY_ID* *KeyName* にはキーIDが含まれます。このオプションはデフォルトのオプションです。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -329,13 +324,13 @@ msgid ""
 "corresponding to the realm key. This option is expected by Microsoft Active "
 "Directory Federation Services.\n"
 msgstr ""
-"*CERT_SUBJECT* *KeyName*は、realmキーに対応する証明書からのサブジェクトを含む。このオプションは、Microsoft "
-"Active Directoryフェデレーションサービスによって期待されています。\n"
+"*CERT_SUBJECT* *KeyName* は、レルムキーに対応する証明書からのサブジェクトを含みます。このオプションは、Microsoft "
+"Active Directoryフェデレーション・サービスによって期待されています。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "*NONE* The *KeyName* hint is completely omitted from the SAML message.\n"
-msgstr "*NONE* SAMLメッセージでは、*KeyName*ヒントは完全に省略される。\n"
+msgstr "*NONE* SAMLメッセージから *KeyName* ヒントが完全に省略されます。\n"
 
 #. type: Labeled list
 #, no-wrap
@@ -355,7 +350,7 @@ msgstr "*Encrypt Assertions*"
 msgid ""
 "Encrypts the assertions in SAML documents with the realms private key. The "
 "AES algorithm uses a key size of 128 bits."
-msgstr "SAML 文書のアサーションをレルム秘密鍵で暗号化する。AES アルゴリズムは、128 ビットのキー・サイズを使用する。"
+msgstr "SAML文書のアサーションをレルム秘密鍵で暗号化します。AES アルゴリズムは、128ビットのキーサイズを使用します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -368,8 +363,9 @@ msgid ""
 "are expected to be signed. {project_name} will validate this signature using"
 " the client public key or cert set up in the `Keys` tab."
 msgstr ""
-"Client Signature Required* "
-"が有効な場合、クライアントからのドキュメントは署名されていることが期待されます。{project_name}は、`鍵`タブで設定されたクライアントの公開鍵または証明書を使用して、この署名を検証します。"
+"*Client Signature Required* "
+"が有効な場合、クライアントからのドキュメントは署名されていることが期待されます。{project_name}は、 `鍵` "
+"タブで設定されたクライアントの公開鍵または証明書を使用して、この署名を検証します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -383,9 +379,9 @@ msgid ""
 "using the SAML POST binding even if the original request used the redirect "
 "binding."
 msgstr ""
-"デフォルトでは、{project_name} は元のリクエストの最初の SAML バインディングを使用して応答します。Force POST "
-"Binding* を有効にすると、{project_name} は、元の要求がリダイレクトバインディングを使用していたとしても、SAML POST "
-"バインディングを使用して応答します。"
+"デフォルトでは、{project_name}は元のリクエストの最初のSAMLバインディングを使用して応答します。 *Force POST "
+"Binding* を有効にすると、{project_name}は、元のリクエストがREDIRECTバインディングを使用していたとしても、SAML "
+"POSTバインディングを使用して応答します。"
 
 #. type: Plain text
 msgid ""
@@ -395,10 +391,10 @@ msgid ""
 "Channel Logout* is disabled, {project_name} invokes a background SAML "
 "request to log out of the application."
 msgstr ""
-"Front Channel "
-"Logout*が有効な場合、アプリケーションはログアウトを実行するためにブラウザのリダイレクトを必要とします。例えば、アプリケーションはリダイレクトによってのみ実行可能なクッキーのリセットを要求するかもしれません。Front"
-" Channel Logout* が無効な場合、{project_name} はアプリケーションからログアウトするためにバックグラウンドの SAML "
-"リクエストを呼び出す。"
+"*Front Channel Logout* "
+"が有効な場合、アプリケーションはログアウトを実行するためにブラウザーのリダイレクトを必要とします。たとえば、アプリケーションはリダイレクトによってのみ実行可能なCookieのリセットを要求するかもしれません。"
+" *Front Channel Logout* "
+"が無効な場合、{project_name}はアプリケーションからログアウトするために、バックグラウンドでSAMLリクエストを呼び出します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -409,7 +405,8 @@ msgstr "*Force Name ID Format*"
 msgid ""
 "If a request has a name ID policy, ignore it and use the value configured in"
 " the Admin Console under *Name ID Format*."
-msgstr "リクエストに名前IDのポリシーがある場合、それを無視してAdmin Consoleの*名前IDの形式*で設定された値を使用します。"
+msgstr ""
+"リクエストにName IDのポリシーがある場合、それを無視して管理コンソールの *Name ID Format* で設定された値を使用します。"
 
 #. type: Labeled list
 #, no-wrap
@@ -422,13 +419,14 @@ msgid ""
 " is specified in a request, or if the Force Name ID Format attribute is set "
 "to ON."
 msgstr ""
-"サブジェクトの名前IDの形式。この形式は、リクエストで名前IDポリシーが指定されていない場合、または名前ID形式の強制属性がONに設定されている場合に使用されます。"
+"サブジェクトのName ID Format。この形式は、リクエストでName IDポリシーが指定されていない場合、またはName "
+"ID形式の強制属性がONに設定されている場合に使用されます。"
 
 #. type: Plain text
 msgid ""
 "When {project_name} uses a configured relative URL, this value is prepended "
 "to the URL."
-msgstr "project_name} が設定された相対 URL を使用する場合、この値が URL の前に付加される。"
+msgstr "{project_name}が設定された相対URLを使用する場合、この値がURLの前に付加されます。"
 
 #. type: Plain text
 msgid ""
@@ -438,14 +436,13 @@ msgid ""
 "used when the exact SAML endpoints are not registered and {project_name} "
 "pulls the Assertion Consumer URL from a request."
 msgstr ""
-"URLパターンを入力し、＋記号をクリックすると追加されます。  削除する場合は、-記号をクリックします。保存*をクリックして、これらの変更を保存します。"
-"  ワイルドカードの値は、URLの末尾にのみ使用できます。例えば、http://host.com/*$$のようになります。  このフィールドは、正確な "
-"SAML エンドポイントが登録されておらず、{project_name} 要求から Assertion Consumer URL "
-"を引き出す場合に使用される。"
+"URLパターンを入力し、+記号をクリックすると追加されます。削除する場合は、-記号をクリックします。 *Save* "
+"をクリックして、これらの変更を保存します。ワイルドカードの値は、URLの末尾にのみ使用できます。たとえば、http://host.com/*$$のようになります。このフィールドは、正確なSAMLエンドポイントが登録されておらず、{project_name}のリクエストからAssertion"
+" Consumer URLを導き出す場合に使用されます。"
 
 #. type: Plain text
 msgid "If {project_name} needs to link to a client, this URL is used."
-msgstr "project_name} がクライアントにリンクする必要がある場合、この URL が使用される。"
+msgstr "{project_name}がクライアントにリンクする必要がある場合、このURLが使用されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -458,8 +455,7 @@ msgid ""
 "SP. It is used as the Assertion Consumer Service URL and the Single Logout "
 "Service URL."
 msgstr ""
-"この URL は、すべての SAML リクエストに使用され、応答は SP に向けられる。これは、アサーション・コンシューマ・サービスの URL "
-"およびシングル・ログアウト・サービスの URL として使用される。"
+"このURLは、すべてのSAMLリクエストに使用され、レスポンスはSPに向けられます。これは、アサーション・コンシューマー・サービスのURLおよびシングル・ログアウト・サービスのURLとして使用されます。"
 
 #. type: Plain text
 msgid ""
@@ -467,7 +463,7 @@ msgid ""
 "login requests will take precedence. This URL must be validated by a "
 "registered Valid Redirect URI pattern."
 msgstr ""
-"ログイン要求にアサーション・コンシューマー・サービスのURLが含まれている場合、そのログイン要求が優先されます。このURLは、登録された有効なリダイレクトURIパターンによって検証される必要があります。"
+"ログインリクエストにアサーション・コンシューマー・サービスのURLが含まれている場合、そのログインリクエストが優先されます。このURLは、登録された有効なリダイレクトURIパターンによって検証される必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -517,9 +513,9 @@ msgid ""
 " and logout flows. _Artifact_ binding is not used for logout unless this "
 "property is set."
 msgstr ""
-"Logout Serviceの_Artifact_ Binding URLです。Force Artifact Binding` "
+"ログアウト・サービスの _Artifact_ Binding URLです。 `Force Artifact Binding` "
 "オプションと一緒に設定すると、ログインとログアウトの両方のフローで _Artifact_ "
-"バインディングが強制される。このプロパティが設定されない限り、ログアウトに_Artifact_バインディングは使用されません。"
+"バインディングが強制されます。このプロパティーが設定されない限り、ログアウトに _Artifact_ バインディングは使用されません。"
 
 #. type: Labeled list
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/saml/proc-creating-saml-client.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__saml__proc-creating-saml-client
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
