### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles-groups/proc-specifying-default-groups.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-specifying-default-groups.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-specifying-default-groups.ja_JP.po
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Using default groups"
+msgstr "デフォルト・グループの使用"
+
+#. type: Plain text
+msgid ""
+"To automatically assign group membership to any users who is created or who "
+"is imported through <<_identity_broker, Identity Brokering>>, you use "
+"default groups."
+msgstr ""
+"作成されたユーザーや<<_identity_broker, "
+"アイデンティティー・ブローカリング>>でインポートされたユーザーに自動的にグループメンバーを割り当てるには、デフォルト・グループを使用します。"
+
+#. type: Plain text
+msgid "Click *Groups* in the menu."
+msgstr "メニューの *Groups* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Default Groups* tab."
+msgstr "*Default Groups* タブをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Default groups"
+msgstr "デフォルト・グループ"
+
+#. type: Plain text
+msgid "image:{project_images}/default-groups.png[Default groups]"
+msgstr "image:{project_images}/default-groups.png[Default groups]"
+
+#. type: Plain text
+msgid "This screenshot shows that some _default groups_ already exist."
+msgstr "このスクリーン・ショットは、いくつかの _default groups_ が既に存在していることを示しています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles-groups/proc-specifying-default-groups.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles-groups__proc-specifying-default-groups
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
