### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-creating-user.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-creating-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-creating-user.ja_JP.po
@@ -49,15 +49,15 @@ msgid ""
 "by those users. Avoid creating users in the master realm, which is only "
 "intended for creating other realms."
 msgstr ""
-"ユーザは、そのユーザが必要とするアプリケーションを持つ予定のレルムに作成します。他のレルムを作成するためだけのマスターレルムにユーザーを作成することは避けてください。"
+"ユーザーは、そのユーザーが必要とするアプリケーションを持つ予定のレルムに作成します。他のレルムを作成するためだけのmasterレルムにユーザーを作成することは避けてください。"
 
 #. type: Plain text
 msgid "You are in a realm other than the master realm."
-msgstr "あなたはマスター領域以外の領域にいるのです。"
+msgstr "masterレルム以外のレルムを選択します。"
 
 #. type: Plain text
 msgid "Click *Add User*."
-msgstr "ユーザーの追加」をクリックします。"
+msgstr "*Add User* をクリックします。"
 
 #. type: Plain text
 msgid "Enter the details for the new user."
@@ -66,7 +66,7 @@ msgstr "新しいユーザーの詳細を入力します。"
 #. type: Plain text
 #, no-wrap
 msgid "*Username* is the only required field.\n"
-msgstr "*ユーザー名*は唯一の必須項目です。\n"
+msgstr "*Username* は唯一の必須項目です。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -78,26 +78,26 @@ msgstr "\n"
 msgid ""
 "Click *Save*. After saving the details, the *Management* page for the new "
 "user is displayed.  \n"
-msgstr "保存］をクリックします。詳細を保存すると、新しいユーザーの*Management*ページが表示されます。  \n"
+msgstr "*Save* をクリックします。詳細を保存すると、新しいユーザーの *Management* ページが表示されます。  \n"
 
 #. type: Plain text
 msgid "Toggle *Email Verified* to *ON*."
-msgstr "Email Verified*を*ON*に切り替えます。"
+msgstr "*Email Verified* を *ON* に切り替えます。"
 
 #. type: Plain text
 msgid "In the *Credentials* tab, set the password in both fields."
-msgstr "認証情報*タブで、両方のフィールドにパスワードを設定します。"
+msgstr "*Credentials* タブで、両方のフィールドにパスワードを設定します。"
 
 #. type: Plain text
 msgid ""
 "Toggle *Temporary* to *OFF* to avoid resetting the password during the next "
 "log in."
-msgstr "Temporary*を*OFF*に切り替えると、次回のログイン時にパスワードがリセットされるのを防ぐことができます。"
+msgstr ":Temporary* を *OFF* に切り替えると、次回のログイン時にパスワードがリセットされるのを防ぐことができます。"
 
 #. type: Plain text
 msgid "Click *Reset Password*."
-msgstr "パスワードのリセット］をクリックします。"
+msgstr "*Reset Password* をクリックします。"
 
 #. type: Plain text
 msgid "Click *Change Password*."
-msgstr "パスワードの変更」をクリックします。"
+msgstr "*Change Password* をクリックします。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-creating-user.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-creating-user.ja_JP.po
@@ -1,0 +1,103 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title =
+#, no-wrap
+msgid "Creating a user"
+msgstr "ユーザーの作成"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Users* in the menu."
+msgstr "メニューの *Users* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Prerequisite"
+msgstr "前提条件"
+
+#. type: Plain text
+msgid ""
+"You create users in the realm where you intend to have applications needed "
+"by those users. Avoid creating users in the master realm, which is only "
+"intended for creating other realms."
+msgstr ""
+"ユーザは、そのユーザが必要とするアプリケーションを持つ予定のレルムに作成します。他のレルムを作成するためだけのマスターレルムにユーザーを作成することは避けてください。"
+
+#. type: Plain text
+msgid "You are in a realm other than the master realm."
+msgstr "あなたはマスター領域以外の領域にいるのです。"
+
+#. type: Plain text
+msgid "Click *Add User*."
+msgstr "ユーザーの追加」をクリックします。"
+
+#. type: Plain text
+msgid "Enter the details for the new user."
+msgstr "新しいユーザーの詳細を入力します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Username* is the only required field.\n"
+msgstr "*ユーザー名*は唯一の必須項目です。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "\n"
+msgstr "\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Click *Save*. After saving the details, the *Management* page for the new "
+"user is displayed.  \n"
+msgstr "保存］をクリックします。詳細を保存すると、新しいユーザーの*Management*ページが表示されます。  \n"
+
+#. type: Plain text
+msgid "Toggle *Email Verified* to *ON*."
+msgstr "Email Verified*を*ON*に切り替えます。"
+
+#. type: Plain text
+msgid "In the *Credentials* tab, set the password in both fields."
+msgstr "認証情報*タブで、両方のフィールドにパスワードを設定します。"
+
+#. type: Plain text
+msgid ""
+"Toggle *Temporary* to *OFF* to avoid resetting the password during the next "
+"log in."
+msgstr "Temporary*を*OFF*に切り替えると、次回のログイン時にパスワードがリセットされるのを防ぐことができます。"
+
+#. type: Plain text
+msgid "Click *Reset Password*."
+msgstr "パスワードのリセット］をクリックします。"
+
+#. type: Plain text
+msgid "Click *Change Password*."
+msgstr "パスワードの変更」をクリックします。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-creating-user.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-creating-user
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
