### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -45,9 +45,7 @@ msgid ""
 "production environments. {project_name} has a set of password policies "
 "available through the Admin Console."
 msgstr ""
-"project_name} がレルムを作成するとき、パスワード "
-"ポリシーをレルムに関連付けません。長さ、セキュリティ、複雑さに制限のない単純なパスワードを設定することができます。単純なパスワードは、実稼働環境では受け入れられません。{project_name}"
-" には、管理者コンソールで利用可能なパスワード ポリシーのセットがあります。"
+"{project_name}がレルムを作成するとき、パスワード・ポリシーをレルムに関連付けません。長さ、セキュリティー、複雑さに制限のない単純なパスワードを設定できます。単純なパスワードは、プロダクション環境では受け入れられません。{project_name}には、管理コンソールで利用可能なパスワード・ポリシーのセットがあります。"
 
 #. type: Plain text
 msgid "Click the *Password Policy* tab."
@@ -60,7 +58,7 @@ msgstr "追加するポリシーを *Add policy* ドロップダウン・ボッ�
 #. type: Plain text
 msgid ""
 "Enter a value for the *Policy Value* corresponding with the policy chosen."
-msgstr "選択したポリシーに対応する*Policy Value*に値を入力します。"
+msgstr "選択したポリシーに対応する *Policy Value* に値を入力します。"
 
 #. type: Plain text
 msgid ""
@@ -74,8 +72,7 @@ msgid ""
 "and sets an Update Password action for existing users to ensure they change "
 "their password the next time they log in. For example:"
 msgstr ""
-"ポリシーを保存した後、{project_name} "
-"は新しいユーザーに対してポリシーを適用し、既存のユーザーに対しては、次回ログイン時にパスワードが変更されるようにパスワードの更新アクションを設定します。たとえば、次のようになります。"
+"ポリシーを保存した後、{project_name}は新しいユーザーに対してポリシーを適用し、既存のユーザーに対しては、次回ログイン時にパスワードが変更されるようにパスワードの更新アクションを設定します。たとえば、次のようになります。"
 
 #. type: Block title
 #, no-wrap
@@ -106,15 +103,15 @@ msgid ""
 "link:{developerguide_link}[{developerguide_name}] on how to add your own "
 "hashing algorithm."
 msgstr ""
-"パスワードは平文で保存されない。保存や検証の前に、{project_name} は標準的なハッシュアルゴリズムでパスワードをハッシュします。PBKDF2"
-" "
-"は、組み込みで利用可能な唯一のデフォルトのアルゴリズムです。独自のハッシュアルゴリズムを追加する方法については、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
+"パスワードは平文で保存されません。保存や検証の前に、{project_name}は標準的なハッシュ・アルゴリズムでパスワードをハッシュします。PBKDF2"
+" は、組み込みで利用可能な唯一のデフォルトのアルゴリズムです。独自のハッシュアルゴリズムを追加する方法については、 "
+"link:{developerguide_link}[{developerguide_name}] を参照してください。"
 
 #. type: delimited block =
 msgid ""
 "If you change the hashing algorithm, password hashes in storage will not "
 "change until the user logs in."
-msgstr "ハッシュアルゴリズムを変更した場合、ユーザーがログインするまで、ストレージ内のパスワードハッシュは変更されません。"
+msgstr "ハッシュ・アルゴリズムを変更した場合、ユーザーがログインするまで、ストレージ内のパスワード・ハッシュは変更されません。"
 
 #. type: Title =====
 #, no-wrap
@@ -128,8 +125,8 @@ msgid ""
 "{project_name} that support the PBKDF2, PBKDF2-SHA256 and PBKDF-SHA512 "
 "hashing algorithms."
 msgstr ""
-"パスワードは平文で保存されません。保存や検証の前に、{project_name} は、PBKDF2、PBKDF2-SHA256、PBKDF-SHA512"
-" のハッシュ化アルゴリズムをサポートする標準のハッシュ化アルゴリズム {project_name} を使ってパスワードをハッシュ化する。"
+"パスワードは平文で保存されません。保存や検証の前に、{project_name}は、PBKDF2、PBKDF2-SHA256、PBKDF-"
+"SHA512の標準のハッシュ化アルゴリズムを使ってパスワードをハッシュ化します。"
 
 #. type: Title =====
 #, no-wrap
@@ -140,14 +137,14 @@ msgstr "Hashing iterations"
 msgid ""
 "Specifies the number of times {project_name} hashes passwords before storage"
 " or verification. The default value is 27,500."
-msgstr "保存または検証前にパスワードをハッシュ化する回数{project_name} を指定します。初期値は 27,500 回です。"
+msgstr "保存または検証前に{project_name}がパスワードをハッシュ化する回数を指定します。初期値は27,500回です。"
 
 #. type: Plain text
 msgid ""
 "{project_name} hashes passwords to ensure that hostile actors with access to"
 " the password database cannot read passwords through reverse engineering."
 msgstr ""
-"{project_name}は、パスワードデータベースにアクセスできる敵対的な行為者がリバースエンジニアリングによってパスワードを読み取れないようにするためにパスワードをハッシュ化します。"
+"{project_name}は、パスワード・データベースにアクセスできる敵対的な行為者がリバース・エンジニアリングによってパスワードを読み取れないようにするためにパスワードをハッシュ化します。"
 
 #. type: delimited block =
 msgid ""
@@ -240,8 +237,7 @@ msgid ""
 " of used passwords. The number of old passwords stored is configurable in "
 "{project_name}."
 msgstr ""
-"パスワードは、ユーザーが既に使用しているものではありません。{project_name} "
-"は、使用されたパスワードの履歴を保存します。古いパスワードの保存数は{project_name}で設定可能です。"
+"パスワードは、ユーザーが既に使用しているものではありません。{project_name}は、使用されたパスワードの履歴を保存します。古いパスワードの保存数は{project_name}で設定可能です。"
 
 #. type: Title =====
 #, no-wrap
@@ -250,14 +246,14 @@ msgstr "Password blacklist"
 
 #. type: Plain text
 msgid "Password must not be in a blacklist file."
-msgstr "パスワードは、ブラックリストファイルに含まれていてはいけません。"
+msgstr "パスワードは、ブラックリスト・ファイルに含まれていてはいけません。"
 
 #. type: Plain text
 msgid ""
 "Blacklist files are UTF-8 plain-text files with Unix line endings. Every "
 "line represents a blacklisted password."
 msgstr ""
-"ブラックリストファイルは、UTF-8のプレーンテキストファイルで、Unixの行末を使用しています。各行はブラックリストに登録されたパスワードを表します。"
+"ブラックリスト・ファイルは、UTF-8のプレーンなテキストファイルで、Unixの行末を使用しています。各行はブラックリストに登録されたパスワードを表します。"
 
 #. type: Plain text
 msgid ""
@@ -269,7 +265,7 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "The value of the blacklist file must be the name of the blacklist file."
-msgstr "の値は、ブラックリストファイルの名前でなければならない。"
+msgstr "ブラックリスト・ファイルの値は、ブラックリスト・ファイルの名前でなければならない。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po
@@ -4,16 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Shinsuke UEDA, 2017
-# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,242 +19,265 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
 #. type: Title ====
 #, no-wrap
-msgid "Password Policies"
+msgid "Password policies"
 msgstr "パスワード・ポリシー"
 
 #. type: Plain text
 msgid ""
-"Each new realm created has no password policies associated with it.  Users "
-"can have as short, as long, as complex, as insecure a password, as they "
-"want.  Simple settings are fine for development or learning {project_name}, "
-"but unacceptable in production environments.  {project_name} has a rich set "
-"of password policies you can enable through the Admin Console."
+"When {project_name} creates a realm, it does not associate password policies"
+" with the realm. You can set a simple password with no restrictions on its "
+"length, security, or complexity. Simple passwords are unacceptable in "
+"production environments. {project_name} has a set of password policies "
+"available through the Admin Console."
 msgstr ""
-"作成された新しいレルムには、パスワード・ポリシーは関連付けられていません。ユーザーは、短くても長くても、複雑でも、安全でなくても、自分の望むパスワードにすることができます。単純な設定は、{project_name}の開発や学習には問題ありませんが、プロダクション環境では受け入れられません。{project_name}には、管理コンソールから有効にできる豊富なパスワード・ポリシーがあります。"
+"project_name} がレルムを作成するとき、パスワード "
+"ポリシーをレルムに関連付けません。長さ、セキュリティ、複雑さに制限のない単純なパスワードを設定することができます。単純なパスワードは、実稼働環境では受け入れられません。{project_name}"
+" には、管理者コンソールで利用可能なパスワード ポリシーのセットがあります。"
+
+#. type: Plain text
+msgid "Click the *Password Policy* tab."
+msgstr "*Password Policy* タブをクリックします。"
+
+#. type: Plain text
+msgid "Select the policy to add in the *Add policy* drop-down box."
+msgstr "追加するポリシーを *Add policy* ドロップダウン・ボックスで選択します。"
 
 #. type: Plain text
 msgid ""
-"Click on the `Authentication` left menu item and go to the `Password Policy`"
-" tab.  Choose the policy you want to add in the right side drop down list "
-"box.  This will add the policy in the table on the screen.  Choose the "
-"parameters for the policy.  Hit the `Save` button to store your changes."
+"Enter a value for the *Policy Value* corresponding with the policy chosen."
+msgstr "選択したポリシーに対応する*Policy Value*に値を入力します。"
+
+#. type: Plain text
+msgid ""
+"Password policy image:{project_images}/password-policy.png[Password Policy]"
 msgstr ""
-"左メニュー項目の `Authentication` をクリックし、 `Password Policy` "
-"タブに移動します。追加するポリシーを右側のドロップダウン・リストボックスで選択します。これにより、画面上の表にポリシーが追加されます。ポリシーのパラメーターを選択します。"
-" `Save` ボタンをクリックして変更を保存します。"
+"Password policy image:{project_images}/password-policy.png[Password Policy]"
+
+#. type: Plain text
+msgid ""
+"After saving the policy, {project_name} enforces the policy for new users "
+"and sets an Update Password action for existing users to ensure they change "
+"their password the next time they log in. For example:"
+msgstr ""
+"ポリシーを保存した後、{project_name} "
+"は新しいユーザーに対してポリシーを適用し、既存のユーザーに対しては、次回ログイン時にパスワードが変更されるようにパスワードの更新アクションを設定します。たとえば、次のようになります。"
 
 #. type: Block title
 #, no-wrap
-msgid "Password Policy"
-msgstr "パスワード・ポリシー"
-
-#. type: Plain text
-msgid "image:{project_images}/password-policy.png[]"
-msgstr "image:{project_images}/password-policy.png[]"
+msgid "Failed password policy"
+msgstr "Failed password policy"
 
 #. type: Plain text
 msgid ""
-"After saving your policy, user registration and the Update Password required"
-" action will enforce your new policy.  An example of a user failing the "
-"policy check:"
+"image:{project_images}/failed-password-policy.png[Failed Password Policy]"
 msgstr ""
-"ポリシーを保存すると、ユーザー登録とUpdate Passwordの必須アクションが新しいポリシーを施行します。 "
-"例として、ポリシーのチェックに失敗したユーザーは以下のようになります。"
-
-#. type: Block title
-#, no-wrap
-msgid "Failed Password Policy"
-msgstr "パスワード・ポリシーの失敗"
-
-#. type: Plain text
-msgid "image:{project_images}/failed-password-policy.png[]"
-msgstr "image:{project_images}/failed-password-policy.png[]"
-
-#. type: Plain text
-msgid ""
-"If the password policy is updated, an Update Password action must be set for"
-" every user. An automatic trigger is scheduled as a future enhancement."
-msgstr ""
-"パスワード・ポリシーを更新する場合は、すべてのユーザーに対してUpdate "
-"Passwordアクションを設定する必要があります。自動トリガーは将来の拡張として予定されています。"
+"image:{project_images}/failed-password-policy.png[Failed Password Policy]"
 
 #. type: Title ====
 #, no-wrap
-msgid "Password Policy Types"
-msgstr "パスワード・ポリシーのタイプ"
+msgid "Password policy types"
+msgstr "Password policy types"
 
-#. type: Plain text
-msgid "Here's an explanation of each policy type:"
-msgstr "各ポリシータイプの説明は次のとおりです。"
-
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
 msgid "HashAlgorithm"
 msgstr "HashAlgorithm"
 
 #. type: Plain text
 msgid ""
-"Passwords are not stored as clear text. Instead they are hashed using "
-"standard hashing algorithms before they are stored or validated.  The only "
-"built-in and default algorithm available is PBKDF2. See the "
-"link:{developerguide_link}[{developerguide_name}] on how to plug in your own"
-" algorithm. Note that if you do change the algorithm, password hashes will "
-"not change in storage until the next time the user logs in."
+"Passwords are not stored in cleartext. Before storage or validation, "
+"{project_name} hashes passwords using standard hashing algorithms. PBKDF2 is"
+" the only built-in and default algorithm available. See the "
+"link:{developerguide_link}[{developerguide_name}] on how to add your own "
+"hashing algorithm."
 msgstr ""
-"パスワードはクリアーテキストとして保存されません。その代わりに、標準のハッシュ・アルゴリズムを使用してハッシュされ、保存または検証されます。利用可能なビルトイン・アルゴリズムかつデフォルト・アルゴリズムは、PBKDF2のみです。独自のアルゴリズムをプラグインする方法については、link:{developerguide_link}[{developerguide_name}]を参照してください。アルゴリズムを変更すると、次回ユーザーがログインするまでパスワード・ハッシュが変更されません。"
+"パスワードは平文で保存されない。保存や検証の前に、{project_name} は標準的なハッシュアルゴリズムでパスワードをハッシュします。PBKDF2"
+" "
+"は、組み込みで利用可能な唯一のデフォルトのアルゴリズムです。独自のハッシュアルゴリズムを追加する方法については、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
 
-#. type: Labeled list
+#. type: delimited block =
+msgid ""
+"If you change the hashing algorithm, password hashes in storage will not "
+"change until the user logs in."
+msgstr "ハッシュアルゴリズムを変更した場合、ユーザーがログインするまで、ストレージ内のパスワードハッシュは変更されません。"
+
+#. type: Title =====
 #, no-wrap
-msgid "Hashing Algorithm"
-msgstr "Hashing Algorithm"
+msgid "Hashing algorithm"
+msgstr "Hashing algorithm"
 
 #. type: Plain text
 msgid ""
-"Passwords are not stored as clear text. Instead they are hashed using "
-"standard hashing algorithms before they are stored or validated.  Supported "
-"values are pbkdf2, pbkdf2-sha256 and pbkdf2-sha512."
+"Passwords are not stored in clear text. Before storage or validation, "
+"{project_name} hashes passwords using standard hashing algorithms "
+"{project_name} that support the PBKDF2, PBKDF2-SHA256 and PBKDF-SHA512 "
+"hashing algorithms."
 msgstr ""
-"パスワードはクリアーテキストとして保存されません。その代わりに、標準のハッシュ・アルゴリズムを使用してハッシュされ、保存または検証されます。サポートされる値は、pbkdf2、pbkdf2-sha256およびpbkdf2-sha512です。"
+"パスワードは平文で保存されません。保存や検証の前に、{project_name} は、PBKDF2、PBKDF2-SHA256、PBKDF-SHA512"
+" のハッシュ化アルゴリズムをサポートする標準のハッシュ化アルゴリズム {project_name} を使ってパスワードをハッシュ化する。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Hashing Iterations"
-msgstr "Hashing Iterations"
+msgid "Hashing iterations"
+msgstr "Hashing iterations"
 
 #. type: Plain text
 msgid ""
-"This value specifies the number of times a password will be hashed before it"
-" is stored or verified. The default value is 27,500.  This hashing is done "
-"in the rare case that a hacker gets access to your password database. Once "
-"they have access to the database, they can reverse engineer user passwords."
-"  The industry recommended value for this parameter changes every year as "
-"CPU power improves. A higher hashing iteration value takes more CPU power "
-"for hashing, and can impact performance. You'll have to weigh what is more "
-"important to you: performance or protecting your passwords stores.  There "
-"may be more cost effective ways of protecting your password stores."
-msgstr ""
-"この値は、パスワードが保存または検証される前にハッシュされる回数を指定します。デフォルト値は27,500です。このハッシングは、ハッカーがパスワード・データベースにアクセスするまれなケースで行われます。データベースにアクセスすると、ユーザーのパスワードをリバース・エンジニアリングすることができます。このパラメーターの業界推奨値は、CPUパワーが向上するにつれて毎年変化します。ハッシュ反復の値が高いほど、ハッシュに必要なCPUパワーが増え、パフォーマンスに影響を与える可能性があります。パフォーマンスとパスワードストアの保護のどちらを重要視するかは、要件により異なります。もしくは、パスワードストアの保護よりも、費用対効果の高い方法があるかもしれません。"
+"Specifies the number of times {project_name} hashes passwords before storage"
+" or verification. The default value is 27,500."
+msgstr "保存または検証前にパスワードをハッシュ化する回数{project_name} を指定します。初期値は 27,500 回です。"
 
-#. type: Labeled list
+#. type: Plain text
+msgid ""
+"{project_name} hashes passwords to ensure that hostile actors with access to"
+" the password database cannot read passwords through reverse engineering."
+msgstr ""
+"{project_name}は、パスワードデータベースにアクセスできる敵対的な行為者がリバースエンジニアリングによってパスワードを読み取れないようにするためにパスワードをハッシュ化します。"
+
+#. type: delimited block =
+msgid ""
+"A high hashing iteration value can impact performance as it requires higher "
+"CPU power."
+msgstr "ハッシュ化の繰り返し値が大きいと、より高いCPUパワーを必要とするため、パフォーマンスに影響を与える可能性があります。"
+
+#. type: Title =====
 #, no-wrap
 msgid "Digits"
 msgstr "Digits"
 
 #. type: Plain text
-msgid "The number of digits required to be in the password string."
-msgstr "パスワード文字列に必要な桁数。"
+msgid "The number of numerical digits required in the password string."
+msgstr "パスワード文字列に必要な数値の桁数。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Lowercase Characters"
-msgstr "Lowercase Characters"
+msgid "Lowercase characters"
+msgstr "Lowercase characters"
 
 #. type: Plain text
-msgid ""
-"The number of lower case letters required to be in the password string."
+msgid "The number of lower case letters required in the password string."
 msgstr "パスワード文字列に必要な小文字の数。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Uppercase Characters"
-msgstr "Uppercase Characters"
+msgid "Uppercase characters"
+msgstr "Uppercase characters"
 
 #. type: Plain text
-msgid ""
-"The number of upper case letters required to be in the password string."
+msgid "The number of upper case letters required in the password string."
 msgstr "パスワード文字列に必要な大文字の数。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Special Characters"
-msgstr "Special Characters"
+msgid "Special characters"
+msgstr "Special characters"
+
+#. type: Plain text
+msgid "The number of special characters required in the password string."
+msgstr "パスワード文字列に必要な特殊文字の数。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Not username"
+msgstr "Not username"
+
+#. type: Plain text
+msgid "The password cannot be the same as the username."
+msgstr "パスワードはユーザー名と同じにすることはできません。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Not email"
+msgstr "Not email"
+
+#. type: Plain text
+msgid "The password cannot be the same as the email address of the user."
+msgstr "パスワードは、ユーザーの電子メールアドレスと同じにはできません。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Regular expression"
+msgstr "Regular expression"
+
+#. type: Plain text
+msgid "Password must match one or more defined regular expression patterns."
+msgstr "パスワードは、定義された1つ以上の正規表現パターンに一致する必要があります。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Expire password"
+msgstr "Expire password"
 
 #. type: Plain text
 msgid ""
-"The number of special characters like '?!#%$' required to be in the password"
-" string."
-msgstr "パスワード文字列に含める必要がある、'?!#%$'のような特殊文字の数。"
+"The number of days the password is valid. When the number of days has "
+"expired, the user must change their password."
+msgstr "パスワードの有効日数です。日数が過ぎると、ユーザーはパスワードを変更する必要があります。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Not Username"
-msgstr "Not Username"
-
-#. type: Plain text
-msgid "When set, the password is not allowed to be the same as the username."
-msgstr "設定すると、パスワードをユーザー名と同じにすることはできません。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "Not Email"
-msgstr "Not Email"
+msgid "Not recently used"
+msgstr "Not recently used"
 
 #. type: Plain text
 msgid ""
-"When set, the password is not allowed to be the same as the email address."
-msgstr "設定すると、パスワードをメールアドレスと同じにすることができなくなります。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "Regular Expression"
-msgstr "Regular Expression"
-
-#. type: Plain text
-msgid ""
-"Define one or more regular expression patterns (defined in "
-"`java.util.regex.Pattern`) that passwords must match."
+"Password cannot be already used by the user. {project_name} stores a history"
+" of used passwords. The number of old passwords stored is configurable in "
+"{project_name}."
 msgstr ""
-"パスワードが一致する必要のある１つ以上の正規表現パターン（ `java.util.regex.Pattern` で定義される）を定義します。"
+"パスワードは、ユーザーが既に使用しているものではありません。{project_name} "
+"は、使用されたパスワードの履歴を保存します。古いパスワードの保存数は{project_name}で設定可能です。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Expire Password"
-msgstr "Expire Password"
+msgid "Password blacklist"
+msgstr "Password blacklist"
+
+#. type: Plain text
+msgid "Password must not be in a blacklist file."
+msgstr "パスワードは、ブラックリストファイルに含まれていてはいけません。"
 
 #. type: Plain text
 msgid ""
-"The number of days for which the password is valid. After the number of days"
-" has expired, the user is required to change their password."
-msgstr "パスワードが有効な日数。有効期限が切れた後、ユーザーはパスワードを変更する必要があります。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "Not Recently Used"
-msgstr "Not Recently Used"
-
-#. type: Plain text
-msgid ""
-"This policy saves a history of previous passwords. The number of old "
-"passwords stored is configurable. When a user changes their password they "
-"cannot use any stored passwords."
+"Blacklist files are UTF-8 plain-text files with Unix line endings. Every "
+"line represents a blacklisted password."
 msgstr ""
-"このポリシーは、以前のパスワードの履歴を保存します。保存されている古いパスワードの数は設定可能です。ユーザーがパスワードを変更する際に、保存されたパスワードを使用することはできません。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "Password Blacklist"
-msgstr "Password Blacklist"
+"ブラックリストファイルは、UTF-8のプレーンテキストファイルで、Unixの行末を使用しています。各行はブラックリストに登録されたパスワードを表します。"
 
 #. type: Plain text
 msgid ""
-"This policy checks if a given password (converted to lowercase) is contained"
-" in a blacklist file, which is potentially a very large file.  Password "
-"blacklists are UTF-8 plain-text files with Unix line endings where every "
-"line represents a blacklisted password.  All passwords in the blacklist must"
-" be lowercase to facilitate case-insensitive comparison.  The file name of "
-"the blacklist file must be provided as the password policy value, e.g. "
-"`10_million_password_list_top_1000000.txt`.  Blacklist files are resolved "
-"against `${jboss.server.data.dir}/password-blacklists/` by default.  This "
-"path can be customized via the `keycloak.password.blacklists.path` system "
-"property, or the `blacklistsPath` property of the `passwordBlacklist` policy"
-" SPI configuration."
+"{project_name} compares passwords in a case-insensitive manner. All "
+"passwords in the blacklist must be lowercase."
 msgstr ""
-"このポリシーは、与えられたパスワード（小文字に変換されます）がブラックリスト・ファイル（非常に大きなファイルになる可能性があります）に含まれているかどうかをチェックします。パスワード"
-"・ブラックリストはUnixの改行コードを持つUTF-"
-"8プレーンテキスト・ファイルで、各行はブラックリストに載っているパスワードを表します。大文字と小文字を区別しない比較を容易にするために、ブラックリスト内のすべてのパスワードを小文字にする必要があります。ブラックリスト・ファイルのファイル名は、パスワード・ポリシー値として提供されなければなりません。例えば、"
-" `10_million_password_list_top_1000000.txt` です。ブラックリスト・ファイルはデフォルトで "
-"`${jboss.server.data.dir}/password-blacklists/` に対して解決されます。このパスは、 "
-"`keycloak.password.blacklists.path` システム・プロパティー、または `passwordBlacklist` "
-"ポリシーSPI設定の `blacklistsPath` プロパティーによってカスタマイズできます。"
+"{project_name}は、大文字と小文字を区別せずにパスワードを比較します。ブラックリストに登録するパスワードはすべて小文字でなければなりません。"
+
+#. type: Plain text
+msgid ""
+"The value of the blacklist file must be the name of the blacklist file."
+msgstr "の値は、ブラックリストファイルの名前でなければならない。"
+
+#. type: Plain text
+msgid ""
+"Blacklist files resolve against `${jboss.server.data.dir}/password-"
+"blacklists/` by default. Customize this path using: ** The "
+"`keycloak.password.blacklists.path` property.  ** The `blacklistsPath` "
+"property of the `passwordBlacklist` policy SPI configuration."
+msgstr ""
+"ブラックリストファイルは、デフォルトで `${jboss.server.data.dir}/password-blacklists/` "
+"に対して解決されます。このパスをカスタマイズするには** `keycloak.password.blacklists.path` プロパティです。  "
+"** `passwordBlacklist` ポリシー SPI 設定の `blacklistsPath` プロパティです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/password-policies.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__password-policies
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
