### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc-auth-flows.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc-auth-flows.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc-auth-flows.ja_JP.po
@@ -1,0 +1,960 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Shinsuke UEDA, 2022
+# Tsukasa Amano <t.amano@pro-japan.co.jp>, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid ""
+"The client requests {project_name} an auth_req_id that identifies the "
+"authentication request made by the client. {project_name} creates the "
+"auth_req_id."
+msgstr ""
+"クライアントは、クライアントによって行われた認証リクエストを識別するauth_req_idを{project_name}に要求します。{project_name}はauth_req_idを作成します。"
+
+#. type: Plain text
+msgid ""
+"After receiving this auth_req_id, this client repeatedly needs to poll "
+"{project_name} to obtain an Access Token, Refresh Token and ID Token from "
+"{project_name} in return for the auth_req_id until the user is "
+"authenticated."
+msgstr ""
+"このauth_req_idを受信した後、このクライアントは{project_name}を繰り返しポーリングして、ユーザーが認証されるまでauth_req_idと引き換えに{project_name}からアクセストークン、リフレッシュトークン、IDトークンを取得する必要があります。"
+
+#. type: Plain text
+msgid "Configuration|Description"
+msgstr "設定|説明"
+
+#. type: Title =====
+#, no-wrap
+msgid "Backchannel Logout"
+msgstr "Backchannel Logout"
+
+#. type: Title ====
+#, no-wrap
+msgid "OIDC auth flows"
+msgstr "OIDC認証フロー"
+
+#. type: Plain text
+msgid ""
+"OIDC has several methods, or flows, that clients or applications can use to "
+"authenticate users and receive _identity_ and _access_ tokens.  The method "
+"depends on the type of application or client requesting access."
+msgstr ""
+"OIDCには、クライアントやアプリケーションがユーザーを認証し、_identity_および_access_トークンを受け取るために使用できるいくつかの方法、またはフローがあります。"
+"  その方法は、アクセスを要求するアプリケーションやクライアントの種類によって異なります。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Authorization Code Flow"
+msgstr "認可コード・フロー"
+
+#. type: Plain text
+msgid ""
+"The Authorization Code Flow is a browser-based protocol and suits "
+"authenticating and authorizing browser-based applications. It uses browser "
+"redirects to obtain _identity_ and _access_ tokens."
+msgstr ""
+"認可コードフローは、ブラウザベースのプロトコルであり、ブラウザベースのアプリケーションの認証と認可に適しています。ブラウザのリダイレクトを利用して、_identity_および_access_トークンを取得します。"
+
+#. type: Plain text
+msgid ""
+"A user connects to an application using a browser. The application detects "
+"the user is not logged into the application."
+msgstr ""
+"あるユーザーがブラウザーを使ってアプリケーションに接続する。アプリケーションは、ユーザーがアプリケーションにログインしていないことを検出します。"
+
+#. type: Plain text
+msgid ""
+"The application redirects the browser to {project_name} for authentication."
+msgstr "アプリケーションは、認証のためにブラウザを{project_name}にリダイレクトします。"
+
+#. type: Plain text
+msgid ""
+"The application passes a callback URL as a query parameter in the browser "
+"redirect. {project_name} uses the parameter upon successful authentication."
+msgstr ""
+"アプリケーションは、ブラウザのリダイレクトのクエリパラメータとしてコールバックURLを渡します。{project_name} "
+"は、認証に成功するとそのパラメータを使用します。"
+
+#. type: Plain text
+msgid ""
+"{project_name} authenticates the user and creates a one-time, short lived, "
+"temporary code."
+msgstr "{project_name} は、ユーザーを認証し、1回限りの短命の一時的なコードを作成する。"
+
+#. type: Plain text
+msgid ""
+"{project_name} redirects to the application using the callback URL and adds "
+"the temporary code as a query parameter in the callback URL."
+msgstr ""
+"{project_name} "
+"は、コールバックURLを用いてアプリケーションにリダイレクトし、コールバックURLのクエリパラメータとしてテンポラリコードを追加します。"
+
+#. type: Plain text
+msgid ""
+"The application extracts the temporary code and makes a background REST "
+"invocation to {project_name} to exchange the code for an _identity_ and "
+"_access_ and _refresh_ token.  To prevent replay attacks, the temporary code"
+" cannot be used more than once."
+msgstr ""
+"アプリケーションは一時的なコードを抽出し、バックグラウンドで {project_name} に REST 呼び出しを行い、コードを _identity_"
+" および _access_ と _refresh_ トークンに交換します。  リプレイ攻撃を防ぐため、一時的なコードを複数回使用することはできません。"
+
+#. type: delimited block =
+msgid ""
+"A system is vulnerable to a stolen token for the lifetime of that token. For"
+" security and scalability reasons, access tokens are generally set to expire"
+" quickly so subsequent token requests fail. If a token expires, an "
+"application can obtain a new access token using the additional _refresh_ "
+"token sent by the login protocol."
+msgstr ""
+"システムは、盗まれたトークンの有効期間中、そのトークンに対して脆弱です。セキュリティとスケーラビリティの観点から、アクセストークンは一般にすぐに期限切れになるように設定されており、それ以降のトークン要求には失敗します。トークンの有効期限が切れた場合、アプリケーションはログインプロトコルによって送信される追加の"
+" _refresh_ トークンを使用して新しいアクセストークンを取得することができます。"
+
+#. type: Plain text
+msgid ""
+"_Confidential_ clients provide client secrets when they exchange the "
+"temporary codes for tokens. _Public_ clients are not required to provide "
+"client secrets.  _Public_ clients are secure when HTTPS is strictly enforced"
+" and redirect URIs registered for the client are strictly controlled.  "
+"HTML5/JavaScript clients have to be _public_ clients because there is no way"
+" to securely transmit the client secret to HTML5/JavaScript clients. For "
+"more details, see the xref:assembly-managing-clients_{context}[Managing "
+"Clients] chapter."
+msgstr ""
+"機密性の高いクライアントは、一時的なコードをトークンに交換する際にクライアントシークレットを提供します。公開クライアントは、クライアントシークレットの提供は必要ありません。"
+"  Publicクライアントは、HTTPSを厳密に実施し、クライアントに登録されるリダイレクトURIを厳密に管理することで安全性を確保します。  "
+"HTML5/JavaScriptクライアントは、クライアントシークレットを安全に送信する方法がないため、_public_クライアントである必要があります。詳しくは"
+" xref:assembly-managing-clients_{context}[Managing Clients] の章を参照してください。"
+
+#. type: Plain text
+msgid ""
+"{project_name} also supports the "
+"https://datatracker.ietf.org/doc/html/rfc7636[Proof Key for Code Exchange] "
+"specification."
+msgstr ""
+"{project_name} は、https://datatracker.ietf.org/doc/html/rfc7636[Proof Key for"
+" Code Exchange]仕様にも対応しています。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Implicit Flow"
+msgstr "インプリシット・フロー"
+
+#. type: Plain text
+msgid ""
+"The Implicit Flow is a browser-based protocol. It is similar to the "
+"Authorization Code Flow but with fewer requests and no refresh tokens."
+msgstr ""
+"Implicit Flowは、ブラウザベースのプロトコルである。認可コードフローと似ているが、リクエスト数が少なく、リフレッシュトークンもない。"
+
+#. type: delimited block =
+msgid ""
+"The possibility exists of _access_ tokens leaking in the browser history "
+"when tokens are transmitted via redirect URIs (see below)."
+msgstr "トークンをリダイレクトURIで送信する場合、_access_トークンがブラウザの履歴に漏れる可能性があります（下記参照）。"
+
+#. type: delimited block =
+msgid ""
+"Also, this flow does not provide clients with refresh tokens. Therefore, "
+"access tokens have to be long-lived or users have to re-authenticate when "
+"they expire."
+msgstr ""
+"また、このフローでは、クライアントにリフレッシュ・トークンを提供しない。したがって、アクセストークンは長寿命でなければならず、また、アクセストークンの有効期限が切れると、ユーザーは再認証をしなければならない。"
+
+#. type: delimited block =
+msgid ""
+"We do not advise using this flow. This flow is supported because it is in "
+"the OIDC and OAuth 2.0 specification."
+msgstr ""
+"このフローを使用することはお勧めしません。このフローがサポートされているのは、OIDC と OAuth 2.0 の仕様に含まれているからです。"
+
+#. type: Plain text
+msgid "The protocol works as follows:"
+msgstr "プロトコルは次のように動作します。"
+
+#. type: Plain text
+msgid ""
+"The application passes a callback URL as a query parameter in the browser "
+"redirect. {project_name} uses the query parameter upon successful "
+"authentication."
+msgstr ""
+"アプリケーションは、ブラウザのリダイレクトにコールバックURLをクエリパラメータとして渡します。{project_name} "
+"は、認証に成功するとクエリパラメータを使用します。"
+
+#. type: Plain text
+msgid ""
+"{project_name} authenticates the user and creates an _identity_ and _access_"
+" token. {project_name} redirects to the application using the callback URL "
+"and additionally adds the _identity_ and _access_ tokens as a query "
+"parameter in the callback URL."
+msgstr ""
+"{project_name} は、ユーザーを認証し、_identity_ と _access_ トークンを作成します。{project_name} "
+"はコールバックURLを使用してアプリケーションにリダイレクトし、さらに _identity_ と _access_ "
+"トークンをコールバックURLのクエリパラメータとして追加します。"
+
+#. type: Plain text
+msgid ""
+"The application extracts the _identity_ and _access_ tokens from the "
+"callback URL."
+msgstr "アプリケーションは、コールバックURLから _ID_ トークンと _アクセス_ トークンを抽出します。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Resource owner password credentials grant (Direct Access Grants)"
+msgstr "リソース所有者のパスワードクレデンシャルグラント（直接アクセスグラント）"
+
+#. type: Plain text
+msgid ""
+"_Direct Access Grants_ are used by REST clients to obtain tokens on behalf "
+"of users.  It is a HTTP POST request that contains:"
+msgstr ""
+"ダイレクトアクセスグラント_は、RESTクライアントがユーザーの代わりにトークンを取得するために使用されます。  これは、HTTP POST "
+"リクエストで、以下を含みます。"
+
+#. type: Plain text
+msgid ""
+"The credentials of the user. The credentials are sent within form "
+"parameters."
+msgstr "ユーザーのクレデンシャル。資格情報はフォームのパラメータで送信されます。"
+
+#. type: Plain text
+msgid "The id of the client."
+msgstr "クライアントのID。"
+
+#. type: Plain text
+msgid "The clients secret (if it is a confidential client)."
+msgstr "クライアントの秘密(機密クライアントの場合)。"
+
+#. type: Plain text
+msgid ""
+"The HTTP response contains the _identity_, _access_, and _refresh_ tokens."
+msgstr "HTTP レスポンスには、_identity_、_access_、_refresh_ の各トークンが含まれます。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Client credentials grant"
+msgstr "クライアント認証の付与"
+
+#. type: Plain text
+msgid ""
+"The _Client Credentials Grant_ creates a token based on the metadata and "
+"permissions of a service account associated with the client instead of "
+"obtaining a token that works on behalf of an external user. _Client "
+"Credentials Grants_ are used by REST clients."
+msgstr ""
+"_Client Credentials Grant_ "
+"は、外部ユーザーの代わりに動作するトークンを取得するのではなく、クライアントに関連付けられたサービスアカウントのメタデータと権限に基づいてトークンを作成します。_Client"
+" Credentials Grants_ は REST クライアントによって使用されます。"
+
+#. type: Plain text
+msgid ""
+"See the <<_service_accounts,Service Accounts>> chapter for more information."
+msgstr ""
+"詳しくは&lt;&gt;の<_service_accounts,Service "
+"Accounts>章を</_service_accounts,Service>ご覧ください。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Device authorization grant"
+msgstr "デバイス認証の付与"
+
+#. type: Plain text
+msgid ""
+"This is used by clients running on internet-connected devices that have "
+"limited input capabilities or lack a suitable browser. Here's a brief "
+"summary of the protocol:"
+msgstr ""
+"これは、入力機能が制限されているか、適切なブラウザーがない、インターネットに接続されたデバイスで実行されているクライアントによって使用されます。プロトコルの簡単な概要は次のとおりです。"
+
+#. type: Plain text
+msgid ""
+"The application requests {project_name} a device code and a user code. "
+"{project_name} creates a device code and a user code. {project_name} returns"
+" a response including the device code and the user code to the application."
+msgstr ""
+"アプリケーションは{project_name}にデバイスコードとユーザーコードを要求します。{project_name}は、デバイスコードとユーザーコードを作成します。{project_name}は、デバイス"
+" コードとユーザーコードを含むレスポンスをアプリケーションに返します。"
+
+#. type: Plain text
+msgid ""
+"The application provides the user with the user code and the verification "
+"URI. The user accesses a verification URI to be authenticated by using "
+"another browser."
+msgstr ""
+"アプリケーションは、ユーザーコードと検証URIをユーザーに提供します。ユーザーは、別のブラウザーを使用して、認証を受けるための検証URIにアクセスします。"
+
+#. type: Plain text
+msgid ""
+"The application repeatedly polls {project_name} to find out if the user "
+"completed the user authorization. If user authentication is complete, the "
+"application exchanges the device code for an _identity_, _access_ and "
+"_refresh_ token."
+msgstr ""
+"アプリケーションは{project_name}を繰り返しポーリングして、ユーザーがユーザー認証を完了したかどうかを調べます。ユーザー認証が完了すると、アプリケーションはデバイス"
+" コードを _ID_ トークン、 _access_ トークン、 および _refresh_ トークンと交換します。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Client initiated backchannel authentication grant"
+msgstr "クライアントが開始したバックチャネル認証の付与"
+
+#. type: Plain text
+msgid ""
+"This feature is used by clients who want to initiate the authentication flow"
+" by communicating with the OpenID Provider directly without redirect through"
+" the user's browser like OAuth 2.0's authorization code grant. Here's a "
+"brief summary of the protocol:"
+msgstr ""
+"この機能は、OAuth "
+"2.0の認可コード付与のようにユーザのブラウザを通してリダイレクトすることなく、OpenIDプロバイダと直接通信して認証フローを開始させたいクライアントが使用します。以下はプロトコルの概要です。"
+
+#. type: Plain text
+msgid ""
+"An administrator can configure Client Initiated Backchannel Authentication "
+"(CIBA) related operations as `CIBA Policy` per realm."
+msgstr ""
+"管理者は、Client Initiated Backchannel Authentication (CIBA) 関連の操作をレルムごとの `CIBA "
+"Policy` として設定できます。"
+
+#. type: Plain text
+msgid ""
+"Also please refer to other places of {project_name} documentation like "
+"link:{adapterguide_link}#_backchannel_authentication_endpoint[Backchannel "
+"Authentication Endpoint section] of {adapterguide_name} and "
+"link:{adapterguide_link}#_client_initiated_backchannel_authentication_grant[Client"
+" Initiated Backchannel Authentication Grant section] of {adapterguide_name}."
+msgstr ""
+"また、{adapterguide_name}の "
+"link:{adapterguide_link}#_backchannel_authentication_endpoint[Backchannel "
+"Authentication Endpointのセクション] や{adapterguide_name}の "
+"link:{adapterguide_link}#_client_initiated_backchannel_authentication_grant[ClientInitiated"
+" Backchannel Authentication Grant] "
+"のセクションなど、{project_name}ドキュメントの他の場所も参照してください。"
+
+#. type: Title ======
+#, no-wrap
+msgid "CIBA Policy"
+msgstr "CIBAポリシー"
+
+#. type: Plain text
+msgid ""
+"An administrator carries out the following operations on the `Admin Console`"
+" :"
+msgstr "管理者は、 `管理コンソール` で次の操作を行います。"
+
+#. type: Plain text
+msgid "Open the `Authentication -> CIBA Policy` tab."
+msgstr "`Authentication -> CIBA Policy` タブを開きます."
+
+#. type: Plain text
+msgid "Configure items and click `Save`."
+msgstr "アイテムを設定し、 `Save` をクリックします。"
+
+#. type: Plain text
+msgid "The configurable items and their description follow."
+msgstr "設定可能な項目とその説明は次のとおりです。"
+
+#. type: Plain text
+msgid "Backchannel Token Delivery Mode"
+msgstr "Backchannel Token Delivery Mode"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"Specifying how the CD (Consumption Device) gets the authentication result and related tokens. There are three modes, \"poll\", \"ping\" and \"push\". {project_name} only supports \"poll\". The default setting is \"poll\". This configuration is required.\n"
+" For more details, see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.5[CIBA Specification].\n"
+msgstr ""
+"CD（Consumption "
+"Device）には認証結果と関連トークンを取得する方法を指定します。\"poll\"、\"ping\"、\"push\"の3つのモードがあります。{project_name}は\"poll\"のみをサポートします。デフォルト設定は\"poll\"です。この設定は必須です。詳細については、"
+" https://openid.net/specs/openid-client-initiated-backchannel-"
+"authentication-core-1_0.html#rfc.section.5[CIBA Specification] を参照してください。\n"
+
+#. type: Plain text
+msgid "Expires In"
+msgstr "Expires In"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"The expiration time of the \"auth_req_id\" in seconds since the authentication request was received. The default setting is 120. This configuration is required.\n"
+" For more details, see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#successful_authentication_request_acknowdlegment[CIBA Specification].\n"
+msgstr ""
+"認証リクエストを受信してからの\"auth_req_id\"の有効期限（秒単位）。デフォルトの設定は120です。この設定は必須です。詳細については、 "
+"https://openid.net/specs/openid-client-initiated-backchannel-authentication-"
+"core-1_0.html#successful_authentication_request_acknowdlegment[CIBA "
+"Specification] を参照してください。\n"
+
+#. type: Plain text
+msgid "Interval"
+msgstr "Interval"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"The interval in seconds the CD (Consumption Device) needs to wait for between polling requests to the token endpoint. The default setting is 5. This configuration is optional.\n"
+" For more details, see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#successful_authentication_request_acknowdlegment[CIBA Specification].\n"
+msgstr ""
+"CD（Consumption "
+"Device）がトークン・エンドポイントへのポーリング・リクエスト間で待機する必要がある秒単位の間隔。デフォルト設定は5です。この設定はオプションです。詳細については、"
+" https://openid.net/specs/openid-client-initiated-backchannel-"
+"authentication-"
+"core-1_0.html#successful_authentication_request_acknowdlegment[CIBA "
+"Specification] を参照してください。\n"
+
+#. type: Plain text
+msgid "Authentication Requested User Hint"
+msgstr "Authentication Requested User Hint"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"The way of identifying the end-user for whom authentication is being requested. The default setting is \"login_hint\".  There are three modes, \"login_hint\", \"login_hint_token\" and \"id_token_hint\". {project_name} only supports \"login_hint\". This configuration is required.\n"
+" For more details, see https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.7.1[CIBA Specification].\n"
+msgstr ""
+"認証が要求されているエンドユーザーを識別する方法。デフォルト設定は\"login_hint\"です。\"login_hint\"、\"login_hint_token\"、\"id_token_hint\"の3つのモードがあります。{project_name}は\"login_hint\"のみをサポートします。この設定は必須です。詳細については、"
+" https://openid.net/specs/openid-client-initiated-backchannel-"
+"authentication-core-1_0.html#rfc.section.5[CIBA Specification] を参照してください。\n"
+
+#. type: Title ======
+#, no-wrap
+msgid "Provider Setting"
+msgstr "プロバイダー設定"
+
+#. type: Plain text
+msgid "The CIBA grant uses the following two providers."
+msgstr "CIBAグラントは、次の2つのプロバイダーを使用します。"
+
+#. type: Plain text
+msgid ""
+"Authentication Channel Provider : provides the communication between "
+"{project_name} and the entity that actually authenticates the user via AD "
+"(Authentication Device)."
+msgstr ""
+"認証チャネル・プロバイダー：{project_name}と、AD（Authentication "
+"Device）を介してユーザーを実際に認証するエンティティーとの間の通信を提供します。"
+
+#. type: Plain text
+msgid ""
+"User Resolver Provider : get `UserModel` of {project_name} from the "
+"information provided by the client to identify the user."
+msgstr ""
+"User Resolver Provider：クライアントから提供された情報から{project_name}の `UserModel` "
+"を取得して、ユーザーを識別します。"
+
+#. type: Plain text
+msgid ""
+"{project_name} has both default providers. However, the administrator needs "
+"to set up Authentication Channel Provider like this:"
+msgstr ""
+"{project_name}には両方のデフォルト・プロバイダーがあります。ただし、管理者は次のように認証チャネル・プロバイダーを設定する必要があります。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"<spi name=\"ciba-auth-channel\">\n"
+"    <default-provider>ciba-http-auth-channel</default-provider>\n"
+"    <provider name=\"ciba-http-auth-channel\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"httpAuthenticationChannelUri\" value=\"https://backend.internal.example.com/auth\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+msgstr ""
+"<spi name=\"ciba-auth-channel\">\n"
+"    <default-provider>ciba-http-auth-channel</default-provider>\n"
+"    <provider name=\"ciba-http-auth-channel\" enabled=\"true\">\n"
+"        <properties>\n"
+"            <property name=\"httpAuthenticationChannelUri\" value=\"https://backend.internal.example.com/auth\"/>\n"
+"        </properties>\n"
+"    </provider>\n"
+"</spi>\n"
+
+#. type: Plain text
+msgid "httpAuthenticationChannelUri"
+msgstr "httpAuthenticationChannelUri"
+
+#. type: Plain text
+msgid ""
+"Specifying URI of the entity that actually authenticates the user via AD "
+"(Authentication Device)."
+msgstr "AD（Authentication Device）を介して実際にユーザーを認証するエンティティーのURIを指定します。"
+
+#. type: Title ======
+#, no-wrap
+msgid "Authentication Channel Provider"
+msgstr "Authentication Channel Provider"
+
+#. type: Plain text
+msgid ""
+"CIBA standard document does not specify how to authenticate the user by AD. "
+"Therefore, it might be implemented at the discretion of products. "
+"{project_name} delegates this authentication to an external authentication "
+"entity. To communicate with the authentication entity, {project_name} "
+"provides Authentication Channel Provider."
+msgstr ""
+"CIBA標準ドキュメントでは、ADによるユーザーの認証方法は指定されていません。したがって、製品の判断で実装される可能性があります。{project_name}は、この認証を外部認証エンティティーに委任します。認証エンティティーと通信するために、{project_name}は認証チャネル・プロバイダーを提供します。"
+
+#. type: Plain text
+msgid ""
+"Its implementation of {project_name} assumes that the authentication entity "
+"is under the control of the administrator of {project_name} so that "
+"{project_name} trusts the authentication entity. It is not recommended to "
+"use the authentication entity that the administrator of {project_name} "
+"cannot control."
+msgstr ""
+"{project_name}の実装は、認証エンティティーが{project_name}の管理者の制御下にあることを前提としているため、{project_name}は認証エンティティーを信頼します。{project_name}の管理者が制御できない認証エンティティーを使用することはお勧めしません。"
+
+#. type: Plain text
+msgid ""
+"Authentication Channel Provider is provided as SPI provider so that users of"
+" {project_name} can implement their own provider in order to meet their "
+"environment. {project_name} provides its default provider called HTTP "
+"Authentication Channel Provider that uses HTTP to communicate with the "
+"authentication entity."
+msgstr ""
+"認証チャネル・プロバイダーはSPIプロバイダーとして提供されるため、{project_name}のユーザーは、環境に合わせて独自のプロバイダーを実装できます。{project_name}は、HTTPを使用して認証エンティティーと通信するHTTP認証チャネル・プロバイダーと呼ばれるデフォルトのプロバイダーを提供します。"
+
+#. type: Plain text
+msgid ""
+"If a user of {project_name} user want to use the HTTP Authentication Channel"
+" Provider, they need to know its contract between {project_name} and the "
+"authentication entity consisting of the following two parts."
+msgstr ""
+"{project_name}のユーザーがHTTP認証チャネル・プロバイダーを使用する場合、{project_name}と次の2つの部分で構成される認証エンティティーとの間のコントラクトを知る必要があります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Authentication Delegation Request/Response"
+msgstr "Authentication Delegation Request/Response"
+
+#. type: Plain text
+msgid ""
+"  {project_name} sends an authentication request to the authentication "
+"entity."
+msgstr "{project_name}は、認証リクエストを認証エンティティーに送信します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Authentication Result Notification/ACK"
+msgstr "Authentication Result Notification/ACK"
+
+#. type: Plain text
+msgid ""
+"  The authentication entity notifies the result of the authentication to "
+"{project_name}."
+msgstr "認証エンティティーは、認証の結果を{project_name}に通知します。"
+
+#. type: Plain text
+msgid ""
+"Authentication Delegation Request/Response consists of the following "
+"messaging."
+msgstr "認証委任リクエスト/レスポンスは、次のメッセージで構成されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Authentication Delegation Request"
+msgstr "Authentication Delegation Request"
+
+#. type: Plain text
+msgid ""
+"The request is sent from {project_name} to the authentication entity to ask "
+"it for user authentication by AD."
+msgstr "リクエストは{project_name}から認証エンティティーに送信され、ADによるユーザー認証を要求します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "POST [delegation_reception]\n"
+msgstr "POST [delegation_reception]\n"
+
+#. type: Plain text
+msgid "Headers"
+msgstr "Headers"
+
+#. type: Plain text
+msgid "Name|Value|Description"
+msgstr "名前|値|説明"
+
+#. type: Plain text
+msgid "Content-Type|application/json|The message body is json formatted."
+msgstr "Content-Type|application/json|メッセージ本文はJSON形式です。"
+
+#. type: Plain text
+msgid ""
+"Authorization|Bearer [token]|The [token] is used when the authentication "
+"entity notifies the result of the authentication to {project_name}."
+msgstr ""
+"Authorization|Bearer "
+"[token]|[トークン]は、認証エンティティーが認証の結果を{project_name}に通知するときに使用されます。"
+
+#. type: Plain text
+msgid "Parameters"
+msgstr "Parameters"
+
+#. type: Plain text
+msgid "Type|Name|Description"
+msgstr "タイプ|名前|説明"
+
+#. type: Plain text
+msgid "Path"
+msgstr "Path"
+
+#. type: Plain text
+msgid ""
+"delegation_reception|The endpoint provided by the authentication entity to "
+"receive the delegation request"
+msgstr "delegation_reception|委任リクストを受信するために認証エンティティーによって提供されるエンドポイント"
+
+#. type: Plain text
+msgid "Body"
+msgstr "Body"
+
+#. type: Plain text
+msgid "Name|Description"
+msgstr "名前|説明"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"login_hint|It tells the authentication entity who is authenticated by AD. +\n"
+"By default, it is the user's \"username\". +\n"
+"This field is required and was defined by CIBA standard document.\n"
+msgstr ""
+"login_hint|ADによって認証された認証エンティティーに通知します。 +\n"
+"デフォルトでは、これはユーザーの\"username\"です。 +\n"
+"このフィールドは必須であり、CIBA標準ドキュメントによって定義されています。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"scope|It tells which scopes the authentication entity gets consent from the authenticated user. +\n"
+"This field is required and was defined by CIBA standard document.\n"
+msgstr ""
+"scope|認証エンティティーが認証されたユーザーから同意を得るスコープを示します。 +\n"
+"このフィールドは必須であり、CIBA標準ドキュメントによって定義されています。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"is_consent_required|It shows whether the authentication entity needs to get consent from the authenticated user about the scope. +\n"
+" This field is required.\n"
+msgstr ""
+"is_consent_required|認証エンティティーがスコープについて認証されたユーザーから同意を得る必要があるかどうかを示します。 +\n"
+"この項目は必須です。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"binding_message|Its value is intended to be shown in both CD and AD's UI to make the user recognize that the authentication by AD is triggered by CD. +\n"
+"This field is optional and was defined by CIBA standard document.\n"
+msgstr ""
+"binding_message|その値は、CDとADのUIの両方に表示され、ADによる認証がCDによってトリガーされたことをユーザーに認識させることを目的としています。 +\n"
+"このフィールドはオプションであり、CIBA標準ドキュメントによって定義されています。\n"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"acr_values|It tells the requesting Authentication Context Class Reference from CD. +\n"
+"This field is optional and was defined by CIBA standard document.\n"
+msgstr ""
+"acr_values|CDから要求している認証コンテキストクラス参照を通知します。 +\n"
+"このフィールドはオプションであり、CIBA標準ドキュメントによって定義されています。\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Authentication Delegation Response"
+msgstr "Authentication Delegation Response"
+
+#. type: Plain text
+msgid ""
+"The response is returned from the authentication entity to {project_name} to"
+" notify that the authentication entity received the authentication request "
+"from {project_name}."
+msgstr ""
+"認証エンティティーから{project_name}にレスポンスが返され、認証エンティティーが{project_name}から認証リクエストを受信したことが通知されます。"
+
+#. type: Plain text
+msgid "Responses"
+msgstr "Responses"
+
+#. type: Plain text
+msgid "HTTP Status Code|Description"
+msgstr "HTTPステータスコード|説明"
+
+#. type: Plain text
+msgid ""
+"201|It notifies {project_name} of receiving the authentication delegation "
+"request."
+msgstr "201|認証委任リクエストを受信したことを{project_name}に通知します。"
+
+#. type: Plain text
+msgid ""
+"Authentication Result Notification/ACK consists of the following messaging."
+msgstr "認証結果通知/ACKは以下のメッセージで構成されています。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Authentication Result Notification"
+msgstr "認証結果通知"
+
+#. type: Plain text
+msgid ""
+"The authentication entity sends the result of the authentication request to "
+"{project_name}."
+msgstr "認証エンティティーは、認証リクエストの結果を{project_name}に送信します。"
+
+#. type: delimited block -
+#, no-wrap
+msgid ""
+"POST /auth/realms/[realm]/protocol/openid-connect/ext/ciba/auth/callback\n"
+msgstr ""
+"POST /auth/realms/[realm]/protocol/openid-connect/ext/ciba/auth/callback\n"
+
+#. type: Plain text
+msgid ""
+"Authorization|Bearer [token]|The [token] must be the one the authentication "
+"entity has received from {project_name} in Authentication Delegation "
+"Request."
+msgstr ""
+"認可|ベアラー[トークン]|[トークン]は、認証エンティティーが認証委任リクエストで{project_name}から受信したものである必要があります。"
+
+#. type: Plain text
+msgid "realm|The realm name"
+msgstr "レルム|レルム名"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"status|It tells the result of user authentication by AD. +\n"
+"It must be one of the following status. +\n"
+"  SUCCEED : The authentication by AD has been successfully completed. +\n"
+"  UNAUTHORIZED : The authentication by AD has not been completed. +\n"
+"  CANCELLED : The authentication by AD has been cancelled by the user.\n"
+msgstr ""
+"status|ADによるユーザー認証の結果を示します。 +\n"
+"以下のステータスのいずれかでなければなりません。 +\n"
+"  SUCCEED：ADによる認証が正常に完了しました。 +\n"
+"UNAUTHORIZED：ADによる認証が完了していません。 +\n"
+"CANCELLED：ADによる認証がユーザーによってキャンセルされました。\n"
+
+#. type: Labeled list
+#, no-wrap
+msgid "Authentication Result ACK"
+msgstr "Authentication Result ACK"
+
+#. type: Plain text
+msgid ""
+"The response is returned from {project_name} to the authentication entity to"
+" notify {project_name} received the result of user authentication by AD from"
+" the authentication entity."
+msgstr ""
+"レスポンスは{project_name}から認証エンティティーに返され、認証エンティティーからADによるユーザー認証の結果を{project_name}が受信したことを通知します。"
+
+#. type: Plain text
+msgid ""
+"200|It notifies the authentication entity of receiving the notification of "
+"the authentication result."
+msgstr "200|認証結果の通知を受信したことを認証エンティティーに通知します。"
+
+#. type: Title ======
+#, no-wrap
+msgid "User Resolver Provider"
+msgstr "User Resolver Provider"
+
+#. type: Plain text
+msgid ""
+"Even if the same user, its representation may differ in each CD, "
+"{project_name} and the authentication entity."
+msgstr "同じユーザーであっても、その表現はCD、{project_name}、および認証エンティティーごとに異なる場合があります。"
+
+#. type: Plain text
+msgid ""
+"For CD, {project_name} and the authentication entity to recognize the same "
+"user, this User Resolver Provider converts their own user representations "
+"among them."
+msgstr ""
+"CD、{project_name}、および認証エンティティーが同じユーザーを認識するために、このユーザー・リゾルバー・プロバイダーは、それらの間で独自のユーザー表現を変換します。"
+
+#. type: Plain text
+msgid ""
+"User Resolver Provider is provided as SPI provider so that users of "
+"{project_name} can implement their own provider in order to meet their "
+"environment. {project_name} provides its default provider called Default "
+"User Resolver Provider that has the following characteristics."
+msgstr ""
+"ユーザー・リゾルバー・プロバイダーはSPIプロバイダーとして提供されるため、{project_name}のユーザーは、環境に合わせて独自のプロバイダーを実装できます。{project_name}は、次の特性を持つDefault"
+" User ResolverProviderと呼ばれるデフォルト・プロバイダーを提供します。"
+
+#. type: Plain text
+msgid "Only support `login_hint` parameter and is used as default."
+msgstr "`login_hint` パラメーターのみをサポートし、デフォルトとして使用されます。"
+
+#. type: Plain text
+msgid ""
+"`username` of UserModel in {project_name} is used to represent the user on "
+"CD, {project_name} and the authentication entity."
+msgstr ""
+"{project_name}のUserModelの `username` "
+"は、CD、{project_name}、および認証エンティティーのユーザーを表すために使用されます。"
+
+#. type: Title ====
+#, no-wrap
+msgid "OIDC Logout"
+msgstr "OIDCログアウト"
+
+#. type: Plain text
+msgid ""
+"OIDC has three different specifications relevant to logout mechanisms, all "
+"of these are currently in draft status:"
+msgstr "OIDCには、ログアウト機構に関連する3つの異なる仕様があり、これらはすべて現在ドラフトの状態です。"
+
+#. type: Plain text
+msgid ""
+"https://openid.net/specs/openid-connect-session-1_0.html[Session Management]"
+msgstr ""
+"https://openid.net/specs/openid-connect-session-1_0.html[Session Management]"
+
+#. type: Plain text
+msgid ""
+"https://openid.net/specs/openid-connect-frontchannel-1_0.html[Front-Channel "
+"Logout]"
+msgstr ""
+"https://openid.net/specs/openid-connect-frontchannel-1_0.html[Front-Channel "
+"Logout]"
+
+#. type: Plain text
+msgid ""
+"https://openid.net/specs/openid-connect-backchannel-1_0.html[Back-Channel "
+"Logout]"
+msgstr ""
+"https://openid.net/specs/openid-connect-backchannel-1_0.html[Back-Channel "
+"Logout]"
+
+#. type: Plain text
+msgid ""
+"Again since all of this is described in the OIDC specification we will only "
+"give a brief overview here."
+msgstr "繰り返しになりますが、これはすべてOIDCの仕様で説明されているため、ここでは簡単な概要のみを示します。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Session Management"
+msgstr "Session Management"
+
+#. type: Plain text
+msgid ""
+"This is a browser-based logout. The application obtains session status "
+"information from {project_name} at a regular basis.  When the session is "
+"terminated at {project_name} the application will notice and trigger it's "
+"own logout."
+msgstr ""
+"これはブラウザーベースのログアウトです。アプリケーションは、定期的に{project_name}からセッション・ステータス情報を取得します。セッションが{project_name}で終了すると、アプリケーションはそれに気づき、自身のログアウトをトリガーします。"
+
+#. type: Title =====
+#, no-wrap
+msgid "Frontchannel Logout"
+msgstr "Frontchannel Logout"
+
+#. type: Plain text
+msgid ""
+"This is also a browser-based logout where the logout starts by redirecting "
+"the user to a specific endpoint at {project_name}."
+msgstr ""
+"これもブラウザー・ベースのログアウトで、ログアウトが始まると、ユーザーは{project_name}の特定のエンドポイントにリダイレクトされます。"
+
+#. type: Plain text
+msgid ""
+"Once the user is redirected to the logout endpoint, {project_name} is going "
+"to send logout requests to clients to let them to invalidate their local "
+"user sessions, and potentially redirect the user to some URL once the logout"
+" process is finished."
+msgstr ""
+"ユーザーがログアウト・エンドポイントにリダイレクトされると、{project_name}はクライアントにログアウト・リクエストを送信して、ローカル・ユーザー・セッションを無効にし、ログアウト・プロセスが終了したらユーザーを何らかのURLにリダイレクトするようにします。"
+
+#. type: Plain text
+msgid ""
+"Depending on the client configuration, logout requests can be sent to "
+"clients through the front-channel or through the back-channel."
+msgstr ""
+"クライアントの設定により、ログアウト・リクエストは、フロントチャネルを介してクライアントに送信される場合と、バックチャネルを介して送信される場合があります。"
+
+#. type: Plain text
+msgid ""
+"To configure clients to receive logout requests through the front-channel, "
+"look at the <<_front-channel-logout, Front-Channel Logout>> client setting. "
+"When using this method, consider the following:"
+msgstr ""
+"フロントチャネルでログアウト・リクエストを受信するようにクライアントを設定するには、<<_front-channel-logout, Front-"
+"Channel Logout>>のクライアントの設定を見てください。この方法を使用する場合、以下の点を考慮してください。"
+
+#. type: Plain text
+msgid ""
+"Logout requests sent by {project_name} to clients rely on the browser and on"
+" embedded `iframes` that are rendered for the logout page."
+msgstr ""
+"{project_name}がクライアントに送信するログアウト・リクエストは、ブラウザーと、ログアウトページでレンダリングされる埋め込みの "
+"`iframe` に依存しています。"
+
+#. type: Plain text
+msgid ""
+"By being based on `iframes`, front-channel logout might be impacted by "
+"Content Security Policies (CSP) and logout requests might be blocked."
+msgstr ""
+"フロントチャネルのログアウトは、「iframe」に基づいているため、コンテンツ・セキュリティー・ポリシー（CSP）の影響を受け、ログアウト・リクエストがブロックされる可能性があります。"
+
+#. type: Plain text
+msgid ""
+"If the user closes the browser prior to rendering the logout page or before "
+"logout requests are actually sent to clients, their sessions at the client "
+"might not be invalidated."
+msgstr ""
+"ログアウトページを表示する前、またはログアウト・リクエストが実際にクライアントに送信される前にユーザーがブラウザーを閉じた場合、クライアントでのセッションが無効にならない可能性があります。"
+
+#. type: delimited block =
+msgid ""
+"Consider using Back-Channel Logout as it provides a more reliable and secure"
+" approach to log out users and terminate their sessions on the clients."
+msgstr ""
+"ユーザーをログアウトさせ、クライアント上のセッションを終了させるには、より信頼性が高く安全な方法であるバックチャネル・ログアウトの使用を検討してください。"
+
+#. type: Plain text
+msgid ""
+"If the client is not enabled with front-channel logout, then {project_name} "
+"is going to try first to send logout requests through the back-channel using"
+" the <<_back-channel-logout-url, Back-Channel Logout URL>>. If not defined, "
+"the server is going to fall back to using the <<_admin-url, Admin URL>>."
+msgstr ""
+"クライアントがフロントチャネル・ログアウトを有効にしていない場合、{project_name}はまず<<_back-channel-logout-"
+"url, Back-Channel Logout URL>>を使ってバックチャネルでログアウト・リクエストを送ろうとします。<_back-"
+"channel-logout-url, Back-Channel Logout URL>定義されていない場合、サーバーは<<_admin-url, "
+"Admin URL>>の使用に戻ります。"
+
+#. type: Plain text
+msgid ""
+"This is a non browser-based logout that uses direct backchannel "
+"communication between {project_name} and clients.  {project_name} sends a "
+"HTTP POST request containing a logout token to all clients logged into "
+"{project_name}. These requests are sent to a registered backchannel logout "
+"URLs at {project_name} and are supposed to trigger a logout at client side."
+msgstr ""
+"これは、{project_name}とクライアント間の直接バックチャネル通信を使用する非ブラウザーベースのログアウトです。{project_name}は、ログアウト・トークンを含むHTTP"
+" "
+"POSTリクエストを{project_name}にログインしているすべてのクライアントに送信します。これらのリクエストは、{project_name}の登録済みバックチャネル・ログアウトURLに送信され、クライアント側でログアウトをトリガーすることになっています。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/sso-protocols/con-oidc-auth-flows.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__sso-protocols__con-oidc-auth-flows
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
