### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sessions/transient.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sessions/transient.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/transient.ja_JP.po
@@ -21,7 +21,7 @@ msgstr ""
 #. type: Title ===
 #, no-wrap
 msgid "Transient sessions"
-msgstr "Transient sessions"
+msgstr "トランジェント・セッション"
 
 #. type: Plain text
 msgid ""
@@ -32,11 +32,8 @@ msgid ""
 "{project_name} can run <<_protocol-mappers, protocol mappers>> using "
 "transient sessions after authentication."
 msgstr ""
-"project_name}では、トランジェントセッションを行うことができます。一時的なセッションを使用する場合、{project_name} "
-"は認証に成功した後にユーザー セッションを作成しません。{project_name} "
-"は、ユーザー認証に成功した現在の要求の範囲に一時的な過渡的セッションを作成します。{project_name} は、<_protocol-"
-"mappers, protocol mappers>認証後に一時的なセッションを使用して</_protocol-mappers,>&lt;&gt; "
-"を実行することができます。"
+"{project_name}では、トランジェント・セッションを使用することができます。トランジェント・セッションを使用する場合、{project_name}は認証に成功した後にユーザー・セッションを作成しません。{project_name}は、ユーザー認証に成功した現在のリクエストのスコープに一時的なトランジェント・セッションを作成します。{project_name}は、認証後にトランジェント・セッションを使用して<<_protocol-"
+"mappers, プロトコル・マッパー>>を実行することができます。"
 
 #. type: Plain text
 msgid ""
@@ -46,4 +43,4 @@ msgid ""
 "user sessions. This session saves performance, memory, and network "
 "communication (in cluster and cross-data center environments) resources."
 msgstr ""
-"一時的なセッションの間、クライアントアプリケーションはトークンのリフレッシュ、トークンのイントロスペクト、または特定のセッションの検証を行うことができません。これらのアクションが不要な場合もあるため、ユーザーセッションを永続化することによるリソースの追加使用を避けることができます。このセッションは、パフォーマンス、メモリ、およびネットワーク通信（クラスタおよびクロスデータセンター環境）リソースを節約します。"
+"トランジェント・セッションの間、クライアント・アプリケーションはトークンのリフレッシュ、トークンのイントロスペクト、または特定のセッションの検証を行うことができません。これらのアクションが不要な場合もあるため、ユーザー・セッションを永続化することによるリソースの追加使用を避けることができます。このセッションは、パフォーマンス、メモリー、およびネットワーク通信（クラスターおよびクロス・データセンター環境）のリソースを節約します。"

--- a/i18n/po/ja_JP/server_admin/topics/sessions/transient.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sessions/transient.ja_JP.po
@@ -4,14 +4,13 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,23 +25,25 @@ msgstr "Transient sessions"
 
 #. type: Plain text
 msgid ""
-"{project_name} has concept of transient sessions. When transient sessions "
-"are used, there is no real user session created after successful "
-"authentication.  Only a temporary transient session is created for the scope"
-" of the current request that successfully authenticated the user. This "
-"transient session allows {project_name} to run <<_protocol-mappers, protocol"
-" mappers>> after the authentication."
+"You can conduct transient sessions in {project_name}. When using transient "
+"sessions, {project_name} does not create a user session after successful "
+"authentication. {project_name} creates a temporary, transient session for "
+"the scope of the current request that successfully authenticates the user. "
+"{project_name} can run <<_protocol-mappers, protocol mappers>> using "
+"transient sessions after authentication."
 msgstr ""
-"{project_name}には一時的セッションの概念があります。一時的セッションが使用される場合、認証が成功した後に作成される実際のユーザー・セッションはありません。ユーザーの認証に成功した現在のリクエストのスコープに対して、一時的セッションのみが作成されます。この一時的なセッションにより、{project_name}は認証後に"
-"<<_protocol-mappers, protocol mappers>>を実行できます。"
+"project_name}では、トランジェントセッションを行うことができます。一時的なセッションを使用する場合、{project_name} "
+"は認証に成功した後にユーザー セッションを作成しません。{project_name} "
+"は、ユーザー認証に成功した現在の要求の範囲に一時的な過渡的セッションを作成します。{project_name} は、<_protocol-"
+"mappers, protocol mappers>認証後に一時的なセッションを使用して</_protocol-mappers,>&lt;&gt; "
+"を実行することができます。"
 
 #. type: Plain text
 msgid ""
-"When transient sessions are used, the client application has no way to "
-"refresh or introspect the token or check if a specific session is valid.  In"
-" some situations, these actions are not needed, so you can avoid the "
-"additional overhead for persistence of user sessions.  This would mean the "
-"save of performance, memory and network communication (in case of cluster "
-"and cross-datacenter environments)."
+"During transient sessions, the client application cannot refresh tokens, "
+"introspect tokens, or validate a specific session. Sometimes these actions "
+"are unnecessary, so you can avoid the additional resource use of persisting "
+"user sessions. This session saves performance, memory, and network "
+"communication (in cluster and cross-data center environments) resources."
 msgstr ""
-"一時的セッションが使用されている場合、クライアント・アプリケーションには、トークンをリフレッシュまたはイントロスペクトしたり、特定のセッションが有効かどうかを確認したりする方法がありません。状況によっては、これらのアクションが不要な場合があるため、ユーザー・セッションを永続化するための追加のオーバーヘッドを回避できます。これは、パフォーマンス、メモリ、およびネットワーク通信の節約を意味します（クラスターおよびクロスデータセンター環境の場合）。"
+"一時的なセッションの間、クライアントアプリケーションはトークンのリフレッシュ、トークンのイントロスペクト、または特定のセッションの検証を行うことができません。これらのアクションが不要な場合もあるため、ユーザーセッションを永続化することによるリソースの追加使用を避けることができます。このセッションは、パフォーマンス、メモリ、およびネットワーク通信（クラスタおよびクロスデータセンター環境）リソースを節約します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sessions/transient.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sessions__transient
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
