### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2020
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2020\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -69,10 +69,9 @@ msgstr "**時間ベースのアクセス・コントロール**\n"
 #. type: Plain text
 #, no-wrap
 msgid ""
-"**Support for custom access control mechanisms (ACMs) through a Policy "
-"Provider Service Provider Interface (SPI)**\n"
-msgstr ""
-"**ポリシー・プロバイダー・サービス・プロバイダー・インターフェイス（SPI）によるカスタム・アクセス・コントロール機構（ACMs）のサポート**\n"
+"**Support for custom access control mechanisms (ACMs) through a Service "
+"Provider Interface (SPI)**\n"
+msgstr "**サービス・プロバイダー・インタフェース（SPI）によるカスタムACM（Access Control Mechanism）のサポート**\n"
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/auth-services-overview.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__auth-services-overview
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
