### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/proc-updating-default-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-updating-default-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-updating-default-scopes.ja_JP.po
@@ -25,31 +25,32 @@ msgstr "手順"
 
 #. type: Plain text
 msgid "Click the *Client Scopes* tab for the client."
-msgstr "クライアントの*Client Scopes*タブをクリックします。"
+msgstr "クライアントの *Client Scopes* タブをクリックします。"
 
 #. type: Plain text
 msgid ""
 "Use *Realm Default Client Scopes* to define sets of client scopes that are "
 "automatically linked to newly created clients."
 msgstr ""
-"Realm Default Client "
-"Scopes*を使用すると、新しく作成されたクライアントに自動的にリンクされるクライアントスコープのセットを定義することができます。"
+"*Realm Default Client Scopes* "
+"を使用すると、新しく作成されたクライアントに自動的にリンクされるクライアント・スコープのセットを定義することができます。"
 
 #. type: Plain text
 msgid "Click *Default Client Scopes*."
-msgstr "Default Client Scopes*をクリックします。"
+msgstr "*Default Client Scopes* をクリックします。"
 
 #. type: Plain text
 msgid ""
 "From here, select the client scopes that you want to add as *Default Client "
 "Scopes* to newly created clients and *Optional Client Scopes*."
 msgstr ""
-"ここから、新しく作成するクライアントに*デフォルトクライアントスコープ*として追加したいクライアントスコープと*オプションのクライアントスコープ*を選択します。"
+"ここから、新しく作成するクライアントに *Default Client Scopes* として追加したいクライアントスコープと *Optional "
+"Client Scopes* を選択します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Default client scopes"
-msgstr "デフォルトのクライアントスコープ"
+msgstr "デフォルト・クライアント・スコープ"
 
 #. type: Plain text
 msgid "image:{project_images}/client-scopes-default.png[]"
@@ -60,5 +61,5 @@ msgid ""
 "When a client is created, you can unlink the default client scopes, if "
 "needed. This is similar to removing <<_default_roles, Default Roles>>."
 msgstr ""
-"クライアントを作成する際、必要に応じてデフォルトのクライアントスコープをアンリンクすることができます。これは、<_default_roles, "
-"Default Roles>&lt;&gt;を</_default_roles,>削除するのと似ています。"
+"クライアントを作成する際、必要に応じてデフォルトのクライアントスコープをアンリンクすることができます。これは、<<_default_roles, "
+"デフォルトロール>>を削除するのと似ています。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-updating-default-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-updating-default-scopes.ja_JP.po
@@ -1,0 +1,64 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click the *Client Scopes* tab for the client."
+msgstr "クライアントの*Client Scopes*タブをクリックします。"
+
+#. type: Plain text
+msgid ""
+"Use *Realm Default Client Scopes* to define sets of client scopes that are "
+"automatically linked to newly created clients."
+msgstr ""
+"Realm Default Client "
+"Scopes*を使用すると、新しく作成されたクライアントに自動的にリンクされるクライアントスコープのセットを定義することができます。"
+
+#. type: Plain text
+msgid "Click *Default Client Scopes*."
+msgstr "Default Client Scopes*をクリックします。"
+
+#. type: Plain text
+msgid ""
+"From here, select the client scopes that you want to add as *Default Client "
+"Scopes* to newly created clients and *Optional Client Scopes*."
+msgstr ""
+"ここから、新しく作成するクライアントに*デフォルトクライアントスコープ*として追加したいクライアントスコープと*オプションのクライアントスコープ*を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Default client scopes"
+msgstr "デフォルトのクライアントスコープ"
+
+#. type: Plain text
+msgid "image:{project_images}/client-scopes-default.png[]"
+msgstr "image:{project_images}/client-scopes-default.png[]"
+
+#. type: Plain text
+msgid ""
+"When a client is created, you can unlink the default client scopes, if "
+"needed. This is similar to removing <<_default_roles, Default Roles>>."
+msgstr ""
+"クライアントを作成する際、必要に応じてデフォルトのクライアントスコープをアンリンクすることができます。これは、<_default_roles, "
+"Default Roles>&lt;&gt;を</_default_roles,>削除するのと似ています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/proc-updating-default-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__proc-updating-default-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
