### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po
@@ -4,14 +4,14 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,53 +19,6 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title =
-#, no-wrap
-msgid "Authorization Process"
-msgstr "認可プロセス"
-
-#. type: Plain text
-msgid ""
-"In UMA, the authorization process starts when a client tries to access a UMA"
-" protected resource server."
-msgstr "UMAでは、クライアントがUMAで保護されたリソースサーバーにアクセスしようとすると、認可プロセスが開始されます。"
-
-#. type: Plain text
-msgid ""
-"A UMA protected resource server expects a bearer token in the request where "
-"the token is an RPT. When a client requests a resource at the resource "
-"server without a permission ticket:"
-msgstr ""
-"UMAで保護されたリソースサーバーは、リクエスト内のベアラートークンがRPTであることを想定しています。クライアントがパーミッション・チケットなしでリソースサーバーにリソースを要求する場合、次のようになります。"
-
-#. type: Block title
-#, no-wrap
-msgid "Client requests a protected resource without sending an RPT"
-msgstr "クライアントは、RPTを送信せずに保護されたリソースを要求します"
-
-#. type: Code block
-#, no-wrap
-msgid ""
-"curl -X GET \\\n"
-"  http://${host}:${port}/my-resource-server/resource/1bfdfe78-a4e1-4c2d-b142-fc92b75b986f\n"
-msgstr ""
-"curl -X GET \\\n"
-"  http://${host}:${port}/my-resource-server/resource/1bfdfe78-a4e1-4c2d-b142-fc92b75b986f\n"
-
-#. type: Plain text
-msgid ""
-"The resource server sends a response back to the client with a permission "
-"`ticket` and a `as_uri` parameter with the location of a {project_name} "
-"server to where the ticket should be sent in order to obtain an RPT."
-msgstr ""
-"リソースサーバーは、RPTを取得するためにチケットが送られるべき{project_name}サーバーの場所とともに、パーミッション `ticket` と"
-" `as_uri` パラメーターを持つレスポンスをクライアントに返します。"
-
-#. type: Block title
-#, no-wrap
-msgid "Resource server responds with a permission ticket"
-msgstr "リソースサーバーはパーミッション・チケットを返します"
-
 #. type: Code block
 #, no-wrap
 msgid ""
@@ -78,30 +31,6 @@ msgstr ""
 "WWW-Authenticate: UMA realm=\"${realm}\",\n"
 "    as_uri=\"https://${host}:${port}/auth/realms/${realm}\",\n"
 "    ticket=\"016f84e8-f9b9-11e0-bd6f-0021cc6004de\"\n"
-
-#. type: Plain text
-msgid ""
-"The permission ticket is a special type of token issued by {project_name} "
-"Permission API. They represent the permissions being requested (e.g.: "
-"resources and scopes)  as well any other information associated with the "
-"request. Only resource servers are allowed to create those tokens."
-msgstr ""
-"パーミッション・チケットは、{project_name} Permission "
-"APIによって発行される特別なタイプのトークンです。これらは、要求されるパーミッション（例えば、リソースおよびスコープ）、ならびにリクエストに関連する他の情報を表します。リソースサーバーのみがこれらのトークンを作成できます。"
-
-#. type: Plain text
-msgid ""
-"Now that the client has a permission ticket and also the location of a "
-"{project_name} server, the client can use the discovery document to obtain "
-"the location of the token endpoint and send an authorization request."
-msgstr ""
-"クライアントはパーミッション・チケットを持つとともに{project_name}サーバーの場所も知っているので、クライアントはディスカバリー文書を使用してトークン・エンドポイントの場所を取得し、認可リクエストを送信できます。"
-
-#. type: Block title
-#, no-wrap
-msgid ""
-"Client sends an authorization request to the token endpoint to obtain an RPT"
-msgstr "クライアントは、RPTを取得するためにトークン・エンドポイントに認可リクエストを送信します"
 
 #. type: Code block
 #, no-wrap
@@ -146,18 +75,6 @@ msgstr ""
 "    \"access_token\": \"${rpt}\",\n"
 "}\n"
 
-#. type: Plain text
-msgid ""
-"The response from the server is just like any other response from the token "
-"endpoint when using some other grant type. The RPT can be obtained from the "
-"`access_token` response parameter. In case the client is not authorized to "
-"have permissions {project_name} responds with a `403` HTTP status code:"
-msgstr ""
-"サーバーからのレスポンスは、他のグラントタイプを使用しているときのトークン・エンドポイントからの任意のレスポンスとまったく同じです。RPTは "
-"`access_token` "
-"レスポンス・パラメーターから取得できます。パーミッションを得るためにクライアントが認可されていない場合、{project_name}は次のように "
-"`403` HTTPステータスコードで応答します。"
-
 #. type: Block title
 #, no-wrap
 msgid "{project_name} denies the authorization request"
@@ -181,3 +98,86 @@ msgstr ""
 "    \"error\": \"access_denied\",\n"
 "    \"error_description\": \"request_denied\"\n"
 "}\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Authorization Process"
+msgstr "認可プロセス"
+
+#. type: Plain text
+msgid ""
+"In UMA, the authorization process starts when a client tries to access a UMA"
+" protected resource server."
+msgstr "UMAでは、クライアントがUMAで保護されたリソースサーバーにアクセスしようとすると、認可プロセスが開始されます。"
+
+#. type: Plain text
+msgid ""
+"A UMA protected resource server expects a bearer token in the request where "
+"the token is an RPT. When a client requests a resource at the resource "
+"server without a RPT:"
+msgstr ""
+"UMAで保護されたリソースサーバーは、リクエスト内のベアラートークンがRPTであることを想定しています。クライアントがRPTなしでリソースサーバーにリソースを要求する場合、次のようになります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Client requests a protected resource without sending an RPT"
+msgstr "クライアントは、RPTを送信せずに保護されたリソースを要求します"
+
+#. type: Code block
+#, no-wrap
+msgid ""
+"curl -X GET \\\n"
+"  http://${host}:${port}/my-resource-server/resource/1bfdfe78-a4e1-4c2d-b142-fc92b75b986f\n"
+msgstr ""
+"curl -X GET \\\n"
+"  http://${host}:${port}/my-resource-server/resource/1bfdfe78-a4e1-4c2d-b142-fc92b75b986f\n"
+
+#. type: Plain text
+msgid ""
+"The resource server sends a response back to the client with a permission "
+"`ticket` and a `as_uri` parameter with the location of a {project_name} "
+"server to where the ticket should be sent in order to obtain an RPT."
+msgstr ""
+"リソースサーバーは、RPTを取得するためにチケットが送られるべき{project_name}サーバーの場所とともに、パーミッション `ticket` と"
+" `as_uri` パラメーターを持つレスポンスをクライアントに返します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Resource server responds with a permission ticket"
+msgstr "リソースサーバーはパーミッション・チケットを返します"
+
+#. type: Plain text
+msgid ""
+"The permission ticket is a special type of token issued by {project_name} "
+"Permission API. They represent the permissions being requested (e.g.: "
+"resources and scopes)  as well any other information associated with the "
+"request. Only resource servers are allowed to create those tokens."
+msgstr ""
+"パーミッション・チケットは、{project_name} Permission "
+"APIによって発行される特別なタイプのトークンです。これらは、要求されるパーミッション（例えば、リソースおよびスコープ）、ならびにリクエストに関連する他の情報を表します。リソースサーバーのみがこれらのトークンを作成できます。"
+
+#. type: Plain text
+msgid ""
+"Now that the client has a permission ticket and also the location of a "
+"{project_name} server, the client can use the discovery document to obtain "
+"the location of the token endpoint and send an authorization request."
+msgstr ""
+"クライアントはパーミッション・チケットを持つとともに{project_name}サーバーの場所も知っているので、クライアントはディスカバリー文書を使用してトークン・エンドポイントの場所を取得し、認可リクエストを送信できます。"
+
+#. type: Block title
+#, no-wrap
+msgid ""
+"Client sends an authorization request to the token endpoint to obtain an RPT"
+msgstr "クライアントは、RPTを取得するためにトークン・エンドポイントに認可リクエストを送信します"
+
+#. type: Plain text
+msgid ""
+"The response from the server is just like any other response from the token "
+"endpoint when using some other grant type. The RPT can be obtained from the "
+"`access_token` response parameter. In case the client is not authorized to "
+"have permissions {project_name} responds with a `403` HTTP status code:"
+msgstr ""
+"サーバーからのレスポンスは、他のグラントタイプを使用しているときのトークン・エンドポイントからの任意のレスポンスとまったく同じです。RPTは "
+"`access_token` "
+"レスポンス・パラメーターから取得できます。パーミッションを得るためにクライアントが認可されていない場合、{project_name}は次のように "
+"`403` HTTPステータスコードで応答します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/service-authorization-uma-authz-process.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__service-authorization-uma-authz-process
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
