### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po
@@ -4,15 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# katakura__pro <h.katakura@pro-japan.co.jp>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,24 +19,37 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Attribute :adminguide_clearcache_name:
+#. type: Block title
 #, no-wrap
-msgid "Clearing Server Caches"
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click the *Cache* tab."
+msgstr "*Cache* タブをクリックします。"
+
+#. type: Plain text
+msgid "Click *Realm Settings* in the menu."
+msgstr "メニューの *Realm Settings* をクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Clearing server caches"
 msgstr "サーバー・キャッシュのクリア"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
-"{project_name} will cache everything it can in memory within the limits of your JVM and/or the limits you've configured\n"
-"it for.  If the {project_name} database is modified by a third party (i.e. a DBA) outside the scope of the server's REST APIs or Admin Console\n"
-"there's a chance parts of the in-memory cache may be stale.  You can clear the realm cache, user cache or cache of external public keys (Public keys of\n"
-" external clients or Identity providers, which {project_name} usually uses to verify signatures of particular external entity) from the Admin Console by going\n"
-"to the `Realm Settings` left menu item and the `Cache` tab.\n"
+"{project_name} caches everything it can in memory within the limits of your JVM and the limits you have configured.  If the {project_name} database is modified by a third party, such as a DBA, outside the scope of the server's REST APIs or Admin Console, parts of the in-memory cache could be stale.  You can clear the realm cache, user cache or cache of external public keys, such as Public keys of\n"
+" external clients or Identity providers, which {project_name} may use to verify signatures of particular external entity.\n"
 msgstr ""
-"{project_name}は、JVMの制限および/または設定した制限の範囲内で、できる限りすべてをメモリーにキャッシュします。サーバーのREST "
-"APIや管理コンソール以外の第三者（即ちDBA）によって{project_name}データベースが変更された場合、インメモリー・キャッシュの一部が失効する可能性があります。管理コンソール左側メニュー項目"
-" `Realm Settings` の `Cache` "
-"タブから、レルムキャッシュ、ユーザー・キャッシュ、または外部公開鍵（外部クライアントやアイデンティティー・プロバイダーの公開鍵など、{project_name}が外部エンティティーの検証署名に使用する公開鍵）のキャッシュをクリアすることができます。\n"
+"{project_name}は、JVMの制限と設定した制限の範囲内で、メモリー内にできる限りのものをキャッシュしています。DBAなどの第三者が、サーバーのREST"
+" "
+"APIや管理コンソールの範囲外で{project_name}のデータベースを変更した場合、メモリー内キャッシュの一部が古くなっている可能性があります。レルムキャッシュ、ユーザー・キャッシュ、外部公開鍵キャッシュ（外部クライアントやアイデンティティー・プロバイダーの公開鍵など、{project_name}が特定の外部エンティティーの署名を検証するために使用する可能性があるもの）をクリアすることができます。\n"
+
+#. type: Plain text
+msgid "Click *Clear* for the cache you want to evict."
+msgstr "退去させたいキャッシュの *Clear* ボタンをクリックします。"
 
 #. type: Block title
 #, no-wrap
@@ -45,9 +57,5 @@ msgid "Cache tab"
 msgstr "Cacheタブ"
 
 #. type: Plain text
-msgid "image:{project_images}/cache-tab.png[]"
-msgstr "image:{project_images}/cache-tab.png[]"
-
-#. type: Plain text
-msgid "Just click the `clear` button on the cache you want to evict."
-msgstr "クリアしたいキャッシュの `clear` ボタンをクリックします。"
+msgid "image:{project_images}/cache-tab.png[Cache tab]"
+msgstr "image:{project_images}/cache-tab.png[Cache tab]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/realms/cache.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__realms__cache
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
