### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/roles-groups/proc-managing-groups.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-managing-groups.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-managing-groups.ja_JP.po
@@ -115,11 +115,11 @@ msgstr "image:{project_images}/group.png[]"
 msgid ""
 "Attributes and role mappings you define are inherited by the groups and "
 "users that are members of the group."
-msgstr "定義した属性と役割のマッピングは、グループのメンバーであるグループとユーザーに継承されます。"
+msgstr "定義した属性とロールマッピングは、グループのメンバーであるグループとユーザーに継承されます。"
 
 #. type: Plain text
 msgid "To add a user to a group:"
-msgstr "ユーザーをグループに追加するには"
+msgstr "ユーザーをグループに追加するには、以下のようにします。"
 
 #. type: Plain text
 msgid "Click *Groups*."
@@ -136,7 +136,7 @@ msgstr "image:{project_images}/user-groups.png[]"
 
 #. type: Plain text
 msgid "Select a group from the *Available Groups* tree."
-msgstr "Available Groups*ツリーからグループを選択します。"
+msgstr "*Available Groups* ツリーからグループを選択します。"
 
 #. type: Plain text
 msgid "Click *Join*."
@@ -144,11 +144,11 @@ msgstr "*Join* をクリックします。"
 
 #. type: Plain text
 msgid "To remove a group from a user:"
-msgstr "ユーザーからグループを削除するには"
+msgstr "ユーザーからグループを削除するには、以下のようにします。"
 
 #. type: Plain text
 msgid "Select the group from the *Group Membership* tree."
-msgstr "グループメンバー*ツリーからグループを選択します。"
+msgstr "*Group Membership* ツリーからグループを選択します。"
 
 #. type: Plain text
 msgid "Click *Leave*."
@@ -159,8 +159,8 @@ msgid ""
 "In this example, the user _jimlincoln_ is in the _North America_ group.  You"
 " can see _jimlincoln_ displayed under the *Members* tab for the group."
 msgstr ""
-"この例では、ユーザー_jimlincoln_は_North America_グループに所属しています。  "
-"グループの*Members*タブに_jimlincoln_が表示されているのが確認できます。"
+"この例では、ユーザー_jimlincoln_ は _North America_ グループに所属しています。グループの *Members* タブに "
+"_jimlincoln_ が表示されているのが確認できます。"
 
 #. type: Block title
 #, no-wrap

--- a/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-managing-groups.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/roles-groups/proc-managing-groups.ja_JP.po
@@ -1,0 +1,172 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Group"
+msgstr "グループ"
+
+#. type: Plain text
+msgid "Click *New*."
+msgstr "*New* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Users* in the menu."
+msgstr "メニューの *Users* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"Click the user that you want to perform a role mapping on. If the user is "
+"not displayed, click *View all users*."
+msgstr ""
+"ロールマッピングを行いたいユーザーをクリックします。ユーザーが表示されていない場合は、 *View all users* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Groups"
+msgstr "グループ"
+
+#. type: Plain text
+msgid ""
+"Groups in {project_name} manage a common set of attributes and role mappings"
+" for each user. Users can be members of any number of groups and inherit the"
+" attributes and role mappings assigned to each group."
+msgstr ""
+"{project_name}のグループは、各ユーザーの属性とロールマッピングの共通セットを管理します。ユーザーは任意の数のグループのメンバーになることができ、各グループに割り当てられた属性とロールマッピングを継承します。"
+
+#. type: Plain text
+msgid "To manage groups, click *Groups* in the menu."
+msgstr "グループを管理するには、メニューの *Groups* をクリックします。"
+
+#. type: Plain text
+msgid "image:{project_images}/groups.png[]"
+msgstr "image:{project_images}/groups.png[]"
+
+#. type: Plain text
+msgid ""
+"Groups are hierarchical. A group can have multiple subgroups but a group can"
+" have only one parent. Subgroups inherit the attributes and role mappings "
+"from their parent. Users inherit the attributes and role mappings from their"
+" parent as well."
+msgstr ""
+"グループは階層構造になっています。グループは複数のサブグループを持つことができますが、1つのグループは1つの親を持つことができるだけです。サブグループは、親グループの属性とロールマッピングを継承します。ユーザーは、その親から属性とロールマッピングを継承します。"
+
+#. type: Plain text
+msgid ""
+"If you have a parent group and a child group, and a user that belongs only "
+"to the child group, the user in the child group inherits the attributes and "
+"role mappings of both the parent group and the child group."
+msgstr ""
+"親グループと子グループがあり、子グループにのみ所属するユーザーがいる場合、子グループのユーザーは、親グループと子グループの両方の属性とロールマッピングを継承します。"
+
+#. type: Plain text
+msgid ""
+"The following example includes a top-level *Sales* group and a child *North "
+"America* subgroup."
+msgstr "次の例では、トップレベルの *Sales* グループと子グループの *North America* サブグループが含まれています。"
+
+#. type: Plain text
+msgid "To add a group:"
+msgstr "グループを追加するには、以下のようにします。"
+
+#. type: Plain text
+msgid "Click the group."
+msgstr "グループをクリックします。"
+
+#. type: Plain text
+msgid "Select the *Groups* icon in the tree to make a top-level group."
+msgstr "ツリーの *Groups* アイコンを選択し、トップレベルのグループを作成します。"
+
+#. type: Plain text
+msgid "Enter a group name in the *Create Group* screen."
+msgstr "*Create Group* 画面で、グループ名を入力する。"
+
+#. type: Plain text
+msgid "The group management page is displayed."
+msgstr "グループ管理ページが表示されます。"
+
+#. type: Plain text
+msgid "image:{project_images}/group.png[]"
+msgstr "image:{project_images}/group.png[]"
+
+#. type: Plain text
+msgid ""
+"Attributes and role mappings you define are inherited by the groups and "
+"users that are members of the group."
+msgstr "定義した属性と役割のマッピングは、グループのメンバーであるグループとユーザーに継承されます。"
+
+#. type: Plain text
+msgid "To add a user to a group:"
+msgstr "ユーザーをグループに追加するには"
+
+#. type: Plain text
+msgid "Click *Groups*."
+msgstr "*Groups* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "User groups"
+msgstr "ユーザーグループ"
+
+#. type: Plain text
+msgid "image:{project_images}/user-groups.png[]"
+msgstr "image:{project_images}/user-groups.png[]"
+
+#. type: Plain text
+msgid "Select a group from the *Available Groups* tree."
+msgstr "Available Groups*ツリーからグループを選択します。"
+
+#. type: Plain text
+msgid "Click *Join*."
+msgstr "*Join* をクリックします。"
+
+#. type: Plain text
+msgid "To remove a group from a user:"
+msgstr "ユーザーからグループを削除するには"
+
+#. type: Plain text
+msgid "Select the group from the *Group Membership* tree."
+msgstr "グループメンバー*ツリーからグループを選択します。"
+
+#. type: Plain text
+msgid "Click *Leave*."
+msgstr "*Leave* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"In this example, the user _jimlincoln_ is in the _North America_ group.  You"
+" can see _jimlincoln_ displayed under the *Members* tab for the group."
+msgstr ""
+"この例では、ユーザー_jimlincoln_は_North America_グループに所属しています。  "
+"グループの*Members*タブに_jimlincoln_が表示されているのが確認できます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Group membership"
+msgstr "グループ・メンバーシップ"
+
+#. type: Plain text
+msgid "image:{project_images}/group-membership.png[]"
+msgstr "image:{project_images}/group-membership.png[]"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/roles-groups/proc-managing-groups.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__roles-groups__proc-managing-groups
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
