### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/proc-creating-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-mappers.ja_JP.po
@@ -29,16 +29,16 @@ msgstr "*Create* をクリックします。"
 
 #. type: Plain text
 msgid "You can add mapper types as follows:"
-msgstr "マッパーの種類は以下のように追加することができます。"
+msgstr "マッパータイプは以下のように追加できます。"
 
 #. type: Plain text
 msgid "Go to the *Mappers* tab."
-msgstr "Mappers* タブに移動します。"
+msgstr "*Mappers* タブに移動します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Add mapper"
-msgstr "マッパーの追加"
+msgstr "マッパーを追加します。"
 
 #. type: Plain text
 msgid "image:{project_images}/add-mapper.png[]"
@@ -46,4 +46,4 @@ msgstr "image:{project_images}/add-mapper.png[]"
 
 #. type: Plain text
 msgid "Select a *Mapper Type* from the list box."
-msgstr "リストボックスから*Mapper Type*を選択します。"
+msgstr "リストボックスから *Mapper Type* を選択します。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-mappers.ja_JP.po
@@ -1,0 +1,49 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Create*."
+msgstr "*Create* をクリックします。"
+
+#. type: Plain text
+msgid "You can add mapper types as follows:"
+msgstr "マッパーの種類は以下のように追加することができます。"
+
+#. type: Plain text
+msgid "Go to the *Mappers* tab."
+msgstr "Mappers* タブに移動します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add mapper"
+msgstr "マッパーの追加"
+
+#. type: Plain text
+msgid "image:{project_images}/add-mapper.png[]"
+msgstr "image:{project_images}/add-mapper.png[]"
+
+#. type: Plain text
+msgid "Select a *Mapper Type* from the list box."
+msgstr "リストボックスから*Mapper Type*を選択します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/proc-creating-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__proc-creating-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
