### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/providers.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -614,7 +614,7 @@ msgstr ""
 #. type: Title ===
 #, no-wrap
 msgid "Leveraging Jakarta EE"
-msgstr "ジャカルタEEの活用"
+msgstr "Jakarta EEの活用"
 
 #. type: Plain text
 msgid ""
@@ -628,13 +628,12 @@ msgid ""
 "{appserver_name} documentation for more details on this file.  It allows you"
 " to pull in external dependencies among other fine grain actions."
 msgstr ""
-"サービスプロバイダは、プロバイダを指すように `META-INF/services` ファイルを正しくセットアップすれば、どのJakarta "
-"EEコンポーネント内でもパッケージ化することができる。  "
-"例えば、プロバイダがサードパーティライブラリを使用する必要がある場合、プロバイダを耳の中にパッケージングして、耳の `lib/` "
-"ディレクトリにサードパーティライブラリを格納することができる。  また、プロバイダー jar は、EJB、WARS、および EAR が "
-"{appserver_name} 環境で使用できる `jboss-deployment-structure.xml` "
-"ファイルを利用できることに注意してください。  このファイルの詳細については、{appserver_name} のドキュメントを参照してください。  "
-"このファイルによって、他の細かいアクションの中で、外部の依存関係を取り込むことができます。"
+"サービス・プロバイダーは、プロバイダーを指すように `META-INF/services` ファイルを正しくセットアップすれば、どのJakarta "
+"EEコンポーネント内でもパッケージ化することができます。たとえば、プロバイダーがサードパーティーのライブラリーを使用する必要がある場合、プロバイダーをEARの中にパッケージングして、EARの"
+" `lib/` "
+"ディレクトリーにサードパーティーのライブラリーを格納することができます。また、プロバイダーのjarは、EJB、WAR、およびEARが{appserver_name}の環境で使用できる"
+" `jboss-deployment-structure.xml` "
+"ファイルを利用できることに注意してください。このファイルの詳細については、{appserver_name}のドキュメントを参照してください。このファイルによって、他の細かいアクションの中で、外部の依存関係を取り込むことができます。"
 
 #. type: Plain text
 msgid ""

--- a/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/providers.ja_JP.po
@@ -6,20 +6,25 @@
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2020
 # katakura__pro <h.katakura@pro-japan.co.jp>, 2020
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
 # Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ====
+#, no-wrap
+msgid "Disabling a provider"
+msgstr "プロバイダーの無効化"
 
 #. type: Title ====
 #, no-wrap
@@ -586,11 +591,6 @@ msgstr ""
 "    </providers>\n"
 "    ...\n"
 
-#. type: Title ====
-#, no-wrap
-msgid "Disabling a provider"
-msgstr "プロバイダーの無効化"
-
 #. type: Plain text
 msgid ""
 "You can disable a provider by setting the enabled attribute for the provider"
@@ -613,13 +613,13 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Leveraging Java EE"
-msgstr "Java EEの活用"
+msgid "Leveraging Jakarta EE"
+msgstr "ジャカルタEEの活用"
 
 #. type: Plain text
 msgid ""
-"The service providers can be packaged within any Java EE component so long "
-"as you set up the `META-INF/services` file correctly to point to your "
+"The service providers can be packaged within any Jakarta EE component so "
+"long as you set up the `META-INF/services` file correctly to point to your "
 "providers.  For example, if your provider needs to use third party "
 "libraries, you can package up your provider within an ear and store these "
 "third party libraries in the ear's `lib/` directory.  Also note that "
@@ -628,11 +628,13 @@ msgid ""
 "{appserver_name} documentation for more details on this file.  It allows you"
 " to pull in external dependencies among other fine grain actions."
 msgstr ""
-"サービス・プロバイダーは、プロバイダーを指し示すように `META-INF/services` ファイルを正しく設定している限りは、いかなるJava "
-"EEコンポーネント内でもこれをパッケージ化することができます。たとえば、プロバイダーがサードパーティーのライブラリーを使用する必要がある場合、プロバイダーをEAR内にパッケージ化し、これらのサードパーティーのライブラリーをEARの"
-" `lib/` ディレクトリーに格納します。また、プロバイダーJARは、{appserver_name}環境でEJB、WAR、およびEARが使用可能な "
-"`jboss-deployment-structure.xml` "
-"ファイルを使用することができる点に注意してください。このファイルについて、詳しくは、{appserver_name}のドキュメントを参照ください。これにより、他の細かい動作間で外部との依存関係を引き出すことができます。"
+"サービスプロバイダは、プロバイダを指すように `META-INF/services` ファイルを正しくセットアップすれば、どのJakarta "
+"EEコンポーネント内でもパッケージ化することができる。  "
+"例えば、プロバイダがサードパーティライブラリを使用する必要がある場合、プロバイダを耳の中にパッケージングして、耳の `lib/` "
+"ディレクトリにサードパーティライブラリを格納することができる。  また、プロバイダー jar は、EJB、WARS、および EAR が "
+"{appserver_name} 環境で使用できる `jboss-deployment-structure.xml` "
+"ファイルを利用できることに注意してください。  このファイルの詳細については、{appserver_name} のドキュメントを参照してください。  "
+"このファイルによって、他の細かいアクションの中で、外部の依存関係を取り込むことができます。"
 
 #. type: Plain text
 msgid ""
@@ -1087,8 +1089,9 @@ msgid ""
 "specific provider type. For that you should provide the following properties"
 " for each entry:"
 msgstr ""
-"`JAR` ファイル内の各スクリプト・ファイルに対して、スクリプト・ファイルを特定のプロバイダー・タイプにマッピングする `META-INF"
-"/keycloak-scripts.json` に対応するエントリーが必要です。そのためには、各エントリーに次のプロパティーを提供する必要があります。"
+"`JAR` ファイル内の各スクリプト・ファイルに対して、スクリプト・ファイルを特定のプロバイダー・タイプにマッピングする `META-"
+"INF/keycloak-scripts.json` "
+"に対応するエントリーが必要です。そのためには、各エントリーに次のプロパティーを提供する必要があります。"
 
 #. type: Plain text
 msgid "`name`"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/providers.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__providers
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
