### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/assembly-roles-groups.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/assembly-roles-groups.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/assembly-roles-groups.ja_JP.po
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Assigning permissions and access using roles and groups"
+msgstr "ロールやグループを使用した権限やアクセスの割り当て"
+
+#. type: Plain text
+msgid ""
+"Roles and groups have a similar purpose, which is to give users access and "
+"permissions to use applications. Groups are a collection of users to which "
+"you apply roles and attributes. Roles define specific applications "
+"permissions and access control."
+msgstr ""
+"ロールとグループは、アプリケーションを使用するためのアクセスや権限をユーザーに与えるという、似たような目的を持っています。グループは、ロールや属性を適用するユーザーの集合体です。ロールは、特定のアプリケーションの使用許可とアクセス制御を定義します。"
+
+#. type: Plain text
+msgid ""
+"A role typically applies to one type of user. For example, an organization "
+"may include `admin`, `user`, `manager`, and `employee` roles. An application"
+" can assign access and permissions to a role and then assign multiple users "
+"to that role so the users have the same access and permissions. For example,"
+" the Admin Console has roles that give permission to users to access "
+"different parts of the Admin Console."
+msgstr ""
+"ロールは通常、1種類のユーザーに適用されます。例えば、ある組織では `admin`, `user`, `manager`, そして `employee`"
+" "
+"というロールがあります。アプリケーションはロールにアクセスやパーミッションを割り当て、複数のユーザーをそのロールに割り当てて、ユーザーが同じアクセスやパーミッションを持てるようにすることができます。例えば、アドミンコンソールには、アドミンコンソールのさまざまな部分にアクセスするための権限をユーザーに与えるロールがあります。"
+
+#. type: Plain text
+msgid ""
+"There is a global namespace for roles and each client also has its own "
+"dedicated namespace where roles can be defined."
+msgstr "ロールのためのグローバルな名前空間があり、各クライアントもロールを定義できる専用の名前空間を持っています。"

--- a/i18n/po/ja_JP/server_admin/topics/assembly-roles-groups.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/assembly-roles-groups.ja_JP.po
@@ -21,7 +21,7 @@ msgstr ""
 #. type: Title ==
 #, no-wrap
 msgid "Assigning permissions and access using roles and groups"
-msgstr "ロールやグループを使用した権限やアクセスの割り当て"
+msgstr "ロールやグループを使用したパーミッションやアクセスの割り当て"
 
 #. type: Plain text
 msgid ""
@@ -30,7 +30,7 @@ msgid ""
 "you apply roles and attributes. Roles define specific applications "
 "permissions and access control."
 msgstr ""
-"ロールとグループは、アプリケーションを使用するためのアクセスや権限をユーザーに与えるという、似たような目的を持っています。グループは、ロールや属性を適用するユーザーの集合体です。ロールは、特定のアプリケーションの使用許可とアクセス制御を定義します。"
+"ロールとグループは、アプリケーションを使用するためのアクセスやパーミッションをユーザーに与えるという、似たような目的を持っています。グループは、ロールや属性を適用するユーザーの集合体です。ロールは、特定のアプリケーションのパーミッションとアクセス・コントロールを定義します。"
 
 #. type: Plain text
 msgid ""
@@ -41,9 +41,9 @@ msgid ""
 " the Admin Console has roles that give permission to users to access "
 "different parts of the Admin Console."
 msgstr ""
-"ロールは通常、1種類のユーザーに適用されます。例えば、ある組織では `admin`, `user`, `manager`, そして `employee`"
-" "
-"というロールがあります。アプリケーションはロールにアクセスやパーミッションを割り当て、複数のユーザーをそのロールに割り当てて、ユーザーが同じアクセスやパーミッションを持てるようにすることができます。例えば、アドミンコンソールには、アドミンコンソールのさまざまな部分にアクセスするための権限をユーザーに与えるロールがあります。"
+"ロールは通常、1種類のユーザーに適用されます。たとえば、ある組織では　 `admin` 、 `user` 、 `manager` 、 そして "
+"`employee` "
+"というロールがあります。アプリケーションはロールにアクセスやパーミッションを割り当て、複数のユーザーをそのロールに割り当てて、ユーザーが同じアクセスやパーミッションを持てるようにすることができます。たとえば、管理コンソールには、管理コンソールのさまざまな部分にアクセスするためのパーミッションをユーザーに与えるロールがあります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/assembly-roles-groups.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__assembly-roles-groups
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
