### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # jic_m_mito <jic-m-mito@nri.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,8 +21,8 @@ msgstr ""
 
 #. type: Title ===
 #, no-wrap
-msgid "Leveraging Java EE"
-msgstr "Java EEの活用"
+msgid "Leveraging Jakarta EE"
+msgstr "Jakarta EEの活用"
 
 #. type: delimited block -
 #, no-wrap
@@ -143,8 +143,8 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The user storage providers can be packaged within any Java EE component if "
-"you set up the `META-INF/services` file correctly to point to your "
+"The user storage providers can be packaged within any Jakarta EE component "
+"if you set up the `META-INF/services` file correctly to point to your "
 "providers. For example, if your provider needs to use third-party libraries,"
 " you can package up your provider within an EAR and store these third-party "
 "libraries in the `lib/` directory of the EAR.  Also note that provider JARs "
@@ -153,7 +153,7 @@ msgid ""
 " file, see the {appserver_name} documentation. It allows you to pull in "
 "external dependencies among other fine-grained actions."
 msgstr ""
-"プロバイダーを指し示す、 `META-INF/services` ファイルを正しく設定すると、ユーザー・ストレージ・プロバイダーは任意のJava "
+"プロバイダーを指し示す、 `META-INF/services` ファイルを正しく設定すると、ユーザー・ストレージ・プロバイダーは任意のJakarta "
 "EEコンポーネント内にパッケージ化することができます。たとえば、プロバイダーがサードパーティー・ライブラリーを使用する必要がある場合は、EAR内でプロバイダーをパッケージ化し、これらのサードパーティー・ライブラリーをEARの"
 " `lib/` "
 "ディレクトリーに格納することができます。また、プロバイダーJARは、EJB、WAR、およびEARが{appserver_name}環境で使用できる "


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/javaee.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__javaee
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
