### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
@@ -21,7 +21,7 @@ msgstr ""
 #. type: Title ==
 #, no-wrap
 msgid "Managing user sessions"
-msgstr "ユーザーセッションの管理"
+msgstr "ユーザー・セッションの管理"
 
 #. type: Plain text
 msgid ""
@@ -29,16 +29,15 @@ msgid ""
 " user and remembers each client visited by the user within the session. "
 "Realm administrators can perform multiple actions on each user session:"
 msgstr ""
-"ユーザーがレルムにログインすると、{project_name} "
-"は各ユーザーのユーザーセッションを維持し、セッション内でユーザーが訪問した各クライアントを記憶します。レルム管理者は、各ユーザー・セッションに対して複数のアクションを実行することができます。"
+"ユーザーがレルムにログインすると、{project_name}は各ユーザーのユーザー・セッションを維持し、セッション内でユーザーがアクセスした各クライアントを記憶します。レルム管理者は、各ユーザー・セッションに対して以下のような複数のアクションを実行することができます。"
 
 #. type: Plain text
 msgid "View login statistics for the realm."
-msgstr "レルムのログイン統計情報を表示します。"
+msgstr "レルムのログイン統計情報を表示する。"
 
 #. type: Plain text
 msgid "View active users and where they logged in."
-msgstr "アクティブなユーザーとログインした場所を表示します。"
+msgstr "アクティブなユーザーとログインした場所を表示する。"
 
 #. type: Plain text
 msgid "Log a user out of their session."

--- a/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po
@@ -4,14 +4,13 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,17 +20,38 @@ msgstr ""
 
 #. type: Title ==
 #, no-wrap
-msgid "User Session Management"
-msgstr "ユーザー・セッションの管理"
+msgid "Managing user sessions"
+msgstr "ユーザーセッションの管理"
 
 #. type: Plain text
 msgid ""
-"When a user logs into a realm, {project_name} maintains a user session for "
-"them and remembers each and every client they have visited within the "
-"session.  There are a lot of administrative functions that realm admins can "
-"perform on these user sessions.  They can view login stats for the entire "
-"realm and dive down into each client to see who is logged in and where.  "
-"Admins can logout a user or a set of users from the Admin Console. They can "
-"revoke tokens and set up all the token and session timeouts there too."
+"When users log into realms, {project_name} maintains a user session for each"
+" user and remembers each client visited by the user within the session. "
+"Realm administrators can perform multiple actions on each user session:"
 msgstr ""
-"ユーザーがレルムにログインすると、{project_name}はユーザー・セッションを維持し、セッション内でアクセスしたすべてのクライアントを記憶します。これらのユーザー・セッションに対してレルム管理者が実行できる多くの管理機能があります。レルム全体のログイン統計を表示し、各クライアントに誰がどこからログインしているのかを確認できます。管理者は、管理コンソールからユーザーまたはユーザーのセットをログアウトできます。トークンを取り消したり、すべてのトークンとセッションのタイムアウトを設定することも可能です。"
+"ユーザーがレルムにログインすると、{project_name} "
+"は各ユーザーのユーザーセッションを維持し、セッション内でユーザーが訪問した各クライアントを記憶します。レルム管理者は、各ユーザー・セッションに対して複数のアクションを実行することができます。"
+
+#. type: Plain text
+msgid "View login statistics for the realm."
+msgstr "レルムのログイン統計情報を表示します。"
+
+#. type: Plain text
+msgid "View active users and where they logged in."
+msgstr "アクティブなユーザーとログインした場所を表示します。"
+
+#. type: Plain text
+msgid "Log a user out of their session."
+msgstr "ユーザーをセッションからログアウトさせる。"
+
+#. type: Plain text
+msgid "Revoke tokens."
+msgstr "トークンを失効させる。"
+
+#. type: Plain text
+msgid "Set up token timeouts."
+msgstr "トークンのタイムアウトを設定する。"
+
+#. type: Plain text
+msgid "Set up session timeouts."
+msgstr "セッションのタイムアウトを設定する。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
