### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.ja_JP.po
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "{project_name} server OIDC URI endpoints"
+msgstr "{project_name} サーバ OIDC URI エンドポイント"
+
+#. type: Plain text
+msgid ""
+"The following is a list of OIDC endpoints that {project_name} publishes. "
+"These endpoints can be used when a non-{project_name} client adapter uses "
+"OIDC to communicate with the authentication server. They are all relative "
+"URLs. The root of the URL consists of the HTTP(S) protocol, hostname, and "
+"the path, which is usually prefixed with _/auth_: For example"
+msgstr ""
+"project_name}が公開しているOIDCエンドポイントの一覧を以下に示します。これらのエンドポイントは、{project_name} "
+"以外のクライアントアダプタが OIDC を用いて認証サーバと通信する際に利用することができる。これらはすべて相対 URL です。URL "
+"のルートは、HTTP(S) プロトコル、ホスト名、パスからなり、通常 _/auth_ が先頭に付きます。例えば"
+
+#. type: delimited block -
+#, no-wrap
+msgid "https://localhost:8080/auth\n"
+msgstr "https://localhost:8080/auth\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/auth::\n"
+"  Used for obtaining a temporary code in the Authorization Code Flow or obtaining tokens using the Implicit Flow, Direct Grants, or Client Grants.\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/auth:。\n"
+"  認証コードフローで一時的なコードを取得したり、暗黙のフロー、直接付与、クライアント付与でトークンを取得する際に使用します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/token::\n"
+"  Used by the Authorization Code Flow to convert a temporary code into a token.\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/token:。\n"
+"  認可コードフローで、一時的なコードをトークンに変換するために使用されます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/logout::\n"
+"  Used for performing logouts.\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/logout:。\n"
+"  ログアウトを実行するために使用します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
+"  Used for the User Info service described in the OIDC specification.\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/userinfo:。\n"
+"  OIDC仕様に記載されているUser Infoサービスに使用されます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/revoke::\n"
+"  Used for OAuth 2.0 Token Revocation described in https://datatracker.ietf.org/doc/html/rfc7009[RFC7009].\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/revoke:。\n"
+"  https://datatracker.ietf.org/doc/html/rfc7009[RFC7009] に記載されている OAuth 2.0 Token Revocation に使用されます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/certs::\n"
+"  Used for the JSON Web Key Set (JWKS) containing the public keys used to verify any JSON Web Token (jwks_uri)\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/certs:。\n"
+"  JSON Web Token (jwks_uri) を検証するために使用する公開鍵を含む JSON Web Key Set (JWKS) に使用します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"/realms/{realm-name}/protocol/openid-connect/auth/device::\n"
+"  Used for Device Authorization Grant to obtain a device code and a user code.\n"
+msgstr ""
+"/realms/{realm-name}/protocol/openid-connect/auth/device:。\n"
+"  デバイス認証グラントで、デバイスコードとユーザーコードを取得するために使用します。\n"
+
+#. type: Plain text
+msgid "In all of these, replace {realm-name} with the name of the realm."
+msgstr "いずれも {realm-name} をレルムの名前に置き換えてください。"

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.ja_JP.po
@@ -21,7 +21,7 @@ msgstr ""
 #. type: Title ====
 #, no-wrap
 msgid "{project_name} server OIDC URI endpoints"
-msgstr "{project_name} サーバ OIDC URI エンドポイント"
+msgstr "{project_name}サーバーのOIDC URIエンドポイント"
 
 #. type: Plain text
 msgid ""
@@ -31,9 +31,8 @@ msgid ""
 "URLs. The root of the URL consists of the HTTP(S) protocol, hostname, and "
 "the path, which is usually prefixed with _/auth_: For example"
 msgstr ""
-"project_name}が公開しているOIDCエンドポイントの一覧を以下に示します。これらのエンドポイントは、{project_name} "
-"以外のクライアントアダプタが OIDC を用いて認証サーバと通信する際に利用することができる。これらはすべて相対 URL です。URL "
-"のルートは、HTTP(S) プロトコル、ホスト名、パスからなり、通常 _/auth_ が先頭に付きます。例えば"
+"{project_name}が公開しているOIDCエンドポイントの一覧を以下に示します。これらのエンドポイントは、{project_name}以外のクライアント・アダプターがOIDCを用いて認証サーバーと通信する際に利用することができます。これらはすべて相対URLです。URLのルートは、HTTP(S)プロトコル、ホスト名、パスからなり、通常"
+" _/auth_ が先頭に付きます。たとえば、以下です。"
 
 #. type: delimited block -
 #, no-wrap
@@ -46,8 +45,8 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/auth::\n"
 "  Used for obtaining a temporary code in the Authorization Code Flow or obtaining tokens using the Implicit Flow, Direct Grants, or Client Grants.\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/auth:。\n"
-"  認証コードフローで一時的なコードを取得したり、暗黙のフロー、直接付与、クライアント付与でトークンを取得する際に使用します。\n"
+"/realms/{realm-name}/protocol/openid-connect/auth::\n"
+"  認可コードフローで一時的なコードを取得したり、インプリシット・フロー、ダイレクト・グラント、クライアント・グラントでトークンを取得する際に使用します。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -55,7 +54,7 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/token::\n"
 "  Used by the Authorization Code Flow to convert a temporary code into a token.\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/token:。\n"
+"/realms/{realm-name}/protocol/openid-connect/token::\n"
 "  認可コードフローで、一時的なコードをトークンに変換するために使用されます。\n"
 
 #. type: Plain text
@@ -64,7 +63,7 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/logout::\n"
 "  Used for performing logouts.\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/logout:。\n"
+"/realms/{realm-name}/protocol/openid-connect/logout::\n"
 "  ログアウトを実行するために使用します。\n"
 
 #. type: Plain text
@@ -73,7 +72,7 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
 "  Used for the User Info service described in the OIDC specification.\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/userinfo:。\n"
+"/realms/{realm-name}/protocol/openid-connect/userinfo::\n"
 "  OIDC仕様に記載されているUser Infoサービスに使用されます。\n"
 
 #. type: Plain text
@@ -82,8 +81,8 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/revoke::\n"
 "  Used for OAuth 2.0 Token Revocation described in https://datatracker.ietf.org/doc/html/rfc7009[RFC7009].\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/revoke:。\n"
-"  https://datatracker.ietf.org/doc/html/rfc7009[RFC7009] に記載されている OAuth 2.0 Token Revocation に使用されます。\n"
+"/realms/{realm-name}/protocol/openid-connect/revoke::\n"
+"  https://datatracker.ietf.org/doc/html/rfc7009[RFC7009] に記載されているOAuth 2.0 Token Revocationに使用されます。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -91,8 +90,8 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/certs::\n"
 "  Used for the JSON Web Key Set (JWKS) containing the public keys used to verify any JSON Web Token (jwks_uri)\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/certs:。\n"
-"  JSON Web Token (jwks_uri) を検証するために使用する公開鍵を含む JSON Web Key Set (JWKS) に使用します。\n"
+"/realms/{realm-name}/protocol/openid-connect/certs::\n"
+" JSON Web Token (jwks_uri) を検証するために使用する公開鍵を含むJSON Web Key Set (JWKS) に使用します。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -100,9 +99,9 @@ msgid ""
 "/realms/{realm-name}/protocol/openid-connect/auth/device::\n"
 "  Used for Device Authorization Grant to obtain a device code and a user code.\n"
 msgstr ""
-"/realms/{realm-name}/protocol/openid-connect/auth/device:。\n"
-"  デバイス認証グラントで、デバイスコードとユーザーコードを取得するために使用します。\n"
+"/realms/{realm-name}/protocol/openid-connect/auth/device::\n"
+"  デバイス認可グラントで、デバイスコードとユーザーコードを取得するために使用します。\n"
 
 #. type: Plain text
 msgid "In all of these, replace {realm-name} with the name of the realm."
-msgstr "いずれも {realm-name} をレルムの名前に置き換えてください。"
+msgstr "いずれも{realm-name}をレルムの名前に置き換えてください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/con-server-oidc-uri-endpoints.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__con-server-oidc-uri-endpoints
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
