### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,26 +21,26 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ====
+#. type: Title =
 #, no-wrap
-msgid "IDP Initiated Login"
-msgstr "IDP Initiated ログイン"
+msgid "IDP Initiated login"
+msgstr "IDP イニシエーションログイン"
 
 #. type: Plain text
 msgid ""
 "IDP Initiated Login is a feature that allows you to set up an endpoint on "
 "the {project_name} server that will log you into a specific "
-"application/client.  In the `Settings` tab for your client, you need to "
-"specify the `IDP Initiated SSO URL Name`.  This is a simple string with no "
+"application/client.  In the *Settings* tab for your client, you need to "
+"specify the *IDP Initiated SSO URL Name*.  This is a simple string with no "
 "whitespace in it.  After this you can reference your client at the following"
 " URL: `root/auth/realms/{realm}/protocol/saml/clients/{url-name}`"
 msgstr ""
 "IDP Initiated "
-"ログインは、特定のアプリケーション／クライアントにログインするエンドポイントを{project_name}サーバーに設定できるようにする機能です。クライアントの"
-" `Settings` タブで、 `IDP Initiated SSO URL Name` "
-"を指定する必要があります。これは空白を含まない単純な文字列です。その後、 "
-"`root/auth/realms/{realm}/protocol/saml/clients/{url-name}` "
-"のURLでクライアントを参照することができます  。"
+"Loginは、特定のアプリケーション/クライアントにログインするエンドポイントを{project_name}サーバーに設定できる機能です。  "
+"クライアントの *Settings* タブで、*IDP Initiated SSO URL Name* を指定する必要があります。  "
+"これは、空白を含まない単純な文字列です。  "
+"この後、以下のURLでクライアントを参照することができます。root/auth/realms/{realm}/protocol/saml/clients/{url-"
+"name}` となります。"
 
 #. type: Plain text
 msgid ""
@@ -54,44 +54,43 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"If the specific `Assertion Consumer Service POST Binding URL` is defined "
-"(inside `Fine Grain SAML Endpoint Configuration` section of the client "
+"If the specific *Assertion Consumer Service POST Binding URL* is defined "
+"(inside *Fine Grain SAML Endpoint Configuration* section of the client "
 "settings) _POST_ binding is used through that URL."
 msgstr ""
-"特定の `Assertion Consumer Service POST Binding URL` が（クライアント設定の `Fine Grain "
-"SAML Endpoint Configuration` セクション内に）定義されている場合、_POST_ "
-"バインディングはそのURLを介して使用されます。"
+"特定の *Assertion Consumer Service POST Binding URL* が定義されている場合 (クライアント設定の "
+"*Fine Grain SAML Endpoint Configuration* セクション内)、その URL を介して _POST_ "
+"バインディングが使用される。"
 
 #. type: Plain text
 msgid ""
-"If the general `Master SAML Processing URL` is specified then _POST_ binding"
+"If the general *Master SAML Processing URL* is specified then _POST_ binding"
 " is used again throught this general URL."
 msgstr ""
-"一般的な `Master SAML Processing URL` が指定されている場合は、この一般的なURLを介して _POST_ "
-"バインディングが再度使用されます。"
+"一般的な *Master SAML Processing URL* が指定されている場合、_POST_ バインディングは、この一般的な URL "
+"を介して再度使用される。"
 
 #. type: Plain text
 msgid ""
-"As the last resort, if the `Assertion Consumer Service Redirect Binding URL`"
-" is configured (inside `Fine Grain SAML Endpoint Configuration`) _REDIRECT_ "
+"As the last resort, if the *Assertion Consumer Service Redirect Binding URL*"
+" is configured (inside *Fine Grain SAML Endpoint Configuration*) _REDIRECT_ "
 "binding is used with this URL."
 msgstr ""
-"最後の手段として、 `Assertion Consumer Service Redirect Binding URL` が（ `Fine Grain "
-"SAML Endpoint Configuration` 内に）設定されている場合、このURLとともに _REDIRECT_ "
-"バインディングが使用されます。"
+"最後の手段として、*Assertion Consumer Service Redirect Binding URL* が構成されている場合（*Fine "
+"Grain SAML Endpoint Configuration* 内）、この URL で _REDIRECT_ バインディングが使用される。"
 
 #. type: Plain text
 msgid ""
 "If your client requires a special relay state, you can also configure this "
-"on the `Settings` tab in the `IDP Initiated SSO Relay State` field.  "
-"Alternatively, browsers can specify the relay state in a `RelayState` query "
+"on the *Settings* tab in the *IDP Initiated SSO Relay State* field.  "
+"Alternatively, browsers can specify the relay state in a *RelayState* query "
 "parameter, i.e.  `root/auth/realms/{realm}/protocol/saml/clients/{url-"
 "name}?RelayState=thestate`."
 msgstr ""
-"クライアントが特別なリレーステートを必要とする場合は、 `IDP Initiated SSO Relay State` フィールドの "
-"`Settings` タブでこれを設定することもできます。あるいはブラウザーは `RelayState` クエリー・パラメーター "
+"クライアントが特別なリレー状態を必要とする場合、*Settings* タブの *IDP Initiated SSO Relay State* "
+"フィールドでこれを構成することもできます。  また、ブラウザは *RelayState* クエリパラメータでリレー状態を指定することもできます（例： "
 "`root/auth/realms/{realm}/protocol/saml/clients/{url-"
-"name}?RelayState=thestate` でリレーステートを指定することができます。"
+"name}?RelayState=thestate`."
 
 #. type: Plain text
 msgid ""
@@ -110,23 +109,24 @@ msgstr ""
 "Initiated ログイン・エンドポイントを代理します。つまり、外部IDPのクライアント設定では次のようになります。"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`IDP Initiated SSO URL Name` is set to a name that will be published as IDP "
-"Initiated Login initial point,"
+"*IDP Initiated SSO URL Name* is set to a name that will be published as IDP "
+"Initiated Login initial point,\n"
 msgstr ""
-"`IDP Initiated SSO URL Name` は、IDP Initiated "
-"ログインのイニシャル・ポイントとして公開される名前に設定されます。"
+"*IDP Initiated SSO URL Name*には、IDP Initiated "
+"Loginの初期ポイントとして公開される名前が設定されます。\n"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"`Assertion Consumer Service POST Binding URL` in the `Fine Grain SAML "
-"Endpoint Configuration` section has to be set to the following URL: `broker-"
-"root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-"
-"id}`, where:"
+"*Assertion Consumer Service POST Binding URL* in the *Fine Grain SAML Endpoint Configuration* section has\n"
+"to be set to the following URL:\n"
+"`broker-root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-id}`, where:\n"
 msgstr ""
-"`Fine Grain SAML Endpoint Configuration` 欄の `Assertion Consumer Service POST"
-" Binding URL` は `broker-root/auth/realms/{broker-realm}/broker/{idp-"
-"name}/endpoint/clients/{client-id}` のURLで設定する必要があります。URLの詳細は次のとおりです。"
+"*Fine Grain SAML Endpoint Configuration* セクションの *Assertion Consumer Service POST Binding URL* は、以下の URL に設定する必要があります。\n"
+"には、次の URL を設定する必要があります。\n"
+"broker-root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-id}`, where.に設定する必要があります。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -134,12 +134,12 @@ msgid ""
 "** _broker-root_ is base broker URL\n"
 "** _broker-realm_ is name of the realm at broker where external IDP is declared\n"
 "** _idp-name_ is name of the external IDP at broker\n"
-"** _client-id_ is the value of `IDP Initiated SSO URL Name` attribute of the SAML client defined at broker. It is\n"
+"** _client-id_ is the value of *IDP Initiated SSO URL Name* attribute of the SAML client defined at broker. It is\n"
 msgstr ""
-"** _broker-root_ はベースブローカーURLです。\n"
-"** _broker-realm_ は外部IDPが宣言されているブローカーのレルムの名前です。\n"
-"** _idp-name_ はブローカーでの外部IDPの名前です。\n"
-"** _client-id_ は、ブローカーで定義されたSAMLクライアントの `IDP Initiated SSO URL Name` 属性の値です。\n"
+"** _broker-root_ はベースブローカー URL です。\n"
+"** _broker-realm_ は、外部 IDP が宣言されているブローカー側のレルム名です。\n"
+"** _idp-name_ は、ブローカーでの外部 IDP の名前です。\n"
+"** _client-id_ は、ブローカーで定義された SAML クライアントの *IDP Initiated SSO URL Name* 属性の値です。です。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -153,8 +153,8 @@ msgid ""
 "Please note that you can import basic client settings from the brokering IDP"
 " into client settings of the external IDP - just use "
 "<<_identity_broker_saml_sp_descriptor,SP Descriptor>> available from the "
-"settings of the identity provider in the brokering IDP, and add `clients"
-"/_client-id_` to the endpoint URL."
+"settings of the identity provider in the brokering IDP, and add "
+"`clients/_client-id_` to the endpoint URL."
 msgstr ""
 "基本的なクライアント設定をブローカリングIDPから外部IDPのクライアント設定にインポートすることができます。ブローカリングIDPのアイデンティティー・プロバイダーの設定から利用可能な<<_identity_broker_saml_sp_descriptor,SP"
 " 記述子>>を使用し、 `clients/_client-id_` をエンドポイントURLに追加します。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po
@@ -24,7 +24,7 @@ msgstr ""
 #. type: Title =
 #, no-wrap
 msgid "IDP Initiated login"
-msgstr "IDP イニシエーションログイン"
+msgstr "IDP Initiated Login"
 
 #. type: Plain text
 msgid ""
@@ -36,11 +36,10 @@ msgid ""
 " URL: `root/auth/realms/{realm}/protocol/saml/clients/{url-name}`"
 msgstr ""
 "IDP Initiated "
-"Loginは、特定のアプリケーション/クライアントにログインするエンドポイントを{project_name}サーバーに設定できる機能です。  "
-"クライアントの *Settings* タブで、*IDP Initiated SSO URL Name* を指定する必要があります。  "
-"これは、空白を含まない単純な文字列です。  "
-"この後、以下のURLでクライアントを参照することができます。root/auth/realms/{realm}/protocol/saml/clients/{url-"
-"name}` となります。"
+"Loginは、特定のアプリケーション/クライアントにログインするエンドポイントを{project_name}サーバーに設定できる機能です。クライアントの"
+" *Settings* タブで、*IDP Initiated SSO URL Name* "
+"を指定する必要があります。これは、空白を含まない単純な文字列です。この後、次のURLでクライアントを参照することができます。 "
+"`root/auth/realms/{realm}/protocol/saml/clients/{url-name}` "
 
 #. type: Plain text
 msgid ""
@@ -59,16 +58,16 @@ msgid ""
 "settings) _POST_ binding is used through that URL."
 msgstr ""
 "特定の *Assertion Consumer Service POST Binding URL* が定義されている場合 (クライアント設定の "
-"*Fine Grain SAML Endpoint Configuration* セクション内)、その URL を介して _POST_ "
-"バインディングが使用される。"
+"*Fine Grain SAML Endpoint Configuration* セクション内に)、そのURLを介して _POST_  "
+"バインディングが使用されます。"
 
 #. type: Plain text
 msgid ""
 "If the general *Master SAML Processing URL* is specified then _POST_ binding"
 " is used again throught this general URL."
 msgstr ""
-"一般的な *Master SAML Processing URL* が指定されている場合、_POST_ バインディングは、この一般的な URL "
-"を介して再度使用される。"
+"一般的な *Master SAML Processing URL* が指定されている場合、_POST_ "
+"バインディングは、この一般的なURLを介して再度使用されます。"
 
 #. type: Plain text
 msgid ""
@@ -76,8 +75,8 @@ msgid ""
 " is configured (inside *Fine Grain SAML Endpoint Configuration*) _REDIRECT_ "
 "binding is used with this URL."
 msgstr ""
-"最後の手段として、*Assertion Consumer Service Redirect Binding URL* が構成されている場合（*Fine "
-"Grain SAML Endpoint Configuration* 内）、この URL で _REDIRECT_ バインディングが使用される。"
+"最後の手段として、*Assertion Consumer Service Redirect Binding URL* が設定されている場合（*Fine "
+"Grain SAML Endpoint Configuration* 内）、このURLで _REDIRECT_ バインディングが使用されます。"
 
 #. type: Plain text
 msgid ""
@@ -87,10 +86,11 @@ msgid ""
 "parameter, i.e.  `root/auth/realms/{realm}/protocol/saml/clients/{url-"
 "name}?RelayState=thestate`."
 msgstr ""
-"クライアントが特別なリレー状態を必要とする場合、*Settings* タブの *IDP Initiated SSO Relay State* "
-"フィールドでこれを構成することもできます。  また、ブラウザは *RelayState* クエリパラメータでリレー状態を指定することもできます（例： "
+"クライアントが特別なリレーステートを必要とする場合、 *Settings* タブの *IDP Initiated SSO Relay State* "
+"フィールドでこれを設定することもできます。また、ブラウザーは *RelayState* "
+"クエリー・パラメーターでリレーステートを指定することもできます（例：  "
 "`root/auth/realms/{realm}/protocol/saml/clients/{url-"
-"name}?RelayState=thestate`."
+"name}?RelayState=thestate` "
 
 #. type: Plain text
 msgid ""
@@ -114,7 +114,7 @@ msgid ""
 "*IDP Initiated SSO URL Name* is set to a name that will be published as IDP "
 "Initiated Login initial point,\n"
 msgstr ""
-"*IDP Initiated SSO URL Name*には、IDP Initiated "
+"*IDP Initiated SSO URL Name* には、IDP Initiated "
 "Loginの初期ポイントとして公開される名前が設定されます。\n"
 
 #. type: Plain text
@@ -124,9 +124,8 @@ msgid ""
 "to be set to the following URL:\n"
 "`broker-root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-id}`, where:\n"
 msgstr ""
-"*Fine Grain SAML Endpoint Configuration* セクションの *Assertion Consumer Service POST Binding URL* は、以下の URL に設定する必要があります。\n"
-"には、次の URL を設定する必要があります。\n"
-"broker-root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-id}`, where.に設定する必要があります。\n"
+"*Fine Grain SAML Endpoint Configuration* のセクションの *Assertion Consumer Service POST Binding URL* は、以下のURLに設定する必要があります。\n"
+"`broker-root/auth/realms/{broker-realm}/broker/{idp-name}/endpoint/clients/{client-id}`\n"
 
 #. type: Plain text
 #, no-wrap
@@ -137,9 +136,9 @@ msgid ""
 "** _client-id_ is the value of *IDP Initiated SSO URL Name* attribute of the SAML client defined at broker. It is\n"
 msgstr ""
 "** _broker-root_ はベースブローカー URL です。\n"
-"** _broker-realm_ は、外部 IDP が宣言されているブローカー側のレルム名です。\n"
-"** _idp-name_ は、ブローカーでの外部 IDP の名前です。\n"
-"** _client-id_ は、ブローカーで定義された SAML クライアントの *IDP Initiated SSO URL Name* 属性の値です。です。\n"
+"** _broker-realm_ は、外部IDPが宣言されているブローカー側のレルム名です。\n"
+"** _idp-name_ は、ブローカーでの外部IDPの名前です。\n"
+"** _client-id_ は、ブローカーで定義されたSAMLクライアントの *IDP Initiated SSO URL Name* 属性の値です。\n"
 
 #. type: Plain text
 #, no-wrap


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/saml/idp-initiated-login.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__saml__idp-initiated-login
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
