### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles-groups/proc-using-default-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-using-default-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-using-default-roles.ja_JP.po
@@ -35,23 +35,23 @@ msgstr "このスクリーン・ショットは、いくつかの _default roles
 #. type: Title =
 #, no-wrap
 msgid "Using default roles"
-msgstr "デフォルトのロールの使用"
+msgstr "デフォルトロールの使用"
 
 #. type: Plain text
 msgid ""
 "Use default roles to automatically assign user role mappings when a user is "
 "created or imported through <<_identity_broker, Identity Brokering>>."
 msgstr ""
-"デフォルトロールを使用すると、&lt;&gt;でユーザーを作成またはインポートしたときに、ユーザーのロールマッピングを自動的に割り当てることができます<_identity_broker,"
-" Identity Brokering>。</_identity_broker,>"
+"デフォルトロールを使用すると、<<_identity_broker, "
+"アイデンティティー・ブローカリング>>でユーザーを作成またはインポートしたときに、ユーザー・ロール・マッピングを自動的に割り当てることができます。"
 
 #. type: Plain text
 msgid "Click *Roles* in the menu"
-msgstr "メニューの *役割* をクリックします"
+msgstr "メニューの *Roles* をクリックします。"
 
 #. type: Plain text
 msgid "Click the *Default Roles* tab."
-msgstr "デフォルトの役割*タブをクリックします。"
+msgstr "*Default Roles* タブをクリックします。"
 
 #. type: Plain text
 msgid "image:{project_images}/default-roles.png[Default roles]"

--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-using-default-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-using-default-roles.ja_JP.po
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Default roles"
+msgstr "デフォルトロール"
+
+#. type: Plain text
+msgid "This screenshot shows that some _default roles_ already exist."
+msgstr "このスクリーン・ショットは、いくつかの _default roles_ が既に存在していることを示しています。"
+
+#. type: Title =
+#, no-wrap
+msgid "Using default roles"
+msgstr "デフォルトのロールの使用"
+
+#. type: Plain text
+msgid ""
+"Use default roles to automatically assign user role mappings when a user is "
+"created or imported through <<_identity_broker, Identity Brokering>>."
+msgstr ""
+"デフォルトロールを使用すると、&lt;&gt;でユーザーを作成またはインポートしたときに、ユーザーのロールマッピングを自動的に割り当てることができます<_identity_broker,"
+" Identity Brokering>。</_identity_broker,>"
+
+#. type: Plain text
+msgid "Click *Roles* in the menu"
+msgstr "メニューの *役割* をクリックします"
+
+#. type: Plain text
+msgid "Click the *Default Roles* tab."
+msgstr "デフォルトの役割*タブをクリックします。"
+
+#. type: Plain text
+msgid "image:{project_images}/default-roles.png[Default roles]"
+msgstr "image:{project_images}/default-roles.png[Default roles]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles-groups/proc-using-default-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles-groups__proc-using-default-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
