### PR TITLE
Translations for i18n/po/ja_JP/authorization_services/topics/policy-regex-policy.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/authorization_services/topics/policy-regex-policy.ja_JP.po
+++ b/i18n/po/ja_JP/authorization_services/topics/policy-regex-policy.ja_JP.po
@@ -1,0 +1,103 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Nomura Research Institute, Ltd.
+# This file is distributed under the same license as the keycloak-documentation-i18n package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+# Translators:
+# KojiNose <knose.dev@gmail.com>, 2022
+# Hiroyuki Wada <wadahiro@gmail.com>, 2022
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: keycloak-documentation-i18n\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ==
+#, no-wrap
+msgid "Configuration"
+msgstr "設定"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Name*\n"
+msgstr "*Name*\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Description*\n"
+msgstr "*Description*\n"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Logic*\n"
+msgstr "*Logic*\n"
+
+#. type: Plain text
+msgid ""
+"The <<_policy_logic, Logic>> of this policy to apply after the other "
+"conditions have been evaluated."
+msgstr "他の条件が評価された後に適用する、このポリシーの<<_policy_logic, ロジック>>。"
+
+#. type: Plain text
+msgid "A string containing details about this policy."
+msgstr "このポリシーに関する詳細情報を含む文字列。"
+
+#. type: Plain text
+msgid ""
+"A human-readable and unique string describing the policy. A best practice is"
+" to use names that are closely related to your business and security "
+"requirements, so you can identify them more easily."
+msgstr ""
+"ポリシーを説明する、人が判読可能で一意の文字列。ベスト・プラクティスは、ビジネス要件とセキュリティー要件に密接に関連する名前を使用することです。そうすることで簡単に識別することができます。"
+
+#. type: Title =
+#, no-wrap
+msgid "Regex-Based Policy"
+msgstr "正規表現ベースのポリシー"
+
+#. type: Plain text
+msgid ""
+"You can use this type of policy to define regex conditions for your "
+"permissions."
+msgstr "このタイプのポリシーを使用して、パーミッションの正規表現の条件を定義することができます。"
+
+#. type: Plain text
+msgid ""
+"To create a new regex-based policy, select *Regex* in the item list in the "
+"upper right corner of the policy listing."
+msgstr "正規表現に基づく新しいポリシーを作成するには、ポリシー一覧の右上にある項目リストで *Regex* を選択します。"
+
+#. type: Block title
+#, no-wrap
+msgid "Add Regex-Based Policy"
+msgstr "正規表現ベースのポリシーの追加"
+
+#. type: Plain text
+msgid "image:images/policy/create-regex.png[alt=\"Add Regex-Based Policy\"]"
+msgstr "image:images/policy/create-regex.png[alt=\"Add Regex-Based Policy\"]"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Target Claim*\n"
+msgstr "*Target Claim*\n"
+
+#. type: Plain text
+msgid "Specifies the name of the target claim in the token."
+msgstr "トークン内の対象クレームの名称を指定します。"
+
+#. type: Plain text
+#, no-wrap
+msgid "*Regex Pattern*\n"
+msgstr "*Regex Pattern*\n"
+
+#. type: Plain text
+msgid "Specifies the regex pattern."
+msgstr "正規表現パターンを指定します。"


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/authorization_services/topics/policy-regex-policy.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/authorization_services__topics__policy-regex-policy
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
