### PR TITLE
Translations for i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
+++ b/i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po
@@ -6,14 +6,14 @@
 # Translators:
 # n.watanabe <nwatanabe.ase@gmail.com>, 2018
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
-# Hiroyuki Wada <wadahiro@gmail.com>, 2021
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Hiroyuki Wada <wadahiro@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,101 +21,119 @@ msgstr ""
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. type: Plain text
+msgid "Click *Save*."
+msgstr "*Save* をクリックします。"
+
 #. type: Attribute :installguide_troubleshooting_name:
 #, no-wrap
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
+#. type: Plain text
+msgid "Click *Authentication* in the menu."
+msgstr "メニューの *Authentication* をクリックします。"
+
+#. type: Plain text
+msgid "Click *Add execution*."
+msgstr "*Add execution*をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Bindings* tab."
+msgstr "*Bindings* をクリックします。"
+
+#. type: Plain text
+msgid "Click the *Browser Flow* drop-down list."
+msgstr "*Browser Flow* のドロップダウン・リストをクリックします。"
+
+#. type: Plain text
+msgid "Click *Ok*."
+msgstr "*Ok* をクリックします。"
+
+#. type: Plain text
+msgid "Enter a name for the copy."
+msgstr "コピーの名前を入力します。"
+
+#. type: Plain text
+msgid "Click *Delete*."
+msgstr "*Delete* をクリックします。"
+
 #. type: Title ===
 #, no-wrap
-msgid "X.509 Client Certificate User Authentication"
-msgstr "X.509クライアント証明書ユーザー認証"
+msgid "X.509 client certificate user authentication"
+msgstr "X.509クライアント証明書によるユーザー認証"
 
 #. type: Plain text
 msgid ""
-"{project_name} supports login with a X.509 client certificate if the server "
-"is configured for mutual SSL authentication."
+"{project_name} supports logging in with an X.509 client certificate if you "
+"have configured the server to use mutual SSL authentication."
 msgstr ""
-"{project_name}は、サーバーがMutual SSL認証用に設定されている場合、X.509クライアント証明書によるログインをサポートします。"
+"{project_name}は、サーバーがMutual "
+"SSL認証を使用するように設定されている場合、X.509クライアント証明書によるログインをサポートします。"
 
 #. type: Plain text
-msgid "A typical workflow is as follows:"
-msgstr "一般的なワークフローは次のとおりです。"
+msgid "A typical workflow:"
+msgstr "以下は、典型的なワークフローです。"
 
 #. type: Plain text
-msgid "A client sends an authentication request over SSL/TLS channel"
-msgstr "クライアントがSSL/TLSチャネルを介して認証リクエストを送信します。"
-
-#. type: Plain text
-msgid ""
-"During SSL/TLS handshake, the server and the client exchange their x.509/v3 "
-"certificates"
-msgstr "SSL/TLSハンドシェイク中に、サーバーとクライアントはx.509/v3証明書を交換します。"
+msgid "A client sends an authentication request over SSL/TLS channel."
+msgstr "クライアントは、SSL/TLSチャネル上で認証要求を送信します。"
 
 #. type: Plain text
 msgid ""
-"The web container (either the reverse proxy or {appserver_name} where "
-"{project_name} is deployed) validates the certificate PKIX path and the "
-"certificate expiration"
-msgstr ""
-"Webコンテナー（リバース・プロキシーまたは{project_name}がデプロイされている{appserver_name}のいずれか）は、証明書のPKIXパスと証明書の有効期限を検証します。"
+"During the SSL/TLS handshake, the server and the client exchange their "
+"x.509/v3 certificates."
+msgstr "SSL/TLSハンドシェイクでは、サーバーとクライアントはx.509/v3証明書を交換します。"
+
+#. type: Plain text
+msgid ""
+"The container ({appserver_name}) validates the certificate PKIX path and the"
+" certificate expiration date."
+msgstr "コンテナー（{appserver_name}）は、証明書のPKIXパスと証明書の有効期限を検証します。"
 
 #. type: Plain text
 msgid ""
 "The x.509 client certificate authenticator validates the client certificate "
-"as follows:"
-msgstr "x.509クライアント証明書オーセンティケーターは、次のようにクライアント証明書を検証します。"
+"by using the following methods:"
+msgstr "x.509クライアント証明書オーセンティケーターは、以下の方法でクライアント証明書を検証します。"
 
 #. type: Plain text
+#, no-wrap
 msgid ""
-"Optionally checks the certificate revocation status using CRL and/or CRL "
-"Distribution Points"
-msgstr "必要に応じて、CRLおよび（または）CRL配布ポイントを使用して証明書失効ステータスをチェックします。"
-
-#. type: Plain text
-msgid ""
-"Optionally checks the Certificate revocation status using OCSP (Online "
-"Certificate Status Protocol)"
-msgstr "必要に応じて、OCSP（オンライン証明書ステータス・プロトコル）を使用して証明書失効ステータスをチェックします。"
-
-#. type: Plain text
-msgid ""
-"Optionally validates whether the key usage in the certificate matches the "
-"expected key usage"
-msgstr "必要に応じて、証明書内のキー使用が予想されるキー使用と一致するかどうかを検証します。"
-
-#. type: Plain text
-msgid ""
-"Optionally validates whether the extended key usage in the certificate "
-"matches the expected extended key usage"
-msgstr "必要に応じて、証明書内の拡張キー使用法が予想される拡張キー使用法と一致するかどうかを検証します。"
-
-#. type: Plain text
-msgid "If any of the above checks fails, the x.509 authentication fails"
-msgstr "上記のチェックのいずれかが失敗した場合、x.509認証は失敗します。"
-
-#. type: Plain text
-msgid ""
-"Otherwise, the authenticator extracts the certificate identity and maps it "
-"to an existing user"
-msgstr "それ以外の場合、オーセンティケーターは証明書アイデンティティーを抽出し、既存のユーザーにマッピングします。"
-
-#. type: Plain text
-msgid ""
-"Once the certificate is mapped to an existing user, the behavior diverges "
-"depending on the authentication flow:"
-msgstr "証明書が既存のユーザーにマップされると、その動作は次のように認証フローによって分岐します。"
-
-#. type: Plain text
-msgid ""
-"In the Browser Flow, the server prompts the user to confirm identity or to "
-"ignore it and instead sign in with username/password"
+"** Checks the certificate revocation status by using CRL or CRL Distribution Points.\n"
+"** Checks the Certificate revocation status by using OCSP (Online Certificate Status Protocol).\n"
+"** Validates whether the key in the certificate matches the expected key.\n"
+"** Validates whether the extended key in the certificate matches the expected extended key.\n"
 msgstr ""
-"ブラウザーフローでは、サーバーはアイデンティティーを確認するかそれを無視して、代わりにユーザー名/パスワードでサインインすることをユーザーに促します。"
+"** CRLやCRL配布ポイントを利用して、証明書の失効状況を確認する。\n"
+"** OCSP（Online Certificate Status Protocol）を用いて証明書の失効状況を確認する。\n"
+"** 証明書に含まれる鍵が、期待される鍵と一致するかどうかを検証する。\n"
+"** 証明書に記載されている拡張鍵が、期待される拡張鍵と一致するかどうかを検証する。\n"
 
 #. type: Plain text
-msgid "In the case of the Direct Grant Flow, the server signs in the user"
-msgstr "ダイレクト・グラント・フローの場合、サーバーはユーザーをサインインします。"
+msgid ""
+"If any of the these checks fail, the x.509 authentication fails. Otherwise, "
+"the authenticator extracts the certificate identity and maps it to an "
+"existing user."
+msgstr ""
+"これらのチェックのいずれかが失敗した場合、x.509認証は失敗します。それ以外の場合、オーセンティケーターは証明書のアイデンティティーを抽出し、既存のユーザーにマッピングします。"
+
+#. type: Plain text
+msgid ""
+"When the certificate maps to an existing user, the behavior diverges "
+"depending on the authentication flow:"
+msgstr "証明書が既存のユーザーにマッピングされる場合、認証フローによって動作が分岐する。"
+
+#. type: Plain text
+msgid ""
+"In the Browser Flow, the server prompts users to confirm their identity or "
+"sign in with a username and password."
+msgstr ""
+"Browser Flowでは、サーバーはユーザーにアイデンティティーの確認やユーザー名とパスワードによるサインインを求めるプロンプトを表示します。"
+
+#. type: Plain text
+msgid "In the Direct Grant Flow, the server signs in the user."
+msgstr "Direct Grant Flowでは、サーバーがユーザーにサインインします。"
 
 #. type: Plain text
 msgid ""
@@ -136,33 +154,32 @@ msgstr ""
 msgid "Features"
 msgstr "機能"
 
-#. type: Labeled list
-#, no-wrap
-msgid "Supported Certificate Identity Sources"
+#. type: Plain text
+msgid "Supported Certificate Identity Sources:"
 msgstr "サポートされている証明書のアイデンティティー・ソース"
 
 #. type: Plain text
-msgid "Match SubjectDN using regular expression"
+msgid "Match SubjectDN by using regular expressions"
 msgstr "正規表現を使用したSubjectDN一致"
 
 #. type: Plain text
-msgid "X500 Subject's e-mail attribute"
-msgstr "X500 Subject's e-mail属性"
+msgid "X500 Subject's email attribute"
+msgstr "X500のSubjectのe-mail属性"
 
 #. type: Plain text
 msgid ""
-"X500 Subject's e-mail from Subject Alternative Name Extension (RFC822Name "
+"X500 Subject's email from Subject Alternative Name Extension (RFC822Name "
 "General Name)"
 msgstr ""
-"Subject Alternative Name Extension（RFC822Name General Name）からのX500 Subject's"
-" e-mail"
+"X500のSubject Alternative Name Extension（RFC822Name General "
+"Name）からのSubjectのemail"
 
 #. type: Plain text
 msgid ""
-"X500 Subject's other name from Subject Alternative Name Extension. This is "
-"typically UPN (User Principal Name)"
+"X500 Subject's other name from Subject Alternative Name Extension. This "
+"other name is the User Principal Name (UPN), typically."
 msgstr ""
-"Subject Alternative Name Extensionから取得したX500サブジェクトの別の名前。これは通常UPN（User "
+"Subject Alternative Name Extensionから取得したX500サブジェクトの別の名前。この別名は通常UPN（User "
 "Principal Name）です。"
 
 #. type: Plain text
@@ -170,7 +187,7 @@ msgid "X500 Subject's Common Name attribute"
 msgstr "X500 Subject's Common Name属性"
 
 #. type: Plain text
-msgid "Match IssuerDN using regular expression"
+msgid "Match IssuerDN by using regular expressions"
 msgstr "正規表現を使用したIssuerDN一致"
 
 #. type: Plain text
@@ -189,19 +206,19 @@ msgstr "SHA-256証明書のサムプリント"
 msgid "Full certificate in PEM format"
 msgstr "PEM形式の完全な証明書"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Regular Expressions"
+msgid "Regular expressions"
 msgstr "正規表現"
 
 #. type: Plain text
 msgid ""
-"The certificate identity can be extracted from either Subject DN or Issuer "
-"DN using a regular expression as a filter. For example, the regular "
-"expression below will match the e-mail attribute:"
+"{project_name} extracts the certificate identity from Subject DN or Issuer "
+"DN by using a regular expression as a filter. For example, this regular "
+"expression matches the email attribute:"
 msgstr ""
-"証明書アイデンティティーは、正規表現をフィルターとして使用して、SubjectDNまたはIssuerDNのいずれかから抽出できます。たとえば"
-"、以下の正規表現はe-mail属性と一致します。"
+"{project_name}は、正規表現をフィルターとして使用し、Subject DNまたはIssuer "
+"DNから証明書のIDを抽出します。たとえば、この正規表現はemail属性にマッチします。"
 
 #. type: Code block
 msgid "emailAddress=(.*?)(?:,|$)"
@@ -209,96 +226,96 @@ msgstr "emailAddress=(.*?)(?:,|$)"
 
 #. type: Plain text
 msgid ""
-"The regular expression filtering is applicable only if the `Identity Source`"
-" is set to either `Match SubjectDN using regular expression` or `Match "
-"IssuerDN using regular expression`."
+"The regular expression filtering applies if the `Identity Source` is set to "
+"either `Match SubjectDN using regular expression` or `Match IssuerDN using "
+"regular expression`."
 msgstr ""
 "正規表現フィルタリングは、 `Identity Source` が `Match SubjectDN using regular expression`"
-" か、 `Match IssuerDN using regular expression` のどちらかにセットされている場合にのみ適用されます。"
+" か、 `Match IssuerDN using regular expression` のどちらかにセットされている場合に適用されます。"
 
-#. type: Labeled list
+#. type: Title ======
 #, no-wrap
 msgid "Mapping certificate identity to an existing user"
 msgstr "既存のユーザーに証明書のアイデンティティーをマッピングする"
 
 #. type: Plain text
 msgid ""
-"The certificate identity mapping can be configured to map the extracted user"
-" identity to an existing user's username or e-mail or to a custom attribute "
-"which value matches the certificate identity. For example, setting the "
-"`Identity source` to _Subject's e-mail_ and `User mapping method` to "
-"_Username or email_ will have the X.509 client certificate authenticator use"
-" the e-mail attribute in the certificate's Subject DN as a search criteria "
-"to look up an existing user by username or by e-mail."
+"The certificate identity mapping can map the extracted user identity to an "
+"existing user's username, email, or a custom attribute whose value matches "
+"the certificate identity. For example, setting `Identity source` to "
+"_Subject's email_ or `User mapping method` to _Username or email_ makes the "
+"X.509 client certificate authenticator use the email attribute in the "
+"certificate's Subject DN as the search criteria when searching for an "
+"existing user by username or by email."
 msgstr ""
-"証明書アイデンティティー・マッピングは、抽出されたユーザー・アイデンティティーを既存のユーザーのユーザー名、電子メール、または証明書アイデンティティーと一致する値を持つカスタム属性にマップするように設定できます。たとえば、"
-" `Identity source` を _Subject's e-mail_ に、 `User mapping method` に _Username"
-" or email_ に設定すると、X.509クライアント証明書オーセンティケーターはユーザー名または電子メールで既存のユーザーをルックアップするために"
-"、検索基準として証明書のSubjectDNのe-mail属性を使用します。"
+"証明書アイデンティティー・マッピングは、抽出されたユーザー・アイデンティティーを既存のユーザーのユーザー名、電子メール、または証明書アイデンティティーと一致する値を持つカスタム属性にマップできます。たとえば、"
+" `Identity source` を _Subject's email_ に、または `User mapping method` を "
+"_Username or email_ "
+"に設定すると、X.509クライアント証明書オーセンティケーターはユーザー名または電子メールで既存のユーザーをルックアップする際の、検索基準として証明書のSubjectDNのemail属性を使用します。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"Please notice that if we disable `Login with email` at realm settings, the "
-"same rules will be applied to certificate authentication. In other words, "
-"users won't be able to log in using e-mail attribute."
+"If you disable *Login with email* at realm settings, the same rules apply to"
+" certificate authentication. Users are unable to log in by using the email "
+"attribute."
 msgstr ""
-"レルム設定で `電子メールによるログイン` を無効にすると、同じルールが証明書認証に適用されることに注意してください。つまり、ユーザーはe-"
-"mail属性を使用してログインすることはできません。"
+"レルムの設定で *Login with email* "
+"を無効にすると、証明書認証と同じルールが適用されます。ユーザーは、email属性を使用してログインすることができません。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"Usage of `Certificate Serial Number and IssuerDN` as an identity source "
-"requires two custom attributes - one for serial number and the other for "
-"IssuerDN."
+"Using `Certificate Serial Number and IssuerDN` as an identity source "
+"requires two custom attributes for the serial number and the IssuerDN."
 msgstr ""
 "アイデンティティー・ソースとして `Certificate Serial Number and IssuerDN` "
 "を使用するには、シリアル番号用とIssuerDN用の2つのカスタム属性が必要です。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"`SHA-256 Certificate thumbprint` is lowercase hexadecimal representation of "
-"SHA-256 certificate thumbprint."
+"`SHA-256 Certificate thumbprint` is the lowercase hexadecimal representation"
+" of SHA-256 certificate thumbprint."
 msgstr "`SHA-256 Certificate thumbprint` は、SHA-256証明書のサムプリントの小文字での16進数表現です。"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"Usage of `Full certificate in PEM format` as an identity source is limited "
-"to custom attributes mapped to external federation sources like LDAP. You "
-"must enable `Always Read Value From LDAP` in this case, because certificates"
-" cannot be stored in Keycloak database due to a length limitation."
+"Using `Full certificate in PEM format` as an identity source is limited to "
+"the custom attributes mapped to external federation sources, such as LDAP. "
+"{project_name} cannot store certificates in its database due to length "
+"limitations, so in the case of LDAP, you must enable `Always Read Value From"
+" LDAP`."
 msgstr ""
-"アイデンティティー･ソースとしての `Full certificate in PEM format` "
-"の使用は、LDAPなどの外部フェデレーション・ソースにマッピングされたカスタム属性に制限されます。この場合、 `Always Read Value "
-"From LDAP` を有効にする必要があります。これは、長さの制限により証明書をKeycloakデータベースに保存できないためです。"
+"IDソースとして `Full certificate in PEM format` "
+"を使用すると、LDAPなどの外部フェデレーション・ソースにマッピングされたカスタム属性に制限されます。{project_name}は長さの制限により証明書をデータベースに保存できないため、LDAPの場合は"
+" `Always Read Value From LDAP` を有効にする必要があります。"
 
-#. type: Labeled list
+#. type: Title ======
 #, no-wrap
-msgid "Other Features: Extended Certificate Validation"
-msgstr "その他の機能：拡張された証明書検証"
+msgid "Extended certificate validation"
+msgstr "拡張された証明書検証"
 
 #. type: Plain text
-msgid "Revocation status checking using CRL"
+msgid "Revocation status checking using CRL."
 msgstr "CRLを使用した失効ステータスの確認"
 
 #. type: Plain text
-msgid "Revocation status checking using CRL/Distribution Point"
+msgid "Revocation status checking using CRL/Distribution Point."
 msgstr "CRL/Distributionポイントを使用した失効ステータスの確認"
 
 #. type: Plain text
-msgid "Revocation status checking using OCSP/Responder URI"
+msgid "Revocation status checking using OCSP/Responder URI."
 msgstr "OCSP/Responder URIを使用した失効ステータスの確認"
 
 #. type: Plain text
-msgid "Certificate KeyUsage validation"
+msgid "Certificate KeyUsage validation."
 msgstr "証明書のKeyUsage検証"
 
 #. type: Plain text
-msgid "Certificate ExtendedKeyUsage validation"
+msgid "Certificate ExtendedKeyUsage validation."
 msgstr "証明書のExtendedKeyUsage検証"
 
 #. type: Title ====
 #, no-wrap
-msgid "Enable X.509 Client Certificate User Authentication"
+msgid "Enable X.509 client certificate user authentication"
 msgstr "X.509クライアント証明書のユーザー認証を有効にする"
 
 #. type: Plain text
@@ -309,18 +326,18 @@ msgid ""
 msgstr ""
 "以下のセクションでは、X.509クライアント証明書認証を有効にするために{appserver_name}/Undertowと{project_name}サーバーを設定する方法について説明します。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
 msgid "Enable mutual SSL in {appserver_name}"
 msgstr "{appserver_name}で相互SSLを有効にする"
 
 #. type: Plain text
 msgid ""
-"See link:https://docs.wildfly.org/19/Admin_Guide.html#enable-ssl[Enable SSL]"
-" for the instructions how to enable SSL in {appserver_name}."
+"See link:https://docs.wildfly.org/24/Admin_Guide.html#enable-ssl[Enable SSL]"
+" for the instructions to enable SSL in {appserver_name}."
 msgstr ""
 "{appserver_name}でSSLを有効にする方法については、 "
-"link:https://docs.wildfly.org/19/Admin_Guide.html#enable-ssl[Enable SSL] "
+"link:https://docs.wildfly.org/24/Admin_Guide.html#enable-ssl[Enable SSL] "
 "を参照してください。"
 
 #. type: Plain text
@@ -337,14 +354,14 @@ msgid ""
 "    <security-realm name=\"ssl-realm\">\n"
 "        <server-identities>\n"
 "            <ssl>\n"
-"                <keystore path=\"servercert.jks\" \n"
-"                          relative-to=\"jboss.server.config.dir\" \n"
+"                <keystore path=\"servercert.jks\"\n"
+"                          relative-to=\"jboss.server.config.dir\"\n"
 "                          keystore-password=\"servercert password\"/>\n"
 "            </ssl>\n"
 "        </server-identities>\n"
 "        <authentication>\n"
-"            <truststore path=\"truststore.jks\" \n"
-"                        relative-to=\"jboss.server.config.dir\" \n"
+"            <truststore path=\"truststore.jks\"\n"
+"                        relative-to=\"jboss.server.config.dir\"\n"
 "                        keystore-password=\"truststore password\"/>\n"
 "        </authentication>\n"
 "    </security-realm>\n"
@@ -354,14 +371,14 @@ msgstr ""
 "    <security-realm name=\"ssl-realm\">\n"
 "        <server-identities>\n"
 "            <ssl>\n"
-"                <keystore path=\"servercert.jks\" \n"
-"                          relative-to=\"jboss.server.config.dir\" \n"
+"                <keystore path=\"servercert.jks\"\n"
+"                          relative-to=\"jboss.server.config.dir\"\n"
 "                          keystore-password=\"servercert password\"/>\n"
 "            </ssl>\n"
 "        </server-identities>\n"
 "        <authentication>\n"
-"            <truststore path=\"truststore.jks\" \n"
-"                        relative-to=\"jboss.server.config.dir\" \n"
+"            <truststore path=\"truststore.jks\"\n"
+"                        relative-to=\"jboss.server.config.dir\"\n"
 "                        keystore-password=\"truststore password\"/>\n"
 "        </authentication>\n"
 "    </security-realm>\n"
@@ -374,9 +391,9 @@ msgstr "`ssl/keystore`"
 
 #. type: Plain text
 msgid ""
-"The `ssl` element contains the `keystore` element that defines how to load "
-"the server public key pair from a JKS keystore"
-msgstr "`ssl` 要素には、JKSキーストアからサーバー公開鍵ペアをロードする方法を定義する `keystore` 要素が含まれています。"
+"The `ssl` element contains the `keystore` element that contains the details "
+"to load the server public key pair from a JKS keystore."
+msgstr "ssl` 要素には、JKS 鍵ストアからサーバーの公開鍵ペアを読み込むための詳細を記述した `keystore` 要素が含まれます。"
 
 #. type: Labeled list
 #, no-wrap
@@ -384,7 +401,7 @@ msgid "`ssl/keystore/path`"
 msgstr "`ssl/keystore/path`"
 
 #. type: Plain text
-msgid "A path to a JKS keystore"
+msgid "The path to the JKS keystore."
 msgstr "JKSキーストアへのパス。"
 
 #. type: Labeled list
@@ -393,8 +410,8 @@ msgid "`ssl/keystore/relative-to`"
 msgstr "`ssl/keystore/relative-to`"
 
 #. type: Plain text
-msgid "Defines a path the keystore path is relative to"
-msgstr "キーストアパスが相対的なパスを定義します。"
+msgid "The path that the keystore path is relative to."
+msgstr "キーストアパスが相対的なパス。"
 
 #. type: Labeled list
 #, no-wrap
@@ -402,7 +419,7 @@ msgid "`ssl/keystore/keystore-password`"
 msgstr "`ssl/keystore/keystore-password`"
 
 #. type: Plain text
-msgid "The password to open the keystore"
+msgid "The password to open the keystore."
 msgstr "キーストアを開くためのパスワード。"
 
 #. type: Labeled list
@@ -412,8 +429,8 @@ msgstr "`ssl/keystore/alias` （オプション）"
 
 #. type: Plain text
 msgid ""
-"The alias of the entry in the keystore. Set it if the keystore contains "
-"multiple entries"
+"The alias of the entry in the keystore. Set if the keystore contains "
+"multiple entries."
 msgstr "キーストア内のエントリーのエイリアス。キーストアに複数のエントリーが含まれている場合に設定します。"
 
 #. type: Labeled list
@@ -431,13 +448,12 @@ msgid "`authentication/truststore`"
 msgstr "`authentication/truststore`"
 
 #. type: Plain text
-#, no-wrap
 msgid ""
 "Defines how to load a trust store to verify the certificate presented by the"
 " remote side of the inbound/outgoing connection. Typically, the truststore "
-"contains a collection of trusted CA certificates.   \n"
+"contains a collection of trusted CA certificates."
 msgstr ""
-"インバウンド/アウトゴーイング接続のリモート側が提示する証明書を検証するためにトラストストアをロードする方法を定義します。通常、トラストストアには、信頼できる認証局の証明書のコレクションが含まれています。\n"
+"インバウンド/アウトゴーイング接続のリモート側が提示する証明書を検証するためにトラストストアをロードする方法を定義します。通常、トラストストアには、信頼できる認証局の証明書のコレクションが含まれています。"
 
 #. type: Labeled list
 #, no-wrap
@@ -446,9 +462,9 @@ msgstr "`authentication/truststore/path`"
 
 #. type: Plain text
 msgid ""
-"A path to a JKS keystore that contains the certificates of the trusted CAs "
-"(certificate authorities)"
-msgstr "信頼できるCA（認証局）の証明書を含むJKSキーストアへのパス。"
+"The path to the JKS keystore containing the certificates of the trusted "
+"certificate authorities."
+msgstr "信頼できる認証局の証明書を含むJKSキーストアへのパス。"
 
 #. type: Labeled list
 #, no-wrap
@@ -456,8 +472,8 @@ msgid "`authentication/truststore/relative-to`"
 msgstr "`authentication/truststore/relative-to`"
 
 #. type: Plain text
-msgid "Defines a path the truststore path is relative to"
-msgstr "トラストストア・パスが相対的なパスを定義します。"
+msgid "The path that the truststore path is relative to."
+msgstr "トラストストアのパスが相対的であることを示すパス。"
 
 #. type: Labeled list
 #, no-wrap
@@ -465,26 +481,26 @@ msgid "`authentication/truststore/keystore-password`"
 msgstr "`authentication/truststore/keystore-password`"
 
 #. type: Plain text
-msgid "The password to open the truststore"
+msgid "The password to open the truststore."
 msgstr "トラストストアを開くためのパスワード。"
 
-#. type: Labeled list
+#. type: Title =====
 #, no-wrap
-msgid "Enable https listener"
-msgstr "httpsリスナーを有効にする"
+msgid "Enable HTTPS listener"
+msgstr "HTTPSリスナーを有効にする"
 
 #. type: Plain text
 msgid ""
-"See link:https://docs.wildfly.org/19/Admin_Guide.html#https-listener[HTTPS "
-"Listener] for the instructions how to enable HTTPS in WildFly."
+"See link:https://docs.wildfly.org/24/Admin_Guide.html#https-listener[HTTPS "
+"Listener] for the instructions to enable HTTPS in WildFly."
 msgstr ""
 "WildFlyでHTTPSを有効にする方法については、 "
-"link:https://docs.wildfly.org/19/Admin_Guide.html#https-listener[HTTPSリスナー] "
+"link:https://docs.wildfly.org/24/Admin_Guide.html#https-listener[HTTPSリスナー] "
 "を参照してください。"
 
 #. type: Plain text
-msgid "Add the <https-listener> element as shown below:"
-msgstr "<https-listener>要素を次のように追加します。"
+msgid "Add the <https-listener> element."
+msgstr "<https-listener>要素を追加します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -515,8 +531,8 @@ msgid "`https-listener/security-realm`"
 msgstr "`https-listener/security-realm`"
 
 #. type: Plain text
-msgid "The value must match the name of the realm from the previous section"
-msgstr "値は、前のセクションのレルムの名前と一致する必要があります。"
+msgid "This value must match the name of the realm from the previous section."
+msgstr "この値は、前のセクションのレルムの名前と一致する必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -525,301 +541,373 @@ msgstr "`https-listener/verify-client`"
 
 #. type: Plain text
 msgid ""
-"If set to `REQUESTED`, the server will optionally ask for a client "
-"certificate. Setting the attribute to `REQUIRED` will have the server to "
-"refuse inbound connections if no client certificate has been provided."
+"If set to *REQUESTED*, the server optionally asks for a client certificate."
+"  If set to *REQUIRED*, the server refuses inbound connections if no client "
+"certificate has been provided."
 msgstr ""
-"`REQUESTED` に設定した場合、サーバーは任意でクライアント証明書を要求します。 `REQUIRED` "
-"に属性を設定すると、クライアント証明書が提供されていない場合、サーバーはインバウンド接続を拒否します。"
+"*REQUESTED* に設定すると、サーバーはオプションでクライアント証明書の提出を求めます。 *REQUIRED* "
+"に設定すると、サーバーは、クライアント証明書が提供されていない場合、受信接続を拒否します。"
 
 #. type: Title ====
 #, no-wrap
-msgid "Adding X.509 Client Certificate Authentication to a Browser Flow"
+msgid "Adding X.509 client certificate authentication to browser flows"
 msgstr "ブラウザーフローへのX.509クライアント証明書認証の追加"
 
 #. type: Plain text
-msgid "Select a realm, click on Authentication link, select the \"Browser\" flow"
-msgstr "レルムを選択し、Authenticationのリンクをクリックし、\"Browser\"フローを選択します。"
+msgid "Click the \"Browser\" flow."
+msgstr "\"Browser\" フローをクリックします。"
 
 #. type: Plain text
-msgid ""
-"Make a copy of the built-in \"Browser\" flow. You may want to give the new "
-"flow a distinctive name, i.e. \"X.509 Browser\""
-msgstr ""
-"ビルトインの \"Browser\" フローのコピーを作成します。新しいフローに特有の名前、すなわち、 \"X.509 Browser\" "
-"を付けることをお勧めします。"
+msgid "Click *Copy* to make a copy of the built-in \"Browser\" flow."
+msgstr "*Copy* をクリックすると、内蔵の \"Browser\" フローのコピーが作成されます。"
 
 #. type: Plain text
-msgid ""
-"Using the drop down, select the copied flow, and click on \"Add execution\""
-msgstr "ドロップダウンを使用して、コピーされたフローを選択し、 \"Add execution\" をクリックします。"
+msgid "Click the copy in the *Add policy* drop-down box."
+msgstr "*Add policy* ドロップダウン・ボックスでコピーをクリックします。"
 
 #. type: Plain text
-msgid ""
-"Select \"X509/Validate Username Form\" using the drop down and click on "
-"\"Save\""
-msgstr "ドロップダウンを使用して\"X509/Validate Username Form\"を選択し、\"Save\"をクリックします。"
+msgid "Click \"X509/Validate Username Form\"."
+msgstr "\"X509/Validate Username Form\"をクリックします。"
 
-#. type: Plain text
-msgid "image:images/x509-execution.png[]"
-msgstr "image:images/x509-execution.png[]"
-
-#. type: Plain text
-msgid ""
-"Using the up/down arrows, change the order of the \"X509/Validate Username "
-"Form\" by moving it above the \"Browser Forms\" execution, and set the "
-"requirement to \"ALTERNATIVE\""
-msgstr ""
-"上（下）の矢印を使用して、\"X509/Validate Username Form\"の順序を\"Browser "
-"Forms\"の上に移動させて、requirementを\"ALTERNATIVE\"に設定します。"
-
-#. type: Plain text
-msgid "image:images/x509-browser-flow.png[]"
-msgstr "image:images/x509-browser-flow.png[]"
-
-#. type: Plain text
-msgid ""
-"Select the \"Bindings\" tab, find the drop down for \"Browser Flow\". Select"
-" the newly created X509 browser flow from the drop down and click on "
-"\"Save\"."
-msgstr ""
-"\"Bindings\"タブを選択し、\"Browser Flow\"のドロップダウンを見つけます。ドロップダウンから新しく作成したX509 "
-"browser flowを選択し、\"Save\"をクリックします。"
-
-#. type: Plain text
-msgid "image:images/x509-browser-flow-bindings.png[]"
-msgstr "image:images/x509-browser-flow-bindings.png[]"
-
-#. type: Labeled list
+#. type: Block title
 #, no-wrap
-msgid "Configuring X.509 Client Certificate Authentication"
+msgid "X509 execution"
+msgstr "X509エグゼキューション"
+
+#. type: Plain text
+msgid "image:images/x509-execution.png[X509 Execution]"
+msgstr "image:images/x509-execution.png[X509 Execution]"
+
+#. type: Plain text
+msgid ""
+"Click the up/down arrow buttons to move the \"X509/Validate Username Form\" "
+"over the \"Browser Forms\" execution."
+msgstr ""
+"上下の矢印ボタンをクリックして、 \"X509/Validate Username Form\" を \"Browser Forms\" "
+"エグゼキューションの上に移動させることができます。"
+
+#. type: Plain text
+msgid "Set the requirement to \"ALTERNATIVE\"."
+msgstr "条件を \"ALTERNATIVE\" に設定します。"
+
+#. type: Block title
+#, no-wrap
+msgid "X509 browser flow"
+msgstr "X509ブラウザーフロー"
+
+#. type: Plain text
+msgid "image:images/x509-browser-flow.png[X509 Browser Flow]"
+msgstr "image:images/x509-browser-flow.png[X509 Browser Flow]"
+
+#. type: Plain text
+msgid "Click the copy of the browser flow from the drop-down list."
+msgstr "ドロップダウン・リストから、ブラウザーフローのコピーをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "X509 browser flow bindings"
+msgstr "X509ブラウザーフロー・バインディング"
+
+#. type: Plain text
+msgid ""
+"image:images/x509-browser-flow-bindings.png[X509 Browser Flow Bindings]"
+msgstr ""
+"image:images/x509-browser-flow-bindings.png[X509 Browser Flow Bindings]"
+
+#. type: Title ====
+#, no-wrap
+msgid "Configuring X.509 client certificate authentication"
 msgstr "X.509クライアント証明書認証の設定"
 
+#. type: Block title
+#, no-wrap
+msgid "X509 configuration"
+msgstr "X509の設定"
+
 #. type: Plain text
-msgid "image:images/x509-configuration.png[]"
-msgstr "image:images/x509-configuration.png[]"
+msgid "image:images/x509-configuration.png[X509 Configuration]"
+msgstr "image:images/x509-configuration.png[X509 Configuration]"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`User Identity Source`"
-msgstr "`User Identity Source`"
-
-#. type: Plain text
-msgid "Defines how to extract the user identity from a client certificate."
-msgstr "クライアント証明書からユーザー・アイデンティティーを抽出する方法を定義します。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "`Canonical DN representation enabled` (optional)"
-msgstr "`Canonical DN representation enabled` （オプション）"
+msgid "*User Identity Source*"
+msgstr "*User Identity Source*"
 
 #. type: Plain text
 msgid ""
-"Defines whether to use the canonical format to determine a distinguished "
-"name.  The format is described in detail in the official "
-"link:https://docs.oracle.com/javase/8/docs/api/javax/security/auth/x500/X500Principal.html"
-"#getName-java.lang.String-[Java API documentation] .  This option only "
+"Defines the method for extracting the user identity from a client "
+"certificate."
+msgstr "クライアント証明書からユーザーIDを抽出する方法を定義します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Canonical DN representation enabled*"
+msgstr "*Canonical DN representation enabled*"
+
+#. type: Plain text
+msgid ""
+"Defines whether to use canonical format to determine a distinguished name. "
+"The official "
+"link:https://docs.oracle.com/javase/8/docs/api/javax/security/auth/x500/X500Principal.html#getName-"
+"java.lang.String-[Java API documentation] describes the format. This option "
 "affects the two User Identity Sources _Match SubjectDN using regular "
-"expression_ and _Match IssuerDN using regular expression_.  If you setup a "
-"new {project_name} instance it is recommended to enable this option. Leave "
-"this option disabled to remain beckward compatible with existing "
-"{project_name} instances."
+"expression_ and _Match IssuerDN using regular expression_ only. Enable this "
+"option when you set up a new {project_name} instance. Disable this option to"
+" retain backward compatibility with existing {project_name} instances."
 msgstr ""
-"標準形式を使用して識別名を決定するかどうかを定義します。形式については、公式 "
-"link:https://docs.oracle.com/javase/8/docs/api/javax/security/auth/x500/X500Principal.html"
-"#getName-java.lang.String-[Java API documentation] "
-"で詳しく説明されています。このオプションは、2つのユーザー・アイデンティティー・ソースの _Match SubjectDN using regular "
-"expression_ と _Match IssuerDN using regular expression_ "
-"にのみ影響します。新しい{project_name}インスタンスをセットアップする場合は、このオプションを有効にすることをお勧めします。既存の{project_name}インスタンスとの互換性を維持するには、このオプションを無効のままにします。"
+"識別名を決定するためにcanonical形式を使用するかどうかを定義します。公式リンク:https://docs.oracle.com/javase/8/docs/api/javax/security/auth/x500/X500Principal.html#getName-"
+"java.lang.String-[Java API "
+"documentation]にフォーマットが記載されています。このオプションは、2つのユーザーIDソース_Match SubjectDN using "
+"regular expression_および_Match IssuerDN using regular "
+"expression_にのみ影響します。このオプションは、新しい {project_name} "
+"インスタンスをセットアップするときに有効にします。このオプションを無効にすると、既存の {project_name} "
+"インスタンスとの後方互換性が保たれます。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`Enable Serial Number hexadecimal representation` (optional)"
-msgstr "`Enable Serial Number hexadecimal representation` （オプション）"
+msgid "*Enable Serial Number hexadecimal representation*"
+msgstr "*Enable Serial Number hexadecimal representation*"
 
 #. type: Plain text
 msgid ""
-"An option to use hexadecimal representation of the Serial Number. See "
-"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2[RFC5280, "
-"Section-4.1.2.2]. Serial Number with sign bit set to 1 should be left padded"
-" with 00 octet. E.g. Serial number with decimal value _161_, or _a1_ in "
-"hexadecimal representation according to RFC5280 must be encoded as _00a1_. "
-"More details can be found: "
+"Represent the "
+"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2[serial "
+"number] as hexadecimal. The serial number with the sign bit set to 1 must be"
+" left padded with 00 octet. For example, a serial number with decimal value "
+"_161_, or _a1_ in hexadecimal representation is encoded as _00a1_, according"
+" to RFC5280. See "
 "link:https://datatracker.ietf.org/doc/html/rfc5280#appendix-B[RFC5280, "
-"appendix-B]."
+"appendix-B] for more details."
 msgstr ""
-"シリアル番号の16進表現を使用するオプション。 "
-"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2[RFC5280, "
-"Section-4.1.2.2] を参照してください。符号ビットが1に設定されたシリアル番号は、00オクテットで埋められる必要があります。例えば。 "
-"RFC5280に従って、10進数値が _161_ のシリアル番号、または16進数表現の _a1_ は _00a1_ "
-"としてエンコードする必要があります。詳細については、 "
+"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2[シリアル番号] "
+"を16進数で表現します。符号ビットを1に設定したシリアル番号は、00オクテットで左詰めをする必要があります。たとえば、10進数で _161_ "
+"、16進数で _a1_ のシリアルナンバーは、RFC5280によれば _00a1_ と符号化されます。詳細は "
 "link:https://datatracker.ietf.org/doc/html/rfc5280#appendix-B[RFC5280, "
 "appendix-B] を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`A regular expression` (optional)"
-msgstr "`A regular expression` （オプション）"
+msgid "*A regular expression*"
+msgstr "*A regular expression*"
 
 #. type: Plain text
 msgid ""
-"Defines a regular expression to use as a filter to extract the certificate "
-"identity. The regular expression must contain a single group."
-msgstr "証明書アイデンティティーを抽出するフィルターとして使用する正規表現を定義します。正規表現には1つのグループが含まれている必要があります。"
+"A regular expression to use as a filter for extracting the certificate "
+"identity. The expression must contain a single group."
+msgstr "証明書のIDを抽出するためのフィルターとして使用する正規表現。この式には1つのグループを含める必要があります。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`User Mapping Method`"
-msgstr "`User Mapping Method`"
+msgid "*User Mapping Method*"
+msgstr "*User Mapping Method*"
 
 #. type: Plain text
 msgid ""
-"Defines how to match the certificate identity to an existing user. _Username"
-" or e-mail_ will search for an existing user by username or e-mail. _Custom "
-"Attribute Mapper_ will search for an existing user with a custom attribute "
-"which value matches the certificate identity. The name of the custom "
+"Defines the method to match the certificate identity with an existing user. "
+"_Username or email_ searches for existing users by username or email. "
+"_Custom Attribute Mapper_ searches for existing users with a custom "
+"attribute that matches the certificate identity. The name of the custom "
 "attribute is configurable."
 msgstr ""
-"既存のユーザーに証明書アイデンティティーを一致させる方法を定義します。 _Username or e-mail_ "
-"は、ユーザー名または電子メールから既存のユーザーを検索します。 _Custom Attribute Mapper_ "
-"は、証明書アイデンティティーと一致するカスタム属性を持つ既存のユーザーを検索します。カスタム属性の名前は設定可能です。"
+"証明書のIDを既存のユーザーと照合する方法を定義します。 _Username or email_ "
+"は、ユーザー名または電子メールによって既存のユーザーを検索します。 _Custom Attribute Mapper_ "
+"は、証明書のIDに一致するカスタム属性を持つ既存のユーザーを検索します。カスタム属性の名前は設定可能です。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`A name of user attribute` (optional)"
-msgstr "`A name of user attribute` （オプション）"
+msgid "*A name of user attribute*"
+msgstr "*A name of user attribute*"
 
 #. type: Plain text
 msgid ""
-"A custom attribute which value will be matched against the certificate "
-"identity. Multiple custom attributes are relevant when attribute mapping is "
-"related to multiple values, e.g. 'Certificate Serial Number and IssuerDN'."
+"A custom attribute whose value matches against the certificate identity. Use"
+" multiple custom attributes when attribute mapping is related to multiple "
+"values, For example, 'Certificate Serial Number and IssuerDN'."
 msgstr ""
-"値が証明書IDと照合されるカスタム属性。属性マッピングが複数の値に関連している場合、複数のカスタム属性が関係します。例：'証明書のシリアル番号と発行者DN'。"
+"証明書IDに対して値が一致するカスタム属性。たとえば、 'Certificate Serial Number and IssuerDN' "
+"のように、属性マッピングが複数の値に関連する場合、複数のカスタム属性を使用します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*CRL Checking Enabled*"
+msgstr "*CRL Checking Enabled*"
 
 #. type: Plain text
 msgid ""
-"It is highly recommended that attribute used here is read-only for the "
-"users. By default, only the `usercertificate` attribute is read-only by "
-"{project_name}.  If you use a different attribute name, you may need to add "
-"it to the list of read-only attributes. See the details in the "
-"link:#_read_only_user_attributes[Threat model mitigation chapter]."
+"Check the revocation status of the certificate by using the Certificate "
+"Revocation List. The location of the list is defined in the *CRL file path* "
+"attribute."
+msgstr "証明書失効リストを使用して、証明書の失効状況を確認します。リストの場所は、 *CRL file path* 属性で定義されます。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Enable CRL Distribution Point to check certificate revocation status*"
 msgstr ""
-"ここで使用する属性は、ユーザーに対して読み取り専用にすることを強くお勧めします。デフォルトでは、 `usercertificate` "
-"属性のみが{project_name}によって読み取り専用になります。別の属性名を使用する場合は、それを読み取り専用属性のリストに追加する必要がある場合があります。"
-" link:#_read_only_user_attributes[脅威モデルの軽減の章] の詳細を参照してください。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "`CRL Checking Enabled` (optional)"
-msgstr "`CRL Checking Enabled` （オプション）"
+"*Enable CRL Distribution Point to check certificate revocation status*"
 
 #. type: Plain text
 msgid ""
-"Defines whether to check the revocation status of the certificate using "
-"Certificate Revocation List."
-msgstr "証明書失効リストを使用して証明書の失効ステータスをチェックするかどうかを定義します。"
+"Use CDP to check the certificate revocation status. Most PKI authorities "
+"include CDP in their certificates."
+msgstr "証明書の失効状況を確認するには、CDPを使用します。ほとんどのPKI機関は、CDPを証明書に含めています。"
 
 #. type: Labeled list
 #, no-wrap
+msgid "*CRL file path*"
+msgstr "*CRL file path*"
+
+#. type: Plain text
 msgid ""
-"`Enable CRL Distribution Point to check certificate revocation status` "
-"(optional)"
+"The path to a file containing a CRL list. The value must be a path to a "
+"valid file if the *CRL Checking Enabled* option is enabled."
 msgstr ""
-"`Enable CRL Distribution Point to check certificate revocation status` "
-"（オプション）"
-
-#. type: Plain text
-msgid ""
-"Defines whether to use CDP to check the certificate revocation status. Most "
-"PKI authorities include CDP in their certificates."
-msgstr "CDPを使用して証明書失効ステータスをチェックするかどうかを定義します。ほとんどのPKI機関には証明書にCDPが含まれています。"
+"CRLのリストを含むファイルへのパス。この値は、 *CRL Checking Enabled* "
+"オプションが有効な場合、有効なファイルへのパスでなければなりません。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`CRL file path` (optional)"
-msgstr "`CRL file path` （オプション）"
+msgid "*OCSP Checking Enabled*"
+msgstr "*OCSP Checking Enabled*"
 
 #. type: Plain text
 msgid ""
-"Defines a path to a file that contains a CRL list. The value must be a path "
-"to a valid file if `CRL Checking Enabled` option is turned on."
+"Checks the certificate revocation status by using Online Certificate Status "
+"Protocol."
+msgstr "オンライン証明書ステータス・プロトコルを用いて、証明書の失効状況を確認します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*OCSP Fail-Open Behavior*"
+msgstr "*OCSP Fail-Open Behavior*"
+
+#. type: Plain text
+msgid ""
+"By default the OCSP check must return a positive response in order to "
+"continue with a successful authentication. Sometimes however this check can "
+"be inconclusive: for example, the OCSP server could be unreachable, "
+"overloaded, or the client certificate may not contain an OCSP responder URI."
+" When this setting is turned ON, authentication will be denied only if an "
+"explicit negative response is received by the OCSP responder and the "
+"certificate is definitely revoked. If a valid OCSP response is not avalaible"
+" the authentication attempt will be accepted."
 msgstr ""
-"CRLリストを含むファイルへのパスを定義します。 `CRL Checking Enabled` "
-"オプションがオンの場合、この値は有効なファイルへのパスである必要があります。"
+"デフォルトでは、認証に成功するためには、OCSPチェックが肯定的な応答を返す必要があります。たとえば、OCSPサーバーに到達できない、オーバーロードしている、クライアント証明書にOCSPレスポンダのURIが含まれていない、などの可能性があります。この設定をオンにすると、OCSPレスポンダーから明示的な否定応答を受信し、かつ証明書が確実に失効している場合にのみ、認証が拒否されます。有効なOCSP応答が得られない場合は、認証の試行が許可されます。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`OCSP Checking Enabled`(optional)"
-msgstr "`OCSP Checking Enabled` （オプション）"
+msgid "*OCSP Responder URI*"
+msgstr "*OCSP Responder URI*"
 
 #. type: Plain text
-msgid ""
-"Defines whether to check the certificate revocation status using Online "
-"Certificate Status Protocol."
-msgstr "オンライン証明書ステータス・プロトコルを使用して証明書失効ステータスをチェックするかどうかを定義します。"
+msgid "Override the value of the OCSP responder URI in the certificate."
+msgstr "証明書に記載されているOCSPレスポンダー URI の値を上書きします。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`OCSP Responder URI` (optional)"
-msgstr "`OCSP Responder URI` （オプション）"
+msgid "*Validate Key Usage*"
+msgstr "*Validate Key Usage*"
 
 #. type: Plain text
 msgid ""
-"Allows to override a value of the OCSP responder URI in the certificate."
-msgstr "証明書内のOCSPレスポンダーURIの値を上書きすることを許可します。"
-
-#. type: Labeled list
-#, no-wrap
-msgid "`Validate Key Usage` (optional)"
-msgstr "`Validate Key Usage` （オプション）"
-
-#. type: Plain text
-msgid ""
-"Verifies whether the certificate's KeyUsage extension bits are set. For "
-"example, \"digitalSignature,KeyEncipherment\" will verify if bits 0 and 2 in"
-" the KeyUsage extension are asserted. Leave the parameter empty to disable "
-"the Key Usage validation. See "
+"Verifies the certificate's KeyUsage extension bits are set. For example, "
+"\"digitalSignature,KeyEncipherment\" verifies if bits 0 and 2 in the "
+"KeyUsage extension are set.  Leave this parameter empty to disable the Key "
+"Usage validation. See "
 "link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3[RFC5280, "
-"Section-4.2.1.3]. The server will raise an error only when flagged as "
-"critical by the issuing CA and there is a key usage extension mismatch."
+"Section-4.2.1.3] for more information. {project_name} raises an error when a"
+" key usage mismatch occurs."
 msgstr ""
-"証明書のKeyUsage拡張のビットが設定されているかどうかを確認します。たとえば、 "
-"\"digitalSignature,KeyEncipherment\" "
-"は、KeyUsage拡張のビット0と2がアサートされているかどうかを検証します。Key "
-"Usageの有効性を無効にするには、パラメータを空のままにします。link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3[RFC5280、セクション4.2.1.3]を参照してください。サーバーは、発行認証局によってクリティカルであるとフラグが立てられ、キー使用拡張の不一致がある場合にのみ、エラーを発生させます。"
+"証明書のKeyUsage拡張ビットが設定されていることを確認します。たとえば、\"digitalSignature,KeyEncipherment\"は、KeyUsage拡張のビット0および2が設定されているかどうかを検証します。このパラメーターを空にすると、Key"
+" Usageの検証を無効にすることができます。詳細は "
+"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3[RFC5280, "
+"Section-4.2.1.3] を参照。{project_name}は、鍵の使用法の不一致が発生した場合にエラーを発生させます。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`Validate Extended Key Usage` (optional)"
-msgstr "`Validate Extended Key Usage` （オプション）"
+msgid "*Validate Extended Key Usage*"
+msgstr "*Validate Extended Key Usage*"
 
 #. type: Plain text
 msgid ""
-"Verifies one or more purposes as defined in the Extended Key Usage "
-"extension. See "
+"Verifies one or more purposes defined in the Extended Key Usage extension. "
+"See "
 "link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12[RFC5280,"
-" Section-4.2.1.12]. Leave the parameter empty to disable the Extended Key "
-"Usage validation. The server will raise an error only when flagged as "
-"critical by the issuing CA and there is a key usage extension mismatch."
+" Section-4.2.1.12] for more information. Leave this parameter empty to "
+"disable the Extended Key Usage validation. {project_name} raises an error "
+"when flagged as critical by the issuing CA and a key usage extension "
+"mismatch occurs."
 msgstr ""
-"Extended Key "
-"Usage拡張で定義されている1つ以上の目的を検証します。link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12[RFC5280、セクション4.2.1.12]を参照してください。Extended"
-" Key "
-"Usageの検証を無効にするには、パラメータを空のままにします。サーバーは、発行認証局によってクリティカルであるとフラグが立てられ、キー使用拡張の不一致がある場合にのみ、エラーを発生させます。"
+"拡張キー使用法の拡張で定義された1つ以上の目的を検証します。詳細は "
+"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12[RFC5280,"
+" Section-4.2.1.12] "
+"を参照してください。拡張キー使用法の検証を無効にするには、このパラメーターを空にします。{project_name}は、発行元のCAがCriticalとフラグを立て、キー使用法の拡張の不一致が発生した場合にエラーを発生させます。"
 
 #. type: Labeled list
 #, no-wrap
-msgid "`Bypass identity confirmation`"
-msgstr "`Bypass identity confirmation`"
+msgid "*Validate Certificate Policy*"
+msgstr "*Validate Certificate Policy*"
 
 #. type: Plain text
 msgid ""
-"If set, X.509 client certificate authentication will not prompt the user to "
-"confirm the certificate identity and will automatically sign in the user "
-"upon successful authentication."
+"Verifies one or more policy OIDs as defined in the Certificate Policy "
+"extension. See "
+"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4[RFC5280, "
+"Section-4.2.1.4]. Leave the parameter empty to disable the Certificate "
+"Policy validation. Multiple policies should be separated using a comma."
 msgstr ""
-"設定されている場合、X.509クライアント証明書認証は、ユーザーに証明書アイデンティティーの確認を促さず、ユーザーの認証に成功すると自動的にサインインします。"
+"証明書ポリシー拡張で定義された、1つ以上のポリシーOIDを検証します。 "
+"link:https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.4[RFC5280、セクション-4.2.1.4]"
+" を参照してください。証明書ポリシーの検証を無効にするには、このパラメーターを空にします。複数のポリシーはカンマで区切る必要があります。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Certificate Policy Validation Mode*"
+msgstr "*Certificate Policy Validation Mode*"
+
+#. type: Plain text
+msgid ""
+"When more than one policy is specified in the `Validate Certificate Policy` "
+"setting, it decides whether the matching should check for all requested "
+"policies to be present, or one match is enough for a successful "
+"authentication. Default value is `All`, meaning that all requested policies "
+"should be present in the client certificate."
+msgstr ""
+"`Validate Certificate Policy` "
+"の設定で複数のポリシーが指定された場合、要求されたすべてのポリシーが存在することを確認するのか、それとも認証に成功するために1つのマッチングで十分なのかを決定します。デフォルト値は"
+" `All` で、要求されたすべてのポリシーがクライアント証明書に存在する必要があることを意味します。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Bypass identity confirmation*"
+msgstr "*Bypass identity confirmation*"
+
+#. type: Plain text
+msgid ""
+"If enabled, X.509 client certificate authentication does not prompt the user"
+" to confirm the certificate identity. {project_name} signs in the user upon "
+"successful authentication."
+msgstr ""
+"このオプションを有効にすると、X.509クライアント証明書認証で、証明書のアイデンティティーを確認するためのプロンプトが表示されなくなります。認証に成功すると、{project_name}がユーザーにサインインします。"
+
+#. type: Labeled list
+#, no-wrap
+msgid "*Revalidate client certificate*"
+msgstr "*Revalidate client certificate*"
+
+#. type: Plain text
+msgid ""
+"If set, the client certificate trust chain will be always verified at the "
+"application level using the certificates present in the configured trust "
+"store. This can be useful if the underlying web server does not enforce "
+"client certificate chain validation, for example because it is behind a non-"
+"validating load balancer or reverse proxy, or when the number of allowed CAs"
+" is too large for the mutual SSL negotiation (most browsers cap the maximum "
+"SSL negotiation packet size at 32767 bytes, which corresponds to about 200 "
+"advertised CAs). By default this option is off."
+msgstr ""
+"設定すると、クライアント証明書のトラストチェーンは、設定されたトラストストアに存在する証明書を使用して、常にアプリケーション・レベルで検証されます。これは、たとえばWebサーバーが検証しないロードバランサーやリバース・プロキシーの背後にあるなどの理由でクライアント証明書チェーンの検証を実施しない場合や、許可されるCAの数がMutual"
+" "
+"SSLネゴシエーションに対して多すぎる場合（ほとんどのブラウザーは最大SSLネゴシエーション・パケット・サイズを32767バイトに制限しており、これは約200のアドバタイズCAに相当します）に有用となります。デフォルトでは、このオプションはオフになっています。"
 
 #. type: Title ====
 #, no-wrap
@@ -827,63 +915,63 @@ msgid "Adding X.509 Client Certificate Authentication to a Direct Grant Flow"
 msgstr "ダイレクト・グラント・フローへのX.509クライアント証明書認証の追加"
 
 #. type: Plain text
-msgid ""
-"Using {project_name} admin console, click on \"Authentication\" and select "
-"the \"Direct Grant\" flow,"
-msgstr ""
-"{project_name}管理コンソールを使用して、 \"Authentication\" をクリックし、 \"Direct Grant\" "
-"フローを選択します。"
+msgid "Click the \"Direct Grant\" flow."
+msgstr "\"Direct Grant\"フローをクリックします。"
+
+#. type: Plain text
+msgid "Click *Copy* to make a copy of the \"Direct Grant\" flow."
+msgstr "*Copy* をクリックすると、\"Direct Grant\"フローのコピーが作成されます。"
 
 #. type: Plain text
 msgid ""
-"Make a copy of the build-in \"Direct Grant\" flow. You may want to give the "
-"new flow a distinctive name, i.e. \"X509 Direct Grant\","
-msgstr ""
-"ビルドインの \"Direct Grant\"フローのコピーを作成します。新しいフローに特有の名前、すなわち、\"X509 Direct "
-"Grant\"を付けることをお勧めします。"
+"Click on the *Actions* link for \"Username Validation\" and click *Delete*."
+msgstr "\"Username Validation\"の *Actions* リンクをクリックし、 *Delete* をクリックします。"
 
 #. type: Plain text
-msgid "Delete \"Username Validation\" and \"Password\" authenticators,"
-msgstr "\"Username Validation\" と \"Password\" のオーセンティケーターを削除します。"
+msgid "Click on the *Actions* link for \"Password\" and click *Delete*."
+msgstr "\"Password\"の *Actions* リンクをクリックし、 *Delete* をクリックします。"
+
+#. type: Plain text
+msgid "Click \"X509/Validate Username\"."
+msgstr "\"X509/Validate Username\"をクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "X509 direct grant execution"
+msgstr "X509ダイレクト・グラント・エグゼキューション"
 
 #. type: Plain text
 msgid ""
-"Click on \"Add execution\" and add \"X509/Validate Username\" and click on "
-"\"Save\" to add the execution step to the parent flow."
+"image:images/x509-directgrant-execution.png[X509 Direct Grant Execution]"
 msgstr ""
-"\"Add execution\" をクリックし、 \"X509/Validate Username\" を追加し、 \"Save\" "
-"をクリックして実行ステップを親フローに追加します。"
-
-#. type: Plain text
-msgid "image:images/x509-directgrant-execution.png[]"
-msgstr "image:images/x509-directgrant-execution.png[]"
-
-#. type: Plain text
-msgid "Change the `Requirement` to _REQUIRED_."
-msgstr "`Requirement` を _REQUIRED_ に変更してください。"
-
-#. type: Plain text
-msgid "image:images/x509-directgrant-flow.png[]"
-msgstr "image:images/x509-directgrant-flow.png[]"
+"image:images/x509-directgrant-execution.png[X509 Direct Grant Execution]"
 
 #. type: Plain text
 msgid ""
 "Set up the x509 authentication configuration by following the steps "
-"described earlier in the x.509 Browser Flow section."
-msgstr "前述のx.509ブラウザーフローのセクションの手順に従って、x509認証設定のセットアップを行います。"
+"described in the <<_browser_flow, x509 Browser Flow>> section."
+msgstr "<<_browser_flow, x509 Browser Flow>>に記載されている手順で、x509認証の設定を行います。"
+
+#. type: Plain text
+msgid "Click the *Direct Grant Flow* drop-down list."
+msgstr "*Direct Grant Flow* のドロップダウン・リストをクリックします。"
+
+#. type: Plain text
+msgid "Click the newly created \"x509 Direct Grant\" flow."
+msgstr "新しく作成した\"x509 Direct Grant\"フローをクリックします。"
+
+#. type: Block title
+#, no-wrap
+msgid "X509 direct grant flow bindings"
+msgstr "X509ダイレクト・グラント・バインディング"
 
 #. type: Plain text
 msgid ""
-"Select the \"Bindings\" tab, find the drop down for \"Direct Grant Flow\". "
-"Select the newly created X509 direct grant flow from the drop down and click"
-" on \"Save\"."
+"image:images/x509-directgrant-flow-bindings.png[X509 Direct Grant Flow "
+"Bindings]"
 msgstr ""
-"\"Bindings\"タブを選択し、\"Direct Grant Flow\"のドロップダウンを見つけます。ドロップダウンから新しく作成したX509 "
-"direct grant flowを選択し、\"Save\"をクリックします。"
-
-#. type: Plain text
-msgid "image:images/x509-directgrant-flow-bindings.png[]"
-msgstr "image:images/x509-directgrant-flow-bindings.png[]"
+"image:images/x509-directgrant-flow-bindings.png[X509 Direct Grant Flow "
+"Bindings]"
 
 #. type: Title ====
 #, no-wrap
@@ -892,46 +980,43 @@ msgstr "クライアント証明書検索"
 
 #. type: Plain text
 msgid ""
-"When an HTTP request is sent directly to {project_name} server, the "
-"{appserver_name} undertow subsystem will establish an SSL handshake and "
-"extract the client certificate. The client certificate will be then saved to"
-" the attribute `javax.servlet.request.X509Certificate` of the HTTP request, "
-"as specified in the servlet specification. The {project_name} X509 "
-"authenticator will be then able to lookup the certificate from this "
-"attribute."
+"When the {project_name} server receives a direct HTTP request, the "
+"{appserver_name} undertow subsystem establishes an SSL handshake and "
+"extracts the client certificate. The {appserver_name} saves the client "
+"certificate to the `javax.servlet.request.X509Certificate` attribute of the "
+"HTTP request, as specified in the servlet specification. The {project_name} "
+"X509 authenticator can look up the certificate from this attribute."
 msgstr ""
-"HTTPリクエストが{project_name}サーバーに直接送信されると、{appserver_name} "
-"undertowサブシステムはSSLハンドシェイクを確立し、クライアント証明書を抽出します。クライアント証明書は、サーブレット仕様で指定されているHTTPリクエストの属性"
-" `javax.servlet.request.X509Certificate` に保存されます。{project_name} "
-"X509オーセンティケーターは、この属性から証明書を検索できます。"
+"project_name} サーバーが直接 HTTP リクエストを受け取ると、{appserver_name} サーブレットサブシステムは SSL "
+"ハンドシェイクを確立し、クライアント証明書を抽出します。appserver_name} は、サーブレット仕様で規定されているように、HTTPリクエストの"
+" `javax.servlet.request.X509Certificate` 属性にクライアント証明書を保存します。project_name} "
+"X509認証ツールは、この属性から証明書を検索することができます。"
 
 #. type: Plain text
 msgid ""
 "However, when the {project_name} server listens to HTTP requests behind a "
-"load balancer or reverse proxy, it may be the proxy server which extracts "
-"the client certificate and establishes the mutual SSL connection. A reverse "
-"proxy usually puts the authenticated client certificate in the HTTP header "
-"of the underlying request and forwards it to the back end {project_name} "
-"server. In this case, {project_name} must be able to look up the X.509 "
-"certificate chain from the HTTP headers instead of from the attribute of "
-"HTTP request, as is done for Undertow."
+"load balancer or reverse proxy, the proxy server may extract the client "
+"certificate and establish a mutual SSL connection. A reverse proxy generally"
+" puts the authenticated client certificate in the HTTP header of the "
+"underlying request. The proxy forwards the request to the back end "
+"{project_name} server. In this case, {project_name} must look up the X.509 "
+"certificate chain from the HTTP headers rather than the attribute of the "
+"HTTP request."
 msgstr ""
-"ただし、{project_name}サーバーがロードバランサーまたはリバース・プロキシーの背後にあるHTTPリクエストをリッスンする場合、クライアント証明書を抽出してMutual"
-" "
-"SSL接続を確立するのはプロキシー・サーバーであるかもしれません。リバース・プロキシーは通常、認証されたクライアント証明書を基礎となるもとのリクエストのHTTPヘッダーに入れ、バックエンドの{project_name}サーバーに転送します。この場合、{project_name}は、Undertowの場合と同様に、HTTPリクエストの属性ではなく、HTTPヘッダーからX.509証明書チェーンをルックアップできる必要があります。"
+"しかし、{project_name}サーバーがロードバランサーやリバース・プロキシーの背後でHTTPリクエストをリッスンしている場合、プロキシー・サーバーはクライアント証明書を抽出し、相互のSSL接続を確立することがあります。リバース・プロキシーは一般に、認証されたクライアント証明書を基礎となるリクエストのHTTPヘッダーにセットします。プロキシーはリクエストをバックエンド{project_name}サーバーに転送します。この場合、{project_name}はHTTPリクエストの属性ではなくHTTPヘッダーからX.509証明書チェーンを調べなければなりません。"
 
 #. type: Plain text
 msgid ""
-"If {project_name} is behind a reverse proxy, you usually need to configure "
-"alternative provider of the `x509cert-lookup` SPI in "
-"{project_dirref}/standalone/configuration/standalone.xml. Along with the "
-"`default` provider, which looks up the certificate from the HTTP header, we "
-"also have two additional built-in providers: `haproxy` and `apache`, which "
-"are described next."
+"If {project_name} is behind a reverse proxy, you generally need to configure"
+" the alternative provider of the `x509cert-lookup` SPI in "
+"{project_dirref}/standalone/configuration/standalone.xml. With the `default`"
+" provider looking up the HTTP header certificate, two additional built-in "
+"providers exist: `haproxy` and `apache`."
 msgstr ""
-"{project_name}がリバース・プロキシーの背後にある場合、通常は{project_dirref}/standalone/configuration/standalone.xmlに"
-" `x509cert-lookup` SPIの代替プロバイダーを設定する必要があります。HTTPヘッダーから証明書を検索する `default` "
-"プロバイダーに加えて、次に説明する `haproxy` と `apache` という2つの組み込みプロバイダーも追加されています。"
+"{project_name}がリバース・プロキシーの背後にある場合、一般的には "
+"{project_dirref}/standalone/configuration/standalone.xml で `x509cert-lookup`"
+" SPI の代替プロバイダーを設定する必要があります。HTTPヘッダー証明書を検索する `default` "
+"プロバイダーには、さらに2つの組み込みプロバイダー `haproxy` と `apache` が存在します。"
 
 #. type: Title =====
 #, no-wrap
@@ -940,10 +1025,10 @@ msgstr "HAProxy証明書検索プロバイダー"
 
 #. type: Plain text
 msgid ""
-"You can use this provider when your {project_name} server is behind an "
-"HAProxy reverse proxy. Configure the server like this:"
+"You use this provider when your {project_name} server is behind an HAProxy "
+"reverse proxy. Use the following configuration for your server:"
 msgstr ""
-"{project_name}サーバーがHAProxyリバース・プロキシーの背後にある場合、このプロバイダーを使用できます。次のようにサーバーを構成します。"
+"このプロバイダーは、{project_name}サーバーがHAProxyのリバース・プロキシーの背後にある場合に使用します。サーバーには、次の設定を使用します。"
 
 #. type: delimited block -
 #, no-wrap
@@ -972,24 +1057,22 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"In this example configuration, the client certificate will be looked up from"
-" the HTTP header, `SSL_CLIENT_CERT`, and the other certificates from its "
-"chain will be looked up from HTTP headers like `CERT_CHAIN_0` , "
-"`CERT_CHAIN_1`, ..., `CERT_CHAIN_9` . The attribute `certificateChainLength`"
-" is the maximum length of the chain, so the last one tried attribute would "
-"be `CERT_CHAIN_9` ."
+"In this example configuration, the client certificate is looked up from the "
+"HTTP header, `SSL_CLIENT_CERT`, and the other certificates from its chain "
+"are looked up from HTTP headers such as `CERT_CHAIN_0` through "
+"`CERT_CHAIN_9`. The attribute `certificateChainLength` is the maximum length"
+" of the chain so the last attribute is `CERT_CHAIN_9`."
 msgstr ""
-"この設定例では、クライアント証明書はHTTPヘッダー `SSL_CLIENT_CERT` から検索され、チェーンの他の証明書は "
-"`CERT_CHAIN_0` 、 `CERT_CHAIN_1` 、…、 `CERT_CHAIN_9` のようなHTTPヘッダーから検索されます。属性 "
-"`certificateChainLength` はチェーンの最大長です。最後に試行された属性は `CERT_CHAIN_9` です。"
+"この設定例では、クライアント証明書はHTTPヘッダーの `SSL_CLIENT_CERT` から検索され、そのチェーンの他の証明書はHTTPヘッダーの "
+"`CERT_CHAIN_0` を介して `CERT_CHAIN_9` などから検索されるようになっています。 "
+"`certificateChainLength` 属性はチェーンの最大長なので、最後の属性は `CERT_CHAIN_9` となります。"
 
 #. type: Plain text
 msgid ""
-"Consult the HAProxy documentation for the details of how the HTTP Headers "
-"for the client certificate and client certificate chain can be configured "
-"and their proper names."
+"Consult the HAProxy documentation for the details of configuring the HTTP "
+"Headers for the client certificate and client certificate chain."
 msgstr ""
-"クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの構成方法と固有名の詳細については、HAProxyのドキュメントを参照してください。"
+"クライアント証明書およびクライアント証明書チェーンのHTTPヘッダーの設定の詳細については、HAProxyのドキュメントを参照してください。"
 
 #. type: Title =====
 #, no-wrap
@@ -999,9 +1082,9 @@ msgstr "Apache証明書検索プロバイダー"
 #. type: Plain text
 msgid ""
 "You can use this provider when your {project_name} server is behind an "
-"Apache reverse proxy. Configure the server like this:"
+"Apache reverse proxy. Use the following configuration for your server:"
 msgstr ""
-"{project_name}サーバーがApacheリバース・プロキシーの背後にある場合、このプロバイダーを使用できます。次のようにサーバーを設定します。"
+"このプロバイダーは、{project_name}サーバーがApacheのリバース・プロキシーの後ろにある場合に使用できます。サーバーには、次の設定を使用してください。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1030,29 +1113,29 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"The configuration is same as for the `haproxy` provider. Consult the Apache "
-"documentation on "
+"This configuration is the same as the `haproxy` provider. Consult the Apache"
+" documentation on "
 "link:https://httpd.apache.org/docs/current/mod/mod_ssl.html[mod_ssl] and "
 "link:https://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers]"
-" for the details of how the HTTP Headers for the client certificate and "
-"client certificate chain can be configured and their proper names."
+" for details on how the HTTP Headers for the client certificate and client "
+"certificate chain are configured."
 msgstr ""
-"設定は `haproxy` プロバイダーと同じです。クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの設定方法とその固有名については、 "
+"この設定は `haproxy` プロバイダーと同じです。クライアント証明書とクライアント証明書チェーンのHTTPヘッダーの設定方法については、  "
 "link:https://httpd.apache.org/docs/current/mod/mod_ssl.html[mod_ssl] と "
 "link:https://httpd.apache.org/docs/current/mod/mod_headers.html[mod_headers]"
-" Apacheのドキュメントを参照してください。"
+" にあるApacheのドキュメントを参照してください。"
 
 #. type: Title =====
 #, no-wrap
-msgid "Nginx certificate lookup provider"
+msgid "NGINX certificate lookup provider"
 msgstr "Nginx証明書検索プロバイダー"
 
 #. type: Plain text
 msgid ""
-"You can use this provider when your {project_name} server is behind an Nginx"
-" reverse proxy. Configure the server like this:"
+"You can use this provider when your {project_name} server is behind an NGINX"
+" reverse proxy. Use the following configuration for your server:"
 msgstr ""
-"{project_name}サーバーがNginxリバース・プロキシーの背後にある場合、このプロバイダーを使用できます。次のようにサーバーを構成します。"
+"このプロバイダーは、{project_name}サーバーがNGINXのリバース・プロキシーの後ろにある場合に使用できます。サーバーには、次の設定を使用してください。"
 
 #. type: delimited block -
 #, no-wrap
@@ -1079,36 +1162,38 @@ msgstr ""
 "    </provider>\n"
 "</spi>\n"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"NGINX "
+"The NGINX "
 "link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#variables[SSL/TLS"
-" module] does not expose the client certificate chain, so Keycloak NGINX "
-"certificate lookup provider is rebuilding it using the "
-"link:{installguide_truststore_link}[{installguide_truststore_name}]. Please "
-"populate Keycloak truststore using keytool CLI with all root and "
-"intermediate CA's needed for rebuilding client certificate chain."
+" module] does not expose the client certificate chain. {project_name}'s "
+"NGINX certificate lookup provider rebuilds it by using the "
+"link:{installguide_truststore_link}[{installguide_truststore_name}]. "
+"Populate the {project_name} truststore by using the keytool CLI with all "
+"root and intermediate CA's for rebuilding client certificate chain."
 msgstr ""
-"NGINX "
-"link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#variables[SSL/TLS"
-" module] はクライアント証明書チェーンを公開しないため、Keycloak NGINX証明書ルックアップ・プロバイダーは "
+"NGINXの "
+"link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#variables[SSL/TLSモジュール]"
+" はクライアント証明書チェーンを公開しません。{project_name}のNGINX証明書検索プロバイダーは、 "
 "link:{installguide_truststore_link}[{installguide_truststore_name}] "
-"を使用して再構築しています。keytool "
-"CLIを使用してクライアント証明書チェーンを再構築するために必要なすべてのルートCAおよび中間CAを使用して、Keycloakトラストストアにデータを入力してください。"
+"を使用してそれを再構築します。クライアント証明書チェーンを再構築するために、keytool "
+"CLIを使用してすべてのルートおよび中間CAで{project_name}トラストストアを入力します。"
 
 #. type: Plain text
 msgid ""
-"Consult the NGINX documentation for the details of how the HTTP Headers for "
-"the client certificate can be configured.  Example of NGINX configuration "
-"file :"
-msgstr ""
-"クライアント証明書のHTTPヘッダーの設定方法の詳細については、NGINXのドキュメントを参照してください。NGINX設定ファイルの例を以下に示します。"
+"Consult the NGINX documentation for the details of configuring the HTTP "
+"Headers for the client certificate."
+msgstr "クライアント証明書のHTTPヘッダーの設定の詳細については、NGINXのドキュメントを参照してください。"
+
+#. type: Plain text
+msgid "Example of NGINX configuration file :"
+msgstr "NGINXの設定ファイルの例を以下に示します。"
 
 #. type: delimited block -
 #, no-wrap
 msgid ""
 " ...\n"
-" server { \n"
+" server {\n"
 "    ...\n"
 "    ssl_client_certificate                  trusted-ca-list-for-client-auth.pem;\n"
 "    ssl_verify_client                       optional_no_ca;\n"
@@ -1123,7 +1208,7 @@ msgid ""
 "}\n"
 msgstr ""
 " ...\n"
-" server { \n"
+" server {\n"
 "    ...\n"
 "    ssl_client_certificate                  trusted-ca-list-for-client-auth.pem;\n"
 "    ssl_verify_client                       optional_no_ca;\n"
@@ -1137,13 +1222,13 @@ msgstr ""
 "    ...\n"
 "}\n"
 
-#. type: Plain text
+#. type: delimited block =
 msgid ""
-"all certificates in trusted-ca-list-for-client-auth.pem must be added to "
+"All certificates in trusted-ca-list-for-client-auth.pem must be added to "
 "link:{installguide_truststore_link}[{installguide_truststore_name}]."
 msgstr ""
-"link:{installguide_truststore_link}[{installguide_truststore_name}] に"
-"、trusted-ca-list-for-client-auth.pemのすべての証明書を追加する必要があります。"
+"link:{installguide_truststore_link}[{installguide_truststore_name}] "
+"に、trusted-ca-list-for-client-auth.pemのすべての証明書を追加する必要があります。"
 
 #. type: Title =====
 #, no-wrap
@@ -1152,21 +1237,21 @@ msgstr "その他のリバース・プロキシーの実装"
 
 #. type: Plain text
 msgid ""
-"We do not have built-in support for other reverse proxy implementations. "
-"However, it is possible that other reverse proxies can be made to behave in "
-"a similar way to `apache` or `haproxy` and that some of those providers can "
-"be used. If none of those works, you may need to create your own "
+"{project_name} does not have built-in support for other reverse proxy "
+"implementations. However, you can make other reverse proxies behave in a "
+"similar way to `apache` or `haproxy`. If none of these work, create your "
 "implementation of the "
 "`org.keycloak.services.x509.X509ClientCertificateLookupFactory` and "
-"`org.keycloak.services.x509.X509ClientCertificateLookup` provider. See the "
-"link:{developerguide_link}[{developerguide_name}] for the details on how to "
-"add your own provider."
+"`org.keycloak.services.x509.X509ClientCertificateLookup` providers. See the "
+"link:{developerguide_link}[{developerguide_name}] for details on how to add "
+"your provider."
 msgstr ""
-"他のリバース・プロキシーの実装のための組み込みサポートはありません。しかし、他のリバース・プロキシーを `apache` や `haproxy` "
-"と同様に動作させることができれば、それらのプロバイダーを使用することも可能です。そのような動作ができない場合は、 "
+"{project_name}は、他のリバース・プロキシーの実装をビルトインでサポートしていません。しかし、他のリバース・プロキシーでも `apache`"
+" や `haproxy` と同じような動作をさせることができます。もし、どれもうまくいかない場合は、 "
 "`org.keycloak.services.x509.X509ClientCertificateLookupFactory` と "
 "`org.keycloak.services.x509.X509ClientCertificateLookup` "
-"プロバイダーの独自の実装を作成する必要があります。独自のプロバイダーを追加する方法については、link:{developerguide_link}[{developerguide_name}]を参照してください。"
+"プロバイダーを自分で実装して作成してください。プロバイダーの追加方法については、 "
+"link:{developerguide_link}[{developerguide_name}] を参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -1175,11 +1260,11 @@ msgstr "HTTPヘッダーのダンプ"
 
 #. type: Plain text
 msgid ""
-"If you want to view what the reverse proxy is sending to Keycloak, enable "
-"the `RequestDumpingHandler` Undertow filter and consult `server.log` file."
+"To view what the reverse proxy sends to Keycloak, enable the "
+"`RequestDumpingHandler` Undertow filter and consult the `server.log` file."
 msgstr ""
-"リバース・プロキシーがKeycloakに送信しているものを表示する場合は、 `RequestDumpingHandler` "
-"Undertowフィルターを有効にして、`server.log` ファイルを調べます。"
+"リバース・プロキシーがKeycloakに送信するものを見るには、 `RequestDumpingHandler` "
+"Undertowフィルターを有効にして、 `server.log` ファイルを参照してください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -1211,12 +1296,9 @@ msgstr ""
 "                <level name=\"TRACE\"/>\n"
 "            </logger>\n"
 
-#. type: Plain text
-#, no-wrap
-msgid ""
-" WARNING: Don't use RequestDumpingHandler or TRACE logging in production.\n"
-msgstr ""
-" WARNING: Don't use RequestDumpingHandler or TRACE logging in production.\n"
+#. type: delimited block =
+msgid "Do not use RequestDumpingHandler or TRACE logging in production."
+msgstr "RequestDumpingHandlerやTRACEロギングをプロダクション環境で使用しないでください。"
 
 #. type: Labeled list
 #, no-wrap
@@ -1225,9 +1307,9 @@ msgstr "X.509によるダイレクト・グラント認証"
 
 #. type: Plain text
 msgid ""
-"The following template can be used to request a token using the Resource "
+"You can use the following template to request a token by using the Resource "
 "Owner Password Credentials Grant:"
-msgstr "次のテンプレートを使用して、リソース・オーナー・パスワード・クレデンシャル・グラントを使用してトークンをリクエストできます。"
+msgstr "リソース・オーナー・パスワード・クレデンシャル・グラントを利用してトークンを要求する場合、以下のテンプレートを使用することができます。"
 
 #. type: Code block
 #, no-wrap
@@ -1250,12 +1332,8 @@ msgid "`[host][:port]`"
 msgstr "`[host][:port]`"
 
 #. type: Plain text
-msgid ""
-"The host and the port number of a remote {project_name} server that has been"
-" configured to allow users authenticate with x.509 client certificates using"
-" the Direct Grant Flow."
-msgstr ""
-"ダイレクト・グラント・フローを使用してx.509クライアント証明書でユーザーを認証できるように設定されているリモートの{project_name}サーバーのホストとポート番号。"
+msgid "The host and the port number of the remote {project_name} server."
+msgstr "リモート{project_name}サーバーのホストとポート番号です。"
 
 #. type: Labeled list
 #, no-wrap
@@ -1263,7 +1341,7 @@ msgid "`CLIENT_ID`"
 msgstr "`CLIENT_ID`"
 
 #. type: Plain text
-msgid "A client id."
+msgid "The client id."
 msgstr "クライアントID。"
 
 #. type: Labeled list
@@ -1272,8 +1350,8 @@ msgid "`CLIENT_SECRET`"
 msgstr "`CLIENT_SECRET`"
 
 #. type: Plain text
-msgid "For confidential clients, a client secret; otherwise, leave it empty."
-msgstr "コンフィデンシャル・クライアントの場合は、クライアント・シークレット。それ以外の場合は、空のままにします。"
+msgid "For confidential clients, a client secret."
+msgstr "コンフィデンシャル・クライアントに対するクライアント・シークレット。"
 
 #. type: Labeled list
 #, no-wrap
@@ -1282,10 +1360,9 @@ msgstr "`client_cert.crt`"
 
 #. type: Plain text
 msgid ""
-"A public key certificate that will be used to verify the identity of the "
-"client in mutual SSL authentication. The certificate should be in PEM "
-"format."
-msgstr "相互SSL認証でクライアントのアイデンティティーを確認するために使用される公開鍵証明書。証明書はPEM形式である必要があります。"
+"A public key certificate to verify the identity of the client in mutual SSL "
+"authentication. The certificate must be in PEM format."
+msgstr "Mutual SSL認証において、クライアントの身元を確認するための公開鍵証明書です。証明書はPEM形式である必要があります。"
 
 #. type: Labeled list
 #, no-wrap
@@ -1293,5 +1370,5 @@ msgid "`client_cert.key`"
 msgstr "`client_cert.key`"
 
 #. type: Plain text
-msgid "A private key in the public key pair. Also expected in PEM format."
-msgstr "公開鍵ペアの秘密鍵。PEM形式であることも期待されます。"
+msgid "A private key in the public key pair. This key must be in PEM format."
+msgstr "公開鍵ペアの秘密鍵。この鍵はPEM形式である必要があります。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_admin/topics/authentication/x509.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_admin__topics__authentication__x509
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
