### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po
@@ -5,24 +5,19 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Block title
-#, no-wrap
-msgid "keycloak.json"
-msgstr "keycloak.json"
 
 #. type: Title =
 #, no-wrap
@@ -76,6 +71,11 @@ msgid ""
 "Here are several examples showing how you can extract claims from an HTTP "
 "request:"
 msgstr "HTTPリクエストからクレームを抽出する方法を示すいくつかの例を以下に示します。"
+
+#. type: Block title
+#, no-wrap
+msgid "keycloak.json"
+msgstr "keycloak.json"
 
 #. type: Code block
 #, no-wrap
@@ -337,8 +337,8 @@ msgid ""
 "defined for this particular CIP provider (via claim-information-point) is "
 "passed as a map."
 msgstr ""
-"リクエストを処理する際に、ポリシー・エンフォーサーは、MyClaimInformationPointProviderのインスタンスを取得するため、MyClaimInformationPointProviderFactory.createメソッドを呼び出します。呼び出されると、この特定のCIPプロバイダー用に定義された設定"
-"（claim-information-pointを経由）がマップとして渡されます。"
+"リクエストを処理する際に、ポリシー・エンフォーサーは、MyClaimInformationPointProviderのインスタンスを取得するため、MyClaimInformationPointProviderFactory.createメソッドを呼び出します。呼び出されると、この特定のCIPプロバイダー用に定義された設定（claim-"
+"information-pointを経由）がマップとして渡されます。"
 
 #. type: Plain text
 msgid "Example of `ClaimInformationPointProvider`:"
@@ -351,7 +351,7 @@ msgid ""
 "\n"
 "    private final Map<String, Object> config;\n"
 "\n"
-"    public ClaimsInformationPointProvider(Map<String, Object> config) {\n"
+"    public MyClaimInformationPointProvider(Map<String, Object> config) {\n"
 "        this.config = config;\n"
 "    }\n"
 "\n"
@@ -369,7 +369,7 @@ msgstr ""
 "\n"
 "    private final Map<String, Object> config;\n"
 "\n"
-"    public ClaimsInformationPointProvider(Map<String, Object> config) {\n"
+"    public MyClaimInformationPointProvider(Map<String, Object> config) {\n"
 "        this.config = config;\n"
 "    }\n"
 "\n"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/enforcer-claim-information-point.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__enforcer-claim-information-point
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
