### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/proc-generating-client-adapter-config.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-generating-client-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-generating-client-adapter-config.ja_JP.po
@@ -22,7 +22,7 @@ msgstr ""
 #. type: Title =
 #, no-wrap
 msgid "Generating client adapter config"
-msgstr "クライアントアダプタのコンフィグを生成する"
+msgstr "クライアント・アダプターの設定の生成"
 
 #. type: Plain text
 msgid ""
@@ -30,15 +30,13 @@ msgid ""
 "a client adapter in your application's deployment environment. A number of "
 "adapter types are supported for OIDC and SAML."
 msgstr ""
-"{project_name} "
-"は、アプリケーションのデプロイメント環境にクライアントアダプタをインストールするために使用する設定ファイルを生成できます。OIDC および SAML "
-"では、さまざまな種類のアダプタがサポートされています。"
+"{project_name}は、アプリケーションのデプロイメント環境にクライアント・アダプターをインストールするために使用する設定ファイルを生成できます。OIDCおよびSAMLでは、さまざまなアダプタータイプがサポートされています。"
 
 #. type: Plain text
 msgid ""
 "Go to the *Installation* tab of the client you want to generate "
 "configuration for."
-msgstr "設定を生成したいクライアントの*Installation*タブに移動します。"
+msgstr "設定を生成したいクライアントの *Installation* タブに移動します。"
 
 #. type: Plain text
 msgid "image:{project_images}/client-installation.png[]"
@@ -46,7 +44,7 @@ msgstr "image:{project_images}/client-installation.png[]"
 
 #. type: Plain text
 msgid "Select the *Format Option* you want configuration generated for."
-msgstr "設定を生成したい*Format Option*を選択します。"
+msgstr "設定を生成したい *Format Option* を選択します。"
 
 #. type: Plain text
 msgid ""
@@ -54,5 +52,5 @@ msgid ""
 "auth-mellon Apache HTTPD adapter for SAML is supported as well as standard "
 "SAML entity descriptor files."
 msgstr ""
-"OIDC および SAML 用のすべての {project_name} クライアントアダプタがサポートされています。SAML 用の Apache "
-"HTTPD アダプタ mod-auth-mellon は、標準の SAML エンティティ記述子ファイルと同様にサポートされています。"
+"OIDCおよびSAML用のすべての{project_name}クライアント・アダプターがサポートされています。SAML用のApache "
+"HTTPDアダプターmod-auth-mellonは、標準のSAMLエンティティー記述子ファイルと同様にサポートされています。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-generating-client-adapter-config.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-generating-client-adapter-config.ja_JP.po
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Generating client adapter config"
+msgstr "クライアントアダプタのコンフィグを生成する"
+
+#. type: Plain text
+msgid ""
+"{project_name} can generate configuration files that you can use to install "
+"a client adapter in your application's deployment environment. A number of "
+"adapter types are supported for OIDC and SAML."
+msgstr ""
+"{project_name} "
+"は、アプリケーションのデプロイメント環境にクライアントアダプタをインストールするために使用する設定ファイルを生成できます。OIDC および SAML "
+"では、さまざまな種類のアダプタがサポートされています。"
+
+#. type: Plain text
+msgid ""
+"Go to the *Installation* tab of the client you want to generate "
+"configuration for."
+msgstr "設定を生成したいクライアントの*Installation*タブに移動します。"
+
+#. type: Plain text
+msgid "image:{project_images}/client-installation.png[]"
+msgstr "image:{project_images}/client-installation.png[]"
+
+#. type: Plain text
+msgid "Select the *Format Option* you want configuration generated for."
+msgstr "設定を生成したい*Format Option*を選択します。"
+
+#. type: Plain text
+msgid ""
+"All {project_name} client adapters for OIDC and SAML are supported. The mod-"
+"auth-mellon Apache HTTPD adapter for SAML is supported as well as standard "
+"SAML entity descriptor files."
+msgstr ""
+"OIDC および SAML 用のすべての {project_name} クライアントアダプタがサポートされています。SAML 用の Apache "
+"HTTPD アダプタ mod-auth-mellon は、標準の SAML エンティティ記述子ファイルと同様にサポートされています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/proc-generating-client-adapter-config.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__proc-generating-client-adapter-config
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
