### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # Shinsuke UEDA, 2019
 # Yoshikazu Nojima <mail@ynojima.net>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
-# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,41 +21,68 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Plain text
 #, no-wrap
 msgid "W3C Web Authentication (WebAuthn)"
 msgstr "W3C Web Authentication（WebAuthn）"
 
 #. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Add execution*."
+msgstr "*Add execution*をクリックします。"
+
+#. type: Plain text
+msgid "Click *Add flow*."
+msgstr "*Add flow* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Bindings* tab."
+msgstr "Click the *Bindings* tab."
+
+#. type: Plain text
+msgid "Click the *Browser Flow* drop-down list."
+msgstr "Click the *Browser Flow* drop-down list."
+
+#. type: Plain text
 msgid ""
-"{project_name} provides the limited support for "
+"{project_name} provides limited support for "
 "https://www.w3.org/TR/webauthn/[W3C Web Authentication (WebAuthn)]. "
-"{project_name} works as a WebAuthn's https://www.w3.org/TR/webauthn/#sctn-"
-"rp-operations[Relying Party (RP)]."
+"{project_name} works as a WebAuthn's "
+"https://www.w3.org/TR/webauthn/#webauthn-relying-party[Relying Party (RP)]."
 msgstr ""
 "{project_name}は、 https://www.w3.org/TR/webauthn/[W3C Web "
 "Authentication（WebAuthn）] の限定的なサポートを提供します。{project_name}はWebAuthnの "
-"https://www.w3.org/TR/webauthn/#sctn-rp-operations[Relying Party（RP）] "
+"https://www.w3.org/TR/webauthn/#webauthn-relying-party[Relying Party（RP）] "
 "として機能します。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"Please note that WebAuthn support is still in development and not yet "
-"complete, so we recommend that you use this feature experimentally. Also, "
-"this support's specification and user interfaces may change."
-msgstr ""
-"WebAuthnのサポートはまだ開発中であり、まだ完全ではないことに注意してください。この機能を実験的に使用することをお勧めします。また、このサポートの仕様とユーザー・インターフェイスは変更される場合があります。"
+"Please note that WebAuthn support is in development. Use this feature "
+"experimentally."
+msgstr "WebAuthnのサポートは開発中であることに注意してください。この機能は実験的に使用してください。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"Whether WebAuthn's operations succeed depends on a user's WebAuthn "
-"supporting authenticator, browser and platform. If you use this WebAuthn "
-"support, please clarify to what extent those entities support the WebAuthn "
-"specification."
+"WebAuthn's operations success depends on the user's WebAuthn supporting "
+"authenticator, browser, and platform. Make sure your authenticator, browser,"
+" and platform support the WebAuthn specification."
 msgstr ""
-"WebAuthnの操作が成功するかどうかは、オーセンティケーター、ブラウザー、およびプラットフォームをサポートするユーザーのWebAuthnに依存します。このWebAuthnサポートを使用する場合は、それらのエンティティーがWebAuthn仕様をサポートする範囲を明確にしてください。"
+"WebAuthnの運用がうまくいくかどうかは、ユーザーのWebAuthn対応オーセンティケーター、ブラウザー、プラットフォームに依存します。お使いのオーセンティケーター、ブブラウザー、プラットフォームが"
+" WebAuthn 仕様をサポートしていることを確認してください。"
 
-#. type: Title =====
+#. type: Title ==
 #, no-wrap
 msgid "Setup"
 msgstr "セットアップ"
@@ -66,141 +93,130 @@ msgstr "2FAのWebAuthnサポートのセットアップ手順は次のとおり�
 
 #. type: Title =====
 #, no-wrap
-msgid "Enable Webauthn Authenticator Registration"
-msgstr "Webauthnオーセンティケーターの登録の有効化"
+msgid "Enable WebAuthn authenticator registration"
+msgstr "WebAuthnオーセンティケーターの登録の有効化"
+
+#. type: Plain text
+msgid "Click the *Required Actions* tab."
+msgstr "*Required Actions* タブをクリックします。"
+
+#. type: Plain text
+msgid "Click *Register*."
+msgstr "*Register* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Required Action* drop-down list."
+msgstr "*Required Action* のドロップダウン・リストをクリックします。"
+
+#. type: Plain text
+msgid "Click *Webauthn Register*."
+msgstr "*Webauthn Register* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Ok*."
+msgstr "Click *Ok*."
 
 #. type: Plain text
 msgid ""
-"An administrator carries out the following operations on the `Admin Console`"
-" :"
-msgstr "管理者は、 `管理コンソール` で次の操作を行います。"
-
-#. type: Plain text
-msgid "Open the `Authentication -> Required Actions` tab."
-msgstr "`Authentication -> Required Actions` タブを開きます。"
-
-#. type: Plain text
-msgid "Click `Register`."
-msgstr "`Register` をクリックします。"
-
-#. type: Plain text
-msgid "Select `Webauthn Register` as `Required Action`."
-msgstr "`Required Action` として `Webauthn Register` を選択します。"
-
-#. type: Plain text
-msgid ""
-"Mark `Enabled` checkbox. Optionally mark `Default Action` checkbox if you "
-"want all new created users to be required to register WebAuthn credential."
+"Mark the *Default Action* checkbox if you want all new users to be required "
+"to register their WebAuthn credentials."
 msgstr ""
-"`Enabled` チェックボックスをチェックしてください。新しく作成された全てのユーザーにWebAuthnクレデンシャルを登録するよう要求したい場合は"
-" `Default Action` チェックボックスにチェックして下さい。"
+"すべての新規ユーザーにWebAuthnのクレデンシャルの登録を要求する場合は、 *Default Action* のチェックボックスをONにします。"
 
 #. type: Title =====
 #, no-wrap
-msgid "Adding WebAuthn Authentication to a Browser Flow"
+msgid "Adding WebAuthn authentication to a browser flow"
 msgstr "ブラウザーフローへのWebAuthn認証の追加"
 
 #. type: Plain text
-msgid ""
-"Select a realm, click on `Authentication` link, select the `Browser` flow"
-msgstr "レルムを選択し、 `Authentication` のリンクをクリックし、 `Browser` フローを選択します。"
+msgid "Click the *Browser* flow."
+msgstr "*Browser* フローをクリックします。"
+
+#. type: Plain text
+msgid "Click *Copy* to make a copy of the built-in *Browser* flow."
+msgstr "*Copy* をクリックすると、内蔵の *Browser* フローのコピーが作成されます。"
+
+#. type: Plain text
+msgid "Enter a name for the copy."
+msgstr "コピーの名前を入力します。"
 
 #. type: Plain text
 msgid ""
-"Make a copy of the built-in \"Browser\" flow. You may want to give the new "
-"flow a distinctive name, for example \"WebAuthn Browser\""
+"Click the _Actions_ link for *WebAuthn Browser Browser - Conditional OTP* "
+"and click _Delete_."
 msgstr ""
-"ビルトインの \"Browser\" フローのコピーを作成します。新しいフローに特有の名前、たとえば、 \"WebAuthn Browser\" "
-"を付けることをお勧めします。"
+"*WebAuthn Browser Browser - Conditional OTP* の _Actions_ リンクをクリックし、 _Delete_"
+" をクリックします。"
 
 #. type: Plain text
-msgid "Using the drop down, select the copied flow"
-msgstr "ドロップダウンを使用して、コピーしたフローを選択します"
+msgid "Click *Delete*."
+msgstr "Click *Delete*."
 
 #. type: Plain text
-msgid ""
-"Delete the `WebAuthn Browser Browser - Conditional OTP` sub-flow using its "
-"`Actions` menu"
-msgstr ""
-"`Actions` メニューを使用して、 `WebAuthn Browser Browser - Conditional OTP` "
-"サブフローを削除します"
+msgid "If you require WebAuthn for all users:"
+msgstr "すべてのユーザーにWebAuthnが必要な場合は、以下のようにします。"
 
 #. type: Plain text
-msgid "If you want to have WebAuthn required for all users:"
-msgstr "すべてのユーザーにWebAuthnが必要な場合は以下のようにします。"
+msgid "Click on the _Actions_ link for *WebAuthn Browser Forms*."
+msgstr "*WebAuthn Browser Forms* の _Actions_ のリンクをクリックします。"
 
 #. type: Plain text
-msgid ""
-"Using the `Actions` menu of the `WebAuthn Browser Forms`, click on `Add "
-"execution`"
-msgstr ""
-"`WebAuthn Browser Forms` の `Actions` メニューを使用して、 `Add execution` をクリックします"
+msgid "Click the *Provider* drop-down list."
+msgstr "*Provider* のドロップダウン・リストをクリックします。"
 
 #. type: Plain text
-msgid ""
-"Select `WebAuthn Authenticator` using the drop down and click on `Save`"
-msgstr "ドロップダウンを使用して `WebAuthn Authenticator` を選択し、 `Save` をクリックします"
+msgid "Click *WebAuthn Authenticator*."
+msgstr "*Webauthn Authenticator* をクリックします。"
 
 #. type: Plain text
-msgid "Set its Requirement to _Required_."
-msgstr "Requirementを _Required_ に変更してください。"
+msgid "Click _REQUIRED_ for *WebAuthn Authenticator*"
+msgstr "*WebAuthn Authenticator* の _REQUIRED_ をクリックします。"
 
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-required.png[]"
 msgstr "image:images/webauthn-browser-flow-required.png[]"
 
 #. type: Plain text
-msgid "In the `Bindings` menu, change the browser flow to `WebAuthn Browser`"
-msgstr "`Bindings` メニューで、ブラウザーフローを `WebAuthn Browser` に変更します"
+msgid "Click *WebAuthn Browser*."
+msgstr "*Webauthn Browser* をクリックします。"
+
+#. type: delimited block =
+msgid ""
+"If a user does not have WebAuthn credentials, the user must register "
+"WebAuthn credentials."
+msgstr "ユーザーが WebAuthn の資格情報を持っていない場合、ユーザーは WebAuthn の資格情報を登録する必要があります。"
 
 #. type: Plain text
 msgid ""
-"Note that in this scenario, if a user doesn't have a WebAuthn credential, a "
-"required action will be set that forces that user to register one."
+"Users can log in with WebAuthn if they have a WebAuthn credential registered"
+" only. So instead of adding the *WebAuthn Authenticator* execution, you can:"
 msgstr ""
-"このシナリオでは、ユーザーがWebAuthnのクレデンシャルを持っていなければ、そのユーザーに強制的に登録させる必須アクションが設定されることに注意してください。"
+"ユーザーは、WebAuthnのクレデンシャルが登録されている場合のみ、WebAuthnでログインすることができます。そのため、*WebAuthn "
+"Authenticator* の実行を追加する代わりに"
 
 #. type: Plain text
-msgid ""
-"Alternatively, you can have users log in with WebAuthn only if they have a "
-"WebAuthn credential registered, so instead of adding the `WebAuthn "
-"Authenticator` execution:"
-msgstr ""
-"あるいは、WebAuthnのクレデンシャルが登録されている場合にのみ、ユーザーにWebAuthnでログインさせることができます。そのため、代わりに以下のように"
-" `WebAuthn Authenticator` のエグゼキューションを追加します。"
+msgid "Enter \"Conditional 2FA\" for the _Alias_ field."
+msgstr "Alias_の項目には「Conditional 2FA」と入力します。"
 
 #. type: Plain text
-msgid ""
-"Using the `Actions` menu of the `WebAuthn Browser Forms`, click on `Add "
-"flow`"
-msgstr "`WebAuthn Browser Forms` の `Actions` メニューを使用して、 `Add flow` をクリックします"
+msgid "Click _CONDITIONAL_ for *Conditional 2FA*"
+msgstr "条件付き2FA*の場合は、_CONDITIONAL_をクリックします。"
 
 #. type: Plain text
-msgid "Set the alias to \"Conditional 2FA\" and click on `Save`"
-msgstr "エイリアスを\"Conditional 2FA\"に設定し、 `Save` をクリックします"
+msgid "Click on the _Actions_ link for *Conditional 2FA*."
+msgstr "条件付き2FA*の_Actions_のリンクをクリックしてください。"
 
 #. type: Plain text
-msgid "Set the Requirement of `Conditional 2FA` to _Conditional_"
-msgstr "`Conditional 2FA` のRequirementを _Conditional_ に設定します"
+msgid "Click *Condition - User Configured*."
+msgstr "条件 - ユーザー設定*」をクリックします。"
 
 #. type: Plain text
-msgid ""
-"Using the `Actions` menu of the `Conditional 2FA`, click on `Add execution`"
-msgstr "`Conditional 2FA` の `Actions` メニューを使用して、 `Add execution` をクリックします"
+msgid "Click _REQUIRED_ for *Conditional 2FA*"
+msgstr "条件付き2FA*の場合は、_REQUIRED_をクリックしてください。"
 
 #. type: Plain text
-msgid ""
-"Select `Condition - User Configured` using the drop down and click on `Save`"
-msgstr "ドロップダウンを使用して `Condition - User Configured` を選択し、 `Save` をクリックします"
-
-#. type: Plain text
-msgid ""
-"Set the Requirement of `Condition - User Configured` execution to _Required_"
-msgstr "`Condition - User Configured` のRequirementを _Required_ に設定します"
-
-#. type: Plain text
-msgid "Set its Requirement to _Alternative_."
-msgstr "Requirementを _Alternative_ に変更してください。"
+msgid "Click _ALTERNATIVE_ for *Conditional 2FA*"
+msgstr "条件付き2FA*の場合は、_ALTERNATIVE_をクリックしてください。"
 
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-conditional.png[]"
@@ -208,13 +224,16 @@ msgstr "image:images/webauthn-browser-flow-conditional.png[]"
 
 #. type: Plain text
 msgid ""
-"You can also allow the user to choose between using WebAuthn and OTP for his"
-" second factor:"
-msgstr "ユーザーが2番目の要素としてWebAuthnとOTPのどちらを使用するかを選択できるようにすることもできます。"
+"The user can choose between using WebAuthn and OTP for the second factor:"
+msgstr "2つ目の要素については、WebAuthnを使用するかOTPを使用するかをユーザーが選択することができます。"
 
 #. type: Plain text
-msgid "Select `OTP Form` using the drop down and click on `Save`"
-msgstr "ドロップダウンを使用して `OTP Form` を選択し、 `Save` をクリックします"
+msgid "Click the _Actions_ link for *Conditional 2FA*."
+msgstr "条件付き2FA*の_Actions_のリンクをクリックしてください。"
+
+#. type: Plain text
+msgid "Click *ITP Form*."
+msgstr "ITP Form*をクリックします。"
 
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-conditional-with-OTP.png[]"
@@ -222,17 +241,14 @@ msgstr "image:images/webauthn-browser-flow-conditional-with-OTP.png[]"
 
 #. type: Title ====
 #, no-wrap
-msgid "Authenticate with WebAuthn Authenticator"
-msgstr "WebAuthnオーセンティケーターで認証する"
+msgid "Authenticate with WebAuthn authenticator"
+msgstr "WebAuthn 認証を使用した認証。"
 
 #. type: Plain text
 msgid ""
 "After registering a WebAuthn authenticator, the user carries out the "
-"following operations assuming that authentication flow configuration above "
-"with the conditional subflow using `WebAuthn Authenticator` was used:"
-msgstr ""
-"`WebAuthn Authenticator` "
-"を用いた条件サブフローが使用された認証フロー設定の場合、WebAuthnオーセンティケーターの登録後、ユーザーは以下の操作を行います。"
+"following operations:"
+msgstr "WebAuthn 認証機能を登録した後、ユーザーは以下の操作を行います。"
 
 #. type: Plain text
 msgid ""
@@ -242,9 +258,9 @@ msgstr "ログインフォームを開きます。ユーザーはユーザー名
 
 #. type: Plain text
 msgid ""
-"The user's browser asks the user to authenticate by their WebAuthn "
+"The user's browser asks the user to authenticate by using their WebAuthn "
 "authenticator."
-msgstr "ユーザーのブラウザーは、WebAuthnオーセンティケーターによる認証をユーザーに要求します。"
+msgstr "ユーザーのブラウザは、ユーザーに WebAuthn 認証を使用した認証を要求します。"
 
 #. type: Title ====
 #, no-wrap
@@ -253,63 +269,62 @@ msgstr "管理者としてWebAuthnを管理する"
 
 #. type: Title =====
 #, no-wrap
-msgid "Managing Credentials"
-msgstr "クレデンシャルの管理"
+msgid "Managing credentials"
+msgstr "認証情報の管理"
 
 #. type: Plain text
 msgid ""
-"WebAuthn credentials are managed in a similar manner as other credentials, "
-"such as OTP, from the <<_user-credentials, User credential management>>:"
+"{project_name} manages WebAuthn credentials similarly to other credentials "
+"from xref:ref-user-credentials_{context}[User credential management]:"
 msgstr ""
-"WebAuthnクレデンシャルは、OTPなどの他のクレデンシャルと同様の方法で、<<_user-credentials, "
-"ユーザー・クレデンシャル管理>>から管理されます。"
+"{project_name} は、xref:ref-user-credentials_{context}[User credential "
+"management] の他のクレデンシャルと同様に WebAuthn のクレデンシャルを管理します。"
 
 #. type: Plain text
 msgid ""
-"Users can be assigned a required action to create a WebAuthn credential from"
-" the `Reset Actions` list, and selecting `Webauthn Register`"
+"{project_name} assigns users a required action to create a WebAuthn "
+"credential from the *Reset Actions* list and select *Webauthn Register*."
 msgstr ""
-"ユーザーに `Reset Actions` のリストからWebAuthnクレデンシャルを作成するために必要なアクションを割り当て、 `Webauthn "
-"Register` を選択することができます"
+"{project_name} は、*Reset Actions* リストから WebAuthn クレデンシャルを作成し、*Webauthn "
+"Register* を選択するという必須アクションをユーザーに割り当てます。"
+
+#. type: Plain text
+msgid "Administrators can delete a WebAuthn credential by clicking *Delete*."
+msgstr "管理者は、*Delete*をクリックして、WebAuthnクレデンシャルを削除することができます。"
 
 #. type: Plain text
 msgid ""
-"The administrator can delete a WebAuthn credential by pressing `Delete`."
-msgstr "管理者は、 `Delete` を押すことでWebAuthnのクレデンシャルを削除できます。"
+"Administrators can view the credential's data, such as the AAGUID, by "
+"selecting *Show data...*."
+msgstr "管理者は、*Show data...* を選択して、AAGUID などのクレデンシャルのデータを表示できます。"
 
 #. type: Plain text
 msgid ""
-"The administrator can view the credential's data such as the AAGUID by "
-"selecting `Show data...`."
-msgstr "管理者は、 `Show data...` を選択して、AAGUIDなどのクレデンシャルのデータを表示できます。"
-
-#. type: Plain text
-msgid ""
-"The administrator can set a label for the credential by setting a value in "
-"the `User Label` field and saving the data."
-msgstr "管理者は、 `User Label` フィールドに値を設定してデータを保存することで、クレデンシャルのラベルを設定できます。"
+"Administrators can set a label for the credential by setting a value in the "
+"*User Label* field and saving the data."
+msgstr "管理者は、*User Label*フィールドに値を設定し、データを保存することで、クレデンシャルにラベルを設定することができます。"
 
 #. type: Title =====
 #, no-wrap
-msgid "Managing Policy"
+msgid "Managing policy"
 msgstr "ポリシーの管理"
 
 #. type: Plain text
 msgid ""
-"An administrator can configure WebAuthn related operations as `WebAuthn "
-"Policy` per realm."
-msgstr "管理者は、レルムごとに `WebAuthn Policy` としてWebAuthn関連の操作を設定できます。"
+"Administrators can configure WebAuthn related operations as *WebAuthn "
+"Policy* per realm."
+msgstr "管理者は、WebAuthn関連の操作をレルムごとに*WebAuthn Policy*として設定することができます。"
 
 #. type: Plain text
-msgid "Open the `Authentication -> WebAuthn Policy` tab."
-msgstr "`Authentication -> WebAuthn Policy` タブを開きます。"
+msgid "Click the *WebAuthn Policy* tab."
+msgstr "*WebAuthn Policy* タブをクリックします。"
 
 #. type: Plain text
-msgid "Configure items and click `Save`."
-msgstr "アイテムを設定し、 `Save` をクリックします。"
+msgid "Configure the items within the policy (see description below)."
+msgstr "ポリシー内の項目を設定する（以下の説明を参照）。"
 
 #. type: Plain text
-msgid "The configurable items and their description follow."
+msgid "The configurable items and their description are as follows:"
 msgstr "設定可能な項目とその説明は次のとおりです。"
 
 #. type: Plain text
@@ -321,123 +336,163 @@ msgid "Relying Party Entity Name"
 msgstr "Relying Party Entity Name"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"Human-readable server name as a WebAuthn Relying Party. This is a mandatory configuration, which is applied to the operation of registering the WebAuthn authenticator. The default setting is \"keycloak\".\n"
-" For more details, see https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity[WebAuthn Specification].\n"
+"The readable server name as a WebAuthn Relying Party. This item is mandatory"
+" and applies to the registration of the WebAuthn authenticator. The default "
+"setting is \"keycloak\". For more details, see "
+"https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity[WebAuthn "
+"Specification]."
 msgstr ""
-"人間が読めるWebAuthn Relying "
-"Partyのサーバー名。これは必須の設定であり、WebAuthnオーセンティケーターを登録する操作に適用されます。デフォルト設定は\"keycloak\"です。詳細については、"
-" https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity[WebAuthn "
-"Specification] を参照してください。\n"
+"WebAuthn Relying Party としての読み取り可能なサーバ名。この項目は必須であり、WebAuthn "
+"認証者の登録に適用されます。デフォルトは \"keycloak\" です。詳しくは "
+"https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity[WebAuthn "
+"Specification]を参照してください。"
 
 #. type: Plain text
 msgid "Signature Algorithms"
 msgstr "Signature Algorithms"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"It tells the WebAuthn authenticator which signature algorithms to use for the https://www.w3.org/TR/webauthn/#public-key-credential[Public Key Credential] that can be used for signing and verifying the https://www.w3.org/TR/webauthn/#authentication-assertion[Authentication Assertion]. Multiple algorithms can be specified. If no algorithm is specified, https://datatracker.ietf.org/doc/html/rfc8152#section-8.1[ES256] is adapted. The default setting is ES256. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator.\n"
-" For more details, see https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialparameters[WebAuthn Specification].\n"
+"The algorithms telling the WebAuthn authenticator which signature algorithms"
+" to use for the https://www.w3.org/TR/webauthn/#iface-pkcredential[Public "
+"Key Credential]. {project_name} uses the Public Key Credential to sign and "
+"verify https://www.w3.org/TR/webauthn/#authentication-"
+"assertion[Authentication Assertions]. If no algorithms exist, the default "
+"https://datatracker.ietf.org/doc/html/rfc8152#section-8.1[ES256] is adapted."
+" ES256 is an optional configuration item applying to the registration of "
+"WebAuthn authenticators. For more details, see "
+"https://www.w3.org/TR/webauthn/#dictdef-"
+"publickeycredentialparameters[WebAuthn Specification]."
 msgstr ""
-"これは、 https://www.w3.org/TR/webauthn/#authentication-assertion[認証アサーション] "
-"の署名と検証に使用される https://www.w3.org/TR/webauthn/#public-key-"
-"credential[公開鍵クレデンシャル] "
-"に使用する署名アルゴリズムをWebAuthnオーセンティケーターに伝えます。複数のアルゴリズムを指定できます。アルゴリズムが指定されていない場合、 "
+"WebAuthn 認証機関に https://www.w3.org/TR/webauthn/#iface-pkcredential[Public Key"
+" Credential]に使用する署名アルゴ リズムを伝えるアルゴリズム。{project_name} は公開鍵クレデンシャルを使用して "
+"https://www.w3.org/TR/webauthn/#authentication-assertion[Authentication "
+"Assertions]に署名および検証を行う。アルゴリズムが存在しない場合、デフォルトの "
 "https://datatracker.ietf.org/doc/html/rfc8152#section-8.1[ES256] "
-"が適応されます。デフォルト設定はES256です。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。詳細については、"
-" https://www.w3.org/TR/webauthn/#dictdef-"
-"publickeycredentialparameters[WebAuthn Specification] を参照してください。\n"
+"が適応される。ES256 は、WebAuthn 認証者の登録に適用されるオプションの設定項目です。詳しくは "
+"https://www.w3.org/TR/webauthn/#dictdef-"
+"publickeycredentialparameters[WebAuthn 仕様]をご覧ください。"
 
 #. type: Plain text
 msgid "Relying Party ID"
 msgstr "Relying Party ID"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"This is the ID as a WebAuthn Relying Party and determines the scope of Public Key Credentials. It must be origin's effective domain. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no entry is entered, the host part of the base URL of {project_name}'s server is adapted.\n"
-" For more details, see https://www.w3.org/TR/webauthn/#rp-id[WebAuthn Specification].\n"
+"The ID of a WebAuthn Relying Party that determines the scope of "
+"https://www.w3.org/TR/webauthn/#public-key-credential[Public Key "
+"Credentials]. The ID must be the origin's effective domain. This ID is an "
+"optional configuration item applied to the registration of WebAuthn "
+"authenticators. If this entry is blank, {project_name} adapts the host part "
+"of {project_name}'s base URL. For more details, see "
+"https://www.w3.org/TR/webauthn/[WebAuthn Specification]."
 msgstr ""
-"これは、WebAuthnリライング・パーティーとしてのIDであり、公開鍵クレデンシャルのスコープを決定します。オリジンの有効なドメインでなければなりません。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。エントリーが入力されていない場合、{project_name}のサーバーのベースURLのホスト部分が適応されます。詳細については、"
-" https://www.w3.org/TR/webauthn/#rp-id[WebAuthn Specification] を参照してください。\n"
+"https://www.w3.org/TR/webauthn/#public-key-credential[Public Key "
+"Credentials]の範囲を決定する、WebAuthn Relying Party の ID。この ID "
+"は、オリジンの有効ドメインでなければならない。この ID は、WebAuthn "
+"認証者の登録に適用されるオプションの設定項目である。この項目が空白の場合、{project_name} は {project_name} のベース "
+"URL のホスト部分を適応します。詳しくは https://www.w3.org/TR/webauthn/[WebAuthn 仕様]を参照してください。"
 
 #. type: Plain text
 msgid "Attestation Conveyance Preference"
 msgstr "Attestation Conveyance Preference"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"It tells the WebAuthn API implementation on the browser (https://www.w3.org/TR/webauthn/#webauthn-client[WebAuthn Client]) the preference of how to generate an Attestation Statement. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no option is selected, its behavior is the same as selecting \"none\".\n"
-" For more details, see https://www.w3.org/TR/webauthn/#attestation-conveyance[WebAuthn Specification].\n"
+"The WebAuthn API implementation on the browser "
+"(https://www.w3.org/TR/webauthn/#webauthn-client[WebAuthn Client]) is the "
+"preferential method to generate Attestation statements. This preference is "
+"an optional configuration item applying to the registration of the WebAuthn "
+"authenticator. If no option exists, its behavior is the same as selecting "
+"\"none\". For more details, see https://www.w3.org/TR/webauthn/[WebAuthn "
+"Specification]."
 msgstr ""
-"ブラウザーのWebAuthn API実装（ https://www.w3.org/TR/webauthn/#webauthn-"
-"client[WebAuthnクライアント] "
-"）に、認証ステートメントの生成方法の設定を伝えます。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。オプションが選択されていない場合、その動作は\"none\"を選択した場合と同じです。詳細については、"
-" https://www.w3.org/TR/webauthn/#attestation-conveyance[WebAuthn "
-"Specification] を参照してください。\n"
+"ブラウザ上のWebAuthn API実装（https://www.w3.org/TR/webauthn/#webauthn-"
+"client[WebAuthn Client]）は、Attestation文を生成するための優先的な方法です。この設定は、WebAuthn "
+"認証機能の登録に適用されるオプションの設定項目です。オプションがない場合は、「none」を選択したのと同じ動作となります。詳しくは "
+"https://www.w3.org/TR/webauthn/[WebAuthn Specification]をご覧ください。"
 
 #. type: Plain text
 msgid "Authenticator Attachment"
 msgstr "Authenticator Attachment"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"It tells the WebAuthn Client an acceptable attachment pattern of a WebAuthn authenticator. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no option is selected, the WebAuthn Client does not consider the attachment pattern.\n"
-" For more details, see https://www.w3.org/TR/webauthn/#enumdef-authenticatorattachment[WebAuthn Specification].\n"
+"The acceptable attachment pattern of a WebAuthn authenticator for the "
+"WebAuthn Client. This pattern is an optional configuration item applying to "
+"the registration of the WebAuthn authenticator. For more details, see "
+"https://www.w3.org/TR/webauthn/#enumdef-authenticatorattachment[WebAuthn "
+"Specification]."
 msgstr ""
-"これは、WebAuthnオーセンティケーターの受け入れ可能なアタッチパターンをWebAuthnクライアントに伝えます。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。オプションが選択されていない場合、WebAuthnクライアントはアタッチパターンを考慮しません。詳細については、"
-" https://www.w3.org/TR/webauthn/#enumdef-authenticatorattachment[WebAuthn "
-"Specification] を参照してください。\n"
+"WebAuthn クライアントで使用可能な WebAuthn 認証子の添付ファイルパターン。このパターンは、WebAuthn "
+"認証器の登録に適用されるオプションの設定項目です。詳しくは https://www.w3.org/TR/webauthn/#enumdef-"
+"authenticatorattachment[WebAuthn Specification]をご覧ください。"
 
 #. type: Plain text
 msgid "Require Resident Key"
 msgstr "Require Resident Key"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"It tells the WebAuthn authenticator to generate the Public Key Credential as https://www.w3.org/TR/webauthn/#client-side-discoverable-public-key-credential-source[Client-side-resident Public Key Credential Source]. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator. If no option is selected, its behavior is the same as selecting \"No\".\n"
-" For more details, see https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-requireresidentkey[WebAuthn Specification].\n"
+"The option requiring that the WebAuthn authenticator generates the Public "
+"Key Credential as https://www.w3.org/TR/webauthn/[Client-side-resident "
+"Public Key Credential Source]. This option applies to the registration of "
+"the WebAuthn authenticator. If left blank, its behavior is the same as "
+"selecting \"No\". For more details, see https://www.w3.org/TR/webauthn/#dom-"
+"authenticatorselectioncriteria-requireresidentkey[WebAuthn Specification]."
 msgstr ""
-"https://www.w3.org/TR/webauthn/#client-side-discoverable-public-key-"
-"credential-source[Client-side-resident Public Key Credential Source] "
-"として公開鍵クレデンシャルを生成するようにWebAuthnオーセンティケーターに指示します。これは、WebAuthnオーセンティケーターを登録する操作に適用されるオプションの設定項目です。オプションが選択されていない場合、その動作は\"No\"を選択した場合と同じです。詳細については、"
-" https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-"
-"requireresidentkey[WebAuthn Specification] を参照してください。\n"
+"WebAuthn 認証機関が公開鍵クレデンシャルを https://www.w3.org/TR/webauthn/[Client-side-"
+"resident Public Key Credential Source]として生成することを要求するオプショ ン。このオプションは、WebAuthn"
+" 認証器の登録に適用されます。空白のままだと、\"No "
+"\"を選択した場合と同じ動作になります。詳しくは、https://www.w3.org/TR/webauthn/#dom-"
+"authenticatorselectioncriteria-requireresidentkey[WebAuthn 仕様]を参照してください。"
 
 #. type: Plain text
 msgid "User Verification Requirement"
 msgstr "User Verification Requirement"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"It tells the WebAuthn authenticator to confirm actually verifying a user. This is an optional configuration item that is applied to the operation of registering a WebAuthn authenticator and authenticating the user by a WebAuthn authenticator. If no option is selected, its behavior is the same as selecting \"preferred\".\n"
-" For more details, see https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-userverification[WebAuthn Specification for registering a WebAuthn authenticator] and https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-userverification[WebAuthn Specification for authenticating the user by a WebAuthn authenticator].\n"
-msgstr ""
-"WebAuthnオーセンティケーターに、ユーザーの実際の検証を確認するよう指示します。これは、WebAuthnオーセンティケーターを登録し、WebAuthnオーセンティケーターによってユーザーを認証する操作に適用されるオプションの設定項目です。オプションが選択されていない場合、その動作は\"preferred\"を選択した場合と同じです。詳細については、"
-" https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-"
+"The option requiring that the WebAuthn authenticator confirms the "
+"verification of a user. This is an optional configuration item applying to "
+"the registration of a WebAuthn authenticator and the authentication of a "
+"user by a WebAuthn authenticator. If no option exists, its behavior is the "
+"same as selecting \"preferred\". For more details, see "
+"https://www.w3.org/TR/webauthn/#dom-authenticatorselectioncriteria-"
 "userverification[WebAuthn Specification for registering a WebAuthn "
-"authenticator] と https://www.w3.org/TR/webauthn/#dom-"
+"authenticator] and https://www.w3.org/TR/webauthn/#dom-"
 "publickeycredentialrequestoptions-userverification[WebAuthn Specification "
-"for authenticating the user by a WebAuthn authenticator] を参照してください。\n"
+"for authenticating the user by a WebAuthn authenticator]."
+msgstr ""
+"WebAuthn 認証機関がユーザーの認証を確認することを要求するオプションです。これは、WebAuthn 認証器の登録および WebAuthn "
+"認証器によるユーザの認証に適用されるオプション設定項目です。オプションがない場合は、\"preferred "
+"\"を選択した場合と同じ動作となります。詳しくは、https://www.w3.org/TR/webauthn/#dom-"
+"authenticatorselectioncriteria-userverification[WebAuthn 認証器の登録に関する仕様] および "
+"https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-"
+"userverification[WebAuthn 認証器によるユーザ認証に関する仕様] をご覧ください。"
 
 #. type: Plain text
 msgid "Timeout"
 msgstr "Timeout"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
-"It specifies the timeout value in seconds for registering a WebAuthn authenticator and authenticating the user by a WebAuthn authenticator. If set to 0, its behavior depends on the WebAuthn authenticator's implementation. The default value is 0.\n"
-" For more details, see https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-timeout[WebAuthn Specification for registering a WebAuthn authenticator] and https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-timeout[WebAuthn Specification for authenticating the user by a WebAuthn authenticator].\n"
+"The timeout value, in seconds, for registering a WebAuthn authenticator and "
+"authenticating the user by using a WebAuthn authenticator. If set to zero, "
+"its behavior depends on the WebAuthn authenticator's implementation. The "
+"default value is 0. For more details, see "
+"https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-"
+"timeout[WebAuthn Specification for registering a WebAuthn authenticator] and"
+" https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-"
+"timeout[WebAuthn Specification for authenticating the user by a WebAuthn "
+"authenticator]."
 msgstr ""
-"WebAuthnオーセンティケーターを登録し、WebAuthnオーセンティケーターによってユーザーを認証するためのタイムアウト値を秒単位で指定します。0に設定した場合、その動作はWebAuthnオーセンティケーターの実装に依存します。デフォルト値は0です。詳細については、 \n"
-"https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-timeout[WebAuthn Specification for registering a WebAuthn authenticator] および https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-timeout[WebAuthn Specification for authenticating the user by a WebAuthn authenticator] を参照してください。\n"
+"WebAuthn 認証機能を用いてユーザーを登録し、認証する際のタイムアウト値を秒単位で指定します。0 を指定すると、その動作は WebAuthn "
+"認証器の実装に依存します。デフォルトは 0 です。詳しくは https://www.w3.org/TR/webauthn/#dom-"
+"publickeycredentialcreationoptions-timeout[WebAuthn 認証器の登録に関する仕様] および "
+"https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-"
+"timeout[WebAuthn 認証器によるユーザ認証に関する仕様] を参照してください。"
 
 #. type: Plain text
 msgid "Avoid Same Authenticator Registration"
@@ -445,11 +500,9 @@ msgstr "Avoid Same Authenticator Registration"
 
 #. type: Plain text
 msgid ""
-"If set to \"ON\", the WebAuthn authenticator that has already been "
-"registered can not be newly registered. This is applied to the operation of "
-"registering a WebAuthn authenticator. The default setting is \"OFF\"."
-msgstr ""
-"\"ON\"に設定すると、すでに登録されているWebAuthnオーセンティケーターを新規登録できません。これは、WebAuthnオーセンティケーターを登録する操作に適用されます。デフォルト設定は\"OFF\"です。"
+"If enabled, {project_name} cannot re-register an already registered WebAuthn"
+" authenticator."
+msgstr "有効な場合、{project_name} は既に登録されている WebAuthn 認証器を再登録することはできません。"
 
 #. type: Plain text
 msgid "Acceptable AAGUIDs"
@@ -457,39 +510,37 @@ msgstr "Acceptable AAGUIDs"
 
 #. type: Plain text
 msgid ""
-"The white list of AAGUID of which a WebAuthn authenticator can be "
-"registered. This is applied to the operation of registering a WebAuthn "
-"authenticator. If no entry is set on this list, any WebAuthn authenticator "
-"can be registered."
-msgstr ""
-"WebAuthnオーセンティケーターを登録できるAAGUIDのホワイトリスト。これは、WebAuthnオーセンティケーターを登録する操作に適用されます。このリストにエントリーが設定されていない場合、任意のWebAuthnオーセンティケーターを登録できます。"
+"The white list of AAGUIDs which a WebAuthn authenticator must register "
+"against."
+msgstr "WebAuthn 認証エージェントが登録しなければならない AAGUID のホワイトリスト。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Attestation Statement Verification"
-msgstr "Attestation Statement Verification"
+msgid "Attestation statement verification"
+msgstr "認証文の検証"
 
 #. type: Plain text
 msgid ""
-"When registering a WebAuthn authenticator, {project_name} verifies an "
-"attestation statement generated by this WebAuthn authenticator. On this "
-"verification process, {project_name} validates this attestation statement's "
-"trustworthiness. It requires trust anchor's certificates. {project_name} "
-"uses the link:{installguide_truststore_link}[{installguide_truststore_name}]"
-" so that you need to import these certificates onto it in advance."
+"When registering a WebAuthn authenticator, {project_name} verifies the "
+"trustworthiness of the attestation statement generated by the WebAuthn "
+"authenticator. {project_name} requires the trust anchor's certificates for "
+"this. {project_name} uses the "
+"link:{installguide_truststore_link}[{installguide_truststore_name}], so you "
+"must import these certificates into it in advance."
 msgstr ""
-"WebAuthnオーセンティケーターを登録するとき、{project_name}はこのWebAuthnオーセンティケーターによって生成された認証ステートメントを検証します。この検証プロセスで、{project_name}はこの認証ステートメントの信頼性を検証します。トラストアンカーの証明書が必要です。{project_name}は"
-" link:{installguide_truststore_link}[{installguide_truststore_name}] "
-"を使用するため、これらの証明書を事前にインポートする必要があります。"
+"WebAuthn認証器を登録する際、{project_name} "
+"はWebAuthn認証器が生成する認証文の信頼性を検証する。{project_name} "
+"は、このためにトラストアンカーの証明書を必要とします。{project_name} は "
+"link:{installguide_truststore_link}[{installguide_truststore_name}] "
+"を利用しているので、事前にこれらの証明書をインポートしておく必要があります。"
 
 #. type: Plain text
 msgid ""
-"If you want to omit this attestation statement trustworthiness validation, "
-"please disable this truststore or set the WebAuthn policy's configuration "
-"item \"Attestation Conveyance Preference\" to \"none\"."
+"To omit this validation, disable this truststore or set the WebAuthn "
+"policy's configuration item \"Attestation Conveyance Preference\" to "
+"\"none\"."
 msgstr ""
-"この検証ステートメントの信頼性検証を省略する場合は、このトラストストアを無効にするか、WebAuthnポリシーの設定項目\"Attestation "
-"Conveyance Preference\"を\"none\"に設定してください。"
+"この検証を省略するには、このトラストストアを無効にするか、WebAuthnポリシーの設定項目「証明書伝達の優先度」を「なし」に設定してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -498,55 +549,44 @@ msgstr "ユーザーとしてのWebAuthnクレデンシャルの管理"
 
 #. type: Title =====
 #, no-wrap
-msgid "Register WebAuthn Authenticator"
-msgstr "WebAuthnオーセンティケーターの登録"
+msgid "Register WebAuthn authenticator"
+msgstr "WebAuthn認証器の登録"
 
 #. type: Plain text
 msgid ""
-"The appropriate method to register a WebAuthn authenticator depends on if "
-"the user has or has not already registered an account on {project_name}."
+"The appropriate method to register a WebAuthn authenticator depends on "
+"whether the user has already registered an account on {project_name}."
 msgstr ""
-"WebAuthnオーセンティケーターを登録する適切な方法は、ユーザーが{project_name}にアカウントを登録しているかどうかによって異なります。"
+"WebAuthn 認証機能を登録する適切な方法は、ユーザーが既に {project_name} にアカウントを登録しているかどうかに依存します。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
 msgid "New user"
 msgstr "新規ユーザー"
 
 #. type: Plain text
 msgid ""
-"If the `WebAuthn Register` required action is set as `Default Action` in a "
-"realm, new users are required to set up the WebAuthn security key after the "
-"first successful login. A new user carries out the following operations :"
+"If the *WebAuthn Register* required action is *Default Action* in a realm, "
+"new users must set up the WebAuthn security key after their first login."
 msgstr ""
-"レルムで `WebAuthn Register` 必須アクションが `Default Action` "
-"として設定された場合、新しいユーザーは最初のログイン成功時にWebAuthnセキュリティキーをセットアップすることが要求されます。新しいユーザーは以下の操作を実行します。"
+"realmで*WebAuthn Register* required actionが*Default "
+"Action*の場合、新規ユーザーは最初のログイン後にWebAuthnセキュリティキーをセットアップしなければなりません。"
 
 #. type: Plain text
 msgid "Open the login form."
 msgstr "ログインフォームを開きます。"
 
 #. type: Plain text
-msgid "Click the `Register` link."
-msgstr "`Register` のリンクをクリックします。"
-
-#. type: Plain text
-msgid "Fill in items on the register form and click `Register`."
-msgstr "登録フォームの項目に入力し、 `Register` をクリックします。"
+msgid "Fill in the items on the form."
+msgstr "フォームの項目を記入する。"
 
 #. type: Plain text
 msgid ""
-"The user's browser asks the user to register their WebAuthn authenticator."
-msgstr "ユーザーのブラウザーは、WebAuthnオーセンティケーターを登録するようにユーザーに要求します。"
+"After successfully registering, the browser asks the user to enter the text "
+"of their WebAuthn authenticator's label."
+msgstr "登録に成功すると、ブラウザは、WebAuthn認証器のラベルのテキストを入力するようユーザーに要求します。"
 
-#. type: Plain text
-msgid ""
-"After successful registration, the user's browser asks the user to enter the"
-" text as their just registered WebAuthn authenticator's label."
-msgstr ""
-"登録が成功すると、ユーザーのブラウザーは、登録されたばかりのWebAuthnオーセンティケーターのラベルとしてテキストを入力するようにユーザーに要求します。"
-
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
 msgid "Existing user"
 msgstr "既存のユーザー"
@@ -555,20 +595,24 @@ msgstr "既存のユーザー"
 msgid ""
 "If `WebAuthn Authenticator` is set up as required as shown in the first "
 "example, then when existing users try to log in, they are required to "
-"register their WebAuthn authenticator automatically :"
+"register their WebAuthn authenticator automatically:"
 msgstr ""
-"最初の例で示されたように、 `WebAuthn Authenticator` "
-"が必須として設定された場合、既存のユーザーがログインを試みた際もWebAuthnオーセンティケーターを登録することが自動的に要求されます。"
+"最初の例のように `WebAuthn Authenticator` を必須として設定すると、既存のユーザーがログインしようとしたときに、自動的に "
+"WebAuthn 認証機能の登録が要求されるようになります。"
 
 #. type: Plain text
-msgid "Fill in items, click `Save` and click `Login`."
-msgstr "項目を入力し、 `Save` をクリックして `Login` をクリックします。"
+msgid "Enter the items on the form."
+msgstr "フォームに項目を入力します。"
+
+#. type: Plain text
+msgid "Click *Login*."
+msgstr "*Login* をクリックします。"
 
 #. type: Plain text
 msgid ""
-"When the users log in, they are required to register their WebAuthn "
-"authenticator."
-msgstr "ユーザーがログインしたら、WebAuthnオーセンティケーターを登録する必要があります。"
+"After successful registration, the user's browser asks the user to enter the"
+" text of their WebAuthn authenticator's label."
+msgstr "登録に成功すると、ユーザーのブラウザは、WebAuthn認証器のラベルのテキストを入力するように要求します。"
 
 #. type: Title ====
 #, no-wrap
@@ -577,114 +621,126 @@ msgstr "パスワードレスWebAuthnと二要素認証の併用"
 
 #. type: Plain text
 msgid ""
-"WebAuthn is often used for two-factor authentication, however it can be "
-"desired to use it also as first factor authentication. In this case, a user "
-"with `passwordless` WebAuthn credential will be able to authenticate to "
-"{project_name} without a password. {project_name} allows to use WebAuthn as "
-"both the passwordless and two-factor authentication mechanism in the context"
-" of a single realm and even in the context of a single authentication flow."
+"{project_name} uses WebAuthn for two-factor authentication, but you can use "
+"WebAuthn as the first-factor authentication. In this case, users with "
+"`passwordless` WebAuthn credentials can authenticate to {project_name} "
+"without a password. {project_name} can use WebAuthn as both the passwordless"
+" and two-factor authentication mechanism in the context of a realm and a "
+"single authentication flow."
 msgstr ""
-"WebAuthnは二要素認証によく使用されますが、認証の第一要素として使用したい場合もあります。この場合、 `passwordless` "
-"WebAuthnクレデンシャルを持つユーザーは{project_name}にパスワード無しで認証することが出来ます。{project_name}は単一のレルムのコンテキスト、更には単一の認証フローのコンテキストでも、パスワードレスと二要素認証の両方でWebAuthnを使用することができます。"
+"{project_name} は二要素認証に WebAuthn を使っていますが、一要素認証に WebAuthn "
+"を使うこともできます。この場合、`パスワードレス`の WebAuthn の資格情報を持つユーザは、パスワードなしで {project_name} "
+"を認証することができます。{project_name} は、ひとつのレルムとひとつの認証フローで、 WebAuthn "
+"をパスワードなし認証と二要素認証の両方の仕組みとして使うことができます。"
 
 #. type: Plain text
 msgid ""
-"Administrator may typically require that Security Keys registered by users "
-"for the WebAuthn passwordless authentication must meet different (usually "
-"stronger) requirements. For example, those security keys may require users "
-"to authenticate to that security key using a PIN, or the security key should"
-" be attested with stronger certificate authority."
+"An administrator typically requires that Security Keys registered by users "
+"for the WebAuthn passwordless authentication meet different requirements. "
+"For example, the security keys may require users to authenticate to the "
+"security key using a PIN, or the security key attests with a stronger "
+"certificate authority."
 msgstr ""
-"管理者は一般に、WebAuthnパスワードレス認証にユーザーが登録したセキュリティキーに対して、異なる（通常より強力な）要件を満たすことを要求する場合があります。たとえば、それらのセキュリティキーは、ユーザーがそのセキュリティキーに対してPINを用いて認証することを要求したり、そのセキュリティキーが強力な認証局で構成証明されていることを要求する場合があります。"
+"管理者は通常、WebAuthn パスワードレス認証のためにユーザーが登録したセキュリティ "
+"キーが、異なる要件を満たすことを要求します。例えば、セキュリティ キーは、ユーザーが PIN を使用してセキュリティ "
+"キーに認証することを要求したり、セキュリティ キーがより強力な認証局で認証することを要求したりすることがあります。"
 
 #. type: Plain text
 msgid ""
-"Because of this situation, {project_name} allows administrator to configure "
-"separate `WebAuthn Passwordless Policy`. There is a separate required action"
-" of type `Webauthn Register Passwordless` and separate authenticator of type"
-" `WebAuthn Passwordless Authenticator`."
+"Because of this, {project_name} permits administrators to configure a "
+"separate `WebAuthn Passwordless Policy`. There is a required `Webauthn "
+"Register Passwordless` action of type and separate authenticator of type "
+"`WebAuthn Passwordless Authenticator`."
 msgstr ""
-"このため、{project_name}では管理者が個別に `WebAuthn Passwordless Policy` を設定できます。個別の "
-"`Webauthn Register Passwordless` タイプの必須アクションや、個別の `WebAuthn Passwordless "
-"Authenticator` タイプのオーセンティケーターを設定します。"
+"このため、{project_name} は管理者に個別の `WebAuthn Passwordless Policy` "
+"を設定することを許可しています。WebAuthn Register Passwordless` アクションが必要で、 `WebAuthn "
+"Passwordless Authenticator` タイプの認証ツールが別途必要です。"
+
+#. type: Plain text
+msgid "Set up WebAuthn passwordless support as follows:"
+msgstr "WebAuthnのパスワードレス対応については、以下のように設定してください。"
 
 #. type: Plain text
 msgid ""
-"The setup procedure of WebAuthn passwordless support is the following :"
-msgstr "WebAuthnパスワードレス・サポートのセットアップ手順は次のとおりです。"
+"Register a new required action for WebAuthn passwordless support. Use the "
+"steps described in <<_webauthn-register, Enable WebAuthn Authenticator "
+"Registration>>. Register the `Webauthn Register Passwordless` action."
+msgstr ""
+"WebAuthnのパスワードレス対応に必要なアクションを新規に登録します。&lt;&gt;で説明した手順を使用して<_webauthn-"
+"register, Enable WebAuthn Authenticator Registration>ください</_webauthn-"
+"register,>。<_webauthn-register, Enable WebAuthn Authenticator "
+"Registration>Webauthn Register Passwordless` アクションを登録します。</_webauthn-"
+"register,>"
 
 #. type: Plain text
 msgid ""
-"Register new required action for WebAuthn passwordless support. Use the same"
-" steps as described <<_webauthn-register, above>> with the only difference, "
-"that you need to register the action called `Webauthn Register "
-"Passwordless`."
+"Configure the policy. You can use the steps and configuration options "
+"described in <<_webauthn-policy, Managing Policy>>. Perform the "
+"configuration in the Admin Console in the tab *WebAuthn Passwordless "
+"Policy*. Typically the requirements for the security key will be stronger "
+"than for the two-factor policy. For example, you can set the *User "
+"Verification Requirement* to *Required* when you configure the passwordless "
+"policy."
 msgstr ""
-"WebAuthnパスワードレス・サポートの為の新しい必須アクションを登録します。<<_webauthn-register, "
-"上記>>と同じ手順を使用しますが、一点異なることとして、 `Webauthn Register Passwordless` "
-"というアクションを登録する必要があります。"
+"ポリシーを設定します。&lt;&gt;で説明した手順と設定オプションが使用できます<_webauthn-policy, Managing "
+"Policy>。管理者コンソールのタブ *WebAuthn Passwordless Policy* "
+"で設定を実行します。通常、セキュリティキーの要件は、2要素ポリシーの要件よりも強くなります。たとえば、パスワードレスポリシーを構成する際に、*User "
+"Verification Requirement* を *Required* に設定します。</_webauthn-policy,>"
 
 #. type: Plain text
 msgid ""
-"Configure the policy. You can use same steps and configuration options as "
-"described <<_webauthn-policy, above>>, however you need to configure them in"
-" the admin console in the tab `WebAuthn Passwordless Policy`. You can "
-"configure this policy as you want, however typically the requirements for "
-"the security key will be stronger than for the two-factor policy. For "
-"example the `User Verification Requirement` can be set to `Required` when "
-"you configure the passwordless policy."
+"Configure the authentication flow. Use the *WebAuthn Browser* flow described"
+" in <<_webauthn-authenticator-setup, Adding WebAuthn Authentication to a "
+"Browser Flow>>. Configure the flow as follows:"
 msgstr ""
-"ポリシーを設定します。<<_webauthn-policy, 上記>>と同じ手順と設定を使用できますが、管理コンソールの `WebAuthn "
-"Passwordless Policy` "
-"タブで設定する必要があります。このポリシーは必要に応じて設定できますが、一般にセキュリティキーに対する要件は二要素認証の場合のポリシーに比べて強力になるでしょう。たとえば、パスワードレス・ポリシーを設定する際は、"
-" `User Verification Requirement` を `Required` に設定できます。"
-
-#. type: Plain text
-msgid ""
-"Finally configure the authentication flow. Let's assume that we will use "
-"same flow called `WebAuthn Browser` as described <<_webauthn-authenticator-"
-"setup, above>>, but we will configure it as follows:"
-msgstr ""
-"最後に、認証フローを設定します。<<_webauthn-authenticator-setup, 上記>>で解説した `WebAuthn "
-"Browser` と同一のフローを使用すると仮定し、以下のように設定します。"
+"認証フローを設定します。&lt;&gt;で説明した*WebAuthn Browser*のフローを使用します<_webauthn-"
+"authenticator-setup, Adding WebAuthn Authentication to a Browser "
+"Flow>。フローを以下のように設定します。</_webauthn-authenticator-setup,>"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
-"** The `WebAuthn Browser Forms` subflow will contain `Username Form` as the first authenticator. Delete the default `Username Password Form`\n"
-"authenticator and add the `Username Form` authenticator instead. This setting means that the user will provide just his or her username as the first step.\n"
+"** The *WebAuthn Browser Forms* subflow contains *Username Form* as the "
+"first authenticator. Delete the default *Username Password Form* "
+"authenticator and add the *Username Form* authenticator. This action "
+"requires the user to provide a username as the first step.\n"
 msgstr ""
-"** `WebAuthn Browser Forms` サブフローは `Username Form` を第一のオーセンティケーターとして含みます。デフォルトの `Username Password Form` \n"
-"オーセンティケーターは削除し、 `Username Form` オーセンティケーターを代わりに追加します。この設定はユーザーがユーザー名だけを最初のステップで提供することを意味します。\n"
+"** WebAuthn Browser Forms* サブフローには、最初の認証子として *Username Form* が含まれています。デフォルトの"
+" *Username Password Form* 認証機能を削除して、*Username Form* "
+"認証機能を追加してください。このアクションでは、最初のステップとしてユーザーにユーザー名を提供するよう要求します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
-"** There will be a required subflow, which can be named for example `Passwordless Or Two-factor` . This setting indicates that user can\n"
-"authenticate either with Passwordless WebAuthn credential or with Two-factor authentication.\n"
+"** There will be a required subflow, which can be named *Passwordless Or "
+"Two-factor*, for example. This subflow indicates the user can authenticate "
+"with Passwordless WebAuthn credential or with Two-factor authentication.\n"
 msgstr ""
-"必須サブフローもあるべきで、たとえば `Passwordless Or Two-factor` "
-"と命名することが出来ます。この設定はユーザーがパスワードレスWebAuthnクレデンシャルでも、二要素認証のどちらでも認証できることを示します。\n"
+"** 例えば、*Passwordless Or Two-factor* "
+"という名前の必須サブフローが存在します。このサブフローは、ユーザーがパスワードなしの WebAuthn クレデンシャルまたは 2 "
+"要素認証で認証できることを示します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
-"** Flow will contain `WebAuthn Passwordless Authenticator` as the first "
+"** The flow contains *WebAuthn Passwordless Authenticator* as the first "
 "alternative.\n"
-msgstr "** フローは `WebAuthn Passwordless Authenticator` を第一の選択肢として含みます。\n"
+msgstr "** このフローには、最初の選択肢として *WebAuthn Passwordless Authenticator* が含まれています。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
-"** The second alternative will be a subflow named for example `Password And Two-factor Webauthn`. This subflow will contain a `Password Form` and\n"
-"a `WebAuthn Authenticator`.\n"
+"** The second alternative will be a subflow named *Password And Two-factor "
+"Webauthn*, for example. This subflow contains a *Password Form* and a "
+"*WebAuthn Authenticator*.\n"
 msgstr ""
-"** 第二の選択肢は、例えば `Password And Two-factor Webauthn` という命名をしたサブフローです。このサブフローは "
-"`Password Form` と `WebAuthn Authenticator` を含みます。\n"
+"** 2つ目の選択肢は、例えば*Password And Two-factor "
+"Webauthn*という名前のサブフローになります。このサブフローには、*Password Form* と *WebAuthn "
+"Authenticator* が含まれます。\n"
 
 #. type: Plain text
-msgid "The final configuration of the flow will look like the following:"
-msgstr "フローの最終的な設定は、次のとおりです。"
+msgid "The final configuration of the flow looks similar to this:"
+msgstr "最終的なフローの構成はこのような感じになります。"
 
 #. type: Plain text
 msgid "image:images/webauthn-passwordless-flow.png[]"
@@ -692,14 +748,13 @@ msgstr "image:images/webauthn-passwordless-flow.png[]"
 
 #. type: Plain text
 msgid ""
-"You can now add `WebAuthn Register Passwordless` as the required action to "
-"some user, already known to {project_name}, to test this.  During the first "
-"authentication, the user will be still required to use the password and "
-"second-factor WebAuthn credential. However, once the user registers the "
-"credentials, that user will be able to choose during future authentications."
-" If he uses his or her WebAuthn Passwordless credential, he won't need to "
-"provide the password and second-factor WebAuthn credential at all."
+"You can now add *WebAuthn Register Passwordless* as the required action to a"
+" user, already known to {project_name}, to test this. During the first "
+"authentication, the user must use the password and second-factor WebAuthn "
+"credential. The user does not need to provide the password and second-factor"
+" WebAuthn credential if they use the WebAuthn Passwordless credential."
 msgstr ""
-"これで、{project_name}に既に存在している任意のユーザーに必須アクションとして `WebAuthn Register "
-"Passwordless` "
-"を追加してテストすることができます。最初の認証では、ユーザーは依然としてパスワードと第二要素WebAuthnクレデンシャルを使用することが要求されます。しかしながら、一度ユーザーがクレデンシャルを登録すれば、ユーザーは今後の認証において、選択することが出来ます。ユーザーがWebAuthnパスワードレス・クレデンシャルを使用した場合、パスワードも、第二要素WebAuthnクレデンシャルも投入する必要はありません。"
+"すでに {project_name} に知られているユーザーに、必須アクションとして *WebAuthn Register Passwordless* "
+"を追加し、これをテストすることができます。最初の認証では、ユーザーはパスワードと第 2 要素の WebAuthn "
+"クレデンシャルを使用する必要があります。WebAuthn Passwordless クレデンシャルを使用する場合、ユーザーはパスワードと第 2 要素の "
+"WebAuthn クレデンシャルを提供する必要はありません。"

--- a/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po
@@ -184,39 +184,39 @@ msgstr "*Webauthn Browser* をクリックします。"
 msgid ""
 "If a user does not have WebAuthn credentials, the user must register "
 "WebAuthn credentials."
-msgstr "ユーザーが WebAuthn の資格情報を持っていない場合、ユーザーは WebAuthn の資格情報を登録する必要があります。"
+msgstr "ユーザーがWebAuthnのクレデンシャルを持っていない場合、ユーザーはWebAuthnのクレデンシャルを登録する必要があります。"
 
 #. type: Plain text
 msgid ""
 "Users can log in with WebAuthn if they have a WebAuthn credential registered"
 " only. So instead of adding the *WebAuthn Authenticator* execution, you can:"
 msgstr ""
-"ユーザーは、WebAuthnのクレデンシャルが登録されている場合のみ、WebAuthnでログインすることができます。そのため、*WebAuthn "
-"Authenticator* の実行を追加する代わりに"
+"ユーザーは、WebAuthnのクレデンシャルが登録されている場合のみ、WebAuthnでログインすることができます。そのため、 *WebAuthn "
+"Authenticator* のエグゼキューションを追加する代わりに、以下ができます。"
 
 #. type: Plain text
 msgid "Enter \"Conditional 2FA\" for the _Alias_ field."
-msgstr "Alias_の項目には「Conditional 2FA」と入力します。"
+msgstr "_Alias_ の項目には \"Conditional 2FA\" と入力します。"
 
 #. type: Plain text
 msgid "Click _CONDITIONAL_ for *Conditional 2FA*"
-msgstr "条件付き2FA*の場合は、_CONDITIONAL_をクリックします。"
+msgstr "*Conditional 2FA* の _CONDITIONAL_ をクリックします。"
 
 #. type: Plain text
 msgid "Click on the _Actions_ link for *Conditional 2FA*."
-msgstr "条件付き2FA*の_Actions_のリンクをクリックしてください。"
+msgstr "条件付き2FA*の_Actions_のリンクをクリックします。"
 
 #. type: Plain text
 msgid "Click *Condition - User Configured*."
-msgstr "条件 - ユーザー設定*」をクリックします。"
+msgstr "*Condition - User Configured* をクリックします。"
 
 #. type: Plain text
 msgid "Click _REQUIRED_ for *Conditional 2FA*"
-msgstr "条件付き2FA*の場合は、_REQUIRED_をクリックしてください。"
+msgstr "*Conditional 2FA* の _REQUIRED_ をクリックします。"
 
 #. type: Plain text
 msgid "Click _ALTERNATIVE_ for *Conditional 2FA*"
-msgstr "条件付き2FA*の場合は、_ALTERNATIVE_をクリックしてください。"
+msgstr "*Conditional 2FA* の _ALTERNATIVE_ をクリックします。"
 
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-conditional.png[]"
@@ -225,15 +225,15 @@ msgstr "image:images/webauthn-browser-flow-conditional.png[]"
 #. type: Plain text
 msgid ""
 "The user can choose between using WebAuthn and OTP for the second factor:"
-msgstr "2つ目の要素については、WebAuthnを使用するかOTPを使用するかをユーザーが選択することができます。"
+msgstr "2つ目の要素については、WebAuthnを使用するかOTPを使用するかをユーザーが選択できます。"
 
 #. type: Plain text
 msgid "Click the _Actions_ link for *Conditional 2FA*."
-msgstr "条件付き2FA*の_Actions_のリンクをクリックしてください。"
+msgstr "*Conditional 2FA* の _Actions_ のリンクをクリックします。"
 
 #. type: Plain text
 msgid "Click *ITP Form*."
-msgstr "ITP Form*をクリックします。"
+msgstr "*ITP Form* をクリックします。"
 
 #. type: Plain text
 msgid "image:images/webauthn-browser-flow-conditional-with-OTP.png[]"
@@ -242,13 +242,13 @@ msgstr "image:images/webauthn-browser-flow-conditional-with-OTP.png[]"
 #. type: Title ====
 #, no-wrap
 msgid "Authenticate with WebAuthn authenticator"
-msgstr "WebAuthn 認証を使用した認証。"
+msgstr "WebAuthnオーセンティケーターを使用した認証"
 
 #. type: Plain text
 msgid ""
 "After registering a WebAuthn authenticator, the user carries out the "
 "following operations:"
-msgstr "WebAuthn 認証機能を登録した後、ユーザーは以下の操作を行います。"
+msgstr "WebAuthnオーセンティケーターを登録した後、ユーザーは以下の操作を行います。"
 
 #. type: Plain text
 msgid ""
@@ -260,7 +260,7 @@ msgstr "ログインフォームを開きます。ユーザーはユーザー名
 msgid ""
 "The user's browser asks the user to authenticate by using their WebAuthn "
 "authenticator."
-msgstr "ユーザーのブラウザは、ユーザーに WebAuthn 認証を使用した認証を要求します。"
+msgstr "ユーザーのブラウザーは、ユーザーにWebAuthnオーセンティケーターを使用した認証を要求します。"
 
 #. type: Title ====
 #, no-wrap
@@ -270,39 +270,39 @@ msgstr "管理者としてWebAuthnを管理する"
 #. type: Title =====
 #, no-wrap
 msgid "Managing credentials"
-msgstr "認証情報の管理"
+msgstr "クレデンシャルの管理"
 
 #. type: Plain text
 msgid ""
 "{project_name} manages WebAuthn credentials similarly to other credentials "
 "from xref:ref-user-credentials_{context}[User credential management]:"
 msgstr ""
-"{project_name} は、xref:ref-user-credentials_{context}[User credential "
-"management] の他のクレデンシャルと同様に WebAuthn のクレデンシャルを管理します。"
+"{project_name}は、 xref:ref-user-credentials_{context}[ユーザークレデンシャル管理] "
+"の他のクレデンシャルと同様にWebAuthnのクレデンシャルを管理します。"
 
 #. type: Plain text
 msgid ""
 "{project_name} assigns users a required action to create a WebAuthn "
 "credential from the *Reset Actions* list and select *Webauthn Register*."
 msgstr ""
-"{project_name} は、*Reset Actions* リストから WebAuthn クレデンシャルを作成し、*Webauthn "
+"{project_name}は、 *Reset Actions* の一覧からWebAuthnクレデンシャルを作成し、 *Webauthn "
 "Register* を選択するという必須アクションをユーザーに割り当てます。"
 
 #. type: Plain text
 msgid "Administrators can delete a WebAuthn credential by clicking *Delete*."
-msgstr "管理者は、*Delete*をクリックして、WebAuthnクレデンシャルを削除することができます。"
+msgstr "管理者は、 *Delete* をクリックして、WebAuthnのクレデンシャルを削除することができます。"
 
 #. type: Plain text
 msgid ""
 "Administrators can view the credential's data, such as the AAGUID, by "
 "selecting *Show data...*."
-msgstr "管理者は、*Show data...* を選択して、AAGUID などのクレデンシャルのデータを表示できます。"
+msgstr "管理者は、 *Show data...* を選択して、AAGUIDなどのクレデンシャルのデータを表示できます。"
 
 #. type: Plain text
 msgid ""
 "Administrators can set a label for the credential by setting a value in the "
 "*User Label* field and saving the data."
-msgstr "管理者は、*User Label*フィールドに値を設定し、データを保存することで、クレデンシャルにラベルを設定することができます。"
+msgstr "管理者は、*User Label* フィールドに値を設定し、データを保存することで、クレデンシャルにラベルを設定することができます。"
 
 #. type: Title =====
 #, no-wrap
@@ -313,7 +313,7 @@ msgstr "ポリシーの管理"
 msgid ""
 "Administrators can configure WebAuthn related operations as *WebAuthn "
 "Policy* per realm."
-msgstr "管理者は、WebAuthn関連の操作をレルムごとに*WebAuthn Policy*として設定することができます。"
+msgstr "管理者は、WebAuthn関連の操作をレルムごとに *WebAuthn Policy* として設定できます。"
 
 #. type: Plain text
 msgid "Click the *WebAuthn Policy* tab."
@@ -321,7 +321,7 @@ msgstr "*WebAuthn Policy* タブをクリックします。"
 
 #. type: Plain text
 msgid "Configure the items within the policy (see description below)."
-msgstr "ポリシー内の項目を設定する（以下の説明を参照）。"
+msgstr "ポリシー内の項目を設定します（以下の説明を参照）。"
 
 #. type: Plain text
 msgid "The configurable items and their description are as follows:"
@@ -343,10 +343,10 @@ msgid ""
 "https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity[WebAuthn "
 "Specification]."
 msgstr ""
-"WebAuthn Relying Party としての読み取り可能なサーバ名。この項目は必須であり、WebAuthn "
-"認証者の登録に適用されます。デフォルトは \"keycloak\" です。詳しくは "
-"https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity[WebAuthn "
-"Specification]を参照してください。"
+"WebAuthn Relying "
+"Partyとしての読み取り可能なサーバー名。この項目は必須であり、WebAuthnオーセンティケーターの登録に適用されます。デフォルトは "
+"\"keycloak\" です。詳しくは https://www.w3.org/TR/webauthn/#dictionary-"
+"pkcredentialentity[WebAuthnの仕様] を参照してください。"
 
 #. type: Plain text
 msgid "Signature Algorithms"
@@ -365,14 +365,15 @@ msgid ""
 "https://www.w3.org/TR/webauthn/#dictdef-"
 "publickeycredentialparameters[WebAuthn Specification]."
 msgstr ""
-"WebAuthn 認証機関に https://www.w3.org/TR/webauthn/#iface-pkcredential[Public Key"
-" Credential]に使用する署名アルゴ リズムを伝えるアルゴリズム。{project_name} は公開鍵クレデンシャルを使用して "
+"WebAuthnオーセンティケーターに https://www.w3.org/TR/webauthn/#iface-"
+"pkcredential[Public Key Credential]に使用する署名アルゴ "
+"リズムを伝えるアルゴリズム。{project_name}は公開鍵クレデンシャルを使用して "
 "https://www.w3.org/TR/webauthn/#authentication-assertion[Authentication "
-"Assertions]に署名および検証を行う。アルゴリズムが存在しない場合、デフォルトの "
+"Assertions] に署名および検証を行います。アルゴリズムが存在しない場合、デフォルトの "
 "https://datatracker.ietf.org/doc/html/rfc8152#section-8.1[ES256] "
-"が適応される。ES256 は、WebAuthn 認証者の登録に適用されるオプションの設定項目です。詳しくは "
+"が適応されます。ES256は、WebAuthnオーセンティケーターの登録に適用されるオプションの設定項目です。詳しくは "
 "https://www.w3.org/TR/webauthn/#dictdef-"
-"publickeycredentialparameters[WebAuthn 仕様]をご覧ください。"
+"publickeycredentialparameters[WebAuthnの仕様]をご覧ください。"
 
 #. type: Plain text
 msgid "Relying Party ID"
@@ -389,10 +390,9 @@ msgid ""
 "https://www.w3.org/TR/webauthn/[WebAuthn Specification]."
 msgstr ""
 "https://www.w3.org/TR/webauthn/#public-key-credential[Public Key "
-"Credentials]の範囲を決定する、WebAuthn Relying Party の ID。この ID "
-"は、オリジンの有効ドメインでなければならない。この ID は、WebAuthn "
-"認証者の登録に適用されるオプションの設定項目である。この項目が空白の場合、{project_name} は {project_name} のベース "
-"URL のホスト部分を適応します。詳しくは https://www.w3.org/TR/webauthn/[WebAuthn 仕様]を参照してください。"
+"Credentials]の範囲を決定する、WebAuthn Relying "
+"PartyのID。このIDは、オリジンの有効ドメインでなければなりません。このIDは、WebAuthnオーセンティケーターの登録に適用されるオプションの設定項目です。この項目が空白の場合、{project_name}は{project_name}のベースURLのホスト部分を適応します。詳しくは"
+" https://www.w3.org/TR/webauthn/[WebAuthnの仕様]を参照してください。"
 
 #. type: Plain text
 msgid "Attestation Conveyance Preference"
@@ -408,10 +408,11 @@ msgid ""
 "\"none\". For more details, see https://www.w3.org/TR/webauthn/[WebAuthn "
 "Specification]."
 msgstr ""
-"ブラウザ上のWebAuthn API実装（https://www.w3.org/TR/webauthn/#webauthn-"
-"client[WebAuthn Client]）は、Attestation文を生成するための優先的な方法です。この設定は、WebAuthn "
-"認証機能の登録に適用されるオプションの設定項目です。オプションがない場合は、「none」を選択したのと同じ動作となります。詳しくは "
-"https://www.w3.org/TR/webauthn/[WebAuthn Specification]をご覧ください。"
+"ブラウザー上のWebAuthn API実装（https://www.w3.org/TR/webauthn/#webauthn-"
+"client[WebAuthn "
+"Client]）は、Attestation文を生成するための優先的な方法です。この設定は、WebAuthnオーセンティケーターの登録に適用されるオプションの設定項目です。オプションがない場合は、"
+" \"none\" を選択したのと同じ動作となります。詳しくは https://www.w3.org/TR/webauthn/[WebAuthnの仕様]"
+" を参照してください。"
 
 #. type: Plain text
 msgid "Authenticator Attachment"
@@ -425,9 +426,9 @@ msgid ""
 "https://www.w3.org/TR/webauthn/#enumdef-authenticatorattachment[WebAuthn "
 "Specification]."
 msgstr ""
-"WebAuthn クライアントで使用可能な WebAuthn 認証子の添付ファイルパターン。このパターンは、WebAuthn "
-"認証器の登録に適用されるオプションの設定項目です。詳しくは https://www.w3.org/TR/webauthn/#enumdef-"
-"authenticatorattachment[WebAuthn Specification]をご覧ください。"
+"WebAuthnクライアントで使用可能なWebAuthnオーセンティケーターの添付ファイルパターン。このパターンは、WebAuthnオーセンティケーターの登録に適用されるオプションの設定項目です。詳しくは"
+" https://www.w3.org/TR/webauthn/#enumdef-authenticatorattachment[WebAuthn "
+"Specification] を参照してください。"
 
 #. type: Plain text
 msgid "Require Resident Key"
@@ -442,11 +443,11 @@ msgid ""
 "selecting \"No\". For more details, see https://www.w3.org/TR/webauthn/#dom-"
 "authenticatorselectioncriteria-requireresidentkey[WebAuthn Specification]."
 msgstr ""
-"WebAuthn 認証機関が公開鍵クレデンシャルを https://www.w3.org/TR/webauthn/[Client-side-"
-"resident Public Key Credential Source]として生成することを要求するオプショ ン。このオプションは、WebAuthn"
-" 認証器の登録に適用されます。空白のままだと、\"No "
-"\"を選択した場合と同じ動作になります。詳しくは、https://www.w3.org/TR/webauthn/#dom-"
-"authenticatorselectioncriteria-requireresidentkey[WebAuthn 仕様]を参照してください。"
+"WebAuthnオーセンティケーターが公開鍵クレデンシャルを https://www.w3.org/TR/webauthn/[Client-side-"
+"resident Public Key Credential Source]として生成することを要求するオプショ "
+"ン。このオプションは、WebAuthnオーセンティケーターの登録に適用されます。空白のままだと、\"No\" "
+"を選択した場合と同じ動作になります。詳しくは、 https://www.w3.org/TR/webauthn/#dom-"
+"authenticatorselectioncriteria-requireresidentkey[WebAuthn 仕様] を参照してください。"
 
 #. type: Plain text
 msgid "User Verification Requirement"
@@ -465,12 +466,12 @@ msgid ""
 "publickeycredentialrequestoptions-userverification[WebAuthn Specification "
 "for authenticating the user by a WebAuthn authenticator]."
 msgstr ""
-"WebAuthn 認証機関がユーザーの認証を確認することを要求するオプションです。これは、WebAuthn 認証器の登録および WebAuthn "
-"認証器によるユーザの認証に適用されるオプション設定項目です。オプションがない場合は、\"preferred "
-"\"を選択した場合と同じ動作となります。詳しくは、https://www.w3.org/TR/webauthn/#dom-"
-"authenticatorselectioncriteria-userverification[WebAuthn 認証器の登録に関する仕様] および "
-"https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-"
-"userverification[WebAuthn 認証器によるユーザ認証に関する仕様] をご覧ください。"
+"WebAuthnオーセンティケーターがユーザーの認証を確認することを要求するオプションです。これは、WebAuthnオーセンティケーターの登録および "
+"WebAuthnオーセンティケーターによるユーザーの認証に適用されるオプション設定項目です。オプションがない場合は、\"preferred\" "
+"を選択した場合と同じ動作となります。詳しくは、 https://www.w3.org/TR/webauthn/#dom-"
+"authenticatorselectioncriteria-userverification[WebAuthnオーセンティケーターの登録に関する仕様]"
+" および https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-"
+"userverification[WebAuthnオーセンティケーターによるユーザー認証に関する仕様] を参照してください。"
 
 #. type: Plain text
 msgid "Timeout"
@@ -488,11 +489,12 @@ msgid ""
 "timeout[WebAuthn Specification for authenticating the user by a WebAuthn "
 "authenticator]."
 msgstr ""
-"WebAuthn 認証機能を用いてユーザーを登録し、認証する際のタイムアウト値を秒単位で指定します。0 を指定すると、その動作は WebAuthn "
-"認証器の実装に依存します。デフォルトは 0 です。詳しくは https://www.w3.org/TR/webauthn/#dom-"
-"publickeycredentialcreationoptions-timeout[WebAuthn 認証器の登録に関する仕様] および "
+"WebAuthnオーセンティケーターを用いてユーザーを登録し、認証する際のタイムアウト値を秒単位で指定します。0を指定すると、その動作は "
+"WebAuthnオーセンティケーターの実装に依存します。デフォルトは 0 です。詳しくは "
+"https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-"
+"timeout[WebAuthnオーセンティケーターの登録に関する仕様] および "
 "https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-"
-"timeout[WebAuthn 認証器によるユーザ認証に関する仕様] を参照してください。"
+"timeout[WebAuthnオーセンティケーターによるユーザー認証に関する仕様] を参照してください。"
 
 #. type: Plain text
 msgid "Avoid Same Authenticator Registration"
@@ -502,7 +504,7 @@ msgstr "Avoid Same Authenticator Registration"
 msgid ""
 "If enabled, {project_name} cannot re-register an already registered WebAuthn"
 " authenticator."
-msgstr "有効な場合、{project_name} は既に登録されている WebAuthn 認証器を再登録することはできません。"
+msgstr "有効な場合、{project_name}は既に登録されているWebAuthnオーセンティケーターを再登録することはできません。"
 
 #. type: Plain text
 msgid "Acceptable AAGUIDs"
@@ -512,12 +514,12 @@ msgstr "Acceptable AAGUIDs"
 msgid ""
 "The white list of AAGUIDs which a WebAuthn authenticator must register "
 "against."
-msgstr "WebAuthn 認証エージェントが登録しなければならない AAGUID のホワイトリスト。"
+msgstr "WebAuthnオーセンティケーターが登録しなければならないAAGUIDのホワイトリスト。"
 
 #. type: Title ====
 #, no-wrap
 msgid "Attestation statement verification"
-msgstr "認証文の検証"
+msgstr "Attestation文の検証"
 
 #. type: Plain text
 msgid ""
@@ -528,10 +530,8 @@ msgid ""
 "link:{installguide_truststore_link}[{installguide_truststore_name}], so you "
 "must import these certificates into it in advance."
 msgstr ""
-"WebAuthn認証器を登録する際、{project_name} "
-"はWebAuthn認証器が生成する認証文の信頼性を検証する。{project_name} "
-"は、このためにトラストアンカーの証明書を必要とします。{project_name} は "
-"link:{installguide_truststore_link}[{installguide_truststore_name}] "
+"WebAuthnオーセンティケーターを登録する際、{project_name}はWebAuthnオーセンティケーターが生成するAttestation文の信頼性を検証します。{project_name}は、このためにトラストアンカーの証明書を必要とします。{project_name}は"
+" link:{installguide_truststore_link}[{installguide_truststore_name}]  "
 "を利用しているので、事前にこれらの証明書をインポートしておく必要があります。"
 
 #. type: Plain text
@@ -540,7 +540,8 @@ msgid ""
 "policy's configuration item \"Attestation Conveyance Preference\" to "
 "\"none\"."
 msgstr ""
-"この検証を省略するには、このトラストストアを無効にするか、WebAuthnポリシーの設定項目「証明書伝達の優先度」を「なし」に設定してください。"
+"この検証を省略するには、このトラストストアを無効にするか、WebAuthnポリシーの設定項目 \"Attestation Conveyance "
+"Preference\" を \"none\" に設定してください。"
 
 #. type: Title ====
 #, no-wrap
@@ -550,14 +551,14 @@ msgstr "ユーザーとしてのWebAuthnクレデンシャルの管理"
 #. type: Title =====
 #, no-wrap
 msgid "Register WebAuthn authenticator"
-msgstr "WebAuthn認証器の登録"
+msgstr "WebAuthnオーセンティケーターの登録"
 
 #. type: Plain text
 msgid ""
 "The appropriate method to register a WebAuthn authenticator depends on "
 "whether the user has already registered an account on {project_name}."
 msgstr ""
-"WebAuthn 認証機能を登録する適切な方法は、ユーザーが既に {project_name} にアカウントを登録しているかどうかに依存します。"
+"WebAuthnオーセンティケーターを登録する適切な方法は、ユーザーが既に {project_name}にアカウントを登録しているかどうかに依存します。"
 
 #. type: Title =====
 #, no-wrap
@@ -569,8 +570,8 @@ msgid ""
 "If the *WebAuthn Register* required action is *Default Action* in a realm, "
 "new users must set up the WebAuthn security key after their first login."
 msgstr ""
-"realmで*WebAuthn Register* required actionが*Default "
-"Action*の場合、新規ユーザーは最初のログイン後にWebAuthnセキュリティキーをセットアップしなければなりません。"
+"レルムで *WebAuthn Register*の必須アクションが *Default Action* "
+"の場合、新規ユーザーは最初のログイン後にWebAuthnセキュリティー鍵をセットアップしなければなりません。"
 
 #. type: Plain text
 msgid "Open the login form."
@@ -578,13 +579,13 @@ msgstr "ログインフォームを開きます。"
 
 #. type: Plain text
 msgid "Fill in the items on the form."
-msgstr "フォームの項目を記入する。"
+msgstr "フォームの項目を記入します。"
 
 #. type: Plain text
 msgid ""
 "After successfully registering, the browser asks the user to enter the text "
 "of their WebAuthn authenticator's label."
-msgstr "登録に成功すると、ブラウザは、WebAuthn認証器のラベルのテキストを入力するようユーザーに要求します。"
+msgstr "登録に成功すると、ブラウザーは、WebAuthnオーセンティケーターのラベルのテキストを入力するようユーザーに要求します。"
 
 #. type: Title =====
 #, no-wrap
@@ -597,8 +598,8 @@ msgid ""
 "example, then when existing users try to log in, they are required to "
 "register their WebAuthn authenticator automatically:"
 msgstr ""
-"最初の例のように `WebAuthn Authenticator` を必須として設定すると、既存のユーザーがログインしようとしたときに、自動的に "
-"WebAuthn 認証機能の登録が要求されるようになります。"
+"最初の例のように `WebAuthn Authenticator` "
+"を必須として設定すると、既存のユーザーがログインしようとしたときに、自動的にWebAuthnオーセンティケーターの登録が要求されるようになります。"
 
 #. type: Plain text
 msgid "Enter the items on the form."
@@ -612,7 +613,7 @@ msgstr "*Login* をクリックします。"
 msgid ""
 "After successful registration, the user's browser asks the user to enter the"
 " text of their WebAuthn authenticator's label."
-msgstr "登録に成功すると、ユーザーのブラウザは、WebAuthn認証器のラベルのテキストを入力するように要求します。"
+msgstr "登録に成功すると、ユーザーのブラウザーは、WebAuthnオーセンティケーターのラベルのテキストを入力するように要求します。"
 
 #. type: Title ====
 #, no-wrap
@@ -628,10 +629,9 @@ msgid ""
 " and two-factor authentication mechanism in the context of a realm and a "
 "single authentication flow."
 msgstr ""
-"{project_name} は二要素認証に WebAuthn を使っていますが、一要素認証に WebAuthn "
-"を使うこともできます。この場合、`パスワードレス`の WebAuthn の資格情報を持つユーザは、パスワードなしで {project_name} "
-"を認証することができます。{project_name} は、ひとつのレルムとひとつの認証フローで、 WebAuthn "
-"をパスワードなし認証と二要素認証の両方の仕組みとして使うことができます。"
+"{project_name}は二要素認証にWebAuthnを使っていますが、一要素認証にWebAuthnを使うこともできます。この場合、 "
+"`passwordless` のWebAuthn "
+"のクレデンシャルを持つユーザーは、パスワードなしで{project_name}を認証することができます。{project_name}は、ひとつのレルムとひとつの認証フローで、WebAuthnをパスワードなし認証と二要素認証の両方の仕組みとして使うことができます。"
 
 #. type: Plain text
 msgid ""
@@ -641,9 +641,7 @@ msgid ""
 "security key using a PIN, or the security key attests with a stronger "
 "certificate authority."
 msgstr ""
-"管理者は通常、WebAuthn パスワードレス認証のためにユーザーが登録したセキュリティ "
-"キーが、異なる要件を満たすことを要求します。例えば、セキュリティ キーは、ユーザーが PIN を使用してセキュリティ "
-"キーに認証することを要求したり、セキュリティ キーがより強力な認証局で認証することを要求したりすることがあります。"
+"管理者は通常、WebAuthnパスワードレス認証のためにユーザーが登録したセキュリティー鍵が、異なる要件を満たすことを要求します。たとえば、セキュリティー鍵は、ユーザーがPINを使用してセキュリティー鍵に認証することを要求したり、セキュリティー鍵がより強力な認証局で認証することを要求したりすることがあります。"
 
 #. type: Plain text
 msgid ""
@@ -652,9 +650,9 @@ msgid ""
 "Register Passwordless` action of type and separate authenticator of type "
 "`WebAuthn Passwordless Authenticator`."
 msgstr ""
-"このため、{project_name} は管理者に個別の `WebAuthn Passwordless Policy` "
-"を設定することを許可しています。WebAuthn Register Passwordless` アクションが必要で、 `WebAuthn "
-"Passwordless Authenticator` タイプの認証ツールが別途必要です。"
+"このため、{project_name}は管理者に個別の `WebAuthn Passwordless Policy` を設定することを許可しています。 "
+"`WebAuthn Register Passwordless` のアクションが必要で、 `WebAuthn Passwordless "
+"Authenticator` タイプのオーセンティケーターが別途必要です。"
 
 #. type: Plain text
 msgid "Set up WebAuthn passwordless support as follows:"
@@ -666,11 +664,9 @@ msgid ""
 "steps described in <<_webauthn-register, Enable WebAuthn Authenticator "
 "Registration>>. Register the `Webauthn Register Passwordless` action."
 msgstr ""
-"WebAuthnのパスワードレス対応に必要なアクションを新規に登録します。&lt;&gt;で説明した手順を使用して<_webauthn-"
-"register, Enable WebAuthn Authenticator Registration>ください</_webauthn-"
-"register,>。<_webauthn-register, Enable WebAuthn Authenticator "
-"Registration>Webauthn Register Passwordless` アクションを登録します。</_webauthn-"
-"register,>"
+"WebAuthnのパスワードレス対応に必須アクションを新規に登録します。<<_webauthn-register, "
+"WebAuthnオーセンティケーターの登録の有効化>>で説明した手順を使用してください。 `Webauthn Register "
+"Passwordless` アクションを登録します。"
 
 #. type: Plain text
 msgid ""
@@ -682,10 +678,10 @@ msgid ""
 "Verification Requirement* to *Required* when you configure the passwordless "
 "policy."
 msgstr ""
-"ポリシーを設定します。&lt;&gt;で説明した手順と設定オプションが使用できます<_webauthn-policy, Managing "
-"Policy>。管理者コンソールのタブ *WebAuthn Passwordless Policy* "
-"で設定を実行します。通常、セキュリティキーの要件は、2要素ポリシーの要件よりも強くなります。たとえば、パスワードレスポリシーを構成する際に、*User "
-"Verification Requirement* を *Required* に設定します。</_webauthn-policy,>"
+"ポリシーを設定します。<<_webauthn-policy, ポリシーの管理>>で説明した手順と設定オプションが使用できます。管理コンソールのタブ "
+"*WebAuthn Passwordless Policy* "
+"で設定を実行します。通常、セキュリティー鍵の要件は、2要素ポリシーの要件よりも強くなります。たとえば、パスワードレスポリシーを設定する際に、*User "
+"Verification Requirement* を *Required* に設定します。"
 
 #. type: Plain text
 msgid ""
@@ -693,9 +689,9 @@ msgid ""
 " in <<_webauthn-authenticator-setup, Adding WebAuthn Authentication to a "
 "Browser Flow>>. Configure the flow as follows:"
 msgstr ""
-"認証フローを設定します。&lt;&gt;で説明した*WebAuthn Browser*のフローを使用します<_webauthn-"
-"authenticator-setup, Adding WebAuthn Authentication to a Browser "
-"Flow>。フローを以下のように設定します。</_webauthn-authenticator-setup,>"
+"認証フローを設定します。<<_webauthn-authenticator-setup, "
+"ブラウザフローへのWebAuthnオーセンティケーターの追加>>で説明した *WebAuthn Browser* "
+"のフローを使用します。フローを以下のように設定します。"
 
 #. type: Plain text
 #, no-wrap
@@ -716,9 +712,8 @@ msgid ""
 "Two-factor*, for example. This subflow indicates the user can authenticate "
 "with Passwordless WebAuthn credential or with Two-factor authentication.\n"
 msgstr ""
-"** 例えば、*Passwordless Or Two-factor* "
-"という名前の必須サブフローが存在します。このサブフローは、ユーザーがパスワードなしの WebAuthn クレデンシャルまたは 2 "
-"要素認証で認証できることを示します。\n"
+"** たとえば、*Passwordless Or Two-factor* "
+"という名前の必須サブフローが存在します。このサブフローは、ユーザーがパスワードレスのWebAuthnクレデンシャルまたは2要素認証で認証できることを示します。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -734,13 +729,13 @@ msgid ""
 "Webauthn*, for example. This subflow contains a *Password Form* and a "
 "*WebAuthn Authenticator*.\n"
 msgstr ""
-"** 2つ目の選択肢は、例えば*Password And Two-factor "
-"Webauthn*という名前のサブフローになります。このサブフローには、*Password Form* と *WebAuthn "
-"Authenticator* が含まれます。\n"
+"** 2つ目の選択肢は、たとえば *Password And Two-factor Webauthn* "
+"という名前のサブフローになります。このサブフローには、 *Password Form* と *WebAuthn Authenticator* "
+"が含まれます。\n"
 
 #. type: Plain text
 msgid "The final configuration of the flow looks similar to this:"
-msgstr "最終的なフローの構成はこのような感じになります。"
+msgstr "最終的なフローの設定はこのような感じになります。"
 
 #. type: Plain text
 msgid "image:images/webauthn-passwordless-flow.png[]"
@@ -754,7 +749,6 @@ msgid ""
 "credential. The user does not need to provide the password and second-factor"
 " WebAuthn credential if they use the WebAuthn Passwordless credential."
 msgstr ""
-"すでに {project_name} に知られているユーザーに、必須アクションとして *WebAuthn Register Passwordless* "
-"を追加し、これをテストすることができます。最初の認証では、ユーザーはパスワードと第 2 要素の WebAuthn "
-"クレデンシャルを使用する必要があります。WebAuthn Passwordless クレデンシャルを使用する場合、ユーザーはパスワードと第 2 要素の "
-"WebAuthn クレデンシャルを提供する必要はありません。"
+"すでに{project_name}に認識されているユーザーに、必須アクションとして *WebAuthn Register Passwordless* "
+"を追加し、これをテストすることができます。最初の認証では、ユーザーはパスワードと第2要素のWebAuthnクレデンシャルを使用する必要があります。WebAuthn"
+" Passwordlessクレデンシャルを使用する場合、ユーザーはパスワードと第2要素の WebAuthn クレデンシャルを提供する必要はありません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/webauthn.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__webauthn
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
