### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/clients/oidc/con-confidential-client-credentials.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-confidential-client-credentials.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/clients/oidc/con-confidential-client-credentials.ja_JP.po
@@ -1,0 +1,278 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Shinsuke UEDA, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title =
+#, no-wrap
+msgid "Confidential client credentials"
+msgstr "機密性の高い顧客情報"
+
+#. type: Plain text
+msgid ""
+"If the <<_access-type, access type>> of the client is set to *confidential*,"
+" the credentials of the client must be configured under the *Credentials* "
+"tab."
+msgstr ""
+"<_access-type, access type>クライアントの</_access-type,>&lt;&gt;が<_access-type, "
+"access "
+"type>*confidential*に設定されている場合、クライアントの資格情報を*Credentials*タブで設定する必要が</_access-"
+"type,>あります。"
+
+#. type: Block title
+#, no-wrap
+msgid "Credentials tab"
+msgstr "認証情報タブ"
+
+#. type: Plain text
+msgid "image:{project_images}/client-credentials.png[Credentials Tab]"
+msgstr "image:{project_images}/client-credentials.png[Credentials Tab]"
+
+#. type: Plain text
+msgid ""
+"The *Client Authenticator* drop-down list specifies the type of credential "
+"to use for your client."
+msgstr "Client Authenticator* ドロップダウンリストでは、クライアントに使用するクレデンシャルの種類を指定します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Client ID and Secret*\n"
+msgstr "*Client ID and Secret*\n"
+
+#. type: Plain text
+msgid ""
+"This choice is the default setting. The secret is automatically generated "
+"for you and the clicking *Regenerate Secret* recreates the secret if "
+"necessary."
+msgstr ""
+"この選択肢はデフォルトの設定です。秘密は自動的に生成され、必要に応じて*Regenerate Secret*をクリックすると、秘密が再作成されます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Signed JWT"
+msgstr "署名付きJWT"
+
+#. type: Plain text
+msgid "image:{project_images}/client-credentials-jwt.png[]"
+msgstr "image:{project_images}/client-credentials-jwt.png[]"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Signed JWT* is \"Signed Json Web Token\".\n"
+msgstr "*Signed JWT* is \"Signed Json Web Token\".\n"
+
+#. type: Plain text
+msgid ""
+"When choosing this credential type you will have to also generate a private "
+"key and certificate for the client in the tab `Keys`. The private key will "
+"be used to sign the JWT, while the certificate is used by the server to "
+"verify the signature."
+msgstr ""
+"このクレデンシャルタイプを選択した場合、`鍵`タブでクライアントの秘密鍵と証明書も生成する必要があります。秘密鍵はJWTに署名するために使われ、一方、証明書はサーバーが署名を検証するために使われます。"
+
+#. type: Block title
+#, no-wrap
+msgid "Keys tab"
+msgstr "Keysタブ"
+
+#. type: Plain text
+msgid "image:images/client-oidc-keys.png[]"
+msgstr "image:images/client-oidc-keys.png[]"
+
+#. type: Plain text
+msgid ""
+"Click on the `Generate new keys and certificate` button to start this "
+"process."
+msgstr "この手順を開始するには、 `Generate new keys and certificate` ボタンをクリックしてください。"
+
+#. type: Block title
+#, no-wrap
+msgid "Generate keys"
+msgstr "鍵を生成する"
+
+#. type: Plain text
+msgid "image:{project_images}/generate-client-keys.png[]"
+msgstr "image:{project_images}/generate-client-keys.png[]"
+
+#. type: Plain text
+msgid "Select the archive format you want to use."
+msgstr "使用するアーカイブ形式を選択します。"
+
+#. type: Plain text
+msgid "Enter a *key password*."
+msgstr "*Key Password* を入力します。"
+
+#. type: Plain text
+msgid "Enter a *store password*."
+msgstr "*store password* を入力します。"
+
+#. type: Plain text
+msgid "Click *Generate and Download*."
+msgstr "*Generate and Download* をクリックします."
+
+#. type: Plain text
+msgid ""
+"When you generate the keys, {project_name} will store the certificate and "
+"you download the private key and certificate for your client."
+msgstr "鍵を生成すると、{project_name} が証明書を保存するので、クライアント用に秘密鍵と証明書をダウンロードする。"
+
+#. type: Plain text
+msgid ""
+"You can also generate keys using an external tool and then import the "
+"client's certificate by clicking *Import Certificate*."
+msgstr ""
+"また、外部ツールを使って鍵を生成し、*Import Certificate*をクリックしてクライアントの証明書をインポートすることも可能です。"
+
+#. type: Block title
+#, no-wrap
+msgid "Import certificate"
+msgstr "輸入証明書"
+
+#. type: Plain text
+msgid "image:{project_images}/import-client-cert.png[Import Certificate]"
+msgstr "image:{project_images}/import-client-cert.png[Import Certificate]"
+
+#. type: Plain text
+msgid "Select the archive format of the certificate."
+msgstr "証明書のアーカイブ形式を選択します。"
+
+#. type: Plain text
+msgid "Enter the store password."
+msgstr "ストアパスワードを入力します。"
+
+#. type: Plain text
+msgid "Select the certificate file by clicking *Import File*."
+msgstr "インポートファイル*をクリックして、証明書ファイルを選択します。"
+
+#. type: Plain text
+msgid "Click *Import*."
+msgstr "インポート」をクリックします。"
+
+#. type: Plain text
+msgid ""
+"Importing a certificate is unnecessary if you click *Use JWKS URL*. In this "
+"case, you can provide the URL where the public key is published in "
+"https://self-issued.info/docs/draft-ietf-jose-json-web-key.html[JWK] format."
+" With this option, if the key is ever changed, {project_name} reimports the "
+"key."
+msgstr ""
+"Use JWKS URL*をクリックすると、証明書のインポートは不要になります。この場合、公開鍵が公開されている URL を https://self-"
+"issued.info/docs/draft-ietf-jose-json-web-key.html[JWK] "
+"形式で指定します。このオプションを使用すると、鍵が変更されることがあっても、{project_name}鍵を再インポートすることができます。"
+
+#. type: Plain text
+msgid ""
+"If you are using a client secured by {project_name} adapter, you can "
+"configure the JWKS URL in this format, assuming that "
+"https://myhost.com/myapp is the root URL of your client application:"
+msgstr ""
+"project_name}アダプタで保護されたクライアントを使用している場合、https://myhost.com/myapp "
+"をクライアントアプリケーションのルートURLと仮定して、この形式でJWKS URLを設定することが可能です。"
+
+#. type: delimited block -
+#, no-wrap
+msgid "https://myhost.com/myapp/k_jwks\n"
+msgstr "https://myhost.com/myapp/k_jwks\n"
+
+#. type: Plain text
+msgid ""
+"See link:{developerguide_link}[{developerguide_name}] for more details."
+msgstr "詳しくはlink:{developerguide_link}[{developerguide_name}]をご覧ください。"
+
+#. type: Plain text
+msgid ""
+"{project_name} caches public keys of OIDC clients. If the private key of "
+"your client is compromised, update your keys and clear the key cache. See "
+"<<_clear-cache, Clearing the cache>> section for more details."
+msgstr ""
+"{project_name} "
+"は、OIDCクライアントの公開鍵をキャッシュしています。クライアントの秘密鍵が漏洩した場合、鍵を更新してキーキャッシュをクリアしてください。詳しくは&lt;&gt;の<_clear-"
+"cache, Clearing the cache>項を</_clear-cache,>参照してください。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Signed JWT with Client Secret*\n"
+msgstr "*Signed JWT with Client Secret*\n"
+
+#. type: Plain text
+msgid ""
+"If you select this option, you can use a JWT signed by client secret instead"
+" of the private key."
+msgstr "このオプションを選択すると、秘密鍵の代わりにclient secretで署名されたJWTを使用することができます。"
+
+#. type: Plain text
+msgid "The client secret will be used to sign the JWT by the client."
+msgstr "クライアントシークレットは、クライアントがJWTに署名するために使用されます。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*X509 Certificate*\n"
+msgstr "*X509 Certificate*\n"
+
+#. type: Plain text
+msgid ""
+"{project_name} will validate if the client uses proper X509 certificate "
+"during the TLS Handshake."
+msgstr "{project_name}は、TLSハンドシェイク時にクライアントが適切なX509証明書を使用しているかどうかを検証する。"
+
+#. type: Plain text
+msgid ""
+"This option requires mutual TLS in {project_name}. See <<_enable-mtls-"
+"wildfly, Enable mutual SSL in WildFly>>."
+msgstr ""
+"このオプションは{project_name}で相互TLSを必要とします。&lt;&gt;を参照してください<_enable-mtls-wildfly, "
+"Enable mutual SSL in WildFly>。</_enable-mtls-wildfly,>"
+
+#. type: Block title
+#, no-wrap
+msgid "X509 certificate"
+msgstr "X509証明書"
+
+#. type: Plain text
+msgid "image:{project_images}/x509-client-auth.png[]"
+msgstr "image:{project_images}/x509-client-auth.png[]"
+
+#. type: Plain text
+msgid ""
+"The validator also checks the Subject DN field of the certificate with a "
+"configured regexp validation expression. For some use cases, it is "
+"sufficient to accept all certificates. In that case, you can use "
+"`(.*?)(?:$)` expression."
+msgstr ""
+"バリデータは、証明書のSubject "
+"DNフィールドを、設定された正規表現でチェックする。いくつかのユースケースでは、すべての証明書を受け入れることで十分です。そのような場合は、`(.*?)(?:$)`"
+" 式を使用することができます。"
+
+#. type: Plain text
+msgid ""
+"Two ways exist for {project_name} to obtain the Client ID from the request:"
+msgstr "project_name}がリクエストからクライアントIDを取得する方法は2つ存在する。"
+
+#. type: Plain text
+msgid ""
+"The `client_id` parameter in the query (described in Section 2.2 of the "
+"https://datatracker.ietf.org/doc/html/rfc6749[OAuth 2.0 Specification])."
+msgstr ""
+"クエリの `client_id` パラメータ (https://datatracker.ietf.org/doc/html/rfc6749[OAuth "
+"2.0 Specification] のセクション 2.2 で説明されています) です。"
+
+#. type: Plain text
+msgid "Supply `client_id` as a form parameter."
+msgstr "フォームのパラメータとして `client_id` を指定します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/clients/oidc/con-confidential-client-credentials.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__clients__oidc__con-confidential-client-credentials
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
