### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/con-protocol-mappers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/con-protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/con-protocol-mappers.ja_JP.po
@@ -1,0 +1,217 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "OIDC token and SAML assertion mappings"
+msgstr "OIDCトークンとSAMLアサーションのマッピング"
+
+#. type: Plain text
+msgid ""
+"Applications receiving ID tokens, access tokens, or SAML assertions may "
+"require different roles and user metadata."
+msgstr ""
+"IDトークン、アクセストークン、またはSAMLアサーションを受け取るアプリケーションは、異なるロールとユーザーメタデータを必要とする場合があります。"
+
+#. type: Plain text
+msgid "You can use {project_name} to:"
+msgstr "project_name} を使用することができます。"
+
+#. type: Plain text
+msgid "Hardcode roles, claims and custom attributes."
+msgstr "ロール、クレーム、カスタム属性をハードコードする。"
+
+#. type: Plain text
+msgid "Pull user metadata into a token or assertion."
+msgstr "ユーザーのメタデータをトークンやアサーションに引き込む。"
+
+#. type: Plain text
+msgid "Rename roles."
+msgstr "役割の名前を変更する。"
+
+#. type: Plain text
+msgid "You perform these actions in the *Mappers* tab in the Admin Console."
+msgstr "これらのアクションは、Admin Consoleの*Mappers*タブで実行します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Mappers tab"
+msgstr "マッパーズ」タブ"
+
+#. type: Plain text
+msgid "image:{project_images}/mappers-oidc.png[]"
+msgstr "image:{project_images}/mappers-oidc.png[]"
+
+#. type: Plain text
+msgid ""
+"New clients do not have built-in mappers but they can inherit some mappers "
+"from client scopes. See the <<_client_scopes, client scopes section>> for "
+"more details."
+msgstr ""
+"新規クライアントはビルトインマッパーを持ちませんが、クライアントスコープからいくつかのマッパーを継承することができます。<_client_scopes,"
+" client scopes section>詳しくは</_client_scopes,>&lt;&gt;を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Protocol mappers map items (such as an email address, for example) to a "
+"specific claim in the identity and access token. The function of a mapper "
+"should be self explanatory from its name. You add pre-configured mappers by "
+"clicking *Add Builtin*."
+msgstr ""
+"プロトコルマッパーは、アイテム（たとえば電子メールアドレスなど）をIDおよびアクセストークンの特定のクレームにマッピングする。マッパーの機能は、その名前から説明できるはずです。事前に設定されたマッパーを追加するには、*Add"
+" Builtin* をクリックします。"
+
+#. type: Plain text
+msgid ""
+"Each mapper has a set of common settings. Additional settings are available,"
+" depending on the mapper type. Click *Edit* next to a mapper to access the "
+"configuration screen to adjust these settings."
+msgstr ""
+"各マッパーには、共通の設定項目があります。マッパーの種類によって、その他の設定も可能です。マッパーの横にある*Edit*をクリックすると、設定画面にアクセスし、これらの設定を調整することができます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Mapper config"
+msgstr "マッパーの設定"
+
+#. type: Plain text
+msgid "image:{project_images}/mapper-config.png[]"
+msgstr "image:{project_images}/mapper-config.png[]"
+
+#. type: Plain text
+msgid "Details on each option can be viewed by hovering over its tooltip."
+msgstr "各オプションの詳細は、ツールチップにカーソルを合わせると表示されます。"
+
+#. type: Plain text
+msgid ""
+"You can use most OIDC mappers to control where the claim gets placed. You "
+"opt to include or exclude the claim from the _id_ and _access_ tokens by "
+"adjusting the *Add to ID token* and *Add to access token* switches."
+msgstr ""
+"ほとんどのOIDCマッパーで、クレームがどこに置かれるかを制御することができます。IDトークン*とアクセストークンに追加する*スイッチを調整することで、"
+" _id_と_access_トークンからクレームを含むかどうかを選択します。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Priority order"
+msgstr "優先順位"
+
+#. type: Plain text
+msgid ""
+"Mapper implementations have _priority order_. _Priority order_ is not the "
+"configuration property of the mapper. It is the property of the concrete "
+"implementation of the mapper."
+msgstr ""
+"マッパーの実装は_priority order_を持ちます。優先順位_はマッパーの設定プロパティではありません。マッパーの具体的な実装のプロパティです。"
+
+#. type: Plain text
+msgid ""
+"Mappers are sorted by the order in the list of mappers. The changes in the "
+"token or assertion are applied in that order with the lowest applying first."
+" Therefore, the implementations that are dependent on other implementations "
+"are processed in the necessary order."
+msgstr ""
+"マッパーはマッパーリストの順番でソートされます。トークンまたはアサーションの変更は、最も低いものが最初に適用されるように、その順序で適用されます。したがって、他の実装に依存している実装は、必要な順序で処理される。"
+
+#. type: Plain text
+msgid "For example, to compute the roles which will be included with a token:"
+msgstr "例えば、あるトークンに含まれるロールを計算する場合。"
+
+#. type: Plain text
+msgid "Resolve audiences based on those roles."
+msgstr "その役割に基づき、オーディエンスを解決する。"
+
+#. type: Plain text
+msgid ""
+"Process a JavaScript script that uses the roles and audiences already "
+"available in the token."
+msgstr "トークンで既に利用可能なロールとオーディエンスを使用するJavaScriptスクリプトを処理します。"
+
+#. type: Title ==
+#, no-wrap
+msgid "OIDC user session note mappers"
+msgstr "OIDCユーザーセッションノートマッパー"
+
+#. type: Plain text
+msgid ""
+"User session details are defined using mappers and are automatically "
+"included when you use or enable a feature on a client. Click *Add builtin* "
+"to include session details."
+msgstr ""
+"ユーザーセッションの詳細は、マッパーを使用して定義され、クライアントで機能を使用または有効にすると、自動的に含まれます。セッションの詳細を含めるには、*ビルトインの追加*をクリックします。"
+
+#. type: Plain text
+msgid "Impersonated user sessions provide the following details:"
+msgstr "代理ユーザー・セッションは、次の詳細を提供します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*IMPERSONATOR_ID*: The ID of an impersonating user.\n"
+msgstr "*impersonator_id*。なりすましユーザーのID。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*IMPERSONATOR_USERNAME*: The username of an impersonating user.\n"
+msgstr "*impersonator_username*。なりすましユーザーのユーザー名。\n"
+
+#. type: Plain text
+msgid "Service account sessions provide the following details:"
+msgstr "サービス・アカウント・セッションは、次の詳細を提供します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*clientId*: The client ID of the service account.\n"
+msgstr "*clientId*:サービスアカウントのクライアントID。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"*clientAddress*: The remote host IP of the service account's authenticated "
+"device.\n"
+msgstr "*clientAddress*:サービスアカウントの認証済みデバイスのリモートホストIP。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"*clientHost*: The remote host name of the service account's authenticated "
+"device.\n"
+msgstr "*clientHost*:サービスアカウントの認証済みデバイスのリモートホスト名。\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Script mapper"
+msgstr "スクリプトマッパー"
+
+#. type: Plain text
+msgid ""
+"Use the *Script Mapper* to map claims to tokens by running user-defined "
+"JavaScript code. For more details about deploying scripts to the server, see"
+" link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]."
+msgstr ""
+"ユーザー定義の JavaScript コードを実行して、クレームをトークンにマッピングするには、 *Script Mapper* "
+"を使用します。サーバーへのスクリプトのデプロイの詳細については、link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]を参照してください。"
+
+#. type: Plain text
+msgid ""
+"When scripts deploy, you should be able to select the deployed scripts from "
+"the list of available mappers."
+msgstr "スクリプトがデプロイされると、利用可能なマッパーのリストからデプロイされたスクリプトを選択できるようになるはずです。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/con-protocol-mappers.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/con-protocol-mappers.ja_JP.po
@@ -30,11 +30,11 @@ msgid ""
 "Applications receiving ID tokens, access tokens, or SAML assertions may "
 "require different roles and user metadata."
 msgstr ""
-"IDトークン、アクセストークン、またはSAMLアサーションを受け取るアプリケーションは、異なるロールとユーザーメタデータを必要とする場合があります。"
+"IDトークン、アクセストークン、またはSAMLアサーションを受け取るアプリケーションは、異なるロールとユーザー・メタデータを必要とする場合があります。"
 
 #. type: Plain text
 msgid "You can use {project_name} to:"
-msgstr "project_name} を使用することができます。"
+msgstr "{project_name}を使用して次のこともできます。"
 
 #. type: Plain text
 msgid "Hardcode roles, claims and custom attributes."
@@ -42,20 +42,20 @@ msgstr "ロール、クレーム、カスタム属性をハードコードする
 
 #. type: Plain text
 msgid "Pull user metadata into a token or assertion."
-msgstr "ユーザーのメタデータをトークンやアサーションに引き込む。"
+msgstr "ユーザーのメタデータをトークンやアサーションに含める。"
 
 #. type: Plain text
 msgid "Rename roles."
-msgstr "役割の名前を変更する。"
+msgstr "ロールの名前を変更する。"
 
 #. type: Plain text
 msgid "You perform these actions in the *Mappers* tab in the Admin Console."
-msgstr "これらのアクションは、Admin Consoleの*Mappers*タブで実行します。"
+msgstr "これらのアクションは、管理コンソールの *Mappers* タブで実行します。"
 
 #. type: Block title
 #, no-wrap
 msgid "Mappers tab"
-msgstr "マッパーズ」タブ"
+msgstr "Mappersタブ"
 
 #. type: Plain text
 msgid "image:{project_images}/mappers-oidc.png[]"
@@ -67,8 +67,8 @@ msgid ""
 "from client scopes. See the <<_client_scopes, client scopes section>> for "
 "more details."
 msgstr ""
-"新規クライアントはビルトインマッパーを持ちませんが、クライアントスコープからいくつかのマッパーを継承することができます。<_client_scopes,"
-" client scopes section>詳しくは</_client_scopes,>&lt;&gt;を参照してください。"
+"新規クライアントはビルトイン・マッパーを持ちませんが、クライアント・スコープからいくつかのマッパーを継承することができます。詳しくは<<_client_scopes,"
+" クライアント・スコープのセクション>>を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -77,8 +77,8 @@ msgid ""
 "should be self explanatory from its name. You add pre-configured mappers by "
 "clicking *Add Builtin*."
 msgstr ""
-"プロトコルマッパーは、アイテム（たとえば電子メールアドレスなど）をIDおよびアクセストークンの特定のクレームにマッピングする。マッパーの機能は、その名前から説明できるはずです。事前に設定されたマッパーを追加するには、*Add"
-" Builtin* をクリックします。"
+"プロトコル・マッパーは、アイテム（たとえば電子メールアドレスなど）をIDトークンおよびアクセストークンの特定のクレームにマッピングします。マッパーの機能は、その名前分かるはずです。事前に設定されたマッパーを追加するには、"
+" *Add Builtin* をクリックします。"
 
 #. type: Plain text
 msgid ""
@@ -86,7 +86,8 @@ msgid ""
 " depending on the mapper type. Click *Edit* next to a mapper to access the "
 "configuration screen to adjust these settings."
 msgstr ""
-"各マッパーには、共通の設定項目があります。マッパーの種類によって、その他の設定も可能です。マッパーの横にある*Edit*をクリックすると、設定画面にアクセスし、これらの設定を調整することができます。"
+"各マッパーには、共通の設定項目があります。マッパータイプによって、その他の設定も可能です。マッパーの横にある *Edit* "
+"をクリックすると、設定画面にアクセスし、これらの設定を調整することができます。"
 
 #. type: Block title
 #, no-wrap
@@ -107,8 +108,8 @@ msgid ""
 "opt to include or exclude the claim from the _id_ and _access_ tokens by "
 "adjusting the *Add to ID token* and *Add to access token* switches."
 msgstr ""
-"ほとんどのOIDCマッパーで、クレームがどこに置かれるかを制御することができます。IDトークン*とアクセストークンに追加する*スイッチを調整することで、"
-" _id_と_access_トークンからクレームを含むかどうかを選択します。"
+"ほとんどのOIDCマッパーで、クレームがどこに置かれるかを制御することができます。 *Add to ID token* と *Add to access"
+" token* のスイッチを調整することで、 _ID_トークンと _アクセス_ トークンからクレームを含むかどうかを選択します。"
 
 #. type: Title ==
 #, no-wrap
@@ -121,7 +122,7 @@ msgid ""
 "configuration property of the mapper. It is the property of the concrete "
 "implementation of the mapper."
 msgstr ""
-"マッパーの実装は_priority order_を持ちます。優先順位_はマッパーの設定プロパティではありません。マッパーの具体的な実装のプロパティです。"
+"マッパーの実装には _優先順位_ があります。 _優先順位_ はマッパーの設定プロパティーではなく、マッパーの具体的な実装のプロパティーです。"
 
 #. type: Plain text
 msgid ""
@@ -130,26 +131,26 @@ msgid ""
 " Therefore, the implementations that are dependent on other implementations "
 "are processed in the necessary order."
 msgstr ""
-"マッパーはマッパーリストの順番でソートされます。トークンまたはアサーションの変更は、最も低いものが最初に適用されるように、その順序で適用されます。したがって、他の実装に依存している実装は、必要な順序で処理される。"
+"マッパーはマッパーの一覧の順番でソートされます。トークンまたはアサーションの変更は、最も低いものが最初に適用されるように、その順序で適用されます。したがって、他の実装に依存している実装は、必要な順序で処理されます。"
 
 #. type: Plain text
 msgid "For example, to compute the roles which will be included with a token:"
-msgstr "例えば、あるトークンに含まれるロールを計算する場合。"
+msgstr "たとえば、あるトークンに含まれるロールを計算する場合は、次のようになります。"
 
 #. type: Plain text
 msgid "Resolve audiences based on those roles."
-msgstr "その役割に基づき、オーディエンスを解決する。"
+msgstr "そのロールに基づき、Audienceを解決する。"
 
 #. type: Plain text
 msgid ""
 "Process a JavaScript script that uses the roles and audiences already "
 "available in the token."
-msgstr "トークンで既に利用可能なロールとオーディエンスを使用するJavaScriptスクリプトを処理します。"
+msgstr "トークンで既に利用可能なロールとAudienceを使用するJavaScriptのスクリプトを処理します。"
 
 #. type: Title ==
 #, no-wrap
 msgid "OIDC user session note mappers"
-msgstr "OIDCユーザーセッションノートマッパー"
+msgstr "OIDCユーザー・セッション・ノート・マッパー"
 
 #. type: Plain text
 msgid ""
@@ -157,7 +158,8 @@ msgid ""
 "included when you use or enable a feature on a client. Click *Add builtin* "
 "to include session details."
 msgstr ""
-"ユーザーセッションの詳細は、マッパーを使用して定義され、クライアントで機能を使用または有効にすると、自動的に含まれます。セッションの詳細を含めるには、*ビルトインの追加*をクリックします。"
+"ユーザー・セッションの詳細は、マッパーを使用して定義され、クライアントで機能を使用または有効にすると、自動的に含まれます。セッションの詳細を含めるには、"
+" *Add builtin* をクリックします。"
 
 #. type: Plain text
 msgid "Impersonated user sessions provide the following details:"
@@ -166,7 +168,7 @@ msgstr "代理ユーザー・セッションは、次の詳細を提供します
 #. type: Plain text
 #, no-wrap
 msgid "*IMPERSONATOR_ID*: The ID of an impersonating user.\n"
-msgstr "*impersonator_id*。なりすましユーザーのID。\n"
+msgstr "*impersonator_id* : 代理ユーザーのID。\n"
 
 #. type: Plain text
 #, no-wrap
@@ -180,21 +182,21 @@ msgstr "サービス・アカウント・セッションは、次の詳細を提
 #. type: Plain text
 #, no-wrap
 msgid "*clientId*: The client ID of the service account.\n"
-msgstr "*clientId*:サービスアカウントのクライアントID。\n"
+msgstr "*clientId* : サービス・アカウントのクライアントID。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "*clientAddress*: The remote host IP of the service account's authenticated "
 "device.\n"
-msgstr "*clientAddress*:サービスアカウントの認証済みデバイスのリモートホストIP。\n"
+msgstr "*clientAddress* : サービス・アカウントの認証済みデバイスのリモートホストIP。\n"
 
 #. type: Plain text
 #, no-wrap
 msgid ""
 "*clientHost*: The remote host name of the service account's authenticated "
 "device.\n"
-msgstr "*clientHost*:サービスアカウントの認証済みデバイスのリモートホスト名。\n"
+msgstr "*clientHost* : サービス・アカウントの認証済みデバイスのリモートホスト名。\n"
 
 #. type: Title ==
 #, no-wrap
@@ -207,11 +209,13 @@ msgid ""
 "JavaScript code. For more details about deploying scripts to the server, see"
 " link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]."
 msgstr ""
-"ユーザー定義の JavaScript コードを実行して、クレームをトークンにマッピングするには、 *Script Mapper* "
-"を使用します。サーバーへのスクリプトのデプロイの詳細については、link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]を参照してください。"
+"ユーザー定義のJavaScriptコードを実行して、クレームをトークンにマッピングするには、  *Script Mapper* "
+"を使用します。サーバーへのスクリプトのデプロイの詳細については、 "
+"link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}] "
+"を参照してください。"
 
 #. type: Plain text
 msgid ""
 "When scripts deploy, you should be able to select the deployed scripts from "
 "the list of available mappers."
-msgstr "スクリプトがデプロイされると、利用可能なマッパーのリストからデプロイされたスクリプトを選択できるようになるはずです。"
+msgstr "スクリプトがデプロイされると、利用可能なマッパーの一覧からデプロイされたスクリプトを選択できるようになるはずです。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/con-protocol-mappers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__con-protocol-mappers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
