### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/proc-setting-default-required-actions.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/proc-setting-default-required-actions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-setting-default-required-actions.ja_JP.po
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Required Actions* tab."
+msgstr "*Required Actions* タブをクリックします。"
+
+#. type: Title =
+#, no-wrap
+msgid "Setting required actions for all users"
+msgstr "全ユーザーに必要なアクションを設定する"
+
+#. type: Plain text
+msgid ""
+"You can specify what actions are required before the first login of all new "
+"users. The requirements apply to a user created by the *Add User* button on "
+"the *Users* page or the *Register* link on the login page."
+msgstr ""
+"すべての新規ユーザーの初回ログイン前に必要なアクションを指定することができます。この条件は、*Users*ページの*Add "
+"User*ボタン、またはログインページの*Register*リンクで作成されたユーザーに適用されます。"
+
+#. type: Plain text
+msgid ""
+"Click the checkbox in the *Default Action* column for one or more required "
+"actions. When a new user logs in for the first time, the selected actions "
+"must be executed."
+msgstr ""
+"1つ以上の必要なアクションの*Default Action* "
+"欄のチェックボックスをクリックします。新規ユーザーの初回ログイン時には、選択したアクションを実行する必要があります。"

--- a/i18n/po/ja_JP/server_admin/topics/users/proc-setting-default-required-actions.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/proc-setting-default-required-actions.ja_JP.po
@@ -34,7 +34,7 @@ msgstr "*Required Actions* タブをクリックします。"
 #. type: Title =
 #, no-wrap
 msgid "Setting required actions for all users"
-msgstr "全ユーザーに必要なアクションを設定する"
+msgstr "全ユーザーへの必須アクションの設定"
 
 #. type: Plain text
 msgid ""
@@ -42,8 +42,8 @@ msgid ""
 "users. The requirements apply to a user created by the *Add User* button on "
 "the *Users* page or the *Register* link on the login page."
 msgstr ""
-"すべての新規ユーザーの初回ログイン前に必要なアクションを指定することができます。この条件は、*Users*ページの*Add "
-"User*ボタン、またはログインページの*Register*リンクで作成されたユーザーに適用されます。"
+"すべての新規ユーザーの初回ログイン前に必要なアクションを指定することができます。この条件は、 *Users* ページの *Add User* "
+"ボタン、またはログインページの *Register* リンクで作成されたユーザーに適用されます。"
 
 #. type: Plain text
 msgid ""
@@ -51,5 +51,5 @@ msgid ""
 "actions. When a new user logs in for the first time, the selected actions "
 "must be executed."
 msgstr ""
-"1つ以上の必要なアクションの*Default Action* "
-"欄のチェックボックスをクリックします。新規ユーザーの初回ログイン時には、選択したアクションを実行する必要があります。"
+"1つ以上の必須アクションの *Default Action* "
+"列のチェックボックスをクリックします。新規ユーザーの初回ログイン時には、選択したアクションを実行する必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/proc-setting-default-required-actions.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__proc-setting-default-required-actions
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
