### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-enabling-recaptcha.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-recaptcha.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-recaptcha.ja_JP.po
@@ -1,0 +1,156 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# katakura__pro <h.katakura@pro-japan.co.jp>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Flows* tab."
+msgstr "*Flows* タブをクリックします。"
+
+#. type: Plain text
+msgid "Click *Realm Settings* in the menu."
+msgstr "メニューの *Realm Settings* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Security Defenses* tab."
+msgstr "*Security Defenses* タブをクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Enabling reCAPTCHA"
+msgstr "reCAPTCHAを有効にする"
+
+#. type: Plain text
+msgid ""
+"To safeguard registration against bots, {project_name} has integration with "
+"Google reCAPTCHA."
+msgstr "ボットからの登録を保護するために、{project_name} は Google reCAPTCHA と統合しています。"
+
+#. type: Plain text
+msgid ""
+"Once reCAPTCHA is enabled, you can edit `register.ftl` in your login theme "
+"to configure the placement and styling of the reCAPTCHA button on the "
+"registration page."
+msgstr ""
+"reCAPTCHAを有効にすると、ログインテーマ内の `register.ftl` "
+"を編集して、登録ページでのreCAPTCHAボタンの配置とスタイルを設定することができます。"
+
+#. type: Plain text
+msgid "Enter the following URL in a browser:"
+msgstr "ブラウザで次のURLを入力します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "https://developers.google.com/recaptcha/\n"
+msgstr "https://developers.google.com/recaptcha/\n"
+
+#. type: Plain text
+msgid ""
+"Create an API key to get your reCAPTCHA site key and secret. Note the "
+"reCAPTCHA site key and secret for future use in this procedure."
+msgstr ""
+"APIキーを作成し、reCAPTCHAサイトのキーとシークレットを取得します。この手順で使用するため、reCAPTCHAサイトのキーとシークレットをメモしておいてください。"
+
+#. type: Plain text
+msgid "The localhost works by default. You do not have to specify a domain."
+msgstr "localhostはデフォルトで動作します。ドメインは指定する必要はありません。"
+
+#. type: Plain text
+msgid "Navigate to the {project_name} admin console."
+msgstr "管理コンソール{project_name}に移動します。"
+
+#. type: Plain text
+msgid "Select *Registration* from the drop down menu."
+msgstr "ドロップダウンメニューから*Registration*を選択します。"
+
+#. type: Plain text
+msgid "Set the *reCAPTCHA* requirement to *Required*. This enables reCAPTCHA."
+msgstr "reCAPTCHA*の要件を*Required*に設定します。これにより、reCAPTCHAが有効になります。"
+
+#. type: Plain text
+msgid "Click *Actions* to the right of the reCAPTCHA flow entry."
+msgstr "reCAPTCHAフローの項目の右側にある*Actions*をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Config* link."
+msgstr "Config*」リンクをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Recaptcha config page"
+msgstr "Recaptchaの設定ページ"
+
+#. type: Plain text
+msgid "image:{project_images}/recaptcha-config.png[]"
+msgstr "image:{project_images}/recaptcha-config.png[]"
+
+#. type: Plain text
+msgid ""
+"Enter the *Recaptcha Site Key* generated from the Google reCAPTCHA website."
+msgstr "Google reCAPTCHAのウェブサイトから生成された*Recaptcha Site Key*を入力してください。"
+
+#. type: Plain text
+msgid ""
+"Enter the *Recaptcha Secret* generated from the Google reCAPTCHA website."
+msgstr "Google reCAPTCHAのウェブサイトから生成された*Recaptcha Secret*を入力してください。"
+
+#. type: Plain text
+msgid "Authorize Google to use the registration page as an iframe."
+msgstr "Googleが登録ページをiframeとして使用することを許可する。"
+
+#. type: Plain text
+msgid ""
+"In {project_name}, websites cannot include a login page dialog in an iframe."
+" This restriction is to prevent clickjacking attacks. You need to change the"
+" default HTTP response headers that is set in {project_name}."
+msgstr ""
+"project_name}では、Webサイトがiframe内にログインページのダイアログを含めることができません。この制限は、クリックジャッキング攻撃を防止するためのものです。project_name}で設定されているデフォルトのHTTPレスポンスヘッダを変更する必要があります。"
+
+#. type: Plain text
+msgid ""
+"Enter `https://www.google.com` in the field for the *X-Frame-Options* "
+"header."
+msgstr "X-Frame-Options*ヘッダーのフィールドに`https://www.google.com`と入力します。"
+
+#. type: Plain text
+msgid ""
+"Enter `https://www.google.com` in the field for the *Content-Security-"
+"Policy* header."
+msgstr "Content-Security-Policy*ヘッダーのフィールドに`https://www.google.com`と入力します。"
+
+#. type: Plain text
+msgid ""
+"For more information on extending and creating themes, see the "
+"link:{developerguide_link}[{developerguide_name}]."
+msgstr ""
+"テーマの拡張と作成の詳細については、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-recaptcha.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-enabling-recaptcha.ja_JP.po
@@ -48,13 +48,13 @@ msgstr "*Security Defenses* タブをクリックします。"
 #. type: Title =
 #, no-wrap
 msgid "Enabling reCAPTCHA"
-msgstr "reCAPTCHAを有効にする"
+msgstr "reCAPTCHAの有効化"
 
 #. type: Plain text
 msgid ""
 "To safeguard registration against bots, {project_name} has integration with "
 "Google reCAPTCHA."
-msgstr "ボットからの登録を保護するために、{project_name} は Google reCAPTCHA と統合しています。"
+msgstr "ボットからの登録を保護するために、{project_name}はGoogle reCAPTCHA と統合しています。"
 
 #. type: Plain text
 msgid ""
@@ -67,7 +67,7 @@ msgstr ""
 
 #. type: Plain text
 msgid "Enter the following URL in a browser:"
-msgstr "ブラウザで次のURLを入力します。"
+msgstr "ブラウザーで次のURLを入力します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -87,23 +87,23 @@ msgstr "localhostはデフォルトで動作します。ドメインは指定す
 
 #. type: Plain text
 msgid "Navigate to the {project_name} admin console."
-msgstr "管理コンソール{project_name}に移動します。"
+msgstr "{project_name}の管理コンソールに移動します。"
 
 #. type: Plain text
 msgid "Select *Registration* from the drop down menu."
-msgstr "ドロップダウンメニューから*Registration*を選択します。"
+msgstr "ドロップダウンメニューから *Registration* を選択します。"
 
 #. type: Plain text
 msgid "Set the *reCAPTCHA* requirement to *Required*. This enables reCAPTCHA."
-msgstr "reCAPTCHA*の要件を*Required*に設定します。これにより、reCAPTCHAが有効になります。"
+msgstr "*reCAPTCHA* の要件を *Required* に設定します。これにより、reCAPTCHAが有効になります。"
 
 #. type: Plain text
 msgid "Click *Actions* to the right of the reCAPTCHA flow entry."
-msgstr "reCAPTCHAフローの項目の右側にある*Actions*をクリックします。"
+msgstr "reCAPTCHAフローの項目の右側にある *Actions* をクリックします。"
 
 #. type: Plain text
 msgid "Click the *Config* link."
-msgstr "Config*」リンクをクリックします。"
+msgstr "*Config* のリンクをクリックします。"
 
 #. type: Block title
 #, no-wrap
@@ -117,16 +117,16 @@ msgstr "image:{project_images}/recaptcha-config.png[]"
 #. type: Plain text
 msgid ""
 "Enter the *Recaptcha Site Key* generated from the Google reCAPTCHA website."
-msgstr "Google reCAPTCHAのウェブサイトから生成された*Recaptcha Site Key*を入力してください。"
+msgstr "Google reCAPTCHAのウェブサイトから生成された *Recaptcha Site Key* を入力してください。"
 
 #. type: Plain text
 msgid ""
 "Enter the *Recaptcha Secret* generated from the Google reCAPTCHA website."
-msgstr "Google reCAPTCHAのウェブサイトから生成された*Recaptcha Secret*を入力してください。"
+msgstr "Google reCAPTCHAのウェブサイトから生成された *Recaptcha Secret* を入力してください。"
 
 #. type: Plain text
 msgid "Authorize Google to use the registration page as an iframe."
-msgstr "Googleが登録ページをiframeとして使用することを許可する。"
+msgstr "Googleが登録ページをiframeとして使用することを認可します。"
 
 #. type: Plain text
 msgid ""
@@ -134,23 +134,25 @@ msgid ""
 " This restriction is to prevent clickjacking attacks. You need to change the"
 " default HTTP response headers that is set in {project_name}."
 msgstr ""
-"project_name}では、Webサイトがiframe内にログインページのダイアログを含めることができません。この制限は、クリックジャッキング攻撃を防止するためのものです。project_name}で設定されているデフォルトのHTTPレスポンスヘッダを変更する必要があります。"
+"{project_name}では、Webサイトがiframe内にログインページのダイアログを含めることができません。この制限は、クリックジャッキング攻撃を防止するためのものです。{project_name}で設定されているデフォルトのHTTPレスポンス・ヘッダーを変更する必要があります。"
 
 #. type: Plain text
 msgid ""
 "Enter `https://www.google.com` in the field for the *X-Frame-Options* "
 "header."
-msgstr "X-Frame-Options*ヘッダーのフィールドに`https://www.google.com`と入力します。"
+msgstr "*X-Frame-Options* ヘッダーのフィールドに `https://www.google.com` と入力します。"
 
 #. type: Plain text
 msgid ""
 "Enter `https://www.google.com` in the field for the *Content-Security-"
 "Policy* header."
-msgstr "Content-Security-Policy*ヘッダーのフィールドに`https://www.google.com`と入力します。"
+msgstr ""
+"*Content-Security-Policy* ヘッダーのフィールドに `https://www.google.com` と入力します。"
 
 #. type: Plain text
 msgid ""
 "For more information on extending and creating themes, see the "
 "link:{developerguide_link}[{developerguide_name}]."
 msgstr ""
-"テーマの拡張と作成の詳細については、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
+"テーマの拡張と作成の詳細については、 link:{developerguide_link}[{developerguide_name}] "
+"を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-enabling-recaptcha.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-enabling-recaptcha
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
