### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po
@@ -4,15 +4,15 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 # 
 # Translators:
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2017
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Title ===
+#. type: Title ====
 #, no-wrap
 msgid "Packaging and Deployment"
 msgstr "パッケージ化とデプロイ"
@@ -62,8 +62,8 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "{project_name} supports hot deployment of these provider JARs. You'll also "
-"see later in this chapter that you can package it within and as Java EE "
+"see later in this chapter that you can package it within and as Jakarta EE "
 "components."
 msgstr ""
-"{project_name}は、これらのプロバイダーのJARのホット・デプロイメントをサポートしています。また、この章の後半では、Java "
+"{project_name}は、これらのプロバイダーのJARのホット・デプロイメントをサポートしています。また、この章の後半では、Jakarta "
 "EEコンポーネント内およびJava EEコンポーネントとしてパッケージ化できることが分かります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage/packaging.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage__packaging
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
