### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles-groups/proc-converting-composite-roles.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-converting-composite-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-converting-composite-roles.ja_JP.po
@@ -1,0 +1,87 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Title =
+#, no-wrap
+msgid "Converting a role to a composite role"
+msgstr "ロールを複合ロールに変換する"
+
+#. type: Plain text
+msgid ""
+"Any realm or client level role can become a _composite role_. A _composite "
+"role_ is a role that has one or more additional roles associated with it. "
+"When a composite role is mapped to a user, the user gains the roles "
+"associated with the composite role.  This inheritance is recursive so users "
+"also inherit any composite of composites. However, we recommend that "
+"composite roles are not overused."
+msgstr ""
+"レルムまたはクライアントレベルのロールはすべて、_composite "
+"role_になることができます。複合ロールとは、1つまたは複数の追加ロールを関連付けたロールのことです。複合ロールがユーザにマップされると、そのユーザは複合ロールに関連付けられたロールを継承します。"
+"  この継承は再帰的であるため、ユーザは複合ロールの複合ロールをも継承します。ただし、複合ロールは使いすぎないようにすることをお勧めします。"
+
+#. type: Plain text
+msgid "Click *Roles* in the menu."
+msgstr "メニューの*役割*をクリックします。"
+
+#. type: Plain text
+msgid "Click the role that you want to convert."
+msgstr "変換するロールをクリックします。"
+
+#. type: Plain text
+msgid "Toggle *Composite Roles* to *ON*."
+msgstr "Composite Roles*を*ON*にトグルします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Composite role"
+msgstr "複合的な役割"
+
+#. type: Plain text
+msgid "image:{project_images}/composite-role.png[Composite role]"
+msgstr "image:{project_images}/composite-role.png[Composite role]"
+
+#. type: Plain text
+msgid ""
+"The role selection UI is displayed on the page and you can associate realm "
+"level and client level roles to the composite role you are creating."
+msgstr "ロール選択UIが表示され、作成中の複合ロールにレルムレベルとクライアントレベルのロールを関連付けることができます。"
+
+#. type: Plain text
+msgid ""
+"In this example, the *employee* realm-level role is associated with the "
+"*developer* composite role.  Any user with the *developer* role also "
+"inherits the *employee* role."
+msgstr ""
+"この例では、*employee*レルムレベルロールは*developer*複合ロールと関連付けられています。  developer* "
+"ロールを持つユーザは、 *employee* ロールも継承します。"
+
+#. type: delimited block =
+msgid ""
+"When creating tokens and SAML assertions, any composite also has its "
+"associated roles added to the claims and assertions of the authentication "
+"response sent back to the client."
+msgstr ""
+"トークンおよび SAML "
+"アサーションを作成する場合、どのコンポジットでも、関連するロールがクライアントに返される認証レスポンスのクレームおよびアサーションに追加される。"

--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-converting-composite-roles.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-converting-composite-roles.ja_JP.po
@@ -37,13 +37,12 @@ msgid ""
 "also inherit any composite of composites. However, we recommend that "
 "composite roles are not overused."
 msgstr ""
-"レルムまたはクライアントレベルのロールはすべて、_composite "
-"role_になることができます。複合ロールとは、1つまたは複数の追加ロールを関連付けたロールのことです。複合ロールがユーザにマップされると、そのユーザは複合ロールに関連付けられたロールを継承します。"
-"  この継承は再帰的であるため、ユーザは複合ロールの複合ロールをも継承します。ただし、複合ロールは使いすぎないようにすることをお勧めします。"
+"レルムレベルまたはクライアントレベルのロールはすべて、 _複合ロール_ "
+"にすることができます。複合ロールとは、1つ以上のロールを関連付けたロールのことです。複合ロールがユーザーにマップされると、そのユーザーは複合ロールに関連付けられたロールを継承します。この継承は再帰的であるため、ユーザーは複合ロールの複合ロールをも継承します。ただし、複合ロールは使いすぎないようにすることをお勧めします。"
 
 #. type: Plain text
 msgid "Click *Roles* in the menu."
-msgstr "メニューの*役割*をクリックします。"
+msgstr "メニューの *Roles* をクリックします。"
 
 #. type: Plain text
 msgid "Click the role that you want to convert."
@@ -51,12 +50,12 @@ msgstr "変換するロールをクリックします。"
 
 #. type: Plain text
 msgid "Toggle *Composite Roles* to *ON*."
-msgstr "Composite Roles*を*ON*にトグルします。"
+msgstr "*Composite Roles* を *ON* にします。"
 
 #. type: Block title
 #, no-wrap
 msgid "Composite role"
-msgstr "複合的な役割"
+msgstr "複合ロール"
 
 #. type: Plain text
 msgid "image:{project_images}/composite-role.png[Composite role]"
@@ -66,7 +65,7 @@ msgstr "image:{project_images}/composite-role.png[Composite role]"
 msgid ""
 "The role selection UI is displayed on the page and you can associate realm "
 "level and client level roles to the composite role you are creating."
-msgstr "ロール選択UIが表示され、作成中の複合ロールにレルムレベルとクライアントレベルのロールを関連付けることができます。"
+msgstr "ロールを選択するUIが表示され、作成中の複合ロールにレルムレベルとクライアントレベルのロールを関連付けることができます。"
 
 #. type: Plain text
 msgid ""
@@ -74,8 +73,8 @@ msgid ""
 "*developer* composite role.  Any user with the *developer* role also "
 "inherits the *employee* role."
 msgstr ""
-"この例では、*employee*レルムレベルロールは*developer*複合ロールと関連付けられています。  developer* "
-"ロールを持つユーザは、 *employee* ロールも継承します。"
+"この例では、 *employee* レルムレベルロールは *developer* 複合ロールと関連付けられています。 *developer* "
+"ロールを持つユーザーは、 *employee* ロールも継承します。"
 
 #. type: delimited block =
 msgid ""
@@ -83,5 +82,4 @@ msgid ""
 "associated roles added to the claims and assertions of the authentication "
 "response sent back to the client."
 msgstr ""
-"トークンおよび SAML "
-"アサーションを作成する場合、どのコンポジットでも、関連するロールがクライアントに返される認証レスポンスのクレームおよびアサーションに追加される。"
+"トークンおよびSAMLアサーションを作成する場合、どの複合ロールでも、関連するロールがクライアントに返される認証レスポンスのクレームおよびアサーションに追加されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles-groups/proc-converting-composite-roles.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles-groups__proc-converting-composite-roles
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
