### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/assembly-managing-users.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/assembly-managing-users.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/assembly-managing-users.ja_JP.po
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Managing users"
+msgstr "ユーザーの管理"
+
+#. type: Plain text
+msgid ""
+"From the Admin Console, you have a wide range of actions you can perform to "
+"manage users."
+msgstr "管理コンソールから、ユーザーを管理するために実行できるアクションは多岐にわたります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/assembly-managing-users.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__assembly-managing-users
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
