### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/con-sso-docker.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-sso-docker.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-sso-docker.ja_JP.po
@@ -1,0 +1,147 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "Docker registry v2 authentication"
+msgstr "Dockerレジストリv2認証"
+
+#. type: delimited block =
+msgid ""
+"Docker authentication is disabled by default. To enable docker "
+"authentication, see "
+"link:{installguide_profile_link}[{installguide_profile_name}]."
+msgstr ""
+"Docker認証はデフォルトで無効になっています。docker "
+"認証を有効にするには、link:{installguide_profile_link}[{installguide_profile_name}] "
+"を参照してください。"
+
+#. type: Plain text
+msgid ""
+"link:https://docs.docker.com/registry/spec/auth/[Docker Registry V2 "
+"Authentication] is a protocol, similar to OIDC, that authenticates users "
+"against Docker registries.  {project_name}'s implementation of this protocol"
+" lets Docker clients use a {project_name} authentication server authenticate"
+" against a registry. This protocol uses standard token and signature "
+"mechanisms but it does deviate from a true OIDC implementation. It deviates "
+"by using a very specific JSON format for requests and responses as well as "
+"mapping repository names and permissions to the OAuth scope mechanism."
+msgstr ""
+"link:https://docs.docker.com/registry/spec/auth/[Docker Registry V2 "
+"Authentication]は、OIDCに似た、Dockerレジストリに対してユーザを認証するプロトコルです。  "
+"{project_name}の実装では、Dockerクライアントが{project_name}認証サーバを使用してレジストリに対して認証を行うことができます。このプロトコルは標準的なトークンと署名のメカニズムを使用していますが、真のOIDCの実装からは逸脱しています。それは、リクエストとレスポンスに非常に特殊なJSONフォーマットを使用することと、リポジトリ名とパーミッションをOAuthスコープ機構にマッピングすることで逸脱しています。"
+
+#. type: Title ====
+#, no-wrap
+msgid "Docker authentication flow"
+msgstr "Dockerの認証フロー"
+
+#. type: Plain text
+msgid ""
+"The authentication flow is described in the "
+"link:https://docs.docker.com/registry/spec/auth/token/[Docker API "
+"documentation]. The following is a summary from the perspective of the "
+"{project_name} authentication server:"
+msgstr ""
+"認証の流れは、リンク:https://docs.docker.com/registry/spec/auth/token/[Docker "
+"APIドキュメント]に記載されています。以下は{project_name}認証サーバーの立場からまとめたものです。"
+
+#. type: Plain text
+msgid "Perform a `docker login`."
+msgstr "docker login`を実行します。"
+
+#. type: Plain text
+msgid ""
+"The Docker client requests a resource from the Docker registry.  If the "
+"resource is protected and no authentication token is in the request, the "
+"Docker registry server responds with a 401 HTTP message with some "
+"information on the permissions that are required and the location of the "
+"authorization server."
+msgstr ""
+"DockerクライアントはDockerレジストリにリソースを要求します。  "
+"リソースが保護されており、認証トークンがリクエストに含まれていない場合、Dockerレジストリサーバーは、必要なパーミッションと認証サーバーの場所に関するいくつかの情報を含む401"
+" HTTPメッセージで応答します。"
+
+#. type: Plain text
+msgid ""
+"The Docker client constructs an authentication request based on the 401 HTTP"
+" message from the Docker registry. The client uses the locally cached "
+"credentials (from the `docker login` command) as part of the "
+"link:https://datatracker.ietf.org/doc/html/rfc2617[HTTP Basic "
+"Authentication] request to the {project_name} authentication server."
+msgstr ""
+"Dockerクライアントは、Dockerレジストリからの401 "
+"HTTPメッセージに基づいて、認証リクエストを構築します。クライアントはローカルにキャッシュされた認証情報（`docker "
+"login`コマンドによる）を、{project_name} 認証サーバへの "
+"link:https://datatracker.ietf.org/doc/html/rfc2617[HTTP Basic "
+"Authentication] リクエストの一部として使用します。"
+
+#. type: Plain text
+msgid ""
+"The {project_name} authentication server attempts to authenticate the user "
+"and return a JSON body containing an OAuth-style Bearer token."
+msgstr "project_name}認証サーバーは、ユーザーの認証を試み、OAuthスタイルのBearerトークンを含むJSONボディを返します。"
+
+#. type: Plain text
+msgid ""
+"The Docker client receives a bearer token from the JSON response and uses it"
+" in the authorization header to request the protected resource."
+msgstr ""
+"DockerクライアントはJSONレスポンスからベアラートークンを受け取り、それをauthorizationヘッダーに使用して保護されたリソースを要求します。"
+
+#. type: Plain text
+msgid ""
+"The Docker registry receives the new request for the protected resource with"
+" the token from the {project_name} server. The registry validates the token "
+"and grants access to the requested resource (if appropriate)."
+msgstr ""
+"Dockerレジストリは、{project_name}サーバーからトークン付きの保護されたリソースに対する新しいリクエストを受信します。レジストリはトークンを検証し、要求されたリソースへのアクセスを許可します"
+" (適切な場合)。"
+
+#. type: Plain text
+msgid ""
+"{project_name} does not create a browser SSO session after successful "
+"authentication with the Docker protocol. The browser SSO session does not "
+"use the Docker protocol as it cannot refresh tokens or obtain the status of "
+"a token or session from the {project_name} server; therefore a browser SSO "
+"session is not necessary. For more details, see the <<_transient-session, "
+"transient session>> section."
+msgstr ""
+"{project_name}は、Dockerプロトコルで認証に成功した後、ブラウザのSSOセッションを作成しない。ブラウザSSOセッションは、トークンのリフレッシュや、トークンやセッションの状態を{project_name}"
+" "
+"サーバから取得できないため、Dockerプロトコルを使用しません。したがって、ブラウザSSOセッションは必要ありません。詳しくは、&lt;&gt;の<_transient-"
+"session, transient session>項を</_transient-session,>ご覧ください。"
+
+#. type: Title ====
+#, no-wrap
+msgid "{project_name} Docker Registry v2 Authentication Server URI Endpoints"
+msgstr "{project_name} Dockerレジストリーv2認証サーバーのURIエンドポイント"
+
+#. type: Plain text
+msgid "{project_name} has one endpoint for all Docker auth v2 requests."
+msgstr "{project_name}は、すべてのDocker auth v2リクエストに対して1つのエンドポイントを持ちます。"
+
+#. type: Plain text
+msgid ""
+"`http(s)://authserver.host/auth/realms/{realm-name}/protocol/docker-v2`"
+msgstr ""
+"`http(s)://authserver.host/auth/realms/{realm-name}/protocol/docker-v2`"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/con-sso-docker.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__con-sso-docker
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
