### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/proc-creating-client-scopes.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-client-scopes.ja_JP.po
@@ -1,0 +1,64 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid "Click *Create*."
+msgstr "*Create* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "To create a client scope, follow these steps:"
+msgstr "クライアント・スコープを作成するには、次の手順を実行します。"
+
+#. type: Plain text
+msgid "Click *Client Scopes* in the menu."
+msgstr "メニューの*Client Scopes*をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Client scopes list"
+msgstr "クライアントスコープの一覧"
+
+#. type: Plain text
+msgid "image:{project_images}/client-scopes-list.png[]"
+msgstr "image:{project_images}/client-scopes-list.png[]"
+
+#. type: Plain text
+msgid "Name your client scope."
+msgstr "クライアントの範囲を指定します。"
+
+#. type: Plain text
+msgid ""
+"A _client scope_ has similar tabs to regular clients. You can define "
+"<<_protocol-mappers, protocol mappers>> and <<_role_scope_mappings, role "
+"scope mappings>>. These mappings can be inherited by other clients and are "
+"configured to inherit from this client scope."
+msgstr ""
+"クライアントスコープ_は、通常のクライアントと同様のタブを持ちます。<_protocol-mappers, protocol "
+"mappers>&lt;&gt;と&lt;&gt;を</_protocol-mappers,>定義することができます<_protocol-"
+"mappers, protocol mappers><_role_scope_mappings, role scope "
+"mappings>。</_role_scope_mappings,></_protocol-mappers,><_protocol-mappers, "
+"protocol mappers><_role_scope_mappings, role scope "
+"mappings></_role_scope_mappings,></_protocol-"
+"mappers,>これらのマッピングは他のクライアントに継承させることができ、このクライアントスコープから継承するように設定されます。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-client-scopes.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/proc-creating-client-scopes.ja_JP.po
@@ -33,12 +33,12 @@ msgstr "クライアント・スコープを作成するには、次の手順を
 
 #. type: Plain text
 msgid "Click *Client Scopes* in the menu."
-msgstr "メニューの*Client Scopes*をクリックします。"
+msgstr "メニューの *Client Scopes* をクリックします。"
 
 #. type: Block title
 #, no-wrap
 msgid "Client scopes list"
-msgstr "クライアントスコープの一覧"
+msgstr "クライアント・スコープの一覧"
 
 #. type: Plain text
 msgid "image:{project_images}/client-scopes-list.png[]"
@@ -46,7 +46,7 @@ msgstr "image:{project_images}/client-scopes-list.png[]"
 
 #. type: Plain text
 msgid "Name your client scope."
-msgstr "クライアントの範囲を指定します。"
+msgstr "クライアント・スコープを指定します。"
 
 #. type: Plain text
 msgid ""
@@ -55,10 +55,6 @@ msgid ""
 "scope mappings>>. These mappings can be inherited by other clients and are "
 "configured to inherit from this client scope."
 msgstr ""
-"クライアントスコープ_は、通常のクライアントと同様のタブを持ちます。<_protocol-mappers, protocol "
-"mappers>&lt;&gt;と&lt;&gt;を</_protocol-mappers,>定義することができます<_protocol-"
-"mappers, protocol mappers><_role_scope_mappings, role scope "
-"mappings>。</_role_scope_mappings,></_protocol-mappers,><_protocol-mappers, "
-"protocol mappers><_role_scope_mappings, role scope "
-"mappings></_role_scope_mappings,></_protocol-"
-"mappers,>これらのマッピングは他のクライアントに継承させることができ、このクライアントスコープから継承するように設定されます。"
+"クライアントスコープ_は、通常のクライアントと同様のタブを持ちます。 <<_protocol-mappers, プロトコル・マッパー>> と "
+"<_role_scope_mappings, ロール・スコープ・マッピング>> "
+"を定義することができます。これらのマッピングは他のクライアントに継承させることができ、このクライアント・スコープから継承するように設定されます。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/proc-creating-client-scopes.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__proc-creating-client-scopes
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
