### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2021
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Title =
 #, no-wrap
 msgid "Enabling account deletion by users"
 msgstr "ユーザーによるアカウント削除の有効化"
@@ -79,8 +79,8 @@ msgid "Finally, select `delete-account` and click on add selected."
 msgstr "最後に、 `delete-account` を選択し、 \"Add selected\" をクリックします。"
 
 #. type: Plain text
-msgid "image:images/delete-account-client-role.png[]"
-msgstr "image:images/delete-account-client-role.png[]"
+msgid "Image:images/delete-account-client-role.png[]"
+msgstr "Image:images/delete-account-client-role.png[]"
 
 #. type: Title ===
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/users/allow-user-to-delete-account.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__users__allow-user-to-delete-account
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
