### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-creating-oidc-client.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-creating-oidc-client.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-creating-oidc-client.ja_JP.po
@@ -1,0 +1,176 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Block title
+#, no-wrap
+msgid "Procedure"
+msgstr "手順"
+
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Additional resources"
+msgstr "追加のリソース"
+
+#. type: Title =
+#, no-wrap
+msgid "Creating an OpenID Connect Client"
+msgstr "OpenID Connectクライアントの作成"
+
+#. type: Plain text
+msgid ""
+"To protect an application that uses the OpenID connect protocol, you create "
+"a client."
+msgstr "OpenID Connectプロトコルを使用するアプリケーションを保護するために、クライアントを作成します。"
+
+#. type: Plain text
+msgid "Click *Clients* in the menu."
+msgstr "メニューの *Clients* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Create* to go to the *Add Client* page."
+msgstr "*Create* をクリックすると、 *Add Client* のページに移動します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add client"
+msgstr "Add client"
+
+#. type: Plain text
+msgid "image:{project_images}/add-client-oidc.png[Add Client]"
+msgstr "image:{project_images}/add-client-oidc.png[Add Client]"
+
+#. type: Plain text
+msgid "Enter any name for *Client ID.*"
+msgstr "Client ID.*に任意の名前を入力します。"
+
+#. type: Plain text
+msgid "Select *openid-connect* in the *Client Protocol* drop down box."
+msgstr "クライアントプロトコル*のドロップダウンボックスで、*openid-connect*を選択します。"
+
+#. type: Plain text
+msgid "Enter the base URL of your application in the *Root URL* field."
+msgstr "Root URL* 欄にアプリケーションのベース URL を入力します。"
+
+#. type: Plain text
+msgid "Configure the client permissions"
+msgstr "クライアントのアクセス権を設定する"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Set *Access Type* to *confidential*.                                     \n"
+msgstr ""
+"Access Type*を*confidential*に設定します。                                     \n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Set *Standard Flow Enabled* to *OFF*.                                     \n"
+msgstr ""
+"Standard Flow Enabled*を*OFF*に設定します。                                     \n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Set *Direct Access Grants Enabled* to *OFF*."
+"                                     \n"
+msgstr ""
+"Direct Access Grants Enabled*を*Off*に設定します。"
+"                                     \n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"set *Service Accounts Enabled* to *ON*.                                     "
+"\n"
+msgstr ""
+"Service Accounts Enabled*を*ON*に設定します。                                     \n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Set the service account roles for the client:                             \n"
+msgstr "クライアントのサービスアカウントの役割を設定します。                             \n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Click the *Service Account Roles* tab.\n"
+msgstr "サービスアカウントの役割*」タブをクリックします。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Click *Client Roles* and enter *realm-management*.\n"
+msgstr "Client Roles*をクリックし、*realm-management*と入力します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Under *Available Roles*, select *manage-clients*.\n"
+msgstr "利用可能な役割*の下で、*manage-clients*を選択します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Click *Add selected >>* to move *manage-clients* under *Assigned Roles*.\n"
+msgstr ""
+"Add selected &gt;&gt;*をクリックして、*Assigned Roles*の下に*manage-clients*を移動します。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Note the client credentials\n"
+msgstr "クライアントの認証情報をメモする\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "On the Credentials tab, make a note of the Secret field\n"
+msgstr "認証情報]タブで、[秘密]フィールドをメモしておきます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "On the *Settings* tab, make note the client ID that you assigned.\n"
+msgstr "設定]タブで、割り当てたクライアントIDをメモしておきます。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "Click *Save*.\n"
+msgstr "保存］をクリックします。\n"
+
+#. type: Plain text
+msgid "This action creates the client and bring you to the *Settings* tab."
+msgstr "この操作により、クライアントが作成され、*設定*タブが表示されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Client settings"
+msgstr "クライアント設定"
+
+#. type: Plain text
+msgid "image:{project_images}/client-settings-oidc.png[Client Settings]"
+msgstr "image:{project_images}/client-settings-oidc.png[Client Settings]"
+
+#. type: Plain text
+msgid ""
+"For more information about the OIDC protocol, see xref:con-"
+"oidc_{context}[OpenID Connect]."
+msgstr "OIDCプロトコルの詳細については、xref:con-oidc_{context}[OpenID Connect]を参照してください。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-creating-oidc-client.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-creating-oidc-client.ja_JP.po
@@ -63,107 +63,102 @@ msgstr "image:{project_images}/add-client-oidc.png[Add Client]"
 
 #. type: Plain text
 msgid "Enter any name for *Client ID.*"
-msgstr "Client ID.*に任意の名前を入力します。"
+msgstr "*Client ID* に任意の名前を入力します。"
 
 #. type: Plain text
 msgid "Select *openid-connect* in the *Client Protocol* drop down box."
-msgstr "クライアントプロトコル*のドロップダウンボックスで、*openid-connect*を選択します。"
+msgstr "*Client Protocol* のドロップダウンボックスで、 *openid-connect* を選択します。"
 
 #. type: Plain text
 msgid "Enter the base URL of your application in the *Root URL* field."
-msgstr "Root URL* 欄にアプリケーションのベース URL を入力します。"
+msgstr "*Root URL* フィールドにアプリケーションのベースURLを入力します。"
 
 #. type: Plain text
 msgid "Configure the client permissions"
-msgstr "クライアントのアクセス権を設定する"
+msgstr "クライアントのパーミッションを設定する"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "Set *Access Type* to *confidential*.                                     \n"
-msgstr ""
-"Access Type*を*confidential*に設定します。                                     \n"
+msgstr "*Access Type* を *confidential* に設定します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "Set *Standard Flow Enabled* to *OFF*.                                     \n"
-msgstr ""
-"Standard Flow Enabled*を*OFF*に設定します。                                     \n"
+msgstr "*Standard Flow Enabled* を *OFF* に設定します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "Set *Direct Access Grants Enabled* to *OFF*."
 "                                     \n"
-msgstr ""
-"Direct Access Grants Enabled*を*Off*に設定します。"
-"                                     \n"
+msgstr "*Direct Access Grants Enabled* を *Off* に設定します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "set *Service Accounts Enabled* to *ON*.                                     "
 "\n"
-msgstr ""
-"Service Accounts Enabled*を*ON*に設定します。                                     \n"
+msgstr "*Service Accounts Enabled* を *ON* に設定します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "Set the service account roles for the client:                             \n"
-msgstr "クライアントのサービスアカウントの役割を設定します。                             \n"
+msgstr "クライアントのサービス・アカウントのロールを設定します。                             \n"
 
 #. type: Plain text
 #, no-wrap
 msgid "Click the *Service Account Roles* tab.\n"
-msgstr "サービスアカウントの役割*」タブをクリックします。\n"
+msgstr "*Service Account Roles* タブをクリックします。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "Click *Client Roles* and enter *realm-management*.\n"
-msgstr "Client Roles*をクリックし、*realm-management*と入力します。\n"
+msgstr "*Client Roles* をクリックし、 *realm-management*と入力します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "Under *Available Roles*, select *manage-clients*.\n"
-msgstr "利用可能な役割*の下で、*manage-clients*を選択します。\n"
+msgstr "*Available Roles* の下で、 *manage-clients* を選択します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "Click *Add selected >>* to move *manage-clients* under *Assigned Roles*.\n"
 msgstr ""
-"Add selected &gt;&gt;*をクリックして、*Assigned Roles*の下に*manage-clients*を移動します。\n"
+"*Add selected >>* をクリックして、 *Assigned Roles* の下に *manage-clients* を移動します。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "Note the client credentials\n"
-msgstr "クライアントの認証情報をメモする\n"
+msgstr "クライアント・クレデンシャルをメモします。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "On the Credentials tab, make a note of the Secret field\n"
-msgstr "認証情報]タブで、[秘密]フィールドをメモしておきます。\n"
+msgstr "*Credentials* タブで、 *Secret* フィールドをメモしておきます。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "On the *Settings* tab, make note the client ID that you assigned.\n"
-msgstr "設定]タブで、割り当てたクライアントIDをメモしておきます。\n"
+msgstr "*Settings* タブで、割り当てたクライアントIDをメモしておきます。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid "Click *Save*.\n"
-msgstr "保存］をクリックします。\n"
+msgstr "*Save* をクリックします。\n"
 
 #. type: Plain text
 msgid "This action creates the client and bring you to the *Settings* tab."
-msgstr "この操作により、クライアントが作成され、*設定*タブが表示されます。"
+msgstr "この操作により、クライアントが作成され、 *Settings* タブが表示されます。"
 
 #. type: Block title
 #, no-wrap
 msgid "Client settings"
-msgstr "クライアント設定"
+msgstr "クライアントの設定"
 
 #. type: Plain text
 msgid "image:{project_images}/client-settings-oidc.png[Client Settings]"
@@ -173,4 +168,4 @@ msgstr "image:{project_images}/client-settings-oidc.png[Client Settings]"
 msgid ""
 "For more information about the OIDC protocol, see xref:con-"
 "oidc_{context}[OpenID Connect]."
-msgstr "OIDCプロトコルの詳細については、xref:con-oidc_{context}[OpenID Connect]を参照してください。"
+msgstr "OIDCプロトコルの詳細については、 xref:con-oidc_{context}[OpenID Connect] を参照してください。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/proc-creating-oidc-client.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__proc-creating-oidc-client
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
