### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-setting-password-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-setting-password-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-setting-password-user.ja_JP.po
@@ -29,7 +29,7 @@ msgstr "ユーザーを選択します。"
 
 #. type: Plain text
 msgid "Click the *Credentials* tab."
-msgstr "認証情報」タブをクリックします。"
+msgstr "*Credentials* タブをクリックします。"
 
 #. type: Plain text
 msgid "Click *Users* in the menu. The *Users* page is displayed."
@@ -38,27 +38,27 @@ msgstr "メニューの *Users* をクリックします。 *Users* ページが
 #. type: Title =
 #, no-wrap
 msgid "Setting a password for a user"
-msgstr "ユーザーのパスワードを設定する"
+msgstr "ユーザーのパスワードの設定"
 
 #. type: Plain text
 msgid ""
 "If a user does not have a password, or if the password has been deleted, the"
 " *Set Password* section is displayed."
-msgstr "ユーザーがパスワードを持っていない場合、またはパスワードを削除した場合は、「*パスワードの設定*」が表示されます。"
+msgstr "ユーザーがパスワードを持っていない場合、またはパスワードを削除した場合は、 *Set Password* のセクションが表示されます。"
 
 #. type: Plain text
 msgid ""
 "If a user already has a password, it can be reset in the *Reset Password* "
 "section."
-msgstr "すでにパスワードが設定されている場合は、*Reset Password*の項目で再設定することができます。"
+msgstr "すでにパスワードが設定されている場合は、 *Reset Password* の項目で再設定することができます。"
 
 #. type: Plain text
 msgid "Type a new password in the *Set Password* section."
-msgstr "パスワードの設定*」に新しいパスワードを入力します。"
+msgstr "*Set Password* のセクションに新しいパスワードを入力します。"
 
 #. type: Plain text
 msgid "Click *Set Password*."
-msgstr "パスワードの設定］をクリックします。"
+msgstr "*Set Password* をクリックします。"
 
 #. type: Plain text
 msgid ""
@@ -66,34 +66,36 @@ msgid ""
 "login. To allow users to keep the password supplied, set *Temporary* to "
 "*OFF.* The user must click *Set Password* to change the password."
 msgstr ""
-"Temporary*が*ON*の場合、ユーザーは初回ログイン時にパスワードを変更する必要があります。ユーザーがパスワードを保持できるようにするには、*Temporary*"
-" を *OFF* に設定し、ユーザーが *Set Password* をクリックしてパスワードを変更する必要があります。"
+"*Temporary* が *ON* "
+"の場合、ユーザーは初回ログイン時にパスワードを変更する必要があります。ユーザーがパスワードを保持できるようにするには、 *Temporary* を "
+"*OFF* に設定し、ユーザーが *Set Password* をクリックしてパスワードを変更する必要があります。"
 
 #. type: Plain text
 msgid ""
 "Alternatively, you can send an email to the user that requests the user "
 "reset the password."
-msgstr "または、ユーザーにパスワードの再設定を依頼するメールを送信することもできます。"
+msgstr "または、ユーザーにパスワードの再設定を依頼する電子メールを送信することもできます。"
 
 #. type: Plain text
 msgid "Navigate to the *Reset Actions* list under *Credential Reset*."
-msgstr "クレデンシャルリセット」の下にある「リセットアクション」リストに移動します。"
+msgstr "*Credential Reset* の下にある *Reset Actions* リストに移動します。"
 
 #. type: Plain text
 msgid "Select *Update Password* from the list."
-msgstr "リストから*Update Password*を選択します。"
+msgstr "リストから *Update Password* を選択します。"
 
 #. type: Plain text
 msgid ""
 "Click *Send Email*. The sent email contains a link that directs the user to "
 "the *Update Password* window."
 msgstr ""
-"メール送信*をクリックします。送信されたメールには、ユーザーを*Update Password*ウィンドウに誘導するリンクが含まれています。"
+"*Send Email* をクリックします。送信された電子メールには、ユーザーを *Update Password* "
+"ウィンドウに誘導するリンクが含まれています。"
 
 #. type: Plain text
 msgid ""
 "Optionally, you can set the validity of the email link. This is set to the "
 "default preset in the *Tokens* tab in *Realm Settings*."
 msgstr ""
-"オプションで、メールリンクの有効期限を設定することができます。これは、*Realm "
-"Settings*の*Tokens*タブにあるデフォルトのプリセットに設定されています。"
+"オプションで、メールリンクの有効期限を設定することができます。これは、 *Realm Settings* の *Tokens* "
+"タブにあるデフォルトのプリセットに設定されています。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-setting-password-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-setting-password-user.ja_JP.po
@@ -1,0 +1,99 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Select a user."
+msgstr "ユーザーを選択します。"
+
+#. type: Plain text
+msgid "Click the *Credentials* tab."
+msgstr "認証情報」タブをクリックします。"
+
+#. type: Plain text
+msgid "Click *Users* in the menu. The *Users* page is displayed."
+msgstr "メニューの *Users* をクリックします。 *Users* ページが表示されます。"
+
+#. type: Title =
+#, no-wrap
+msgid "Setting a password for a user"
+msgstr "ユーザーのパスワードを設定する"
+
+#. type: Plain text
+msgid ""
+"If a user does not have a password, or if the password has been deleted, the"
+" *Set Password* section is displayed."
+msgstr "ユーザーがパスワードを持っていない場合、またはパスワードを削除した場合は、「*パスワードの設定*」が表示されます。"
+
+#. type: Plain text
+msgid ""
+"If a user already has a password, it can be reset in the *Reset Password* "
+"section."
+msgstr "すでにパスワードが設定されている場合は、*Reset Password*の項目で再設定することができます。"
+
+#. type: Plain text
+msgid "Type a new password in the *Set Password* section."
+msgstr "パスワードの設定*」に新しいパスワードを入力します。"
+
+#. type: Plain text
+msgid "Click *Set Password*."
+msgstr "パスワードの設定］をクリックします。"
+
+#. type: Plain text
+msgid ""
+"If *Temporary* is *ON*, the user must change the password at the first "
+"login. To allow users to keep the password supplied, set *Temporary* to "
+"*OFF.* The user must click *Set Password* to change the password."
+msgstr ""
+"Temporary*が*ON*の場合、ユーザーは初回ログイン時にパスワードを変更する必要があります。ユーザーがパスワードを保持できるようにするには、*Temporary*"
+" を *OFF* に設定し、ユーザーが *Set Password* をクリックしてパスワードを変更する必要があります。"
+
+#. type: Plain text
+msgid ""
+"Alternatively, you can send an email to the user that requests the user "
+"reset the password."
+msgstr "または、ユーザーにパスワードの再設定を依頼するメールを送信することもできます。"
+
+#. type: Plain text
+msgid "Navigate to the *Reset Actions* list under *Credential Reset*."
+msgstr "クレデンシャルリセット」の下にある「リセットアクション」リストに移動します。"
+
+#. type: Plain text
+msgid "Select *Update Password* from the list."
+msgstr "リストから*Update Password*を選択します。"
+
+#. type: Plain text
+msgid ""
+"Click *Send Email*. The sent email contains a link that directs the user to "
+"the *Update Password* window."
+msgstr ""
+"メール送信*をクリックします。送信されたメールには、ユーザーを*Update Password*ウィンドウに誘導するリンクが含まれています。"
+
+#. type: Plain text
+msgid ""
+"Optionally, you can set the validity of the email link. This is set to the "
+"default preset in the *Tokens* tab in *Realm Settings*."
+msgstr ""
+"オプションで、メールリンクの有効期限を設定することができます。これは、*Realm "
+"Settings*の*Tokens*タブにあるデフォルトのプリセットに設定されています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-setting-password-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-setting-password-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
