### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/con-audience.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-audience.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-audience.ja_JP.po
@@ -1,0 +1,416 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Setup"
+msgstr "セットアップ"
+
+#. type: Title =
+#, no-wrap
+msgid "Audience support"
+msgstr "Audienceのサポート"
+
+#. type: Plain text
+msgid ""
+"Typically, the environment where {project_name} is deployed consists of a "
+"set of _confidential_ or _public_ client applications that use "
+"{project_name} for authentication."
+msgstr ""
+"通常、{project_name}が配置される環境は、{project_name}を認証に使用する _confidential_ "
+"クライアント・アプリケーションまたは _public_ クライアント・アプリケーションのセットで構成されています。"
+
+#. type: Plain text
+msgid ""
+"_Services_ (_Resource Servers_ in the "
+"https://datatracker.ietf.org/doc/html/draft-ietf-oauth-"
+"mtls-08#section-4.2[OAuth 2 specification]) are also available that serve "
+"requests from client applications and provide resources to these "
+"applications. These services require an _Access token_ (Bearer token) to be "
+"sent to them to authenticate a request. This token is obtained by the "
+"frontend application upon login to {project_name}."
+msgstr ""
+"クライアント・アプリケーションからのリクエストに対応し、これらのアプリケーションにリソースを提供する _サービス_  （ "
+"https://datatracker.ietf.org/doc/html/draft-ietf-oauth-"
+"mtls-08#section-4.2[OAuth 2 仕様]では _リソースサーバー_ ) "
+"も用意されています。これらのサービスでは、リクエストを認証するために _アクセストークン_ "
+"（ベアラートークン）を送信する必要があります。このトークンは、フロントエンド・アプリケーションが{project_name}にログインした際に取得します。"
+
+#. type: Plain text
+msgid ""
+"In the environment where trust among services is low, you may encounter this"
+" scenario:"
+msgstr "サービス間の信頼性が低い環境では、このようなシナリオに遭遇することがあります。"
+
+#. type: Plain text
+msgid ""
+"A frontend client application requires authentication against "
+"{project_name}."
+msgstr "フロントエンド・クライアント・アプリケーションが{project_name}に対して認証を要求します。"
+
+#. type: Plain text
+msgid "{project_name} authenticates a user."
+msgstr "{project_name}は、ユーザーを認証します。"
+
+#. type: Plain text
+msgid "{project_name} issues a token to the application."
+msgstr "{project_name}は、アプリケーションにトークンを発行します。"
+
+#. type: Plain text
+msgid "The application uses the token to invoke an untrusted service."
+msgstr "アプリケーションはトークンを使って、信頼できないサービスを呼び出します。"
+
+#. type: Plain text
+msgid ""
+"The untrusted service returns the response to the application. However, it "
+"keeps the applications token."
+msgstr "信頼されないサービスはアプリケーションにレスポンスを返します。ただし、アプリケーションのトークンは保持します。"
+
+#. type: Plain text
+msgid ""
+"The untrusted service then invokes a trusted service using the applications "
+"token. This results in broken security as the untrusted service misuses the "
+"token to access other services on behalf of the client application."
+msgstr ""
+"信頼されていないサービスは、アプリケーションのトークンを使用して信頼されたサービスを呼び出します。この結果、信頼されていないサービスがトークンを悪用して、クライアント・アプリケーションに代わって他のサービスにアクセスするため、セキュリティーが破られることになります。"
+
+#. type: Plain text
+msgid ""
+"This scenario is unlikely in environments with a high level of trust between"
+" services but not in environments where trust is low. In some environments, "
+"this workflow may be correct as the untrusted service may have to retrieve "
+"data from a trusted service to return data to the original client "
+"application."
+msgstr ""
+"このシナリオは、サービス間の信頼度が高い環境ではありえないが、信頼度が低い環境ではありえます。環境によっては、信頼されていないサービスが、元のクライアント・アプリケーションにデータを返すために、信頼されているサービスからデータを取得する必要があるため、このワークフローは正しいかもしれません。"
+
+#. type: Plain text
+msgid ""
+"An unlimited audience is useful when a high level of trust exists between "
+"services. Otherwise, the audience should be limited. You can limit the "
+"audience and, at the same time, allow untrusted services to retrieve data "
+"from trusted services. In this case, ensure that the untrusted service and "
+"the trusted service are added as audiences to the token."
+msgstr ""
+"サービス間に高い信頼性が存在する場合、無制限のAudienceが有効です。それ以外の場合は、Audienceを制限する必要があります。Audienceを制限すると同時に、信頼されていないサービスが信頼されているサービスからデータを取得することを許可することができます。この場合、信頼されていないサービスと信頼されたサービスがトークンのAudienceとして追加されていることを確認します。"
+
+#. type: Plain text
+msgid ""
+"To prevent any misuse of the access token, limit the audience on the token "
+"and configure your services to verify the audience on the token. The flow "
+"will change as follows:"
+msgstr ""
+"アクセストークンの悪用を防ぐため、トークンのAudienceを制限し、トークンのAudienceを確認するようにサービスを設定してください。フローは以下のように変更されます。"
+
+#. type: Plain text
+msgid "A frontend application authenticates against {project_name}."
+msgstr "フロントエンド・アプリケーションは{project_name}に対して認証を行います。"
+
+#. type: Plain text
+msgid ""
+"{project_name} issues a token to the application. The application knows that"
+" it will need to invoke an untrusted service so it places *scope=<untrusted "
+"service>* in the authentication request sent to {project_name} (see "
+"<<_client_scopes, Client Scopes section>> for more details about the _scope_"
+" parameter)."
+msgstr ""
+"{project_name}はアプリケーションにトークンを発行します。アプリケーションは信頼できないサービスを呼び出す必要があることを知っているので、{project_name}に送信する認証リクエストに"
+" *scope=<untrusted service>* を指定します。 _scope_ "
+"パラメーターの詳細については、<<_client_scopes, Client Scopes section>>を参照してください。"
+
+#. type: Plain text
+msgid ""
+"The token issued to the application contains a reference to the untrusted "
+"service in its audience (*\"audience\": [ \"<untrusted service>\" ]*) which "
+"declares that the client uses this access token to invoke the untrusted "
+"service."
+msgstr ""
+"アプリケーションに発行されたトークンは、そのAudience（ *\"audience\": [ \"<untrusted service>\" ]* "
+"）に信頼されないサービスへの参照を含み、クライアントはこのアクセストークンを使って信頼されないサービスを呼び出すと宣言しています。"
+
+#. type: Block title
+#, no-wrap
+msgid ""
+"The untrusted service serves the request to the client application but also "
+"keeps the token."
+msgstr "信頼されないサービスは、クライアント・アプリケーションにリクエストを提供しますが、トークンも保持します。"
+
+#. type: Plain text
+msgid ""
+"The untrusted service invokes a trusted service with the token. Invocation "
+"is not successful because the trusted service checks the audience on the "
+"token and find that its audience is only for the untrusted service. This "
+"behavior is expected and security is not broken."
+msgstr ""
+"信頼されていないサービスは、トークンを使って信頼されたサービスを呼び出します。信頼されたサービスがトークンのAudienceをチェックし、そのAudienceが信頼されていないサービスのみであることを発見したため、呼び出しは成功しません。この動作は予期されるものであり、セキュリティーが破られることはありません。"
+
+#. type: Plain text
+msgid ""
+"If the client wants to invoke the trusted service later, it must obtain "
+"another token by reissuing the SSO login with *scope=<trusted service>*. The"
+" returned token will then contain the trusted service as an audience:"
+msgstr ""
+"クライアントが後で信頼できるサービスを呼び出したい場合、SSOログインを *scope=<trusted service>* "
+"で再発行して別のトークンを取得する必要があります。返されたトークンには、信頼されたサービスがAudienceとして含まれています。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "\"audience\": [ \"<trusted service>\" ]\n"
+msgstr "\"audience\": [ \"<trusted service>\" ]\n"
+
+#. type: Plain text
+msgid "Use this value to invoke the *<trusted service>*."
+msgstr "この値で *<trusted service>* を呼び出す。"
+
+#. type: Plain text
+msgid "When setting up audience checking:"
+msgstr "Audienceチェックを設定する場合は、以下のようにします。"
+
+#. type: Plain text
+msgid ""
+"Ensure that services are configured to check audience on the access token "
+"sent to them by adding the flag *_verify-token-audience_* in the adapter "
+"configuration. See "
+"link:{adapterguide_link_latest}#_java_adapter_config[Adapter configuration] "
+"for details."
+msgstr ""
+"アダプターの設定に *_verify-token-audience_* "
+"フラグを追加して、サービスが送信されたアクセストークンのAudienceチェックを行うよう設定されていることを確認します。詳しくは "
+"link:{adapterguide_link_latest}#_java_adapter_config[アダプターの設定] を参照してください。"
+
+#. type: Plain text
+msgid ""
+"Ensure that access tokens issued by {project_name} contain all necessary "
+"audiences. Audiences can be added using the client roles as described in the"
+" <<_audience_resolve, next section>> or hardcoded. See "
+"<<_audience_hardcoded, Hardcoded audience>>."
+msgstr ""
+"{project_name}が発行するアクセストークンには、必要なAudienceをすべて含んでいることを確認してください。Audienceは、<<_audience_resolve,"
+" 次のセクション>>で説明したクライアントロールを使用して追加するか、ハードコードすることができます。<<_audience_hardcoded, "
+"ハードコードされたAudience>>を参照してください。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Automatically add audience"
+msgstr "Audienceを自動的に追加"
+
+#. type: Plain text
+msgid ""
+"An _Audience Resolve_ protocol mapper is defined in the default client scope"
+" _roles_. The mapper checks for clients that have at least one client role "
+"available for the current token. The client ID of each client is then added "
+"as an audience, which is useful if your service (usually bearer-only) "
+"clients rely on client roles."
+msgstr ""
+"_Audience Resolve_ プロトコル・マッパーは、デフォルトのクライアントスコープ _roles_ "
+"に定義されています。このマッパーは、現在のトークンに対して少なくとも一つのクライアントロールが利用可能であるクライアントをチェックします。これは、サービス（通常はbearer-"
+"only）クライアントがクライアントロールに依存している場合に有用です。"
+
+#. type: Plain text
+msgid ""
+"For example, for a bearer-only client and a confidential client, you can use"
+" the access token issued for the confidential client to invoke the bearer-"
+"only client REST service. The bearer-only client will be automatically added"
+" as an audience to the access token issued for the confidential client if "
+"the following are true:"
+msgstr ""
+"たとえば、bearer-"
+"onlyクライアントとコンフィデンシャル・クライアントの場合、コンフィデンシャル・クライアント用に発行されたアクセストークンを使用して、bearer-"
+"onlyクライアントのRESTサービスを呼び出すことが可能です。bearer-"
+"onlyクライアントは、以下の条件を満たす場合、コンフィデンシャル・クライアント用に発行されたアクセストークンに自動的にAudienceとして追加されます。"
+
+#. type: Plain text
+msgid "The bearer-only client has any client roles defined on itself."
+msgstr "bearer-onlyクライアントは、自分自身に定義された任意のクライアントロールを持ちます。"
+
+#. type: Plain text
+msgid "Target user has at least one of those client roles assigned."
+msgstr "対象のユーザーは、これらのクライアントロールのうち少なくとも1つが割り当てられています。"
+
+#. type: Plain text
+msgid "Confidential client has the role scope mappings for the assigned role."
+msgstr "コンフィデンシャル・クライアントは、割り当てられたロールのロール・スコープ・マッピングを持ちます。"
+
+#. type: delimited block =
+msgid ""
+"If you want to ensure that the audience is not added automatically, do not "
+"configure role scope mappings directly on the confidential client. Instead, "
+"you can create a dedicated client scope that contains the role scope "
+"mappings for the client roles of your dedicated client scope."
+msgstr ""
+"Audienceが自動的に追加されないようにするには、コンフィデンシャル・クライアントで直接ロール・スコープ・マッピングを設定しないでください。代わりに、専用クライアント・スコープを作成し、その専用クライアント・スコープのクライアントロールのロール・スコープ・マッピングを含むことができます。"
+
+#. type: delimited block =
+msgid ""
+"Assuming that the client scope is added as an optional client scope to the "
+"confidential client, the client roles and the audience will be added to the "
+"token if explicitly requested by the *scope=<trusted service>* parameter."
+msgstr ""
+"コンフィデンシャル・クライアントにオプションのクライアント・スコープが追加されたと仮定すると、*scope=*<trusted "
+"service>パラメーターで明示的に要求された場合、クライアントロールとAudienceがトークンに追加されます。"
+
+#. type: delimited block =
+msgid ""
+"The frontend client itself is not automatically added to the access token "
+"audience, therefore allowing easy differentiation between the access token "
+"and the ID token, since the access token will not contain the client for "
+"which the token is issued as an audience."
+msgstr ""
+"フロントエンド・クライアント自身はアクセストークンのAudienceに自動的に追加されないため、アクセストークンとIDトークンを容易に区別することができます（アクセストークンには、トークンがAudienceとして発行されるクライアントが含まれないためです）。"
+
+#. type: delimited block =
+msgid ""
+"If you need the client itself as an audience, see the <<_audience_hardcoded,"
+" hardcoded audience>> option. However, using the same client as both "
+"frontend and REST service is not recommended."
+msgstr ""
+"クライアント自体をAudienceとして必要とする場合は、<<_audience_hardcoded, "
+"ハードコードされたAudience>>オプションを参照してください。しかし、同じクライアントをフロントエンドとRESTサービスの両方に使用することは推奨されません。"
+
+#. type: Title ==
+#, no-wrap
+msgid "Hardcoded audience"
+msgstr "ハードコードされたAudience"
+
+#. type: Plain text
+msgid ""
+"When your service relies on realm roles or does not rely on the roles in the"
+" token at all, it can be useful to use a hardcoded audience. A hardcoded "
+"audience is a protocol mapper, that will add the client ID of the specified "
+"service client as an audience to the token.  You can use any custom value, "
+"for example a URL, if you want to use a different audience than the client "
+"ID."
+msgstr ""
+"サービスがレルムロールに依存している場合や、トークン内のロールに全く依存していない場合は、ハードコードされたAudienceを使用すると便利です。ハードコードされたAudienceとは、指定したサービス・クライアントのクライアントIDをAudienceとしてトークンに追加するプロトコル・マッパーのことです。クライアントIDとは異なるAudienceを使用したい場合は、任意のカスタム値（たとえば、URL）を使用することができます。"
+
+#. type: Plain text
+msgid ""
+"You can add the protocol mapper directly to the frontend client. If the "
+"protocol mapper is added directly, the audience will be always added as "
+"well."
+msgstr ""
+"プロトコル・マッパーは、フロントエンド・クライアントに直接追加することができます。プロトコル・マッパーを直接追加した場合、Audienceも必ず追加されます。"
+
+#. type: Plain text
+msgid ""
+"For more control over the protocol mapper, you can create the protocol "
+"mapper on the dedicated client scope, which will be called for example "
+"*good-service*."
+msgstr ""
+"プロトコル・マッパーをより詳細に制御するには、専用のクライアント・スコープにプロトコル・マッパーを作成し、たとえば *good-service* "
+"と呼ばれるようにします。"
+
+#. type: Block title
+#, no-wrap
+msgid "Audience protocol mapper"
+msgstr "Audienceプロトコル・マッパー"
+
+#. type: Plain text
+msgid "image:{project_images}/audience_mapper.png[]"
+msgstr "image:{project_images}/audience_mapper.png[]"
+
+#. type: Plain text
+msgid ""
+"From the <<_client_installation, Installation tab>> of the *good-service* "
+"client, you can generate the adapter configuration and you can confirm that "
+"_verify-token-audience_ option will be set to *true*. This forces the "
+"adapter to verify the audience if you use this configuration."
+msgstr ""
+"<_client_installation, Installation tab>good-"
+"service*クライアントの</_client_installation,>&lt;&gt;から、<_client_installation, "
+"Installation tab>アダプタの設定を生成することができ、_verify-token-"
+"audience_オプションが*true*に設定</_client_installation,>されることを確認することができます。<_client_installation,"
+" Installation "
+"tab>これにより、この設定を使用した場合、アダプタは強制的にオーディエンスを確認することになります。</_client_installation,>"
+
+#. type: Plain text
+msgid ""
+"You need to ensure that the confidential client is able to request *good-"
+"service* as an audience in its tokens."
+msgstr "機密保持クライアントが、そのトークンにオーディエンスとして*good-service*を要求できるようにする必要があります。"
+
+#. type: Plain text
+msgid "On the confidential client:"
+msgstr "機密保持のクライアントについて。"
+
+#. type: Plain text
+msgid "Click the _Client Scopes_ tab."
+msgstr "クライアントのスコープ]タブをクリックします。"
+
+#. type: Plain text
+msgid "Assign *good-service* as an optional (or default) client scope."
+msgstr "オプション（またはデフォルト）のクライアントスコープとして*good-service*を割り当てる。"
+
+#. type: Plain text
+msgid ""
+"See <<_client_scopes_linking, Client Scopes Linking section>> for more "
+"details."
+msgstr ""
+"<_client_scopes_linking, Client Scopes Linking "
+"section>詳しくは</_client_scopes_linking,>&lt;&gt;をご覧ください。"
+
+#. type: Plain text
+msgid ""
+"You can optionally <<_client_scopes_evaluate, Evaluate Client Scopes>> and "
+"generate an example access token. *good-service* will be added to the "
+"audience of the generated access token if *good-service* is included in the "
+"_scope_ parameter, when you assigned it as an optional client scope."
+msgstr ""
+"オプションで<_client_scopes_evaluate, Evaluate Client "
+"Scopes>&lt;&gt;とアクセストークンの例を生成</_client_scopes_evaluate,>することができます。<_client_scopes_evaluate,"
+" Evaluate Client Scopes>オプションのクライアントスコープとして割り当てた場合、_scope_パラメータに*good-"
+"service*が含まれていれば、生成されたアクセストークンのオーディエンスに*good-"
+"service*が追加されます。</_client_scopes_evaluate,>"
+
+#. type: Plain text
+msgid ""
+"In your confidential client application, ensure that the _scope_ parameter "
+"is used. The value *good-service* must be included when you want to issue "
+"the token for accessing *good-service*."
+msgstr ""
+"機密クライアントアプリケーションでは、_scope_パラメータが使用されていることを確認してください。good-"
+"service*にアクセスするためのトークンを発行する場合は、値 *good-service* を含める必要があります。"
+
+#. type: Plain text
+msgid "See:"
+msgstr "ご覧ください。"
+
+#. type: Plain text
+#, no-wrap
+msgid ""
+"** link:{adapterguide_link}#_params_forwarding[parameters forwarding section] if your application uses the servlet adapter.\n"
+"** link:{adapterguide_link}#_javascript_adapter[javascript adapter section] if your application uses the javascript adapter.\n"
+msgstr ""
+"** link:{adapterguide_link}#_params_forwarding[parameters forwarding section]（サーブレットアダプタを使用する場合）。\n"
+"** link:{adapterguide_link}#_javascript_adapter[javascript adapter section]は、アプリケーションがjavascriptアダプタを使用する場合に使用します。\n"
+
+#. type: Plain text
+msgid ""
+"Both the _Audience_ and _Audience Resolve_ protocol mappers add the "
+"audiences to the access token only, by default. The ID Token typically "
+"contains only a single audience, the client ID for which the token was "
+"issued, a requirement of the OpenID Connect specification. However, the "
+"access token does not necessarily have the client ID, which was the token "
+"issued for, unless the audience mappers added it."
+msgstr ""
+"Audience_ と _Audience Resolve_ "
+"の両プロトコルマッパーは、デフォルトではアクセストークンにのみオーディエンスを追加します。IDトークンは通常、OpenID "
+"Connect仕様の要件である、トークンが発行されたクライアントIDという単一のオーディエンスのみを含みます。しかし、アクセストークンには、オーディエンスマッパーが追加しない限り、トークンが発行されたクライアントIDが含まれているとは限りません。"

--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-audience.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-audience.ja_JP.po
@@ -334,38 +334,34 @@ msgid ""
 "_verify-token-audience_ option will be set to *true*. This forces the "
 "adapter to verify the audience if you use this configuration."
 msgstr ""
-"<_client_installation, Installation tab>good-"
-"service*クライアントの</_client_installation,>&lt;&gt;から、<_client_installation, "
-"Installation tab>アダプタの設定を生成することができ、_verify-token-"
-"audience_オプションが*true*に設定</_client_installation,>されることを確認することができます。<_client_installation,"
-" Installation "
-"tab>これにより、この設定を使用した場合、アダプタは強制的にオーディエンスを確認することになります。</_client_installation,>"
+"*good-service* クライアントの<<_client_installation, "
+"Installationタブ>>から、アダプターの設定を生成することができ、 _verify-token-audience_ オプションが *true*"
+" に設定されることを確認することができます。これにより、この設定を使用した場合、アダプターは強制的にAudienceを確認することになります。"
 
 #. type: Plain text
 msgid ""
 "You need to ensure that the confidential client is able to request *good-"
 "service* as an audience in its tokens."
-msgstr "機密保持クライアントが、そのトークンにオーディエンスとして*good-service*を要求できるようにする必要があります。"
+msgstr ""
+"コンフィデンシャル・クライアントが、そのトークンにAudienceとして *good-service* を要求できるようにする必要があります。"
 
 #. type: Plain text
 msgid "On the confidential client:"
-msgstr "機密保持のクライアントについて。"
+msgstr "コンフィデンシャル・クライアントでは以下のようにします。"
 
 #. type: Plain text
 msgid "Click the _Client Scopes_ tab."
-msgstr "クライアントのスコープ]タブをクリックします。"
+msgstr "_Client Scopes_ タブをクリックします。"
 
 #. type: Plain text
 msgid "Assign *good-service* as an optional (or default) client scope."
-msgstr "オプション（またはデフォルト）のクライアントスコープとして*good-service*を割り当てる。"
+msgstr "オプション（またはデフォルト）のクライアント・スコープとして *good-service* を割り当てます。"
 
 #. type: Plain text
 msgid ""
 "See <<_client_scopes_linking, Client Scopes Linking section>> for more "
 "details."
-msgstr ""
-"<_client_scopes_linking, Client Scopes Linking "
-"section>詳しくは</_client_scopes_linking,>&lt;&gt;をご覧ください。"
+msgstr "詳しくは<<_client_scopes_linking, Client Scopes Linkingのセクション>>を参照してください。"
 
 #. type: Plain text
 msgid ""
@@ -374,11 +370,10 @@ msgid ""
 "audience of the generated access token if *good-service* is included in the "
 "_scope_ parameter, when you assigned it as an optional client scope."
 msgstr ""
-"オプションで<_client_scopes_evaluate, Evaluate Client "
-"Scopes>&lt;&gt;とアクセストークンの例を生成</_client_scopes_evaluate,>することができます。<_client_scopes_evaluate,"
-" Evaluate Client Scopes>オプションのクライアントスコープとして割り当てた場合、_scope_パラメータに*good-"
-"service*が含まれていれば、生成されたアクセストークンのオーディエンスに*good-"
-"service*が追加されます。</_client_scopes_evaluate,>"
+"オプションで<<_client_scopes_evaluate, "
+"クライアント・スコープの評価>>とアクセストークンの例を生成することができます。オプションのクライアントスコープとして割り当てた場合、 _scope_ "
+"パラメーターに *good-service* が含まれていれば、生成されたアクセストークンのAudienceに *good-service* "
+"が追加されます。"
 
 #. type: Plain text
 msgid ""
@@ -386,12 +381,12 @@ msgid ""
 "is used. The value *good-service* must be included when you want to issue "
 "the token for accessing *good-service*."
 msgstr ""
-"機密クライアントアプリケーションでは、_scope_パラメータが使用されていることを確認してください。good-"
-"service*にアクセスするためのトークンを発行する場合は、値 *good-service* を含める必要があります。"
+"コンフィデンシャル・クライアント・アプリケーションでは、 _scope_ パラメーターが使用されていることを確認してください。 *good-"
+"service* にアクセスするためのトークンを発行する場合は、値 *good-service* を含める必要があります。"
 
 #. type: Plain text
 msgid "See:"
-msgstr "ご覧ください。"
+msgstr "以下を参照してください。"
 
 #. type: Plain text
 #, no-wrap
@@ -399,8 +394,8 @@ msgid ""
 "** link:{adapterguide_link}#_params_forwarding[parameters forwarding section] if your application uses the servlet adapter.\n"
 "** link:{adapterguide_link}#_javascript_adapter[javascript adapter section] if your application uses the javascript adapter.\n"
 msgstr ""
-"** link:{adapterguide_link}#_params_forwarding[parameters forwarding section]（サーブレットアダプタを使用する場合）。\n"
-"** link:{adapterguide_link}#_javascript_adapter[javascript adapter section]は、アプリケーションがjavascriptアダプタを使用する場合に使用します。\n"
+"** link:{adapterguide_link}#_params_forwarding[parameters forwarding section] （サーブレットアダプタを使用する場合）。\n"
+"** link:{adapterguide_link}#_javascript_adapter[javascript adapter section] （アプリケーションがJavaScriptアダプターを使用する場合）。\n"
 
 #. type: Plain text
 msgid ""
@@ -411,6 +406,6 @@ msgid ""
 "access token does not necessarily have the client ID, which was the token "
 "issued for, unless the audience mappers added it."
 msgstr ""
-"Audience_ と _Audience Resolve_ "
-"の両プロトコルマッパーは、デフォルトではアクセストークンにのみオーディエンスを追加します。IDトークンは通常、OpenID "
-"Connect仕様の要件である、トークンが発行されたクライアントIDという単一のオーディエンスのみを含みます。しかし、アクセストークンには、オーディエンスマッパーが追加しない限り、トークンが発行されたクライアントIDが含まれているとは限りません。"
+"_Audience_ と _Audience Resolve_ "
+"の両プロトコル・マッパーは、デフォルトではアクセストークンにのみAudienceを追加します。IDトークンは通常、OpenID "
+"Connectの仕様の要件である、トークンが発行されたクライアントIDという単一のAudienceのみを含みます。しかし、アクセストークンには、Audienceマッパーが追加しない限り、トークンが発行されたクライアントIDが含まれているとは限りません。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/con-audience.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__con-audience
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
