### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-enabling-user-registration.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-user-registration.ja_JP.po
@@ -1,0 +1,56 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Login* tab."
+msgstr "*Login* タブをクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Enabling user registration"
+msgstr "ユーザー登録ができるようにする"
+
+#. type: Plain text
+msgid "Enable users to self-register."
+msgstr "ユーザーの自己登録を可能にする。"
+
+#. type: Plain text
+msgid "Click *Realm Settings* in the main menu."
+msgstr "メインメニューの*Realm Settings*をクリックします。"
+
+#. type: Plain text
+msgid "Toggle *User Registration* to *ON*."
+msgstr "User Registration*を*ON*に切り替えます。"
+
+#. type: Plain text
+msgid ""
+"After you enable this setting, a *Register* link displays on the login page "
+"of the Admin Console."
+msgstr "この設定を有効にすると、Admin Consoleのログインページに*Register*リンクが表示されます。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-user-registration.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-user-registration.ja_JP.po
@@ -35,22 +35,22 @@ msgstr "*Login* タブをクリックします。"
 #. type: Title =
 #, no-wrap
 msgid "Enabling user registration"
-msgstr "ユーザー登録ができるようにする"
+msgstr "ユーザー登録の有効化"
 
 #. type: Plain text
 msgid "Enable users to self-register."
-msgstr "ユーザーの自己登録を可能にする。"
+msgstr "ユーザーの自己登録を有効にします。"
 
 #. type: Plain text
 msgid "Click *Realm Settings* in the main menu."
-msgstr "メインメニューの*Realm Settings*をクリックします。"
+msgstr "メインメニューの *Realm Settings* をクリックします。"
 
 #. type: Plain text
 msgid "Toggle *User Registration* to *ON*."
-msgstr "User Registration*を*ON*に切り替えます。"
+msgstr "*User Registration* を *ON* に切り替えます。"
 
 #. type: Plain text
 msgid ""
 "After you enable this setting, a *Register* link displays on the login page "
 "of the Admin Console."
-msgstr "この設定を有効にすると、Admin Consoleのログインページに*Register*リンクが表示されます。"
+msgstr "この設定を有効にすると、管理コンソールのログインページに *Register* リンクが表示されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-enabling-user-registration.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-enabling-user-registration
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
