### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/admin-console-permissions/per-realm.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/admin-console-permissions/per-realm.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/admin-console-permissions/per-realm.ja_JP.po
@@ -6,13 +6,13 @@
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2017
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2017
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,31 +23,6 @@ msgstr ""
 #. type: Plain text
 msgid "impersonation"
 msgstr "impersonation"
-
-#. type: Title ===
-#, no-wrap
-msgid "Dedicated Realm Admin Consoles"
-msgstr "レルム専用の管理コンソール"
-
-#. type: Plain text
-msgid ""
-"Each realm has a dedicated Admin Console that can be accessed by going to "
-"the url `/auth/admin/{realm-name}/console`.  Users within that realm can be "
-"granted realm management permissions by assigning specific user role "
-"mappings."
-msgstr ""
-"各レルムには専用の管理コンソールがあり、 `/auth/admin/{realm-name}/console` "
-"のURLでアクセスできます。特定のユーザー・ロール・マッピングを割り当てることによって、そのレルム内のユーザーにレルム管理パーミッションを与えることができます。"
-
-#. type: Plain text
-msgid ""
-"Each realm has a built-in client called `realm-management`.  You can view "
-"this client by going to the `Clients` left menu item of your realm.  This "
-"client defines client-level roles that specify permissions that can be "
-"granted to manage the realm."
-msgstr ""
-"各レルムには、 `realm-management` という名前のビルトイン・クライアントがあります。レルムの左メニュー項目の `Clients` "
-"をクリックすることでこのクライアントを見ることができます。このクライアントは、レルムを管理するパーミッションを指定するクライアントレベルのロールを定義します。"
 
 #. type: Plain text
 msgid "view-realm"
@@ -82,6 +57,37 @@ msgid "manage-clients"
 msgstr "manage-clients"
 
 #. type: Plain text
+msgid ""
+"Assign the roles you want to your users and they will only be able to use "
+"that specific part of the administration console."
+msgstr "ユーザーに必要なロールを割り当てると、管理コンソールの特定の部分のみを使用できます。"
+
+#. type: Title ===
+#, no-wrap
+msgid "Dedicated realm admin consoles"
+msgstr "レルム専用の管理コンソール"
+
+#. type: Plain text
+msgid ""
+"Each realm has a dedicated Admin Console that can be accessed by going to "
+"the url `/auth/admin/{realm-name}/console`.  Users within that realm can be "
+"granted realm management permissions by assigning specific user role "
+"mappings."
+msgstr ""
+"各レルムには専用の管理コンソールがあり、 `/auth/admin/{realm-name}/console` "
+"のURLでアクセスできます。特定のユーザー・ロール・マッピングを割り当てることによって、そのレルム内のユーザーにレルム管理パーミッションを与えることができます。"
+
+#. type: Plain text
+msgid ""
+"Each realm has a built-in client called `realm-management`.  You can view "
+"this client by going to the `Clients` left menu item of your realm.  This "
+"client defines client-level roles that specify permissions that can be "
+"granted to manage the realm."
+msgstr ""
+"各レルムには、 `realm-management` という名前のビルトイン・クライアントがあります。レルムの左メニュー項目の `Clients` "
+"をクリックすることでこのクライアントを見ることができます。このクライアントは、レルムを管理するパーミッションを指定するクライアントレベルのロールを定義します。"
+
+#. type: Plain text
 msgid "manage-events"
 msgstr "manage-events"
 
@@ -92,9 +98,3 @@ msgstr "view-identity-providers"
 #. type: Plain text
 msgid "manage-identity-providers"
 msgstr "manage-identity-providers"
-
-#. type: Plain text
-msgid ""
-"Assign the roles you want to your users and they will only be able to use "
-"that specific part of the administration console."
-msgstr "ユーザーに必要なロールを割り当てると、管理コンソールの特定の部分のみを使用できます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/admin-console-permissions/per-realm.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__admin-console-permissions__per-realm
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
