### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -67,11 +67,11 @@ msgstr ""
 #. type: Plain text
 msgid ""
 "User Storage SPI provider implementations are packaged and deployed "
-"similarly to (and often are) Java EE components. They are not enabled by "
+"similarly to (and often are) Jakarta EE components. They are not enabled by "
 "default, but instead must be enabled and configured per realm under the "
 "`User Federation` tab in the administration console."
 msgstr ""
-"ユーザー・ストレージSPIプロバイダーの実装は、Java EEコンポーネントと同様にパッケージ化され、デプロイされます（しばしばJava "
+"ユーザー・ストレージSPIプロバイダーの実装は、Jakarta EEコンポーネントと同様にパッケージ化され、デプロイされます（しばしばJakarta "
 "EEコンポーネントです）。デフォルトでは有効になっていませんが、管理コンソールの `User Federation` "
 "タブでレルムごとに有効にして設定する必要があります。"
 


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/user-storage.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__user-storage
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
