### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/con-basic-settings.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-basic-settings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-basic-settings.ja_JP.po
@@ -28,7 +28,7 @@ msgstr "基本設定"
 msgid ""
 "When you create an OIDC client, you see the following fields on the "
 "*Settings* tab."
-msgstr "OIDCクライアントを作成すると、*Settings*タブに以下のフィールドが表示されます。"
+msgstr "OIDCクライアントを作成すると、 *Settings* タブに以下のフィールドが表示されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -39,7 +39,7 @@ msgstr "*Client ID*"
 msgid ""
 "The alpha-numeric ID string that is used in OIDC requests and in the "
 "{project_name} database to identify the client."
-msgstr "OIDC リクエストおよび {project_name} データベースでクライアントを識別するために使用される英数字の ID 文字列です。"
+msgstr "OIDCリクエストおよび{project_name}データベースでクライアントを識別するために使用される英数字のID文字列です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -53,9 +53,8 @@ msgid ""
 "$\\{myapp}.  See the link:{developerguide_link}[{developerguide_name}] for "
 "more information."
 msgstr ""
-"project_name} "
-"におけるクライアントの名前。UI画面での名称。名前をローカライズするには、置換文字列値を設定する。例えば、${myapp}のような文字列値です。  "
-"詳しくは、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
+"{project_name}におけるクライアントの名前。UI画面での名称。名前をローカライズするには、置換文字列値を設定します。たとえば、${myapp}のような文字列値です。詳しくは、"
+" link:{developerguide_link}[{developerguide_name}] を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -86,8 +85,7 @@ msgid ""
 "to that application.  It will also display metadata so the user knows the "
 "exact information that the client can access."
 msgstr ""
-"オンにすると、ユーザーはそのアプリケーションへのアクセスを許可するために使用できる同意ページを見ることができます。  "
-"また、クライアントがアクセスできる正確な情報をユーザーが知ることができるように、メタデータが表示されます。"
+"オンにすると、ユーザーはそのアプリケーションへのアクセスを許可するために使用できる同意ページを見ることができます。また、クライアントがアクセスできる正確な情報をユーザーが知ることができるように、メタデータが表示されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -109,7 +107,7 @@ msgid ""
 "secrets when making an Access Token Request. This setting should be used for"
 " server-side applications."
 msgstr ""
-"ブラウザログインを行うサーバーサイドクライアントで、アクセストークンリクエストを行う際にクライアントシークレットを要求する場合。この設定は、サーバーサイドのアプリケーションで使用する必要があります。"
+"ブラウザー・ログインを行い、アクセストークン・リクエストの際にクライアント・シークレットを要求するサーバーサイド・クライアント用。この設定は、サーバーサイドのアプリケーションで使用する必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -122,7 +120,7 @@ msgid ""
 "to ensure that secrets can be kept safe with client-side clients, it is "
 "important to restrict access by configuring correct redirect URIs."
 msgstr ""
-"ブラウザログインを行うクライアントサイドクライアントの場合。クライアント側のクライアントでは、秘密の保持を確実に行うことができないため、正しいリダイレクトURIを設定することでアクセスを制限することが重要である。"
+"ブラウザー・ログインを行うクライアントサイドのクライアント用。クライアントサイドのクライアントでは、シークレットの保持を確実に行うことができないため、正しいリダイレクトURIを設定することでアクセスを制限することが重要です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -147,7 +145,7 @@ msgid ""
 "authorization[Authorization Code Flow]."
 msgstr ""
 "有効にすると、クライアントはOIDC xref:_oidc-auth-flows-"
-"authorization[認証コードフロー]を使用できるようになります。"
+"authorization[認可コードフロー]を使用できるようになります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -159,7 +157,7 @@ msgid ""
 "When enabled, clients can use the OIDC xref:_oidc-auth-flows-"
 "implicit[Implicit Flow]."
 msgstr ""
-"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-implicit[暗黙フロー]を使用できるようになります。"
+"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-implicit[インプリシット・フロー]を使用できるようになります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -171,8 +169,8 @@ msgid ""
 "When enabled, clients can use the OIDC xref:_oidc-auth-flows-direct[Direct "
 "Access Grants]."
 msgstr ""
-"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-direct[Direct Access "
-"Grants]を使用することができます。"
+"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-direct[Direct Access Grants] "
+"を使用することができます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -184,8 +182,8 @@ msgid ""
 "If this is on, clients are allowed to use the OIDC xref:con-oidc-auth-"
 "flows_server_administration_guide[Device Authorization Grant]."
 msgstr ""
-"onの場合、クライアントはOIDC xref:con-oidc-auth-"
-"flows_server_administration_guide[Device Authorization Grant]の利用が許可されます。"
+"オンの場合、クライアントはOIDC xref:con-oidc-auth-"
+"flows_server_administration_guide[Device認可グラント] の利用が許可されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -199,8 +197,8 @@ msgid ""
 "  If this is on, clients are allowed to use the OIDC xref:con-oidc-auth-"
 "flows_{context}[Client Initiated Backchannel Authentication Grant]."
 msgstr ""
-"  これが on の場合、クライアントは OIDC xref:con-oidc-auth-flows_{context}[Client "
-"Initiated Backchannel Authentication Grant]の使用を許可されます。"
+" これがオンの場合、クライアントは OIDC xref:con-oidc-auth-flows_{context}[Client Initiated "
+"Backchannel Authentication Grant]の使用を許可されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -224,8 +222,8 @@ msgid ""
 "existing URLs and click *Save*. You can use wildcards at the end of the URL "
 "pattern. For example $$http://host.com/*$$"
 msgstr ""
-"必須項目です。  "
-"URLパターンを入力し、*+*で追加、*-*で既存のURLを削除して*Save*をクリックします。URLパターンの末尾にワイルドカードを使用することができます。例）$$http://host.com/*$$"
+"必須項目です。URLパターンを入力し、 *+* で追加、 *-* で既存のURLを削除して *Save* "
+"をクリックします。URLパターンの末尾にワイルドカードを使用することができます。例） $$http://host.com/*$$"
 
 #. type: Plain text
 msgid ""
@@ -233,7 +231,7 @@ msgid ""
 "xref:unspecific-redirect-uris_{context}[Unspecific Redirect URIs] for more "
 "information."
 msgstr ""
-"排他的リダイレクト URL パターンは、通常、より安全です。  詳しくは xref:unspecific-redirect-"
+"排他的リダイレクトURLパターンは、通常、より安全です。詳しくは xref:unspecific-redirect-"
 "uris_{context}[Unspecific Redirect URIs] を参照してください。"
 
 #. type: Labeled list
@@ -243,7 +241,7 @@ msgstr "*Base URL*"
 
 #. type: Plain text
 msgid "This URL is used when {project_name} needs to link to the client."
-msgstr "このURLは、{project_name} がクライアントにリンクする必要がある場合に使用されます。"
+msgstr "このURLは、 {project_name} がクライアントにリンクする必要がある場合に使用されます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -258,10 +256,10 @@ msgid ""
 "can be the root URL of the servlet application.  For more information, see "
 "link:{adapterguide_link}[{adapterguide_name}]."
 msgstr ""
-"クライアントのコールバックエンドポイント。  "
-"サーバーはこのURLを使用して、取り消しポリシーのプッシュ、バックチャネルログアウトの実行、およびその他の管理操作などのコールバックを実行します。  "
-"project_name }サーブレットアダプターの場合、このURLはサーブレットアプリケーションのルートURLにすることができます。  "
-"詳しくは、link:{adapterguide_link}[{adapterguide_name}]を参照してください。"
+"クライアントのコールバック・エンドポイント。  "
+"サーバーはこのURLを使用して、取り消しポリシーのプッシュ、バックチャネル・ログアウトの実行、およびその他の管理操作などのコールバックを実行します。{project_name"
+" }サーブレット・アダプターの場合、このURLはサーブレット・アプリケーションのルートURLにすることができます。詳しくは、 "
+"link:{adapterguide_link}[{adapterguide_name}] を参照してください。"
 
 #. type: Plain text
 #, no-wrap
@@ -303,7 +301,7 @@ msgstr "*Web Origins*"
 msgid ""
 "Enter a URL pattern and click *+* to add and *-* to remove existing URLs. "
 "Click *Save*."
-msgstr "URLのパターンを入力し、*+*で追加、*-*で既存のURLを削除します。保存*をクリックします。"
+msgstr "URLのパターンを入力し、 *+* で追加、 *-* で既存のURLを削除します。 *Save* をクリックします。"
 
 #. type: Plain text
 msgid ""
@@ -315,9 +313,9 @@ msgid ""
 "to be processed. This protocol protects against XSS, CSRF, and other "
 "JavaScript-based attacks."
 msgstr ""
-"このオプションは、link:https://fetch.spec.whatwg.org/[Cross-Origin Resource Sharing "
-"(CORS)](リンク)を処理します。  ブラウザのJavaScriptが、JavaScriptコードが由来するドメインとは異なるサーバーにAJAX "
-"HTTPリクエストを試みる場合、そのリクエストはCORSを使用する必要があります。サーバーはCORSリクエストを処理する必要があり、そうでない場合、ブラウザはそのリクエストを表示しないか、処理することを許可しません。このプロトコルは、XSS、CSRF、およびその他のJavaScriptベースの攻撃から保護します。"
+"このオプションは、 link:https://fetch.spec.whatwg.org/[Cross-Origin Resource Sharing "
+"(CORS)] を処理します。ブラウザーのJavaScriptが、JavaScriptコードが由来するドメインとは異なるサーバーにAJAX "
+"HTTPリクエストを試みる場合、そのリクエストはCORSを使用する必要があります。サーバーはCORSリクエストを処理する必要があり、そうでない場合、ブラウザーはそのリクエストを表示しないか、処理することを許可しません。このプロトコルは、XSS、CSRF、およびその他のJavaScriptベースの攻撃から保護します。"
 
 #. type: Plain text
 msgid ""
@@ -327,11 +325,8 @@ msgid ""
 "client adapters support this feature. See "
 "link:{adapterguide_link}[{adapterguide_name}] for more information."
 msgstr ""
-"ここに記載されているドメイン URL "
-"は、クライアントアプリケーションに送信されるアクセストークン内に埋め込まれています。クライアントアプリケーションは、この情報を使用して、CORS "
-"リクエストの呼び出しを許可するかどうかを決定します。  project_name } クライアント "
-"アダプターのみがこの機能をサポートしています。詳細については、link:{adapterguide_link}[{adapterguide_name}]"
-" を参照してください。"
+"ここに記載されているドメインURLは、クライアント・アプリケーションに送信されるアクセストークン内に埋め込まれています。クライアント・アプリケーションは、この情報を使用して、CORSリクエストの呼び出しを許可するかどうかを決定します。{project_name}クライアント・アダプターのみがこの機能をサポートしています。詳細については、"
+" link:{adapterguide_link}[{adapterguide_name}] を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -346,10 +341,11 @@ msgid ""
 "Connect Front-Channel Logout] specification. If enabled, you should also "
 "provide the `Front-Channel Logout URL`."
 msgstr ""
-"Front Channel Logout* が有効な場合、アプリケーションは link:https://openid.net/specs/openid-"
-"connect-frontchannel-1_0.html[OpenID Connect Front-Channel Logout] "
-"仕様に従って、フロントチャンネルを通してユーザーをログアウトできるようにする必要があります。有効にした場合、`Front-Channel Logout "
-"URL`も提供する必要があります。"
+"*Front Channel Logout* が有効な場合、アプリケーションは "
+"link:https://openid.net/specs/openid-connect-frontchannel-1_0.html[OpenID "
+"Connect Front-Channel Logout] "
+"の仕様に従って、フロントチャネルを通してユーザーをログアウトできるようにする必要があります。有効にした場合、 `Front-Channel Logout"
+" URL` も提供する必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -360,7 +356,7 @@ msgstr "*Front-Channel Logout URL*"
 msgid ""
 "URL that will be used by {project_name} to send logout requests to clients "
 "through the front-channel."
-msgstr "project_name} がフロントチャネルを通じてクライアントにログアウト要求を送信するために使用する URL。"
+msgstr "{project_name}がフロントチャネルを通じてクライアントにログアウト・リクエストを送信するために使用するURL。"
 
 #. type: Labeled list
 #, no-wrap
@@ -373,5 +369,5 @@ msgid ""
 "sent to this realm (via end_session_endpoint). If omitted, no logout "
 "requests are sent to the client."
 msgstr ""
-"ログアウト要求がこの realm に (end_session_endpoint 経由で) "
-"送られたときに、クライアントが自分自身をログアウトさせるための URL。省略された場合、ログアウト要求はクライアントに送信されません。"
+"ログアウト・リクエストがこのレルムに(end_session_endpoint経由で) "
+"送られたときに、クライアントが自分自身をログアウトさせるためのURL。省略された場合、ログアウト・リクエストはクライアントに送信されません。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-basic-settings.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-basic-settings.ja_JP.po
@@ -1,0 +1,377 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Basic settings"
+msgstr "基本設定"
+
+#. type: Plain text
+msgid ""
+"When you create an OIDC client, you see the following fields on the "
+"*Settings* tab."
+msgstr "OIDCクライアントを作成すると、*Settings*タブに以下のフィールドが表示されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Client ID*"
+msgstr "*Client ID*"
+
+#. type: Plain text
+msgid ""
+"The alpha-numeric ID string that is used in OIDC requests and in the "
+"{project_name} database to identify the client."
+msgstr "OIDC リクエストおよび {project_name} データベースでクライアントを識別するために使用される英数字の ID 文字列です。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Name*"
+msgstr "*Name*"
+
+#. type: Plain text
+msgid ""
+"The name for the client in {project_name} UI screen. To localize the name, "
+"set up a replacement string value. For example, a string value such as "
+"$\\{myapp}.  See the link:{developerguide_link}[{developerguide_name}] for "
+"more information."
+msgstr ""
+"project_name} "
+"におけるクライアントの名前。UI画面での名称。名前をローカライズするには、置換文字列値を設定する。例えば、${myapp}のような文字列値です。  "
+"詳しくは、リンク:{developerguide_link}[{developerguide_name}]を参照してください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Description*"
+msgstr "*Description*"
+
+#. type: Plain text
+msgid "The description of the client.  This setting can also be localized."
+msgstr "クライアントの説明文です。この設定はローカライズすることも可能です。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Enabled*"
+msgstr "*Enabled*"
+
+#. type: Plain text
+msgid "When turned off, the client cannot request authentication."
+msgstr "オフにすると、クライアントは認証を要求できなくなります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Consent Required*"
+msgstr "*Consent Required*"
+
+#. type: Plain text
+msgid ""
+"When turned on, users see a consent page that they can use to grant access "
+"to that application.  It will also display metadata so the user knows the "
+"exact information that the client can access."
+msgstr ""
+"オンにすると、ユーザーはそのアプリケーションへのアクセスを許可するために使用できる同意ページを見ることができます。  "
+"また、クライアントがアクセスできる正確な情報をユーザーが知ることができるように、メタデータが表示されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Access Type*"
+msgstr "*Access Type*"
+
+#. type: Plain text
+msgid "The type of OIDC client."
+msgstr "OIDCクライアントの種類を表します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "_Confidential_"
+msgstr "_Confidential_"
+
+#. type: Plain text
+msgid ""
+"For server-side clients that perform browser logins and require client "
+"secrets when making an Access Token Request. This setting should be used for"
+" server-side applications."
+msgstr ""
+"ブラウザログインを行うサーバーサイドクライアントで、アクセストークンリクエストを行う際にクライアントシークレットを要求する場合。この設定は、サーバーサイドのアプリケーションで使用する必要があります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "_Public_"
+msgstr "_Public_"
+
+#. type: Plain text
+msgid ""
+"For client-side clients that perform browser logins. As it is not possible "
+"to ensure that secrets can be kept safe with client-side clients, it is "
+"important to restrict access by configuring correct redirect URIs."
+msgstr ""
+"ブラウザログインを行うクライアントサイドクライアントの場合。クライアント側のクライアントでは、秘密の保持を確実に行うことができないため、正しいリダイレクトURIを設定することでアクセスを制限することが重要である。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "_Bearer-only_"
+msgstr "_Bearer-only_"
+
+#. type: Plain text
+msgid ""
+"The application allows only bearer token requests. When turned on, this "
+"application cannot participate in browser logins."
+msgstr ""
+"このアプリケーションは、ベアラートークンの要求のみを許可します。オンにすると、このアプリケーションはブラウザーのログインに参加できなくなります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Standard Flow Enabled*"
+msgstr "*Standard Flow Enabled*"
+
+#. type: Plain text
+msgid ""
+"When enabled, clients can use the OIDC xref:_oidc-auth-flows-"
+"authorization[Authorization Code Flow]."
+msgstr ""
+"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-"
+"authorization[認証コードフロー]を使用できるようになります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Implicit Flow Enabled*"
+msgstr "*Implicit Flow Enabled*"
+
+#. type: Plain text
+msgid ""
+"When enabled, clients can use the OIDC xref:_oidc-auth-flows-"
+"implicit[Implicit Flow]."
+msgstr ""
+"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-implicit[暗黙フロー]を使用できるようになります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Direct Access Grants Enabled*"
+msgstr "*Direct Access Grants Enabled*"
+
+#. type: Plain text
+msgid ""
+"When enabled, clients can use the OIDC xref:_oidc-auth-flows-direct[Direct "
+"Access Grants]."
+msgstr ""
+"有効にすると、クライアントはOIDC xref:_oidc-auth-flows-direct[Direct Access "
+"Grants]を使用することができます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*OAuth 2.0 Device Authorization Grant Enabled*"
+msgstr "*OAuth 2.0 Device Authorization Grant Enabled*"
+
+#. type: Plain text
+msgid ""
+"If this is on, clients are allowed to use the OIDC xref:con-oidc-auth-"
+"flows_server_administration_guide[Device Authorization Grant]."
+msgstr ""
+"onの場合、クライアントはOIDC xref:con-oidc-auth-"
+"flows_server_administration_guide[Device Authorization Grant]の利用が許可されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid ""
+"*OpenID Connect Client Initiated Backchannel Authentication Grant Enabled*"
+msgstr ""
+"*OpenID Connect Client Initiated Backchannel Authentication Grant Enabled*"
+
+#. type: Plain text
+msgid ""
+"  If this is on, clients are allowed to use the OIDC xref:con-oidc-auth-"
+"flows_{context}[Client Initiated Backchannel Authentication Grant]."
+msgstr ""
+"  これが on の場合、クライアントは OIDC xref:con-oidc-auth-flows_{context}[Client "
+"Initiated Backchannel Authentication Grant]の使用を許可されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Root URL*"
+msgstr "*Root URL*"
+
+#. type: Plain text
+msgid ""
+"If {project_name} uses any configured relative URLs, this value is prepended"
+" to them."
+msgstr "{project_name}が設定された相対URLを使用する場合、この値が先頭に追加されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Valid Redirect URIs*"
+msgstr "*Valid Redirect URIs*"
+
+#. type: Plain text
+msgid ""
+"Required field.  Enter a URL pattern and click *+* to add and *-* to remove "
+"existing URLs and click *Save*. You can use wildcards at the end of the URL "
+"pattern. For example $$http://host.com/*$$"
+msgstr ""
+"必須項目です。  "
+"URLパターンを入力し、*+*で追加、*-*で既存のURLを削除して*Save*をクリックします。URLパターンの末尾にワイルドカードを使用することができます。例）$$http://host.com/*$$"
+
+#. type: Plain text
+msgid ""
+"Exclusive redirect URL patterns are typically more secure.  See "
+"xref:unspecific-redirect-uris_{context}[Unspecific Redirect URIs] for more "
+"information."
+msgstr ""
+"排他的リダイレクト URL パターンは、通常、より安全です。  詳しくは xref:unspecific-redirect-"
+"uris_{context}[Unspecific Redirect URIs] を参照してください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Base URL*"
+msgstr "*Base URL*"
+
+#. type: Plain text
+msgid "This URL is used when {project_name} needs to link to the client."
+msgstr "このURLは、{project_name} がクライアントにリンクする必要がある場合に使用されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Admin URL*"
+msgstr "*Admin URL*"
+
+#. type: Plain text
+msgid ""
+"Callback endpoint for a client.  The server uses this URL to make callbacks "
+"like pushing revocation policies, performing backchannel logout, and other "
+"administrative operations.  For {project_name} servlet adapters, this URL "
+"can be the root URL of the servlet application.  For more information, see "
+"link:{adapterguide_link}[{adapterguide_name}]."
+msgstr ""
+"クライアントのコールバックエンドポイント。  "
+"サーバーはこのURLを使用して、取り消しポリシーのプッシュ、バックチャネルログアウトの実行、およびその他の管理操作などのコールバックを実行します。  "
+"project_name }サーブレットアダプターの場合、このURLはサーブレットアプリケーションのルートURLにすることができます。  "
+"詳しくは、link:{adapterguide_link}[{adapterguide_name}]を参照してください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Logo URL*\n"
+msgstr "*Logo URL*\n"
+
+#. type: Plain text
+msgid "URL that references a logo for the Client application."
+msgstr "クライアント・アプリケーション用のロゴを参照するURL。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Policy URL*\n"
+msgstr "*Policy URL*\n"
+
+#. type: Plain text
+msgid ""
+"URL that the Relying Party Client provides to the End-User to read about how"
+" the profile data will be used."
+msgstr "プロファイル・データがどのように使用されるかについて読むために、Relying Partyがエンドユーザーに提供するURL。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Terms of Service URL*\n"
+msgstr "*Terms of Service URL*\n"
+
+#. type: Plain text
+msgid ""
+"URL that the Relying Party Client provides to the End-User to read about the"
+" Relying Party's terms of service."
+msgstr "Relying Partyが、Relying Partyの利用規約を読むためにエンドユーザーに提供するURL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Web Origins*"
+msgstr "*Web Origins*"
+
+#. type: Plain text
+msgid ""
+"Enter a URL pattern and click *+* to add and *-* to remove existing URLs. "
+"Click *Save*."
+msgstr "URLのパターンを入力し、*+*で追加、*-*で既存のURLを削除します。保存*をクリックします。"
+
+#. type: Plain text
+msgid ""
+"This option handles link:https://fetch.spec.whatwg.org/[Cross-Origin "
+"Resource Sharing (CORS)].  If browser JavaScript attempts an AJAX HTTP "
+"request to a server whose domain is different from the one that the "
+"JavaScript code came from, the request must use CORS. The server must handle"
+" CORS requests, otherwise the browser will not display or allow the request "
+"to be processed. This protocol protects against XSS, CSRF, and other "
+"JavaScript-based attacks."
+msgstr ""
+"このオプションは、link:https://fetch.spec.whatwg.org/[Cross-Origin Resource Sharing "
+"(CORS)](リンク)を処理します。  ブラウザのJavaScriptが、JavaScriptコードが由来するドメインとは異なるサーバーにAJAX "
+"HTTPリクエストを試みる場合、そのリクエストはCORSを使用する必要があります。サーバーはCORSリクエストを処理する必要があり、そうでない場合、ブラウザはそのリクエストを表示しないか、処理することを許可しません。このプロトコルは、XSS、CSRF、およびその他のJavaScriptベースの攻撃から保護します。"
+
+#. type: Plain text
+msgid ""
+"Domain URLs listed here are embedded within the access token sent to the "
+"client application. The client application uses this information to decide "
+"whether to allow a CORS request to be invoked on it.  Only {project_name} "
+"client adapters support this feature. See "
+"link:{adapterguide_link}[{adapterguide_name}] for more information."
+msgstr ""
+"ここに記載されているドメイン URL "
+"は、クライアントアプリケーションに送信されるアクセストークン内に埋め込まれています。クライアントアプリケーションは、この情報を使用して、CORS "
+"リクエストの呼び出しを許可するかどうかを決定します。  project_name } クライアント "
+"アダプターのみがこの機能をサポートしています。詳細については、link:{adapterguide_link}[{adapterguide_name}]"
+" を参照してください。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Front Channel Logout*"
+msgstr "*Front Channel Logout*"
+
+#. type: Plain text
+msgid ""
+"If *Front Channel Logout* is enabled, the application should be able to log "
+"out users through the front channel as per "
+"link:https://openid.net/specs/openid-connect-frontchannel-1_0.html[OpenID "
+"Connect Front-Channel Logout] specification. If enabled, you should also "
+"provide the `Front-Channel Logout URL`."
+msgstr ""
+"Front Channel Logout* が有効な場合、アプリケーションは link:https://openid.net/specs/openid-"
+"connect-frontchannel-1_0.html[OpenID Connect Front-Channel Logout] "
+"仕様に従って、フロントチャンネルを通してユーザーをログアウトできるようにする必要があります。有効にした場合、`Front-Channel Logout "
+"URL`も提供する必要があります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Front-Channel Logout URL*"
+msgstr "*Front-Channel Logout URL*"
+
+#. type: Plain text
+msgid ""
+"URL that will be used by {project_name} to send logout requests to clients "
+"through the front-channel."
+msgstr "project_name} がフロントチャネルを通じてクライアントにログアウト要求を送信するために使用する URL。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Backchannel Logout URL*"
+msgstr "*Backchannel Logout URL*"
+
+#. type: Plain text
+msgid ""
+"URL that will cause the client to log itself out when a logout request is "
+"sent to this realm (via end_session_endpoint). If omitted, no logout "
+"requests are sent to the client."
+msgstr ""
+"ログアウト要求がこの realm に (end_session_endpoint 経由で) "
+"送られたときに、クライアントが自分自身をログアウトさせるための URL。省略された場合、ログアウト要求はクライアントに送信されません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/con-basic-settings.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__con-basic-settings
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
