### PR TITLE
Translations for i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po

### DIFF
--- a/i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po
+++ b/i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po
@@ -5,13 +5,13 @@
 # 
 # Translators:
 # Hiroyuki Wada <wadahiro@gmail.com>, 2019
-# Kohei Tamura <ktamura.biz.80@gmail.com>, 2021
+# Kohei Tamura <ktamura.biz.80@gmail.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: keycloak-documentation-i18n\n"
-"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2021\n"
+"Last-Translator: Kohei Tamura <ktamura.biz.80@gmail.com>, 2022\n"
 "Language-Team: Japanese (Japan) (https://www.transifex.com/openstandia/teams/79437/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,12 +41,26 @@ msgstr ""
 
 #. type: Plain text
 msgid ""
-"This behaviour can be changed through the `LocaleSelectorSPI` by "
-"implementing the `LocaleSelectorProvider` and "
-"`LocaleSelectorProviderFactory`."
+"This behavior can be changed through the `LocaleSelectorSPI` by implementing"
+" the `LocaleSelectorProvider` and `LocaleSelectorProviderFactory`."
 msgstr ""
 "この動作は `LocaleSelectorProvider` と `LocaleSelectorProviderFactory` を実装することで "
 "`LocaleSelectorSPI` を通して変更することができます。"
+
+#. type: Plain text
+msgid ""
+"By default, the locale is selected using the "
+"`DefaultLocaleSelectorProvider`, which implements the "
+"`LocaleSelectorProvider` interface. English is the default language when "
+"internationalization is disabled.  With internationalization enabled, the "
+"locale is resolved according to the logic described in the "
+"link:{adminguide_link}#_user_locale_selection[{adminguide_name}]."
+msgstr ""
+"デフォルトでは、ロケールは `LocaleSelectorProvider` インターフェイスを実装する "
+"`DefaultLocaleSelectorProvider` "
+"を使用して選択されます。国際化が無効の場合は、英語がデフォルトの言語です。国際化を有効にすると、ロケールは "
+"link:{adminguide_link}#_user_locale_selection[{adminguide_name}] "
+"で説明されているロジックに従って解決されます。 "
 
 #. type: Plain text
 msgid ""


### PR DESCRIPTION
* Path: `i18n/po/ja_JP/server_development/topics/locale-selector.ja_JP.po`
* Language: `ja_JP`
* Translate-URL: https://www.transifex.com/openstandia/keycloak-documentation-i18n/translate/#ja_JP/server_development__topics__locale-selector
* Translated-Site-URL: http://keycloak-documentation.openstandia.jp/review/ja_JP/
