### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles-groups/proc-assigning-role-mappings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-assigning-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-assigning-role-mappings.ja_JP.po
@@ -32,7 +32,7 @@ msgstr "ロールマッピングの割り当て"
 msgid ""
 "You can assign role mappings to a user through the *Role Mappings* tab for "
 "that user."
-msgstr "ロールマッピングは、そのユーザーの*Role Mappings*タブで割り当てることができます。"
+msgstr "ロールマッピングは、そのユーザーの *Role Mappings* タブで割り当てることができます。"
 
 #. type: Plain text
 msgid "Click *Users* in the menu."
@@ -42,7 +42,8 @@ msgstr "メニューの *Users* をクリックします。"
 msgid ""
 "Click the user that you want to perform a role mapping on. If the user is "
 "not displayed, click *View all users*."
-msgstr "ロールマッピングを行いたいユーザーをクリックします。ユーザーが表示されていない場合は、*すべてのユーザーを見る*をクリックします。"
+msgstr ""
+"ロールマッピングを行いたいユーザーをクリックします。ユーザーが表示されていない場合は、 *View all users* をクリックします。"
 
 #. type: Plain text
 msgid "Click the *Role Mappings* tab."
@@ -51,7 +52,7 @@ msgstr "*Role Mappings* タブをクリックします。"
 #. type: Plain text
 msgid ""
 "Click the role you want to assign to the user in the *Available Roles* box."
-msgstr "利用可能なロール*」ボックスで、ユーザーに割り当てるロールをクリックします。"
+msgstr "*Available Roles* のボックスで、ユーザーに割り当てるロールをクリックします。"
 
 #. type: Plain text
 msgid "Click *Add selected*."
@@ -72,13 +73,13 @@ msgid ""
 " a user. That role was created in the <<_composite-roles, Composite Roles>> "
 "topic."
 msgstr ""
-"この例では、あるユーザーに対して複合ロール *developer* を割り当てています。このロールは<_composite-roles, "
-"Composite Roles>&lt;&gt;トピックで</_composite-roles,>作成されました。"
+"この例では、あるユーザーに対して複合ロール *developer* を割り当てています。このロールは<<_composite-roles, "
+"複合ロール>>のトピックで作成されました。"
 
 #. type: Block title
 #, no-wrap
 msgid "Effective role mappings"
-msgstr "効果的な役割分担"
+msgstr "効果的なロールマッピング"
 
 #. type: Plain text
 msgid ""
@@ -93,5 +94,6 @@ msgid ""
 "*Effective Roles* are the roles explicitly assigned to users and roles that "
 "are inherited from composites."
 msgstr ""
-"developer*ロールが割り当てられると、*developer*コンポジットに関連付けられた*employee*ロールが*Effective "
-"Roles*ボックスに表示されます。*有効なロールとは、ユーザーに明示的に割り当てられたロールと、コンポジットから継承されたロールのことです。"
+"*developer* ロールが割り当てられると、 *developer* コンポジットに関連付けられた *employee* ロールが "
+"*Effective Roles* ボックスに表示されます。 *Effective Roles* "
+"とは、ユーザーに明示的に割り当てられたロールと、複合ロールから継承されたロールのことです。"

--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-assigning-role-mappings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-assigning-role-mappings.ja_JP.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title =
+#, no-wrap
+msgid "Assigning role mappings"
+msgstr "ロールマッピングの割り当て"
+
+#. type: Plain text
+msgid ""
+"You can assign role mappings to a user through the *Role Mappings* tab for "
+"that user."
+msgstr "ロールマッピングは、そのユーザーの*Role Mappings*タブで割り当てることができます。"
+
+#. type: Plain text
+msgid "Click *Users* in the menu."
+msgstr "メニューの *Users* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"Click the user that you want to perform a role mapping on. If the user is "
+"not displayed, click *View all users*."
+msgstr "ロールマッピングを行いたいユーザーをクリックします。ユーザーが表示されていない場合は、*すべてのユーザーを見る*をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Role Mappings* tab."
+msgstr "*Role Mappings* タブをクリックします。"
+
+#. type: Plain text
+msgid ""
+"Click the role you want to assign to the user in the *Available Roles* box."
+msgstr "利用可能なロール*」ボックスで、ユーザーに割り当てるロールをクリックします。"
+
+#. type: Plain text
+msgid "Click *Add selected*."
+msgstr "*Add selected* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Role mappings"
+msgstr "ロールマッピング"
+
+#. type: Plain text
+msgid "image:{project_images}/user-role-mappings.png[Role mappings]"
+msgstr "image:{project_images}/user-role-mappings.png[Role mappings]"
+
+#. type: Plain text
+msgid ""
+"In the preceding example, we are assigning the composite role *developer* to"
+" a user. That role was created in the <<_composite-roles, Composite Roles>> "
+"topic."
+msgstr ""
+"この例では、あるユーザーに対して複合ロール *developer* を割り当てています。このロールは<_composite-roles, "
+"Composite Roles>&lt;&gt;トピックで</_composite-roles,>作成されました。"
+
+#. type: Block title
+#, no-wrap
+msgid "Effective role mappings"
+msgstr "効果的な役割分担"
+
+#. type: Plain text
+msgid ""
+"image:{project_images}/effective-role-mappings.png[Effective role mappings]"
+msgstr ""
+"image:{project_images}/effective-role-mappings.png[Effective role mappings]"
+
+#. type: Plain text
+msgid ""
+"When the *developer* role is assigned, the *employee* role associated with "
+"the *developer* composite is displayed in the *Effective Roles* box. "
+"*Effective Roles* are the roles explicitly assigned to users and roles that "
+"are inherited from composites."
+msgstr ""
+"developer*ロールが割り当てられると、*developer*コンポジットに関連付けられた*employee*ロールが*Effective "
+"Roles*ボックスに表示されます。*有効なロールとは、ユーザーに明示的に割り当てられたロールと、コンポジットから継承されたロールのことです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles-groups/proc-assigning-role-mappings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles-groups__proc-assigning-role-mappings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
