### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/authorization-quickstarts.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/authorization-quickstarts.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/authorization-quickstarts.ja_JP.po
@@ -6,19 +6,23 @@
 # Translators:
 # Tsukasa Amano <t.amano@pro-japan.co.jp>, 2018
 # Hiroyuki Wada <wadahiro@gmail.com>, 2018
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2019
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2019\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ja_JP\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+msgid "Name |Description"
+msgstr "名前 |説明"
 
 #. type: Block title
 #, no-wrap
@@ -57,10 +61,6 @@ msgstr ""
 "ファイルがあります。次の表に、使用可能な認可クイックスタートの簡単な説明を示します。"
 
 #. type: Plain text
-msgid "Name |Description"
-msgstr "名前 |説明"
-
-#. type: Plain text
 msgid ""
 "https://github.com/keycloak/keycloak-quickstarts/tree/latest/app-authz-jee-"
 "servlet[app-authz-jee-servlet]"
@@ -70,11 +70,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Demonstrates how to enable fine-grained authorization to a Java EE "
+"Demonstrates how to enable fine-grained authorization to a Jakarta EE "
 "application in order to protect specific resources and build a dynamic menu "
 "based on the permissions obtained from a Keycloak Server."
 msgstr ""
-"特定のリソースを保護し、Keycloakサーバーから取得したパーミッションに基づいて動的メニューを構築するために、Java "
+"特定のリソースを保護し、Keycloakサーバーから取得したパーミッションに基づいて動的メニューを構築するために、Jakarta "
 "EEアプリケーションに対するきめ細かい認可を有効にする方法を示します。"
 
 #. type: Plain text
@@ -87,11 +87,11 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"Demonstrates how to enable fine-grained authorization to a Java EE "
+"Demonstrates how to enable fine-grained authorization to a Jakarta EE "
 "application and use the default authorization settings to protect all "
 "resources in the application."
 msgstr ""
-"Java "
+"Jakarta "
 "EEアプリケーションに対するきめ細かな認可を有効にし、デフォルトの認可設定を使用してアプリケーション内のすべてのリソースを保護する方法を示します。"
 
 #. type: Plain text


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/authorization-quickstarts.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__authorization-quickstarts
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
