### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/proc-evaluating-client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-evaluating-client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-evaluating-client-scopes.ja_JP.po
@@ -1,0 +1,87 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid ""
+"The *Mappers* tab contains the protocol mappers and the *Scope* tab contains"
+" the role scope mappings declared for this client. They do not contain the "
+"mappers and scope mappings inherited from client scopes. It is possible to "
+"see the effective protocol mappers (that is the protocol mappers defined on "
+"the client itself as well as inherited from the linked client scopes) and "
+"the effective role scope mappings used when generating a token for a client."
+msgstr ""
+"マッパー*タブにはプロトコルマッパーが、*スコープ*タブにはこのクライアント用に宣言されたロールスコープマッピングが含まれます。クライアントのスコープから継承されたマッパーとスコープマッピングは含まれません。クライアントのトークンを生成するときに使用される有効なプロトコルマッパー（クライアント自身で定義されたプロトコルマッパーおよびリンクされたクライアントスコープから継承されたプロトコルマッパー）および有効なロールスコープマッピングを確認することは可能です。"
+
+#. type: Plain text
+msgid "Click the *Client Scopes* tab for the client."
+msgstr "クライアントの *Client Scopes* タブをクリックします。"
+
+#. type: Plain text
+msgid "Open the sub-tab *Evaluate*."
+msgstr "サブタブ *Evaluate* を開きます。"
+
+#. type: Plain text
+msgid "Select the optional client scopes that you want to apply."
+msgstr "適用したいオプションのクライアントスコープを選択します。"
+
+#. type: Plain text
+msgid ""
+"This will also show you the value of the *scope* parameter. This parameter "
+"needs to be sent from the application to the {project_name} OpenID Connect "
+"authorization endpoint."
+msgstr ""
+"これは、*scope*パラメータの値も表示されます。このパラメータは、アプリケーションから {project_name} OpenID Connect "
+"認証エンドポイントに送信される必要があります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Evaluating client scopes"
+msgstr "クライアントのスコープを評価する"
+
+#. type: Plain text
+msgid "image:{project_images}/client-scopes-evaluate.png[]"
+msgstr "image:{project_images}/client-scopes-evaluate.png[]"
+
+#. type: delimited block =
+msgid ""
+"To send a custom value for a *scope* parameter from your application, see "
+"the link:{adapterguide_link_latest}#_params_forwarding[parameters forwarding"
+" section], for servlet adapters or the "
+"link:{adapterguide_link_latest}#_javascript_adapter[javascript adapter "
+"section], for javascript adapters."
+msgstr ""
+"アプリケーションから *scope* パラメータにカスタム値を送るには、 servlet アダプタについては "
+"link:{adapterguide_link_latest}#_params_forwarding[parameters forwarding "
+"section] を、 javascript アダプタについては "
+"link:{adapterguide_link_latest}#_javascript_adapter[javascript adapter "
+"section] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"All examples are generated for the particular user and issued for the "
+"particular client, with the specified value of the *scope* parameter. The "
+"examples include all of the claims and role mappings used."
+msgstr ""
+"すべてのサンプルは、特定のユーザーに対して生成され、特定のクライアントに対して、*scope*パラメータの指定値で発行されます。例には、使用されたすべてのクレームとロールマッピングが含まれます。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-evaluating-client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-evaluating-client-scopes.ja_JP.po
@@ -40,7 +40,7 @@ msgstr "クライアントの *Client Scopes* タブをクリックします。"
 
 #. type: Plain text
 msgid "Open the sub-tab *Evaluate*."
-msgstr "サブタブ *Evaluate* を開きます。"
+msgstr "*Evaluate* サブタブを開きます。"
 
 #. type: Plain text
 msgid "Select the optional client scopes that you want to apply."
@@ -52,13 +52,13 @@ msgid ""
 "needs to be sent from the application to the {project_name} OpenID Connect "
 "authorization endpoint."
 msgstr ""
-"これは、*scope*パラメータの値も表示されます。このパラメータは、アプリケーションから {project_name} OpenID Connect "
-"認証エンドポイントに送信される必要があります。"
+"これは、 *scope* パラメーターの値も表示されます。このパラメーターは、アプリケーションから{project_name} OpenID "
+"Connect認可エンドポイントに送信される必要があります。"
 
 #. type: Block title
 #, no-wrap
 msgid "Evaluating client scopes"
-msgstr "クライアントのスコープを評価する"
+msgstr "クライアント・スコープの評価"
 
 #. type: Plain text
 msgid "image:{project_images}/client-scopes-evaluate.png[]"
@@ -72,11 +72,11 @@ msgid ""
 "link:{adapterguide_link_latest}#_javascript_adapter[javascript adapter "
 "section], for javascript adapters."
 msgstr ""
-"アプリケーションから *scope* パラメータにカスタム値を送るには、 servlet アダプタについては "
-"link:{adapterguide_link_latest}#_params_forwarding[parameters forwarding "
-"section] を、 javascript アダプタについては "
-"link:{adapterguide_link_latest}#_javascript_adapter[javascript adapter "
-"section] を参照してください。"
+"アプリケーションから *scope* パラメーターにカスタム値を送るには、 サーブレット・アダプターについては "
+"link:{adapterguide_link_latest}#_params_forwarding[パラメーター転送のセクション]を、JavaScript"
+" アダプターについては "
+"link:{adapterguide_link_latest}#_javascript_adapter[JavaScriptアダプターのセクション] "
+"を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -84,4 +84,5 @@ msgid ""
 "particular client, with the specified value of the *scope* parameter. The "
 "examples include all of the claims and role mappings used."
 msgstr ""
-"すべてのサンプルは、特定のユーザーに対して生成され、特定のクライアントに対して、*scope*パラメータの指定値で発行されます。例には、使用されたすべてのクレームとロールマッピングが含まれます。"
+"すべてのサンプルは、特定のユーザーに対して生成され、特定のクライアントに対して、 *scope* "
+"パラメーターの指定値で発行されます。例には、使用されたすべてのクレームとロールマッピングが含まれます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/proc-evaluating-client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__proc-evaluating-client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
