### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/con-advanced-settings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-advanced-settings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-advanced-settings.ja_JP.po
@@ -1,0 +1,323 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Advanced settings"
+msgstr "詳細設定"
+
+#. type: Plain text
+msgid "When you click _Advanced Settings_, additional fields are displayed."
+msgstr "詳細設定_をクリックすると、追加項目が表示されます。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*OAuth 2.0 Mutual TLS Certificate Bound Access Tokens Enabled*\n"
+msgstr "*OAuth 2.0 Mutual TLS Certificate Bound Access Tokens Enabled*\n"
+
+#. type: delimited block =
+msgid ""
+"To enable mutual TLS in {project_name}, see <<_enable-mtls-wildfly, Enable "
+"mutual SSL in WildFly>>."
+msgstr ""
+"{project_name}でMutual TLSを有効にするには、<<_enable-mtls-wildfly, WildFlyでMutual "
+"SSLを有効にする>>を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Mutual TLS binds an access token and a refresh token together with a client "
+"certificate, which is exchanged during a TLS handshake. This binding "
+"prevents an attacker from using stolen tokens."
+msgstr ""
+"Mutual "
+"TLSは、アクセストークンとリフレッシュトークンを、TLSハンドシェイク中に交換されるクライアント証明書とともにバインドする。この結合により、攻撃者が盗んだトークンを使用することを防ぐことができます。"
+
+#. type: Plain text
+msgid ""
+"This type of token is a holder-of-key token. Unlike bearer tokens, the "
+"recipient of a holder-of-key token can verify if the sender of the token is "
+"legitimate."
+msgstr ""
+"このタイプのトークンは、Holder-of-Keyトークンです。ベアラ・トークンと異なり、Holder-of-Key "
+"トークンの受信者は、トークンの送信者が正当であるかどうかを検証することができます。"
+
+#. type: Plain text
+msgid "If this setting is on, the workflow is:"
+msgstr "この設定がオンの場合、ワークフローは次のようになります。"
+
+#. type: Plain text
+msgid ""
+"A token request is sent to the token endpoint in an authorization code flow "
+"or hybrid flow."
+msgstr "トークン・リクエストは、認可コード・フローまたはハイブリッド・フローでトークン・エンドポイントに送信されます。"
+
+#. type: Plain text
+msgid "{project_name} requests a client certificate."
+msgstr "{project_name} は、クライアント証明書を要求する。"
+
+#. type: Plain text
+msgid "{project_name} receives the client certificate."
+msgstr "{project_name} は、クライアント証明書を受信する。"
+
+#. type: Plain text
+msgid "{project_name} successfully verifies the client certificate."
+msgstr "{project_name} は、クライアント証明書の検証に成功しました。"
+
+#. type: Plain text
+msgid "If verification fails, {project_name} rejects the token."
+msgstr "検証に失敗した場合、{project_name} はトークンを拒否する。"
+
+#. type: Plain text
+msgid ""
+"In the following cases, {project_name} will verify the client sending the "
+"access token or the refresh token:"
+msgstr "以下の場合、{project_name}はアクセストークンまたはリフレッシュトークンを送信するクライアントを確認します。"
+
+#. type: Plain text
+msgid ""
+"A token refresh request is sent to the token endpoint with a holder-of-key "
+"refresh token."
+msgstr "トークン更新リクエストは、Holder-of-Keyのリフレッシュトークンと共にトークンエンドポイントに送信されます。"
+
+#. type: Plain text
+msgid ""
+"A UserInfo request is sent to UserInfo endpoint with a holder-of-key access "
+"token."
+msgstr "UserInfoリクエストは、Holder-of-Keyアクセストークンを伴ってUserInfoエンドポイントに送信される。"
+
+#. type: Plain text
+msgid ""
+"A logout request is sent to Logout endpoint with a holder-of-key refresh "
+"token."
+msgstr "ログアウト要求は、Holder-of-keyリフレッシュトークンと共にLogoutエンドポイントに送信されます。"
+
+#. type: Plain text
+msgid ""
+"See https://datatracker.ietf.org/doc/html/draft-ietf-oauth-"
+"mtls-08#section-3[Mutual TLS Client Certificate Bound Access Tokens] in the "
+"OAuth 2.0 Mutual TLS Client Authentication and Certificate Bound Access "
+"Tokens for more details."
+msgstr ""
+"詳しくは、OAuth 2.0 相互TLSクライアント認証と証明書バウンドアクセストークンの "
+"https://datatracker.ietf.org/doc/html/draft-ietf-oauth-"
+"mtls-08#section-3[Mutual TLS Client Certificate Bound Access Tokens]をご覧ください。"
+
+#. type: delimited block =
+msgid ""
+"Currently, {project_name} client adapters do not support holder-of-key token"
+" verification. {project_name} adapters treat access and refresh tokens as "
+"bearer tokens."
+msgstr ""
+"現在、{project_name}クライアントアダプタは、Holder-of-Keyトークン検証をサポートしていない。{project_name} "
+"アダプタは、アクセス・トークンとリフレッシュ・トークンをベアラ・トークンとし て扱います。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Proof Key for Code Exchange Code Challenge Method*\n"
+msgstr "*Proof Key for Code Exchange Code Challenge Method*\n"
+
+#. type: Plain text
+msgid ""
+"If an attacker steals an authorization code of a legitimate client, Proof "
+"Key for Code Exchange (PKCE) prevents the attacker from receiving the tokens"
+" that apply to the code."
+msgstr ""
+"攻撃者が正規のクライアントの認証コードを盗んだ場合、Proof Key for Code "
+"Exchange（PKCE）により、そのコードに該当するトークンを攻撃者が受け取ることを防ぐことができます。"
+
+#. type: Plain text
+msgid "An administrator can select one of these options:"
+msgstr "管理者は、これらのオプションのいずれかを選択することができます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*(blank)*"
+msgstr "*(blank)*"
+
+#. type: Plain text
+msgid ""
+"{project_name} does not apply PKCE unless the client sends appropriate PKCE "
+"parameters to {project_name}s authorization endpoint."
+msgstr ""
+"{project_name}は、クライアントが{project_name}の認可エンドポイントに適切なPKCEパラメータを送信しない限り、PKCEを適用しない。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*S256*"
+msgstr "*S256*"
+
+#. type: Plain text
+msgid ""
+"{project_name} applies to the client PKCE whose code challenge method is "
+"S256."
+msgstr "{project_name}は、コードチャレンジ方式がS256であるクライアントPKCEに適用される。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*plain*"
+msgstr "*plain*"
+
+#. type: Plain text
+msgid ""
+"{project_name} applies to the client PKCE whose code challenge method is "
+"plain."
+msgstr "{project_name}は、コードチャレンジ方式がplainであるクライアントPKCEに適用される。"
+
+#. type: Plain text
+msgid ""
+"See https://datatracker.ietf.org/doc/html/rfc7636[RFC 7636 Proof Key for "
+"Code Exchange by OAuth Public Clients] for more details."
+msgstr ""
+"詳しくは https://datatracker.ietf.org/doc/html/rfc7636[RFC 7636 Proof Key for "
+"Code Exchange by OAuth Public Clients]をご覧ください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Signed and Encrypted ID Token Support*\n"
+msgstr "*Signed and Encrypted ID Token Support*\n"
+
+#. type: Plain text
+msgid ""
+"{project_name} can encrypt ID tokens according to the "
+"https://datatracker.ietf.org/doc/html/rfc7516[Json Web Encryption (JWE)] "
+"specification. The administrator determines if ID tokens are encrypted for "
+"each client."
+msgstr ""
+"{project_name} は、https://datatracker.ietf.org/doc/html/rfc7516[Json Web "
+"Encryption (JWE)] の仕様に従って ID "
+"トークンを暗号化することができます。管理者は、クライアントごとにIDトークンを暗号化するかどうかを決定します。"
+
+#. type: Plain text
+msgid ""
+"The key used for encrypting the ID token is the Content Encryption Key "
+"(CEK). {project_name} and a client must negotiate which CEK is used and how "
+"it is delivered. The method used to determine the CEK is the Key Management "
+"Mode. The Key Management Mode that {project_name} supports is Key "
+"Encryption."
+msgstr ""
+"IDトークンの暗号化に使用される鍵は、コンテンツ暗号化鍵（CEK）である。どのCEKを使うか、どのように配信するかは、{project_name} "
+"とクライアントが交渉する必要がある。CEK を決定するために使用される方法は、Key Management Mode "
+"である。project_name}がサポートするKey Management ModeはKey Encryptionである。"
+
+#. type: Plain text
+msgid "In Key Encryption:"
+msgstr "鍵の暗号化で。"
+
+#. type: Plain text
+msgid "The client generates an asymmetric cryptographic key pair."
+msgstr "クライアントは、非対称暗号鍵ペアを生成する。"
+
+#. type: Plain text
+msgid "The public key is used to encrypt the CEK."
+msgstr "公開鍵は、CEK を暗号化するために使用される。"
+
+#. type: Plain text
+msgid "{project_name} generates a CEK per ID token"
+msgstr "{project_name} IDトークンごとにCEKを生成する。"
+
+#. type: Plain text
+msgid "{project_name} encrypts the ID token using this generated CEK"
+msgstr "{project_name} この生成されたCEKを用いてIDトークンを暗号化する。"
+
+#. type: Plain text
+msgid "{project_name} encrypts the CEK using the client's public key."
+msgstr "{project_name}は、クライアントの公開鍵を用いてCEKを暗号化する。"
+
+#. type: Plain text
+msgid "The client decrypts this encrypted CEK using their private key"
+msgstr "クライアントは、この暗号化されたCEKを自分の秘密鍵で復号化する。"
+
+#. type: Plain text
+msgid "The client decrypts the ID token using the decrypted CEK."
+msgstr "クライアントは復号化されたCEKを使用してIDトークンを復号化する。"
+
+#. type: Plain text
+msgid "No party, other than the client, can decrypt the ID token."
+msgstr "クライアント以外の第三者は、IDトークンを復号化することはできない。"
+
+#. type: Plain text
+msgid ""
+"The client must pass its public key for encrypting CEK to {project_name}. "
+"{project_name} supports downloading public keys from a URL provided by the "
+"client. The client must provide public keys according to the "
+"https://datatracker.ietf.org/doc/html/rfc7517[Json Web Keys (JWK)] "
+"specification."
+msgstr ""
+"クライアントはCEKを暗号化するための公開鍵を{project_name}に渡さなければならない。{project_name} "
+"は、クライアントが提供するURLからの公開鍵のダウンロードに対応している。クライアントは "
+"https://datatracker.ietf.org/doc/html/rfc7517[Json Web Keys "
+"(JWK)]の仕様に従った公開鍵を提供しなければならない。"
+
+#. type: Plain text
+msgid "The procedure is:"
+msgstr "その手順とは"
+
+#. type: Plain text
+msgid "Open the client's *Keys* tab."
+msgstr "クライアントの*Keys*タブを開きます。"
+
+#. type: Plain text
+msgid "Toggle *JWKS URL* to ON."
+msgstr "JWKS URL*をONに切り替えます。"
+
+#. type: Plain text
+msgid "Input the client's public key URL in the *JWKS URL* textbox."
+msgstr "JWKS URL* テキストボックスに、クライアントの公開鍵の URL を入力します。"
+
+#. type: Plain text
+msgid ""
+"Key Encryption's algorithms are defined in the "
+"https://datatracker.ietf.org/doc/html/rfc7518#section-4.1[Json Web Algorithm"
+" (JWA)] specification. {project_name} supports:"
+msgstr ""
+"Key "
+"Encryptionのアルゴリズムは、https://datatracker.ietf.org/doc/html/rfc7518#section-4.1[Json"
+" Web Algorithm (JWA)]仕様で定義されています。{project_name} に対応しています。"
+
+#. type: Plain text
+msgid "RSAES-PKCS1-v1_5(RSA1_5)"
+msgstr "RSAES-PKCS1-v1_5(RSA1_5)"
+
+#. type: Plain text
+msgid "RSAES OAEP using default parameters (RSA-OAEP)"
+msgstr "デフォルト・パラメータを使用したRSAES OAEP（RSA-OAEP）。"
+
+#. type: Plain text
+msgid "RSAES OAEP 256 using SHA-256 and MFG1 (RSA-OAEP-256)"
+msgstr "SHA-256とMFG1を用いたRSAES OAEP 256 (RSA-OAEP-256)"
+
+#. type: Plain text
+msgid "The procedure to select the algorithm is:"
+msgstr "アルゴリズムを選択する手順としては"
+
+#. type: Plain text
+msgid "Open the client's *Settings* tab."
+msgstr "クライアントの*Settings*タブを開きます。"
+
+#. type: Plain text
+msgid "Open *Fine Grain OpenID Connect Configuration*."
+msgstr "Fine Grain OpenID Connect Configuration*を開きます。"
+
+#. type: Plain text
+msgid ""
+"Select the algorithm from *ID Token Encryption Content Encryption Algorithm*"
+" pulldown menu."
+msgstr "IDトークン暗号化コンテンツ暗号化アルゴリズム*のプルダウンメニューから、アルゴリズムを選択します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/con-advanced-settings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__con-advanced-settings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
