### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/ref-saml-vs-oidc.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/ref-saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/ref-saml-vs-oidc.ja_JP.po
@@ -1,0 +1,89 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ===
+#, no-wrap
+msgid "OpenID Connect compared to SAML"
+msgstr "OpenID ConnectとSAMLの比較"
+
+#. type: Plain text
+msgid ""
+"The following lists a number of factors to consider when choosing a "
+"protocol."
+msgstr "以下に、プロトコルを選択する際に考慮すべきいくつかの要素を列挙する。"
+
+#. type: Plain text
+msgid "For most purposes, {project_name} recommends using OIDC."
+msgstr "ほとんどの場合、{project_name}はOIDCの使用を推奨しています。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*OIDC*\n"
+msgstr "*OIDC*\n"
+
+#. type: Plain text
+msgid "OIDC is specifically designed to work with the web."
+msgstr "OIDCはウェブとの連携に特化して設計されています。"
+
+#. type: Plain text
+msgid ""
+"OIDC is suited for HTML5/JavaScript applications because it is easier to "
+"implement on the client side than SAML."
+msgstr "OIDCは、SAMLに比べてクライアント側での実装が容易なため、HTML5/JavaScriptアプリケーションに向いています。"
+
+#. type: Plain text
+msgid ""
+"OIDC tokens are in the JSON format which makes them easier for Javascript to"
+" consume."
+msgstr "OIDCトークンはJSON形式であるため、Javascriptで簡単に利用することができます。"
+
+#. type: Plain text
+msgid ""
+"OIDC has features to make security implementation easier. For example, see "
+"the link:https://openid.net/specs/openid-connect-"
+"session-1_0.html#ChangeNotification[iframe trick] that the specification "
+"uses to determine a users login status."
+msgstr ""
+"OIDCは、セキュリティの実装を容易にするための機能を備えています。例えば、ユーザーのログイン状態を判断するために仕様が使用している "
+"link:https://openid.net/specs/openid-connect-"
+"session-1_0.html#ChangeNotification[iframe trick] をご覧ください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*SAML*\n"
+msgstr "*SAML*\n"
+
+#. type: Plain text
+msgid "SAML is designed as a layer to work on top of the web."
+msgstr "SAMLは、Webの上で動作するレイヤーとして設計されています。"
+
+#. type: Plain text
+msgid "SAML can be more verbose than OIDC."
+msgstr "SAMLは、OIDCよりも冗長である可能性がある。"
+
+#. type: Plain text
+msgid ""
+"Users pick SAML over OIDC because there is a perception that it is mature."
+msgstr "ユーザーがOIDCよりSAMLを選ぶのは、SAMLが成熟しているという認識があるからです。"
+
+#. type: Plain text
+msgid ""
+"Users pick SAML over OIDC existing applications that are secured with it."
+msgstr "ユーザーは、SAMLで保護されたOIDCの既存アプリケーションよりも、SAMLを選ぶのです。"

--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/ref-saml-vs-oidc.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/ref-saml-vs-oidc.ja_JP.po
@@ -27,7 +27,7 @@ msgstr "OpenID ConnectとSAMLの比較"
 msgid ""
 "The following lists a number of factors to consider when choosing a "
 "protocol."
-msgstr "以下に、プロトコルを選択する際に考慮すべきいくつかの要素を列挙する。"
+msgstr "以下に、プロトコルを選択する際に考慮すべきいくつかの要素を列挙します。"
 
 #. type: Plain text
 msgid "For most purposes, {project_name} recommends using OIDC."
@@ -52,7 +52,7 @@ msgstr "OIDCは、SAMLに比べてクライアント側での実装が容易な�
 msgid ""
 "OIDC tokens are in the JSON format which makes them easier for Javascript to"
 " consume."
-msgstr "OIDCトークンはJSON形式であるため、Javascriptで簡単に利用することができます。"
+msgstr "OIDCのトークンはJSON形式であるため、JavaScriptで簡単に利用することができます。"
 
 #. type: Plain text
 msgid ""
@@ -61,9 +61,9 @@ msgid ""
 "session-1_0.html#ChangeNotification[iframe trick] that the specification "
 "uses to determine a users login status."
 msgstr ""
-"OIDCは、セキュリティの実装を容易にするための機能を備えています。例えば、ユーザーのログイン状態を判断するために仕様が使用している "
+"OIDCは、セキュリティーの実装を容易にするための機能を備えています。たとえば、ユーザーのログイン状態を判断するために仕様が使用している "
 "link:https://openid.net/specs/openid-connect-"
-"session-1_0.html#ChangeNotification[iframe trick] をご覧ください。"
+"session-1_0.html#ChangeNotification[iframe trick] を参照してください。"
 
 #. type: Plain text
 #, no-wrap
@@ -76,7 +76,7 @@ msgstr "SAMLは、Webの上で動作するレイヤーとして設計されて�
 
 #. type: Plain text
 msgid "SAML can be more verbose than OIDC."
-msgstr "SAMLは、OIDCよりも冗長である可能性がある。"
+msgstr "SAMLは、OIDCよりも冗長である可能性があります。"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/ref-saml-vs-oidc.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__ref-saml-vs-oidc
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
